### PR TITLE
Disable codex Responses WebSocket transport via subrouter provider

### DIFF
--- a/cmd/subrouter/codex_config.go
+++ b/cmd/subrouter/codex_config.go
@@ -10,10 +10,15 @@ import (
 )
 
 var codexRoutingConfigKeys = []string{
+	"model_provider",
 	"openai_base_url",
 	"chatgpt_base_url",
 	"experimental_realtime_ws_base_url",
 }
+
+// codexSubrouterProviderID is the model_providers key written into a client's
+// codex config so requests route through a provider with WebSockets disabled.
+const codexSubrouterProviderID = "subrouter"
 
 func defaultCodexConfigPath() (string, error) {
 	if codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME")); codexHome != "" {
@@ -40,12 +45,17 @@ func writeCodexConfigForBaseURL(baseURL string) (string, error) {
 		return "", err
 	}
 	root := codexProxyRootURL(baseURL)
+	providerBaseURL := root + "/v1"
 	values := map[string]string{
-		"openai_base_url":                   root + "/v1",
+		"model_provider":                    codexSubrouterProviderID,
+		"openai_base_url":                   providerBaseURL,
 		"chatgpt_base_url":                  root + "/backend-api",
-		"experimental_realtime_ws_base_url": root + "/v1",
+		"experimental_realtime_ws_base_url": providerBaseURL,
 	}
-	if err := writeCodexConfigValues(path, values); err != nil {
+	if err := writeCodexConfig(path, func(existing string) string {
+		next := updateTopLevelTomlStrings(existing, values)
+		return ensureCodexWebsocketDisabledProvider(next, providerBaseURL)
+	}); err != nil {
 		return "", err
 	}
 	return path, nil
@@ -63,11 +73,19 @@ func codexProxyRootURL(baseURL string) string {
 }
 
 func writeCodexConfigValues(path string, values map[string]string) error {
+	return writeCodexConfig(path, func(existing string) string {
+		return updateTopLevelTomlStrings(existing, values)
+	})
+}
+
+// writeCodexConfig reads the codex config, applies transform, and writes the
+// result back atomically (with a `.bak` backup) only when it changed.
+func writeCodexConfig(path string, transform func(existing string) string) error {
 	body, err := os.ReadFile(path)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	next := updateTopLevelTomlStrings(string(body), values)
+	next := transform(string(body))
 	if string(body) == next {
 		return nil
 	}
@@ -84,6 +102,57 @@ func writeCodexConfigValues(path string, values map[string]string) error {
 		return err
 	}
 	return os.Rename(tmp, path)
+}
+
+// ensureCodexWebsocketDisabledProvider rewrites the
+// `[model_providers.subrouter]` table so codex routes through a provider with
+// `supports_websockets = false`. codex 0.136+ otherwise derives a `ws://` URL
+// from `openai_base_url` and opens the Responses transport over a WebSocket;
+// the subrouter's upstream rejects that upgrade (403), and codex retries the
+// connect without falling back to HTTP, surfacing the turn as a 429. Pinning a
+// provider with WebSockets disabled keeps codex on the proven HTTP Responses
+// path. `name = "OpenAI"` preserves codex's OpenAI-specific behavior (request
+// compression, remote compaction); the subrouter still selects the upstream
+// account, so client auth is unchanged.
+func ensureCodexWebsocketDisabledProvider(text, baseURL string) string {
+	text = removeTomlTable(text, "model_providers."+codexSubrouterProviderID)
+	block := strings.Join([]string{
+		"[model_providers." + codexSubrouterProviderID + "]",
+		`name = "OpenAI"`,
+		"base_url = " + strconv.Quote(baseURL),
+		`wire_api = "responses"`,
+		"requires_openai_auth = true",
+		"supports_websockets = false",
+		"",
+	}, "\n")
+	if text != "" && !strings.HasSuffix(text, "\n") {
+		text += "\n"
+	}
+	if text != "" {
+		text += "\n"
+	}
+	return text + block
+}
+
+// removeTomlTable strips a `[header]` table (its header line through the line
+// before the next table header or EOF) from a TOML document, leaving other
+// top-level keys and tables untouched.
+func removeTomlTable(text, header string) string {
+	lines := splitLinesKeepingEndings(text)
+	out := make([]string, 0, len(lines))
+	target := "[" + header + "]"
+	skipping := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(strings.TrimRight(line, "\r\n"))
+		if isTomlTableHeader(trimmed) {
+			skipping = trimmed == target
+		}
+		if skipping {
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.TrimRight(strings.Join(out, ""), "\n")
 }
 
 func updateTopLevelTomlStrings(text string, values map[string]string) string {

--- a/cmd/subrouter/codex_config_test.go
+++ b/cmd/subrouter/codex_config_test.go
@@ -66,3 +66,92 @@ func TestWriteCodexConfigValuesCreatesBackup(t *testing.T) {
 		t.Fatalf("backup = %q", string(backup))
 	}
 }
+
+func TestWriteCodexConfigForBaseURLDisablesWebsockets(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+	path := filepath.Join(home, "config.toml")
+	if err := os.WriteFile(path, []byte("model = \"gpt-5.5\"\n\n[projects.\"/\"]\ntrust_level = \"trusted\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := writeCodexConfigForBaseURL("http://100.64.0.1:31415")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != path {
+		t.Fatalf("path = %q, want %q", got, path)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`model_provider = "subrouter"`,
+		`openai_base_url = "http://100.64.0.1:31415/v1"`,
+		`chatgpt_base_url = "http://100.64.0.1:31415/backend-api"`,
+		"[model_providers.subrouter]",
+		`name = "OpenAI"`,
+		`base_url = "http://100.64.0.1:31415/v1"`,
+		"supports_websockets = false",
+		`requires_openai_auth = true`,
+		// pre-existing tables are preserved
+		`[projects."/"]`,
+		`trust_level = "trusted"`,
+	} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("missing %q in config:\n%s", want, string(body))
+		}
+	}
+	if strings.Count(string(body), "[model_providers.subrouter]") != 1 {
+		t.Fatalf("expected exactly one subrouter provider table:\n%s", string(body))
+	}
+
+	// Running again is a no-op: idempotent regeneration must not duplicate the
+	// table or rewrite the file.
+	if _, err := writeCodexConfigForBaseURL("http://100.64.0.1:31415"); err != nil {
+		t.Fatal(err)
+	}
+	body2, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body2) != string(body) {
+		t.Fatalf("second write changed config:\nfirst:\n%s\nsecond:\n%s", string(body), string(body2))
+	}
+	if strings.Count(string(body2), "[model_providers.subrouter]") != 1 {
+		t.Fatalf("idempotent write duplicated provider table:\n%s", string(body2))
+	}
+}
+
+func TestEnsureCodexWebsocketDisabledProviderReplacesStaleBlock(t *testing.T) {
+	input := strings.Join([]string{
+		`model = "gpt-5.5"`,
+		``,
+		`[model_providers.subrouter]`,
+		`name = "OpenAI"`,
+		`base_url = "http://old.example/v1"`,
+		`supports_websockets = false`,
+		``,
+		`[projects."/"]`,
+		`trust_level = "trusted"`,
+		``,
+	}, "\n")
+
+	got := ensureCodexWebsocketDisabledProvider(input, "http://new.example/v1")
+
+	if strings.Contains(got, "http://old.example/v1") {
+		t.Fatalf("stale base_url not replaced:\n%s", got)
+	}
+	if !strings.Contains(got, `base_url = "http://new.example/v1"`) {
+		t.Fatalf("new base_url missing:\n%s", got)
+	}
+	if strings.Count(got, "[model_providers.subrouter]") != 1 {
+		t.Fatalf("expected one provider table:\n%s", got)
+	}
+	for _, want := range []string{`[projects."/"]`, `trust_level = "trusted"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing preserved table content %q:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
codex-cli 0.136+ defaults to the **Responses-over-WebSocket** transport: it derives a `ws://…/v1/responses` URL from `openai_base_url` (independent of `experimental_realtime_ws_base_url`) and opens the Responses stream over a WebSocket. The subrouter proxies that upgrade to the upstream, and chatgpt.com **rejects it with 403** for pooled accounts (the same accounts return 200 over HTTP). codex treats a 403 connect as a *retryable* error, retries 5×, and on exhaustion does **not** fall back to the HTTP transport, so every codex turn dies and surfaces to the user as:

```
ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket: HTTP error: 403 Forbidden, url: ws://…/v1/responses
ERROR: exceeded retry limit, last status: 429 Too Many Requests
```

The HTTP Responses path through the subrouter works fine (verified end-to-end, including tool calls + streaming).

## Fix

Pin codex to the HTTP Responses transport by generating a provider with `supports_websockets = false` in the client config that `sr` writes:

```toml
model_provider = "subrouter"

[model_providers.subrouter]
name = "OpenAI"
base_url = "http://<server>:31415/v1"
wire_api = "responses"
requires_openai_auth = true
supports_websockets = false
```

The built-in `openai` provider cannot be overridden (codex merges configured providers with `entry().or_insert`, so the built-in wins), hence a distinct provider id. `name = "OpenAI"` keeps codex's OpenAI-specific behavior (`is_openai()` gates request compression + remote compaction); token refresh is gated on the ChatGPT auth credential, not the provider name, so client auth is unchanged. The subrouter still selects the upstream account.

## Notes
- Idempotent: re-running `sr` server switch rewrites the `[model_providers.subrouter]` table in place and is a no-op when unchanged; existing `[projects.*]` tables are preserved.
- Rollout: clients pick this up after updating `sr` and re-running a `server use`/`server switch` (or by adding the block manually).
- Two `sr_test.go` cooked-account display tests fail on this branch **and on `main`** (pre-existing, environment-dependent, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783057931&installation_id=133855650&pr_number=3&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F3&signature=bcc8ff06131af2709821952ade26673321eab5497a8ca4f44d046c5ff8a63474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `codex` to the HTTP Responses transport by generating a `subrouter` provider with WebSockets disabled, preventing 403 upgrade failures and retry loops that surfaced as 429s. This keeps requests working end-to-end (including streaming and tool calls).

- **Bug Fixes**
  - Write `[model_providers.subrouter]` with `supports_websockets = false` and set `model_provider = "subrouter"`.
  - Keep OpenAI-specific behavior via `name = "OpenAI"`; auth and upstream selection remain unchanged.
  - Config writes are idempotent: preserve existing `[projects.*]`, replace stale provider block, and only write a `.bak` when the file changes.

- **Migration**
  - Users should update `sr` and run `server use` or `server switch` to regenerate the config (or add the block manually).
  - No token or project changes required.

<sup>Written for commit cea46e0c3cb4c97ad5bff65d31f97906422736f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Codex configuration now properly routes through the subrouter provider with WebSocket support disabled to improve reliability.
  * Configuration updates are now idempotent, preventing duplicate entries when configuration is written multiple times.

* **Tests**
  * Added comprehensive test coverage for Codex configuration generation, including idempotency verification and provider configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->