### PR TITLE
Prefer Claude account alias config paths

### DIFF
--- a/cmd/subrouter/cx_claude.go
+++ b/cmd/subrouter/cx_claude.go
@@ -117,6 +117,7 @@ func (r claudeRunner) add(ctx context.Context, name string) error {
 			return err
 		}
 	}
+	claudeConfigDir := r.store.PreferredInstancePath(instancePath)
 
 	fmt.Fprintln(r.out, "Starting Claude Code...")
 	fmt.Fprintln(r.out, "Complete the OAuth login in your browser, then exit Claude to finish setup.")
@@ -126,7 +127,7 @@ func (r claudeRunner) add(ctx context.Context, name string) error {
 	cmd.Stdin = r.in
 	cmd.Stdout = r.out
 	cmd.Stderr = r.errOut
-	cmd.Env = append(os.Environ(), "CLAUDE_CONFIG_DIR="+instancePath)
+	cmd.Env = append(os.Environ(), "CLAUDE_CONFIG_DIR="+claudeConfigDir)
 	if err := cmd.Run(); err != nil {
 		if name != "" {
 			_, _ = r.store.RemoveProfile(name)
@@ -136,7 +137,7 @@ func (r claudeRunner) add(ctx context.Context, name string) error {
 		return fmt.Errorf("Claude login did not complete: %w", err)
 	}
 
-	status, err := claude.AuthStatusForPath(ctx, claudePath, instancePath)
+	status, err := claude.AuthStatusForPath(ctx, claudePath, claudeConfigDir)
 	if err != nil || status == nil || !status.LoggedIn {
 		if name != "" {
 			_, _ = r.store.RemoveProfile(name)
@@ -215,7 +216,7 @@ func (r claudeRunner) fetchInfos(ctx context.Context) []claude.ProfileInfo {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			instancePath := r.store.InstancePath(profile.Name)
+			claudeConfigDir := r.store.ClaudeConfigDir(profile.Name)
 			var auth *claude.AuthStatus
 			var credential *claude.CredentialInfo
 			var authErr, credentialErr error
@@ -223,11 +224,11 @@ func (r claudeRunner) fetchInfos(ctx context.Context) []claude.ProfileInfo {
 			inner.Add(2)
 			go func() {
 				defer inner.Done()
-				auth, authErr = claude.AuthStatusForPath(ctx, claudePath, instancePath)
+				auth, authErr = claude.AuthStatusForPath(ctx, claudePath, claudeConfigDir)
 			}()
 			go func() {
 				defer inner.Done()
-				credential, credentialErr = r.store.ReadCredential(ctx, instancePath)
+				credential, credentialErr = r.store.ReadCredential(ctx, claudeConfigDir)
 			}()
 			inner.Wait()
 			if authErr != nil {
@@ -264,7 +265,7 @@ func (r claudeRunner) switchProfile(selector string) error {
 		return err
 	}
 	fmt.Fprintf(r.out, "Active Claude profile: %s\n", profile.Name)
-	fmt.Fprintf(r.out, "\n  export CLAUDE_CONFIG_DIR=%s\n", r.store.InstancePath(profile.Name))
+	fmt.Fprintf(r.out, "\n  export CLAUDE_CONFIG_DIR=%s\n", r.store.ClaudeConfigDir(profile.Name))
 	fmt.Fprintln(r.out, "\nOr add to shell rc: eval \"$(cx claude env)\"")
 	return nil
 }
@@ -293,7 +294,7 @@ func (r claudeRunner) env() error {
 	if active == "" {
 		return nil
 	}
-	fmt.Fprintf(r.out, "export CLAUDE_CONFIG_DIR=%s\n", r.store.InstancePath(active))
+	fmt.Fprintf(r.out, "export CLAUDE_CONFIG_DIR=%s\n", r.store.ClaudeConfigDir(active))
 	return nil
 }
 
@@ -322,7 +323,7 @@ func (r claudeRunner) runClaude(ctx context.Context, name string, extra []string
 	cmd.Stdin = r.in
 	cmd.Stdout = r.out
 	cmd.Stderr = r.errOut
-	cmd.Env = append(os.Environ(), "CLAUDE_CONFIG_DIR="+r.store.InstancePath(profile.Name))
+	cmd.Env = append(os.Environ(), "CLAUDE_CONFIG_DIR="+r.store.ClaudeConfigDir(profile.Name))
 	return cmd.Run()
 }
 

--- a/cmd/subrouter/cx_claude_test.go
+++ b/cmd/subrouter/cx_claude_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -27,6 +29,28 @@ func TestClaudeEnvPrintsActiveProfile(t *testing.T) {
 	}
 	if !strings.Contains(got, "/claude/work") {
 		t.Fatalf("env output missing profile path: %q", got)
+	}
+}
+
+func TestClaudeEnvPrefersCodexAccountsAlias(t *testing.T) {
+	home := t.TempDir()
+	store := claude.Store{Dir: filepath.Join(home, ".subrouter", "codex")}
+	if _, err := store.CreateProfile("work"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(store.Dir, filepath.Join(home, ".codex-accounts")); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	runner := claudeRunner{store: store, in: strings.NewReader(""), out: &out, errOut: &out}
+	if err := runner.run(context.Background(), []string{"env"}); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "export CLAUDE_CONFIG_DIR=" + filepath.Join(home, ".codex-accounts", "claude", "work")
+	if got := strings.TrimSpace(out.String()); got != want {
+		t.Fatalf("env output = %q, want %q", got, want)
 	}
 }
 

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -117,6 +117,28 @@ func (s Store) InstancePath(name string) string {
 	return filepath.Join(s.InstancesDir(), dir)
 }
 
+func (s Store) ClaudeConfigDir(name string) string {
+	return s.PreferredInstancePath(s.InstancePath(name))
+}
+
+func (s Store) PreferredInstancePath(instancePath string) string {
+	cleanDir := filepath.Clean(s.Dir)
+	cleanInstance := filepath.Clean(instancePath)
+	if filepath.Base(cleanDir) != "codex" || filepath.Base(filepath.Dir(cleanDir)) != ".subrouter" {
+		return cleanInstance
+	}
+	rel, err := filepath.Rel(cleanDir, cleanInstance)
+	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || rel == ".." {
+		return cleanInstance
+	}
+	home := filepath.Dir(filepath.Dir(cleanDir))
+	candidate := filepath.Join(home, ".codex-accounts", rel)
+	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+		return candidate
+	}
+	return cleanInstance
+}
+
 func (s Store) ListProfiles() []Profile {
 	data := s.readProfiles()
 	out := make([]Profile, 0, len(data.Profiles))

--- a/internal/agents/claude/store_test.go
+++ b/internal/agents/claude/store_test.go
@@ -53,6 +53,35 @@ func TestRegisterProfileAllowsEmailName(t *testing.T) {
 	}
 }
 
+func TestClaudeConfigDirPrefersCodexAccountsAlias(t *testing.T) {
+	home := t.TempDir()
+	store := Store{Dir: filepath.Join(home, ".subrouter", "codex")}
+	if _, err := store.CreateProfile("work"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(store.Dir, filepath.Join(home, ".codex-accounts")); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(home, ".codex-accounts", "claude", "work")
+	if got := store.ClaudeConfigDir("work"); got != want {
+		t.Fatalf("ClaudeConfigDir = %q, want %q", got, want)
+	}
+}
+
+func TestClaudeConfigDirFallsBackWhenAliasMissing(t *testing.T) {
+	home := t.TempDir()
+	store := Store{Dir: filepath.Join(home, ".subrouter", "codex")}
+	instancePath, err := store.CreateProfile("work")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := store.ClaudeConfigDir("work"); got != filepath.Clean(instancePath) {
+		t.Fatalf("ClaudeConfigDir = %q, want %q", got, filepath.Clean(instancePath))
+	}
+}
+
 func TestReadCredentialFile(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(`{"claudeAiOauth":{"accessToken":"tok","subscriptionType":"pro"}}`), 0o600); err != nil {


### PR DESCRIPTION
## Summary
- prefer the .codex-accounts Claude config alias when it points at subrouter-managed profiles
- use the same preferred config dir for cx claude env, run, login status, and credential reads
- add coverage for alias and fallback behavior

## Tests
- go test -ldflags=-linkmode=external ./...

Note: plain go test ./... fails locally before tests run because dyld rejects generated Go test binaries with missing LC_UUID; external linking avoids that local toolchain issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer the `.codex-accounts` alias for Claude config when available, and use it consistently across `cx claude` commands. This fixes path mismatches and stabilizes `CLAUDE_CONFIG_DIR` for login, status, run, and env.

- **Bug Fixes**
  - Added `PreferredInstancePath` and `ClaudeConfigDir` to select the `.codex-accounts` path when it points to subrouter-managed profiles; falls back if missing.
  - Updated env/add/run/status to read and export the preferred path, ensuring auth and credentials use the same dir.
  - Added tests for alias preference and fallback.

<sup>Written for commit 13373465e2e81651e11dc19836b95e65b24dcd81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Codex accounts alias to customize Claude configuration directory paths

* **Bug Fixes**
  * Standardized Claude configuration directory path handling across commands for consistency

* **Tests**
  * Added test coverage for environment variable output with Codex accounts alias
  * Added test cases for fallback behavior when alias is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->