### PR TITLE
Route Codex Spark requests using Spark quota

### DIFF
--- a/cmd/subrouter/codex.go
+++ b/cmd/subrouter/codex.go
@@ -35,7 +35,7 @@ func codex(args []string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	env := os.Environ()
-	if userEmail != "" || accountID != "" {
+	if userEmail != "" || accountID != "" || codexModelArg(args) != "" {
 		env = upsertEnv(env, "SUBROUTER_CODEX_DUMMY_API_KEY", "subrouter")
 	}
 	cmd.Env = env
@@ -90,7 +90,8 @@ func codexBaseURLForServer(server srServerConfig) string {
 }
 
 func codexArgs(args []string, baseURL, userEmail, accountID string) []string {
-	configArgs := codexConfigArgs(baseURL, userEmail, accountID)
+	model := codexModelArg(args)
+	configArgs := codexConfigArgs(baseURL, userEmail, accountID, model)
 	if len(args) == 0 || strings.HasPrefix(args[0], "-") || !isKnownCodexCommand(args[0]) {
 		return append(configArgs, args...)
 	}
@@ -103,8 +104,8 @@ func codexArgs(args []string, baseURL, userEmail, accountID string) []string {
 	return out
 }
 
-func codexConfigArgs(baseURL, userEmail, accountID string) []string {
-	if userEmail == "" && accountID == "" {
+func codexConfigArgs(baseURL, userEmail, accountID, model string) []string {
+	if userEmail == "" && accountID == "" && model == "" {
 		return []string{"-c", "openai_base_url=" + strconv.Quote(baseURL)}
 	}
 	return []string{
@@ -114,11 +115,11 @@ func codexConfigArgs(baseURL, userEmail, accountID string) []string {
 		"-c", `model_providers.subrouter.env_key="SUBROUTER_CODEX_DUMMY_API_KEY"`,
 		"-c", `model_providers.subrouter.wire_api="responses"`,
 		"-c", `model_providers.subrouter.supports_websockets=true`,
-		"-c", `model_providers.subrouter.http_headers=` + codexSubrouterHeaders(userEmail, accountID),
+		"-c", `model_providers.subrouter.http_headers=` + codexSubrouterHeaders(userEmail, accountID, model),
 	}
 }
 
-func codexSubrouterHeaders(userEmail, accountID string) string {
+func codexSubrouterHeaders(userEmail, accountID, model string) string {
 	headers := []string{`"X-Subrouter-Agent"="codex"`}
 	if userEmail != "" {
 		headers = append(headers, `"X-Subrouter-User-Email"=`+strconv.Quote(userEmail))
@@ -126,7 +127,27 @@ func codexSubrouterHeaders(userEmail, accountID string) string {
 	if accountID != "" {
 		headers = append(headers, `"X-Subrouter-Account-ID"=`+strconv.Quote(accountID))
 	}
+	if model != "" {
+		headers = append(headers, `"X-Subrouter-Model"=`+strconv.Quote(model))
+	}
 	return "{" + strings.Join(headers, ",") + "}"
+}
+
+func codexModelArg(args []string) string {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-m" || arg == "--model":
+			if i+1 < len(args) {
+				return session.NormalizeModel(args[i+1])
+			}
+		case strings.HasPrefix(arg, "--model="):
+			return session.NormalizeModel(strings.TrimPrefix(arg, "--model="))
+		case strings.HasPrefix(arg, "-m="):
+			return session.NormalizeModel(strings.TrimPrefix(arg, "-m="))
+		}
+	}
+	return ""
 }
 
 func isSubrouterRoutedCodexCommand(command string) bool {

--- a/cmd/subrouter/codex_test.go
+++ b/cmd/subrouter/codex_test.go
@@ -181,6 +181,20 @@ func TestCodexArgsInjectsUserEmailAndAccountID(t *testing.T) {
 	}
 }
 
+func TestCodexArgsInjectsModelHeader(t *testing.T) {
+	got := codexArgs([]string{"exec", "-m", "GPT-5.3-Codex-Spark", "prompt"}, "http://127.0.0.1:31415/v1", "", "")
+	headers := `model_providers.subrouter.http_headers={"X-Subrouter-Agent"="codex","X-Subrouter-Model"="GPT-5.3-Codex-Spark"}`
+	if !contains(got, headers) {
+		t.Fatalf("args = %#v, want headers %q", got, headers)
+	}
+}
+
+func TestCodexModelArgSupportsEqualsForm(t *testing.T) {
+	if got := codexModelArg([]string{"exec", "--model=GPT-5.3-Codex-Spark"}); got != "GPT-5.3-Codex-Spark" {
+		t.Fatalf("model = %q", got)
+	}
+}
+
 func TestUpsertEnvReplacesExistingValue(t *testing.T) {
 	got := upsertEnv([]string{"A=1", "SUBROUTER_CODEX_DUMMY_API_KEY=old"}, "SUBROUTER_CODEX_DUMMY_API_KEY", "subrouter")
 	want := []string{"A=1", "SUBROUTER_CODEX_DUMMY_API_KEY=subrouter"}

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -512,6 +512,7 @@ func fetchCodexScoresWithStore(ctx context.Context, store accounts.CodexStore, c
 					UsedPercent:        window.UsedPercent,
 					LimitWindowSeconds: window.LimitWindowSeconds,
 					ResetAfterSeconds:  window.ResetAfterSeconds,
+					Feature:            window.Feature,
 				})
 			}
 			score := selectacct.ScoreFromLimitWindows(account.ID, 0, limitWindows)

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -1058,6 +1058,7 @@ func scoreFromWindows(accountID string, windows []accounts.UsageWindow) selectac
 			UsedPercent:        window.UsedPercent,
 			LimitWindowSeconds: window.LimitWindowSeconds,
 			ResetAfterSeconds:  window.ResetAfterSeconds,
+			Feature:            window.Feature,
 		})
 	}
 	return selectacct.ScoreFromLimitWindows(accountID, 0, limitWindows)

--- a/internal/accounts/codex_usage.go
+++ b/internal/accounts/codex_usage.go
@@ -15,6 +15,11 @@ type UsageWindow struct {
 	UsedPercent        float64
 	LimitWindowSeconds int64
 	ResetAfterSeconds  int64
+	// Feature is the upstream limit_name of the additional (per-model) rate
+	// limit this window belongs to, e.g. "GPT-5.3-Codex-Spark". Empty for the
+	// account-wide primary/secondary windows. Used to route a request to its
+	// model-specific quota pool without matching on display strings.
+	Feature string
 }
 
 type CodexUsageDetails struct {
@@ -152,10 +157,11 @@ func (u codexUsageResponse) windows() []UsageWindow {
 
 func (u codexUsageResponse) displayWindows() []UsageWindow {
 	windows := u.windows()
-	appendDetails := func(prefix string, details codexRateLimitDetails) {
+	appendDetails := func(prefix, feature string, details codexRateLimitDetails) {
 		if details.PrimaryWindow != nil {
 			windows = append(windows, UsageWindow{
 				Name:               prefix + "primary",
+				Feature:            feature,
 				UsedPercent:        details.PrimaryWindow.UsedPercent,
 				LimitWindowSeconds: details.PrimaryWindow.LimitWindowSeconds,
 				ResetAfterSeconds:  details.PrimaryWindow.resetAfterSeconds(),
@@ -164,13 +170,14 @@ func (u codexUsageResponse) displayWindows() []UsageWindow {
 		if details.SecondaryWindow != nil {
 			windows = append(windows, UsageWindow{
 				Name:               prefix + "secondary",
+				Feature:            feature,
 				UsedPercent:        details.SecondaryWindow.UsedPercent,
 				LimitWindowSeconds: details.SecondaryWindow.LimitWindowSeconds,
 				ResetAfterSeconds:  details.SecondaryWindow.resetAfterSeconds(),
 			})
 		}
 		if details.LimitReached {
-			windows = append(windows, UsageWindow{Name: prefix + "reached", UsedPercent: 100})
+			windows = append(windows, UsageWindow{Name: prefix + "reached", Feature: feature, UsedPercent: 100})
 		}
 	}
 	for _, additional := range u.AdditionalRateLimits {
@@ -181,7 +188,7 @@ func (u codexUsageResponse) displayWindows() []UsageWindow {
 		if name == "" {
 			name = "unknown"
 		}
-		appendDetails(name+"/", additional.RateLimit)
+		appendDetails(name+"/", name, additional.RateLimit)
 	}
 	return windows
 }

--- a/internal/accounts/codex_usage_test.go
+++ b/internal/accounts/codex_usage_test.go
@@ -1,0 +1,54 @@
+package accounts
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDisplayWindowsTagsAdditionalLimitsWithFeature(t *testing.T) {
+	// Mirrors a real chatgpt usage response: an account-wide rate_limit plus one
+	// additional rate limit whose machine name is a rotating codename
+	// (codex_bengalfox) but whose limit_name is the model display name. The
+	// Feature must be set from limit_name so routing keys off it rather than the
+	// codename or a display-string substring.
+	raw := `{
+		"plan_type": "pro",
+		"rate_limit": {
+			"allowed": true,
+			"primary_window": {"used_percent": 7, "limit_window_seconds": 18000, "reset_after_seconds": 3600},
+			"secondary_window": {"used_percent": 2, "limit_window_seconds": 604800, "reset_after_seconds": 600000}
+		},
+		"additional_rate_limits": [
+			{
+				"metered_feature": "codex_bengalfox",
+				"limit_name": "GPT-5.3-Codex-Spark",
+				"rate_limit": {
+					"primary_window": {"used_percent": 0, "limit_window_seconds": 18000, "reset_after_seconds": 3600}
+				}
+			}
+		]
+	}`
+	var usage codexUsageResponse
+	if err := json.Unmarshal([]byte(raw), &usage); err != nil {
+		t.Fatal(err)
+	}
+
+	accountWide := 0
+	featureWindows := 0
+	for _, w := range usage.displayWindows() {
+		if w.Feature == "" {
+			accountWide++
+			continue
+		}
+		if w.Feature != "GPT-5.3-Codex-Spark" {
+			t.Fatalf("window %q has feature %q, want GPT-5.3-Codex-Spark", w.Name, w.Feature)
+		}
+		featureWindows++
+	}
+	if accountWide == 0 {
+		t.Fatal("expected account-wide windows tagged with an empty Feature")
+	}
+	if featureWindows == 0 {
+		t.Fatal("expected the additional rate limit window tagged with its limit_name as Feature")
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -614,6 +614,7 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 				UsedPercent:        window.UsedPercent,
 				LimitWindowSeconds: window.LimitWindowSeconds,
 				ResetAfterSeconds:  window.ResetAfterSeconds,
+				Feature:            window.Feature,
 			})
 		}
 		if idx, ok := scoreByID[account.ID]; ok {
@@ -1396,7 +1397,11 @@ func (s Server) accountForSession(agentType, sessionID string, r *http.Request) 
 	if provider == accounts.ProviderCodex {
 		s.refreshUsageScoresIfStale(r.Context(), availableAccounts)
 	}
-	scheduler := s.scheduler().ForModel(model).WithSessionCounts(s.Sessions.CountByAccount())
+	base := s.scheduler()
+	if model != "" && s.Logger != nil && base.HasModelPool(model) {
+		s.Logger.Info("model quota pool matched", "agent", agentType, "model", model, "pool", selectacct.ModelKey(model))
+	}
+	scheduler := base.ForModel(model).WithSessionCounts(s.Sessions.CountByAccount())
 	if assignment, ok := s.Sessions.Get(agentType, sessionID); ok {
 		if userEmail != "" && userEmail != assignment.UserEmail {
 			updated, err := s.Sessions.Put(agentType, sessionID, assignment.AccountID, userEmail)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1373,6 +1373,7 @@ func (s Server) accountFor(agentType string, r *http.Request) (accounts.Account,
 func (s Server) accountForSession(agentType, sessionID string, r *http.Request) (accounts.Account, string, string, error) {
 	userEmail := session.ExtractUserEmail(r)
 	forcedAccountID := session.ExtractAccountID(r)
+	model := session.ExtractModel(r, s.MaxBodyBytes)
 	provider := providerForAgent(agentType)
 	availableAccounts := filterAccountsForProvider(s.accountList(), provider)
 	if forcedAccountID != "" {
@@ -1395,7 +1396,7 @@ func (s Server) accountForSession(agentType, sessionID string, r *http.Request) 
 	if provider == accounts.ProviderCodex {
 		s.refreshUsageScoresIfStale(r.Context(), availableAccounts)
 	}
-	scheduler := s.scheduler().WithSessionCounts(s.Sessions.CountByAccount())
+	scheduler := s.scheduler().ForModel(model).WithSessionCounts(s.Sessions.CountByAccount())
 	if assignment, ok := s.Sessions.Get(agentType, sessionID); ok {
 		if userEmail != "" && userEmail != assignment.UserEmail {
 			updated, err := s.Sessions.Put(agentType, sessionID, assignment.AccountID, userEmail)

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -2219,6 +2219,70 @@ func TestHandlerReroutesColdStickySessionWhenAssignedAccountBelowHeadroom(t *tes
 	}
 }
 
+func TestHandlerRoutesSparkModelUsingSparkQuota(t *testing.T) {
+	var auths []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auths = append(auths, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := Server{
+		Upstream: upstreamURL,
+		Accounts: []accounts.Account{
+			{ID: "normal-healthy@example.com", AuthMode: accounts.AuthModeOAuth, Token: "normal-token"},
+			{ID: "spark-healthy@example.com", AuthMode: accounts.AuthModeOAuth, Token: "spark-token"},
+		},
+		Sessions: store,
+		Scheduler: selectacct.NewScheduler([]selectacct.Score{
+			selectacct.ScoreFromLimitWindows("normal-healthy@example.com", 0, []selectacct.LimitWindow{
+				{Name: "primary", UsedPercent: 1, LimitWindowSeconds: 5 * 60 * 60},
+				{Name: "secondary", UsedPercent: 2, LimitWindowSeconds: 7 * 24 * 60 * 60},
+				{Name: "GPT-5.3-Codex-Spark/primary", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
+				{Name: "GPT-5.3-Codex-Spark/secondary", UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
+			}),
+			selectacct.ScoreFromLimitWindows("spark-healthy@example.com", 0, []selectacct.LimitWindow{
+				{Name: "primary", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
+				{Name: "secondary", UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
+				{Name: "GPT-5.3-Codex-Spark/primary", UsedPercent: 1, LimitWindowSeconds: 5 * 60 * 60},
+				{Name: "GPT-5.3-Codex-Spark/secondary", UsedPercent: 2, LimitWindowSeconds: 7 * 24 * 60 * 60},
+			}),
+		}),
+		MaxBodyBytes: 1024,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	req, err := http.NewRequest(http.MethodPost, subrouter.URL+"/v1/responses", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Subrouter-Session", "spark-session")
+	req.Header.Set("X-Subrouter-Model", "GPT-5.3-Codex-Spark")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if _, err := io.Copy(io.Discard, response.Body); err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", response.StatusCode)
+	}
+	if strings.Join(auths, "\x00") != "Bearer spark-token" {
+		t.Fatalf("auths = %#v, want Spark account", auths)
+	}
+}
+
 func TestHandlerKeepsActiveStickySessionWhenAssignedAccountBelowHeadroom(t *testing.T) {
 	var mu sync.Mutex
 	var auths []string

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -2246,14 +2246,14 @@ func TestHandlerRoutesSparkModelUsingSparkQuota(t *testing.T) {
 			selectacct.ScoreFromLimitWindows("normal-healthy@example.com", 0, []selectacct.LimitWindow{
 				{Name: "primary", UsedPercent: 1, LimitWindowSeconds: 5 * 60 * 60},
 				{Name: "secondary", UsedPercent: 2, LimitWindowSeconds: 7 * 24 * 60 * 60},
-				{Name: "GPT-5.3-Codex-Spark/primary", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
-				{Name: "GPT-5.3-Codex-Spark/secondary", UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
+				{Name: "GPT-5.3-Codex-Spark/primary", Feature: "GPT-5.3-Codex-Spark", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
+				{Name: "GPT-5.3-Codex-Spark/secondary", Feature: "GPT-5.3-Codex-Spark", UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
 			}),
 			selectacct.ScoreFromLimitWindows("spark-healthy@example.com", 0, []selectacct.LimitWindow{
 				{Name: "primary", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
 				{Name: "secondary", UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
-				{Name: "GPT-5.3-Codex-Spark/primary", UsedPercent: 1, LimitWindowSeconds: 5 * 60 * 60},
-				{Name: "GPT-5.3-Codex-Spark/secondary", UsedPercent: 2, LimitWindowSeconds: 7 * 24 * 60 * 60},
+				{Name: "GPT-5.3-Codex-Spark/primary", Feature: "GPT-5.3-Codex-Spark", UsedPercent: 1, LimitWindowSeconds: 5 * 60 * 60},
+				{Name: "GPT-5.3-Codex-Spark/secondary", Feature: "GPT-5.3-Codex-Spark", UsedPercent: 2, LimitWindowSeconds: 7 * 24 * 60 * 60},
 			}),
 		}),
 		MaxBodyBytes: 1024,

--- a/internal/selectacct/limits.go
+++ b/internal/selectacct/limits.go
@@ -1,5 +1,7 @@
 package selectacct
 
+import "strings"
+
 type LimitWindow struct {
 	Name               string
 	UsedPercent        float64
@@ -8,6 +10,45 @@ type LimitWindow struct {
 }
 
 func ScoreFromLimitWindows(accountID string, sessions int, windows []LimitWindow) Score {
+	score := scoreFromLimitWindows(accountID, sessions, windows)
+	if spark, ok := ScoreFromLimitWindowsForModel(accountID, sessions, windows, "spark"); ok {
+		score.ModelScores = map[string]Score{ModelKey("spark"): spark}
+	}
+	return score
+}
+
+func ScoreFromLimitWindowsForModel(accountID string, sessions int, windows []LimitWindow, model string) (Score, bool) {
+	key := ModelKey(model)
+	if key == "" {
+		return scoreFromLimitWindows(accountID, sessions, windows), true
+	}
+	filtered := make([]LimitWindow, 0, len(windows))
+	for _, window := range windows {
+		if limitWindowModelKey(window) == key {
+			filtered = append(filtered, window)
+		}
+	}
+	if len(filtered) == 0 {
+		return Score{AccountID: accountID, Headroom: 0, ShortHeadroom: 0, Sessions: sessions}, false
+	}
+	return scoreFromLimitWindows(accountID, sessions, filtered), true
+}
+
+func ModelKey(model string) string {
+	if strings.Contains(strings.ToLower(model), "spark") {
+		return "spark"
+	}
+	return ""
+}
+
+func limitWindowModelKey(window LimitWindow) string {
+	if strings.Contains(strings.ToLower(window.Name), "spark") {
+		return "spark"
+	}
+	return ""
+}
+
+func scoreFromLimitWindows(accountID string, sessions int, windows []LimitWindow) Score {
 	headroom := 1.0
 	shortHeadroom := 1.0
 	shortResetAfterSeconds := int64(0)

--- a/internal/selectacct/limits.go
+++ b/internal/selectacct/limits.go
@@ -7,45 +7,83 @@ type LimitWindow struct {
 	UsedPercent        float64
 	LimitWindowSeconds int64
 	ResetAfterSeconds  int64
+	// Feature is the upstream limit_name of the model-specific quota pool this
+	// window belongs to (e.g. "GPT-5.3-Codex-Spark"); empty for account-wide
+	// windows.
+	Feature string
 }
 
+// ScoreFromLimitWindows computes an account's base score from its account-wide
+// windows, plus a per-feature score for every model-specific quota pool present
+// in the windows. Model-specific windows are excluded from the base score so a
+// request for a regular model is not penalized by an unrelated pool's usage, and
+// a request for a metered model (e.g. Spark) is scored only against its own pool.
+// This is fully general: any additional rate limit the upstream reports becomes
+// its own pool, keyed by the limit name, with no per-model special cases.
 func ScoreFromLimitWindows(accountID string, sessions int, windows []LimitWindow) Score {
-	score := scoreFromLimitWindows(accountID, sessions, windows)
-	if spark, ok := ScoreFromLimitWindowsForModel(accountID, sessions, windows, "spark"); ok {
-		score.ModelScores = map[string]Score{ModelKey("spark"): spark}
+	base := scoreFromLimitWindows(accountID, sessions, filterWindowsByModelKey(windows, ""))
+	var modelScores map[string]Score
+	for _, key := range distinctModelKeys(windows) {
+		if modelScores == nil {
+			modelScores = make(map[string]Score)
+		}
+		modelScores[key] = scoreFromLimitWindows(accountID, sessions, filterWindowsByModelKey(windows, key))
 	}
-	return score
+	base.ModelScores = modelScores
+	return base
 }
 
-func ScoreFromLimitWindowsForModel(accountID string, sessions int, windows []LimitWindow, model string) (Score, bool) {
-	key := ModelKey(model)
-	if key == "" {
-		return scoreFromLimitWindows(accountID, sessions, windows), true
+// ModelKey reduces a request model (or a window feature name) to a comparison
+// key by lowercasing and dropping non-alphanumeric characters, so a request
+// model "gpt-5.3-codex-spark" and the upstream quota name "GPT-5.3-Codex-Spark"
+// resolve to the same key. Matching is strict equality on this key: a regular
+// model key ("gpt53codex") is a prefix of the Spark key ("gpt53codexspark"), so
+// any looser (substring) match would misroute regular traffic into the Spark pool.
+func ModelKey(model string) string {
+	return normalizeModelKey(model)
+}
+
+func limitWindowModelKey(window LimitWindow) string {
+	return normalizeModelKey(window.Feature)
+}
+
+func normalizeModelKey(value string) string {
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		}
 	}
+	return b.String()
+}
+
+func distinctModelKeys(windows []LimitWindow) []string {
+	seen := make(map[string]bool)
+	var keys []string
+	for _, window := range windows {
+		key := limitWindowModelKey(window)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func filterWindowsByModelKey(windows []LimitWindow, key string) []LimitWindow {
 	filtered := make([]LimitWindow, 0, len(windows))
 	for _, window := range windows {
 		if limitWindowModelKey(window) == key {
 			filtered = append(filtered, window)
 		}
 	}
-	if len(filtered) == 0 {
-		return Score{AccountID: accountID, Headroom: 0, ShortHeadroom: 0, Sessions: sessions}, false
-	}
-	return scoreFromLimitWindows(accountID, sessions, filtered), true
-}
-
-func ModelKey(model string) string {
-	if strings.Contains(strings.ToLower(model), "spark") {
-		return "spark"
-	}
-	return ""
-}
-
-func limitWindowModelKey(window LimitWindow) string {
-	if strings.Contains(strings.ToLower(window.Name), "spark") {
-		return "spark"
-	}
-	return ""
+	return filtered
 }
 
 func scoreFromLimitWindows(accountID string, sessions int, windows []LimitWindow) Score {

--- a/internal/selectacct/saturation_test.go
+++ b/internal/selectacct/saturation_test.go
@@ -46,6 +46,40 @@ func TestScoreFromLimitWindowsComputesExpiryPressure(t *testing.T) {
 	}
 }
 
+func TestSchedulerForSparkModelUsesSparkWindows(t *testing.T) {
+	scheduler := NewScheduler([]Score{
+		ScoreFromLimitWindows("spark-healthy", 0, []LimitWindow{
+			{Name: "primary", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
+			{Name: "secondary", UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
+			{Name: "GPT-5.3-Codex-Spark/primary", UsedPercent: 1, LimitWindowSeconds: 5 * 60 * 60},
+			{Name: "GPT-5.3-Codex-Spark/secondary", UsedPercent: 2, LimitWindowSeconds: 7 * 24 * 60 * 60},
+		}),
+		ScoreFromLimitWindows("spark-cooked", 0, []LimitWindow{
+			{Name: "primary", UsedPercent: 0, LimitWindowSeconds: 5 * 60 * 60},
+			{Name: "secondary", UsedPercent: 0, LimitWindowSeconds: 7 * 24 * 60 * 60},
+			{Name: "GPT-5.3-Codex-Spark/primary", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
+			{Name: "GPT-5.3-Codex-Spark/secondary", UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
+		}),
+	}).ForModel("GPT-5.3-Codex-Spark")
+
+	got, err := scheduler.Pick([]accounts.Account{
+		{ID: "spark-cooked", AuthMode: accounts.AuthModeOAuth},
+		{ID: "spark-healthy", AuthMode: accounts.AuthModeOAuth},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "spark-healthy" {
+		t.Fatalf("got %q, want spark-healthy", got.ID)
+	}
+	if !scheduler.UsableForNewSession("spark-healthy") {
+		t.Fatal("spark-healthy should be usable for a Spark request")
+	}
+	if !scheduler.Exhausted("spark-cooked") {
+		t.Fatal("spark-cooked should be exhausted for a Spark request")
+	}
+}
+
 func TestExpiryAwareRoutingMatchesSnapshotOrder(t *testing.T) {
 	state := []simulatedAccount{
 		{id: "alpha@example.com", used5h: 73, used7d: 16},

--- a/internal/selectacct/saturation_test.go
+++ b/internal/selectacct/saturation_test.go
@@ -47,20 +47,22 @@ func TestScoreFromLimitWindowsComputesExpiryPressure(t *testing.T) {
 }
 
 func TestSchedulerForSparkModelUsesSparkWindows(t *testing.T) {
+	// spark-healthy has a cooked account-wide quota but an open Spark pool;
+	// spark-cooked is the reverse. A Spark request must pick spark-healthy.
 	scheduler := NewScheduler([]Score{
 		ScoreFromLimitWindows("spark-healthy", 0, []LimitWindow{
 			{Name: "primary", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
 			{Name: "secondary", UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
-			{Name: "GPT-5.3-Codex-Spark/primary", UsedPercent: 1, LimitWindowSeconds: 5 * 60 * 60},
-			{Name: "GPT-5.3-Codex-Spark/secondary", UsedPercent: 2, LimitWindowSeconds: 7 * 24 * 60 * 60},
+			{Name: "GPT-5.3-Codex-Spark/primary", Feature: "GPT-5.3-Codex-Spark", UsedPercent: 1, LimitWindowSeconds: 5 * 60 * 60},
+			{Name: "GPT-5.3-Codex-Spark/secondary", Feature: "GPT-5.3-Codex-Spark", UsedPercent: 2, LimitWindowSeconds: 7 * 24 * 60 * 60},
 		}),
 		ScoreFromLimitWindows("spark-cooked", 0, []LimitWindow{
 			{Name: "primary", UsedPercent: 0, LimitWindowSeconds: 5 * 60 * 60},
 			{Name: "secondary", UsedPercent: 0, LimitWindowSeconds: 7 * 24 * 60 * 60},
-			{Name: "GPT-5.3-Codex-Spark/primary", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
-			{Name: "GPT-5.3-Codex-Spark/secondary", UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
+			{Name: "GPT-5.3-Codex-Spark/primary", Feature: "GPT-5.3-Codex-Spark", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
+			{Name: "GPT-5.3-Codex-Spark/secondary", Feature: "GPT-5.3-Codex-Spark", UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
 		}),
-	}).ForModel("GPT-5.3-Codex-Spark")
+	}).ForModel("gpt-5.3-codex-spark")
 
 	got, err := scheduler.Pick([]accounts.Account{
 		{ID: "spark-cooked", AuthMode: accounts.AuthModeOAuth},
@@ -77,6 +79,108 @@ func TestSchedulerForSparkModelUsesSparkWindows(t *testing.T) {
 	}
 	if !scheduler.Exhausted("spark-cooked") {
 		t.Fatal("spark-cooked should be exhausted for a Spark request")
+	}
+}
+
+func TestRegularModelDoesNotMatchSparkPool(t *testing.T) {
+	// "gpt-5.3-codex" normalizes to "gpt53codex", a prefix of the Spark feature
+	// key "gpt53codexspark". Matching is strict equality, so a regular request
+	// must use base quota, never the (here cooked) Spark pool. Any loosening to
+	// substring matching would regress this.
+	scheduler := NewScheduler([]Score{
+		ScoreFromLimitWindows("acct", 0, []LimitWindow{
+			{Name: "primary", UsedPercent: 10, LimitWindowSeconds: 5 * 60 * 60},
+			{Name: "secondary", UsedPercent: 20, LimitWindowSeconds: 7 * 24 * 60 * 60},
+			{Name: "GPT-5.3-Codex-Spark/primary", Feature: "GPT-5.3-Codex-Spark", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
+		}),
+	}).ForModel("gpt-5.3-codex")
+
+	if scheduler.Exhausted("acct") {
+		t.Fatal("regular model must use base quota, not the cooked Spark pool")
+	}
+	if math.Abs(scheduler.score("acct").Headroom-0.80) > 0.0001 {
+		t.Fatalf("regular headroom = %.2f, want 0.80 (base)", scheduler.score("acct").Headroom)
+	}
+}
+
+func TestSchedulerGeneralizesToAnyMeteredFeature(t *testing.T) {
+	// A metered model the code has never heard of must route to its own pool,
+	// keyed purely from the upstream limit name. No per-model special case.
+	scheduler := NewScheduler([]Score{
+		ScoreFromLimitWindows("turbo-open", 0, []LimitWindow{
+			{Name: "primary", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
+			{Name: "GPT-6-Codex-Turbo/primary", Feature: "GPT-6-Codex-Turbo", UsedPercent: 5, LimitWindowSeconds: 5 * 60 * 60},
+		}),
+		ScoreFromLimitWindows("turbo-cooked", 0, []LimitWindow{
+			{Name: "primary", UsedPercent: 0, LimitWindowSeconds: 5 * 60 * 60},
+			{Name: "GPT-6-Codex-Turbo/primary", Feature: "GPT-6-Codex-Turbo", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
+		}),
+	}).ForModel("gpt-6-codex-turbo")
+
+	got, err := scheduler.Pick([]accounts.Account{
+		{ID: "turbo-cooked", AuthMode: accounts.AuthModeOAuth},
+		{ID: "turbo-open", AuthMode: accounts.AuthModeOAuth},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "turbo-open" {
+		t.Fatalf("got %q, want turbo-open (routed by its own metered pool)", got.ID)
+	}
+}
+
+func TestScoreExcludesFeatureWindowsFromBase(t *testing.T) {
+	// An exhausted Spark pool must not drag down the base score used for regular
+	// models. This is an intended behavior change to the regular selection path.
+	score := ScoreFromLimitWindows("acct", 0, []LimitWindow{
+		{Name: "5h", UsedPercent: 10},
+		{Name: "7d", UsedPercent: 20},
+		{Name: "GPT-5.3-Codex-Spark/primary", Feature: "GPT-5.3-Codex-Spark", UsedPercent: 100},
+	})
+
+	if math.Abs(score.Headroom-0.80) > 0.0001 {
+		t.Fatalf("base headroom = %.2f, want 0.80 (Spark exhaustion excluded)", score.Headroom)
+	}
+	spark, ok := score.ModelScores[ModelKey("gpt-5.3-codex-spark")]
+	if !ok {
+		t.Fatal("expected a Spark model pool score")
+	}
+	if !spark.exhausted() {
+		t.Fatal("Spark pool should be exhausted")
+	}
+}
+
+func TestForModelZeroesAccountsLackingTheFeature(t *testing.T) {
+	// One account advertises the Spark pool, another does not. A Spark request
+	// must not land on the account that cannot serve it.
+	scheduler := NewScheduler([]Score{
+		ScoreFromLimitWindows("has-spark", 0, []LimitWindow{
+			{Name: "primary", UsedPercent: 50, LimitWindowSeconds: 5 * 60 * 60},
+			{Name: "GPT-5.3-Codex-Spark/primary", Feature: "GPT-5.3-Codex-Spark", UsedPercent: 0, LimitWindowSeconds: 5 * 60 * 60},
+		}),
+		ScoreFromLimitWindows("no-spark", 0, []LimitWindow{
+			{Name: "primary", UsedPercent: 0, LimitWindowSeconds: 5 * 60 * 60},
+		}),
+	}).ForModel("gpt-5.3-codex-spark")
+
+	if !scheduler.Exhausted("no-spark") {
+		t.Fatal("account without the Spark pool must score zero for a Spark request")
+	}
+	if scheduler.Exhausted("has-spark") {
+		t.Fatal("account with an open Spark pool must be usable")
+	}
+}
+
+func TestForModelWithoutAnyPoolsFallsBackToBase(t *testing.T) {
+	// If no account advertises a matching pool (e.g. the upstream renamed the
+	// feature), a model request falls back to base quota rather than zeroing
+	// every account. This documents the version-skew fallback behavior.
+	scheduler := NewScheduler([]Score{
+		ScoreFromLimitWindows("a", 0, []LimitWindow{{Name: "5h", UsedPercent: 30}}),
+	}).ForModel("gpt-5.3-codex-spark")
+
+	if math.Abs(scheduler.score("a").Headroom-0.70) > 0.0001 {
+		t.Fatalf("headroom = %.2f, want 0.70 (base, no matching pool)", scheduler.score("a").Headroom)
 	}
 }
 

--- a/internal/selectacct/scheduler.go
+++ b/internal/selectacct/scheduler.go
@@ -57,9 +57,14 @@ func (s Scheduler) WithSessionCounts(counts map[string]int) Scheduler {
 	return next
 }
 
+// ForModel narrows scoring to a model's dedicated quota pool when one exists.
+// If the model maps to no known pool (the common case: regular models), the
+// base scheduler is returned unchanged so account-wide quota is used. When a
+// pool exists but a given account lacks it, that account scores zero so it is
+// not picked for a model it cannot serve.
 func (s Scheduler) ForModel(model string) Scheduler {
 	key := ModelKey(model)
-	if key == "" {
+	if key == "" || !s.hasModelScore(key) {
 		return s
 	}
 	next := Scheduler{
@@ -74,6 +79,22 @@ func (s Scheduler) ForModel(model string) Scheduler {
 		next.scores[accountID] = modelScore
 	}
 	return next
+}
+
+// HasModelPool reports whether the model maps to a dedicated quota pool present
+// on at least one scored account.
+func (s Scheduler) HasModelPool(model string) bool {
+	key := ModelKey(model)
+	return key != "" && s.hasModelScore(key)
+}
+
+func (s Scheduler) hasModelScore(key string) bool {
+	for _, score := range s.scores {
+		if _, ok := score.ModelScores[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func (s Scheduler) Pick(candidates []accounts.Account) (accounts.Account, error) {

--- a/internal/selectacct/scheduler.go
+++ b/internal/selectacct/scheduler.go
@@ -16,6 +16,7 @@ type Score struct {
 	ShortResetAfterSeconds int64
 	ExpiryPressure         float64
 	Sessions               int
+	ModelScores            map[string]Score
 }
 
 type Scheduler struct {
@@ -52,6 +53,25 @@ func (s Scheduler) WithSessionCounts(counts map[string]int) Scheduler {
 	}
 	for accountID, count := range counts {
 		next.sessionCounts[accountID] = count
+	}
+	return next
+}
+
+func (s Scheduler) ForModel(model string) Scheduler {
+	key := ModelKey(model)
+	if key == "" {
+		return s
+	}
+	next := Scheduler{
+		scores:        make(map[string]Score, len(s.scores)),
+		sessionCounts: s.sessionCounts,
+	}
+	for accountID, score := range s.scores {
+		modelScore, ok := score.ModelScores[key]
+		if !ok {
+			modelScore = Score{AccountID: accountID, Headroom: 0, ShortHeadroom: 0}
+		}
+		next.scores[accountID] = modelScore
 	}
 	return next
 }

--- a/internal/session/extract.go
+++ b/internal/session/extract.go
@@ -41,6 +41,11 @@ var accountIDHeaderCandidates = []string{
 	"X-Subrouter-Account",
 }
 
+var modelHeaderCandidates = []string{
+	"X-Subrouter-Model",
+	"X-Model",
+}
+
 var codexAgentHeaderCandidates = []string{
 	"X-Codex-Window-ID",
 	"X-Codex-Turn-State",
@@ -120,6 +125,26 @@ func ExtractAccountID(r *http.Request) string {
 	return ""
 }
 
+func ExtractModel(r *http.Request, maxBodyBytes int64) string {
+	for _, header := range modelHeaderCandidates {
+		if value := NormalizeModel(r.Header.Get(header)); value != "" {
+			return value
+		}
+	}
+	if value := NormalizeModel(r.URL.Query().Get("model")); value != "" {
+		return value
+	}
+	return extractJSONModel(r, maxBodyBytes)
+}
+
+func NormalizeModel(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || len(trimmed) > 256 {
+		return ""
+	}
+	return trimmed
+}
+
 func NormalizeUserEmail(value string) string {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" || len(trimmed) > 320 {
@@ -148,6 +173,8 @@ func StripSubrouterHeaders(headers http.Header) {
 	headers.Del("X-User-Email")
 	headers.Del("X-Subrouter-Account-ID")
 	headers.Del("X-Subrouter-Account")
+	headers.Del("X-Subrouter-Model")
+	headers.Del("X-Model")
 }
 
 func ExtractID(r *http.Request, maxBodyBytes int64) string {
@@ -171,30 +198,46 @@ func ExtractID(r *http.Request, maxBodyBytes int64) string {
 }
 
 func extractJSONID(r *http.Request, maxBodyBytes int64) string {
-	if r.Body == nil || maxBodyBytes <= 0 {
+	value := extractJSONValue(r, maxBodyBytes)
+	if value == nil {
 		return ""
+	}
+	return findJSONID(value)
+}
+
+func extractJSONModel(r *http.Request, maxBodyBytes int64) string {
+	value := extractJSONValue(r, maxBodyBytes)
+	if value == nil {
+		return ""
+	}
+	return findJSONModel(value)
+}
+
+func extractJSONValue(r *http.Request, maxBodyBytes int64) any {
+	if r.Body == nil || maxBodyBytes <= 0 {
+		return nil
 	}
 	if r.ContentLength < 0 || r.ContentLength > maxBodyBytes {
-		return ""
+		return nil
 	}
 	if contentType := r.Header.Get("Content-Type"); !strings.Contains(contentType, "json") {
-		return ""
+		return nil
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes+1))
 	if err != nil {
-		return ""
+		return nil
 	}
 	r.Body = io.NopCloser(bytes.NewReader(body))
 	if int64(len(body)) > maxBodyBytes {
-		return ""
+		return nil
 	}
 
 	var value any
 	if err := json.Unmarshal(body, &value); err != nil {
-		return ""
+		return nil
 	}
-	return findJSONID(value)
+	return value
 }
 
 func findJSONID(value any) string {
@@ -216,6 +259,27 @@ func findJSONID(value any) string {
 		for _, child := range typed {
 			if id := findJSONID(child); id != "" {
 				return id
+			}
+		}
+	}
+	return ""
+}
+
+func findJSONModel(value any) string {
+	switch typed := value.(type) {
+	case map[string]any:
+		if str, ok := typed["model"].(string); ok {
+			return NormalizeModel(str)
+		}
+		for _, child := range typed {
+			if model := findJSONModel(child); model != "" {
+				return model
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if model := findJSONModel(child); model != "" {
+				return model
 			}
 		}
 	}

--- a/internal/session/extract_test.go
+++ b/internal/session/extract_test.go
@@ -69,6 +69,32 @@ func TestExtractAccountIDFromSubrouterHeader(t *testing.T) {
 	}
 }
 
+func TestExtractModelFromHeader(t *testing.T) {
+	req := httptest.NewRequest("POST", "/v1/responses", nil)
+	req.Header.Set("X-Subrouter-Model", " GPT-5.3-Codex-Spark ")
+
+	if got := ExtractModel(req, 1024); got != "GPT-5.3-Codex-Spark" {
+		t.Fatalf("got %q, want GPT-5.3-Codex-Spark", got)
+	}
+}
+
+func TestExtractModelFromJSONAndRestoresBody(t *testing.T) {
+	body := `{"model":"GPT-5.3-Codex-Spark","input":"hello"}`
+	req := httptest.NewRequest("POST", "/v1/responses", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	if got := ExtractModel(req, 1024); got != "GPT-5.3-Codex-Spark" {
+		t.Fatalf("got %q, want GPT-5.3-Codex-Spark", got)
+	}
+	restored, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(restored) != body {
+		t.Fatalf("body was not restored: %s", restored)
+	}
+}
+
 func TestExtractAgentTypeFromSubrouterHeader(t *testing.T) {
 	req := httptest.NewRequest("POST", "/v1/responses", nil)
 	req.Header.Set("X-Subrouter-Agent", "Claude")
@@ -120,6 +146,8 @@ func TestStripSubrouterHeaders(t *testing.T) {
 	req.Header.Set("X-User-Email", "alice@example.com")
 	req.Header.Set("X-Subrouter-Account-ID", "apikey:paid")
 	req.Header.Set("X-Subrouter-Account", "paid")
+	req.Header.Set("X-Subrouter-Model", "GPT-5.3-Codex-Spark")
+	req.Header.Set("X-Model", "GPT-5.3-Codex-Spark")
 	req.Header.Set("X-Other", "keep")
 
 	StripSubrouterHeaders(req.Header)
@@ -144,6 +172,12 @@ func TestStripSubrouterHeaders(t *testing.T) {
 	}
 	if got := req.Header.Get("X-Subrouter-Account"); got != "" {
 		t.Fatalf("X-Subrouter-Account = %q, want empty", got)
+	}
+	if got := req.Header.Get("X-Subrouter-Model"); got != "" {
+		t.Fatalf("X-Subrouter-Model = %q, want empty", got)
+	}
+	if got := req.Header.Get("X-Model"); got != "" {
+		t.Fatalf("X-Model = %q, want empty", got)
 	}
 	if got := req.Header.Get("X-Other"); got != "keep" {
 		t.Fatalf("X-Other = %q, want keep", got)


### PR DESCRIPTION
Adds model-aware Codex routing so GPT-5.3-Codex-Spark requests use Spark usage windows instead of the general 5h/7d pool.\n\n- injects X-Subrouter-Model from sr codex -m/--model\n- extracts request model from headers, query, or JSON bodies\n- lets the scheduler score Spark requests from Spark-specific usage windows\n- covers CLI header injection, model extraction, scheduler selection, and proxy routing\n\nVerification:\n- docker run --rm -v "/Users/lawrence/fun/subrouter-worktrees/feat-spark-quota-routing":/src -w /src golang:1.22 go test ./...\n- go test -exec /usr/bin/true ./...\n\nLocal macOS go test execution on this machine aborts before tests run with dyld missing LC_UUID from Go 1.22 test binaries, so Docker is the runtime verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782734738&installation_id=133855650&pr_number=2&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F2&signature=def77434dab645559e03b436f4cb542749c77d74fb4b937c2d095c4e3e60f4d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Codex requests to per-model quotas using upstream `additional_rate_limits`, so any metered model (e.g., `GPT-5.3-Codex-Spark`) uses its own pool instead of the 5h/7d base. This improves fairness and routing accuracy.

- **New Features**
  - Codex CLI injects `X-Subrouter-Model` from `-m/--model` (supports `--model=...` and `-m=...`) into `model_providers.subrouter.http_headers`.
  - Server extracts `model` from `X-Subrouter-Model`/`X-Model`, query, or JSON; restores the body; strips model headers before proxying.
  - Usage windows carry `Feature` from upstream `limit_name`; base score excludes feature windows; strict normalized equality maps a request model to its pool; falls back to base if no pool exists.
  - Scheduler/Proxy use `scheduler.ForModel(model)` so metered models pick accounts with that pool; accounts without the pool score zero; logs when a model pool is matched.
  - Tests cover header injection, model extraction/restoration, feature tagging, strict matching (Spark and arbitrary models), and proxy routing.

- **Migration**
  - No changes for Codex CLI users; the header is added automatically.
  - API callers should set `X-Subrouter-Model: <model>` or include `model` in query/JSON to route via a model’s quota pool.

<sup>Written for commit 83a43ceb71b287e494a9a6fe746afc97fbf3e1df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model-specific routing: specify a model via CLI or request (headers/body) to route using model-scoped quotas and schedulers.

* **Behavior Changes**
  * Account selection and session limits now honor per-model quota pools when a model is provided; fall back to base quotas otherwise.

* **Tests**
  * Added tests for model argument parsing, header/body model extraction, header injection, and model-aware routing decisions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/subrouter/pull/2?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->