### PR TITLE
Claude pooling + provider-labeled error footnotes in sr status

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -227,7 +227,9 @@ func serve(args []string) error {
 	}
 	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler(scores))
 	outboundTransport := proxy.NewOutboundTransport()
-	accountRef := proxy.NewAccountRef(codexStore, codexAccounts, &http.Client{
+	initialAccounts := append([]accounts.Account(nil), codexAccounts...)
+	initialAccounts = append(initialAccounts, claudeAccounts...)
+	accountRef := proxy.NewAccountRef(codexStore, initialAccounts, &http.Client{
 		Timeout:   15 * time.Second,
 		Transport: outboundTransport,
 	})
@@ -237,7 +239,7 @@ func serve(args []string) error {
 		CodexUpstream:  codexUpstream,
 		APIUpstream:    apiUpstream,
 		ClaudeUpstream: claudeUpstream,
-		Accounts:       claudeAccounts,
+		Accounts:       nil,
 		AccountRef:     accountRef,
 		Sessions:       store,
 		SchedulerRef:   schedulerRef,
@@ -570,7 +572,7 @@ func usageText(program string) string {
 	return fmt.Sprintf(`%[1]s routes AI coding-agent traffic across subscription accounts.
 
 Usage:
-  %[1]s                    Show Codex usage for all accounts and switch
+  %[1]s                    Show Codex and Claude usage, grouped by provider
   %[1]s add                Add a new Codex account (opens OAuth login)
   %[1]s add-key            Add a Codex API key account
   %[1]s import             Import current ~/.codex/auth.json account
@@ -580,7 +582,7 @@ Usage:
   %[1]s gui [email]        Switch active account, sync OpenCode/pi, and restart Codex.app
   %[1]s gui-switch [email] Switch active account, sync OpenCode/pi, and restart Codex.app
   %[1]s remove <email>     Remove a Codex account
-  %[1]s status             Show Codex usage (non-interactive)
+  %[1]s status             Show Codex and Claude usage (non-interactive)
   %[1]s pick               Switch to the recommended account, failing if none has quota
   %[1]s usage [days]       Refresh and show API-key spend
   %[1]s trace <email>      Show OAuth refresh breadcrumbs for an account

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -1150,6 +1150,28 @@ func isLongQuotaWindow(window accounts.UsageWindow) bool {
 	return strings.Contains(name, "7d") || strings.Contains(name, "weekly")
 }
 
+func isClaudeSessionWindow(window accounts.UsageWindow) bool {
+	name := strings.ToLower(window.Name)
+	return name == "5h" || strings.Contains(name, "session")
+}
+
+func isClaudeWeeklyWindow(window accounts.UsageWindow) bool {
+	name := strings.ToLower(window.Name)
+	return name == "7d" || name == "weekly"
+}
+
+func isClaudeOpusWeeklyWindow(window accounts.UsageWindow) bool {
+	return strings.Contains(strings.ToLower(window.Name), "opus")
+}
+
+func isClaudeSonnetWeeklyWindow(window accounts.UsageWindow) bool {
+	return strings.Contains(strings.ToLower(window.Name), "sonnet")
+}
+
+func isClaudeExtraWindow(window accounts.UsageWindow) bool {
+	return strings.Contains(strings.ToLower(window.Name), "extra")
+}
+
 func clampUsagePercent(value float64) float64 {
 	switch {
 	case value < 0:
@@ -1467,36 +1489,28 @@ func displayUsageRows(out io.Writer, rows []srUsageRow, numbered bool) {
 }
 
 func displayUsageRowsGrid(out io.Writer, rows []srUsageRow, numbered bool, colored bool) {
-	columns := usageGridColumns(out, numbered)
 	fmt.Fprintln(out)
-	printUsageGridLine(out, columns, func(col usageGridColumn) usageGridCell {
-		return usageGridCell{Text: col.Title, Style: ansiDim}
-	}, colored, "")
-	printUsageGridSeparator(out, columns, colored)
 	currentGroup := ""
 	accountRowIndex := 0
 	for i, row := range rows {
 		group := usageProviderLabel(row)
+		columns := usageGridColumns(out, numbered, usageProvider(row))
 		if group != currentGroup {
+			if currentGroup != "" {
+				fmt.Fprintln(out)
+			}
 			printUsageGridGroup(out, columns, group, colored)
+			printUsageGridLine(out, columns, func(col usageGridColumn) usageGridCell {
+				return usageGridCell{Text: col.Title, Style: ansiDim}
+			}, colored, "")
+			printUsageGridSeparator(out, columns, colored)
 			currentGroup = group
 		}
 		rowIndex := ""
 		if numbered {
 			rowIndex = strconv.Itoa(i + 1)
 		}
-		values := map[string]usageGridCell{
-			"#":        {Text: rowIndex, Style: ansiDim},
-			"Account":  {Text: displayAccountName(row.email), Style: ansiBold + ansiWhite},
-			"Plan":     {Text: row.planType, Style: ansiDim},
-			"State":    {Text: usageGridState(row), Style: usageGridStateColor(row)},
-			"Pick":     {Text: compactPickReason(row), Style: usageGridPickColor(row)},
-			"5h":       usageGridShortWindowCell(row),
-			"7d":       usageGridWindowCell(row.windows, isLongQuotaWindow),
-			"Spark":    usageGridShortNamedWindowCell(row),
-			"Spark wk": usageGridNamedWindowCell(row.windows, true),
-			"Credits":  usageGridCreditsCell(row),
-		}
+		values := usageGridValues(row, rowIndex)
 		printUsageGridLine(out, columns, func(col usageGridColumn) usageGridCell {
 			return values[col.Key]
 		}, colored, usageGridRowStyle(accountRowIndex))
@@ -1517,7 +1531,7 @@ func printUsageGridGroup(out io.Writer, columns []usageGridColumn, label string,
 	fmt.Fprintln(out, style(colored, ansiBold+ansiDim, fitCell(label, usageGridWidth(columns))))
 }
 
-func usageGridColumns(out io.Writer, numbered bool) []usageGridColumn {
+func usageGridColumns(out io.Writer, numbered bool, provider accounts.Provider) []usageGridColumn {
 	termWidth := terminalColumns(out)
 	accountWidth := 22
 	planWidth := 6
@@ -1543,12 +1557,24 @@ func usageGridColumns(out io.Writer, numbered bool) []usageGridColumn {
 		usageGridColumn{Key: "Plan", Title: "Plan", Width: planWidth},
 		usageGridColumn{Key: "State", Title: "State", Width: stateWidth},
 		usageGridColumn{Key: "Pick", Title: "Use", Width: pickWidth},
-		usageGridColumn{Key: "5h", Title: "5h", Width: windowWidth},
-		usageGridColumn{Key: "7d", Title: "7d", Width: windowWidth},
 	)
-	columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Credits", Title: "$", Width: creditsWidth}, termWidth)
-	columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Spark", Title: "Spark", Width: sparkWidth}, termWidth)
-	columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Spark wk", Title: "Spark wk", Width: sparkWidth}, termWidth)
+	if provider == accounts.ProviderClaude {
+		columns = append(columns,
+			usageGridColumn{Key: "Session", Title: "Session", Width: windowWidth},
+			usageGridColumn{Key: "Weekly", Title: "Weekly", Width: windowWidth},
+		)
+		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Opus wk", Title: "Opus wk", Width: sparkWidth}, termWidth)
+		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Sonnet wk", Title: "Sonnet wk", Width: 9}, termWidth)
+		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Extra", Title: "Extra", Width: sparkWidth}, termWidth)
+	} else {
+		columns = append(columns,
+			usageGridColumn{Key: "5h", Title: "5h", Width: windowWidth},
+			usageGridColumn{Key: "7d", Title: "7d", Width: windowWidth},
+		)
+		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Credits", Title: "$", Width: creditsWidth}, termWidth)
+		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Spark", Title: "Spark", Width: sparkWidth}, termWidth)
+		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Spark wk", Title: "Spark wk", Width: sparkWidth}, termWidth)
+	}
 
 	extra := termWidth - usageGridWidth(columns)
 	if extra <= 0 {
@@ -1557,9 +1583,31 @@ func usageGridColumns(out io.Writer, numbered bool) []usageGridColumn {
 	extra = widenUsageGridColumn(columns, "Account", extra, 36)
 	extra = widenUsageGridColumn(columns, "Pick", extra, 34)
 	extra = widenUsageGridColumn(columns, "State", extra, 14)
+	extra = widenUsageGridColumn(columns, "Sonnet wk", extra, 10)
 	extra = widenUsageGridColumn(columns, "Spark wk", extra, 10)
+	extra = widenUsageGridColumn(columns, "Weekly", extra, 12)
 	_ = widenUsageGridColumn(columns, "7d", extra, 12)
 	return columns
+}
+
+func usageGridValues(row srUsageRow, rowIndex string) map[string]usageGridCell {
+	return map[string]usageGridCell{
+		"#":         {Text: rowIndex, Style: ansiDim},
+		"Account":   {Text: displayAccountName(row.email), Style: ansiBold + ansiWhite},
+		"Plan":      {Text: row.planType, Style: ansiDim},
+		"State":     {Text: usageGridState(row), Style: usageGridStateColor(row)},
+		"Pick":      {Text: compactPickReason(row), Style: usageGridPickColor(row)},
+		"5h":        usageGridShortWindowCell(row),
+		"7d":        usageGridWindowCell(row.windows, isLongQuotaWindow),
+		"Spark":     usageGridShortNamedWindowCell(row),
+		"Spark wk":  usageGridNamedWindowCell(row.windows, true),
+		"Credits":   usageGridCreditsCell(row),
+		"Session":   usageGridWindowCell(row.windows, isClaudeSessionWindow),
+		"Weekly":    usageGridWindowCell(row.windows, isClaudeWeeklyWindow),
+		"Opus wk":   usageGridWindowCell(row.windows, isClaudeOpusWeeklyWindow),
+		"Sonnet wk": usageGridWindowCell(row.windows, isClaudeSonnetWeeklyWindow),
+		"Extra":     usageGridWindowCell(row.windows, isClaudeExtraWindow),
+	}
 }
 
 type usageGridColumn struct {
@@ -1724,6 +1772,9 @@ func compactPickReason(row srUsageRow) string {
 		return fmt.Sprintf("%s, protected < %d%%", left, int(selectacct.MinNewSessionHeadroom*100))
 	}
 	if row.score.ShortResetAfterSeconds > 0 {
+		if usageProvider(row) == accounts.ProviderClaude {
+			return fmt.Sprintf("%s, session reset %s", left, formatDuration(row.score.ShortResetAfterSeconds))
+		}
 		return fmt.Sprintf("%s, 5h reset %s", left, formatDuration(row.score.ShortResetAfterSeconds))
 	}
 	return left

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -18,11 +18,11 @@ import (
 	"time"
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
+	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
 	"github.com/manaflow-ai/subrouter/internal/selectacct"
 )
 
 const srUsageCacheTTL = time.Hour
-const srUsageGridMinWidth = 140
 
 const (
 	ansiReset    = "\x1b[0m"
@@ -41,10 +41,10 @@ const (
 	ansiBGRowAlt = "\x1b[48;5;236m"
 )
 
-const srHelp = `sr - Manage multiple Codex accounts
+const srHelp = `sr - Manage Subrouter accounts
 
 Usage:
-  sr                    Show Codex usage for all accounts and switch
+  sr                    Show Codex and Claude usage, grouped by provider
   sr add                Add a new Codex account (opens OAuth login)
   sr add-key            Add a Codex API key account
   sr import             Import current ~/.codex/auth.json account
@@ -54,7 +54,7 @@ Usage:
   sr gui [email]        Switch active account, sync OpenCode/pi, and restart Codex.app
   sr gui-switch [email] Switch active account, sync OpenCode/pi, and restart Codex.app
   sr remove <email>     Remove a Codex account
-  sr status             Show Codex usage (non-interactive)
+  sr status             Show Codex and Claude usage (non-interactive)
   sr pick               Switch to the recommended account, failing if none has quota
   sr usage [days]       Refresh and show API-key spend
   sr trace <email>      Show OAuth refresh breadcrumbs for an account
@@ -110,6 +110,7 @@ type srUsageRow struct {
 	tempCooked       bool
 	tempCookedReason string
 	authMode         accounts.AuthMode
+	provider         accounts.Provider
 }
 
 func cxAlias(args []string) error {
@@ -701,7 +702,7 @@ func (r srRunner) fetchUsageRows(ctx context.Context) ([]srUsageRow, error) {
 	var wg sync.WaitGroup
 	for i, account := range all {
 		i, account := i, account
-		rows[i] = srUsageRow{email: account.Email, active: account.Email == active}
+		rows[i] = srUsageRow{email: account.Email, active: account.Email == active, provider: accounts.ProviderCodex}
 		if account.IsAPIKey() {
 			rows[i].authMode = accounts.AuthModeAPIKey
 			rows[i].score = selectacct.Score{AccountID: account.Email, Headroom: 0.01, ShortHeadroom: 0.01}
@@ -743,6 +744,41 @@ func (r srRunner) fetchUsageRows(ctx context.Context) ([]srUsageRow, error) {
 			rows[i].score = scoreFromWindows(account.Email, details.Windows)
 			rows[i].cooked, rows[i].cookedReason = cookedFromWindows(details.Windows)
 			rows[i].tempCooked, rows[i].tempCookedReason = tempCookedFromWindows(details.Windows)
+		}()
+	}
+	wg.Wait()
+	claudeStore := agentclaude.DefaultStore()
+	claudeProfiles := claudeStore.ListProfiles()
+	claudeOffset := len(rows)
+	rows = append(rows, make([]srUsageRow, len(claudeProfiles))...)
+	activeClaude := claudeStore.ActiveProfile()
+	for i, profile := range claudeProfiles {
+		i, profile := claudeOffset+i, profile
+		rows[i] = srUsageRow{
+			email:    profile.Name,
+			active:   profile.Name == activeClaude,
+			planType: "claude",
+			authMode: accounts.AuthModeOAuth,
+			provider: accounts.ProviderClaude,
+			score:    selectacct.Score{AccountID: profile.Name, Headroom: 1, ShortHeadroom: 1},
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			account, _, err := claudeStore.RefreshCredentialIfExpired(ctx, r.client, profile)
+			if err != nil {
+				rows[i].err = err
+				rows[i].score = selectacct.Score{AccountID: profile.Name, Headroom: 0, ShortHeadroom: 0}
+				return
+			}
+			usage, err := agentclaude.FetchUsage(ctx, r.client, account.Token)
+			if err != nil {
+				rows[i].err = err
+				rows[i].score = selectacct.Score{AccountID: profile.Name, Headroom: 0, ShortHeadroom: 0}
+				return
+			}
+			rows[i].windows = claudeUsageWindows(usage)
+			rows[i].score = scoreFromWindows(profile.Name, rows[i].windows)
 		}()
 	}
 	wg.Wait()
@@ -1128,6 +1164,9 @@ func clampUsagePercent(value float64) float64 {
 func allOAuthRowsCooked(rows []srUsageRow) bool {
 	seenOAuth := false
 	for _, row := range rows {
+		if row.provider != "" && row.provider != accounts.ProviderCodex {
+			continue
+		}
 		if row.err != nil || row.authMode == accounts.AuthModeAPIKey {
 			return false
 		}
@@ -1145,6 +1184,9 @@ func allOAuthRowsCooked(rows []srUsageRow) bool {
 func allOAuthRowsBlockedForNewSession(rows []srUsageRow) bool {
 	seenOAuth := false
 	for _, row := range rows {
+		if row.provider != "" && row.provider != accounts.ProviderCodex {
+			continue
+		}
 		if row.err != nil || row.authMode == accounts.AuthModeAPIKey {
 			return false
 		}
@@ -1161,6 +1203,9 @@ func allOAuthRowsBlockedForNewSession(rows []srUsageRow) bool {
 
 func hasSwitchableUsageRows(rows []srUsageRow) bool {
 	for _, row := range rows {
+		if row.provider != "" && row.provider != accounts.ProviderCodex {
+			continue
+		}
 		if row.err != nil {
 			continue
 		}
@@ -1175,6 +1220,9 @@ func hasSwitchableUsageRows(rows []srUsageRow) bool {
 }
 
 func ensureUsageRowSwitchable(row srUsageRow) error {
+	if row.provider != "" && row.provider != accounts.ProviderCodex {
+		return fmt.Errorf("cannot switch to %s with sr; use sr claude switch %s", row.email, row.email)
+	}
 	if row.cooked {
 		return fmt.Errorf("cannot switch to %s: account is cooked (%s)", row.email, row.cookedReason)
 	}
@@ -1182,6 +1230,35 @@ func ensureUsageRowSwitchable(row srUsageRow) error {
 		return fmt.Errorf("cannot switch to %s: account is temporarily cooked (%s)", row.email, row.tempCookedReason)
 	}
 	return nil
+}
+
+func claudeUsageWindows(usage *agentclaude.UsageResponse) []accounts.UsageWindow {
+	if usage == nil {
+		return nil
+	}
+	var windows []accounts.UsageWindow
+	add := func(name string, limit *agentclaude.RateLimit) {
+		if limit == nil || limit.Utilization == nil {
+			return
+		}
+		window := accounts.UsageWindow{Name: name, UsedPercent: *limit.Utilization}
+		if reset, err := time.Parse(time.RFC3339, limit.ResetsAt); err == nil {
+			seconds := int64(time.Until(reset).Seconds())
+			if seconds < 0 {
+				seconds = 0
+			}
+			window.ResetAfterSeconds = seconds
+		}
+		windows = append(windows, window)
+	}
+	add("5h", usage.FiveHour)
+	add("7d", usage.SevenDay)
+	add("opus-weekly", usage.SevenDayOpus)
+	add("sonnet-weekly", usage.SevenDaySonnet)
+	if usage.ExtraUsage != nil && usage.ExtraUsage.IsEnabled && usage.ExtraUsage.Utilization != nil {
+		windows = append(windows, accounts.UsageWindow{Name: "extra", UsedPercent: *usage.ExtraUsage.Utilization})
+	}
+	return windows
 }
 
 func (r srRunner) ensureSwitchableForFreshUsage(ctx context.Context, account accounts.StoredCodexAccount) error {
@@ -1209,33 +1286,14 @@ func (r srRunner) ensureSwitchableForFreshUsage(ctx context.Context, account acc
 func rankUsageRows(rows []srUsageRow) {
 	sort.SliceStable(rows, func(i, j int) bool {
 		a, b := rows[i], rows[j]
-		if (a.err != nil) != (b.err != nil) {
-			return a.err == nil
+		ao, bo := usageProviderOrder(a), usageProviderOrder(b)
+		if ao != bo {
+			return ao < bo
 		}
-		at, bt := usageRowTier(a), usageRowTier(b)
-		if at != bt {
-			return at < bt
+		if usageProvider(a) == accounts.ProviderClaude {
+			return claudeUsageRowLess(a, b)
 		}
-		au, bu := usableForNewSession(a.score), usableForNewSession(b.score)
-		if au != bu {
-			return au
-		}
-		if au && bu && a.score.ExpiryPressure != b.score.ExpiryPressure {
-			return a.score.ExpiryPressure > b.score.ExpiryPressure
-		}
-		if a.score.Headroom != b.score.Headroom {
-			return a.score.Headroom > b.score.Headroom
-		}
-		if a.score.ShortResetAfterSeconds != b.score.ShortResetAfterSeconds {
-			if a.score.ShortResetAfterSeconds == 0 {
-				return false
-			}
-			if b.score.ShortResetAfterSeconds == 0 {
-				return true
-			}
-			return a.score.ShortResetAfterSeconds < b.score.ShortResetAfterSeconds
-		}
-		return rows[i].email < rows[j].email
+		return codexUsageRowLess(a, b)
 	})
 	recommended := false
 	for i := range rows {
@@ -1248,7 +1306,95 @@ func rankUsageRows(rows []srUsageRow) {
 	}
 }
 
+func codexUsageRowLess(a, b srUsageRow) bool {
+	if (a.err != nil) != (b.err != nil) {
+		return a.err == nil
+	}
+	at, bt := usageRowTier(a), usageRowTier(b)
+	if at != bt {
+		return at < bt
+	}
+	au, bu := usableForNewSession(a.score), usableForNewSession(b.score)
+	if au != bu {
+		return au
+	}
+	if au && bu && a.score.ExpiryPressure != b.score.ExpiryPressure {
+		return a.score.ExpiryPressure > b.score.ExpiryPressure
+	}
+	if a.score.Headroom != b.score.Headroom {
+		return a.score.Headroom > b.score.Headroom
+	}
+	if a.score.ShortResetAfterSeconds != b.score.ShortResetAfterSeconds {
+		if a.score.ShortResetAfterSeconds == 0 {
+			return false
+		}
+		if b.score.ShortResetAfterSeconds == 0 {
+			return true
+		}
+		return a.score.ShortResetAfterSeconds < b.score.ShortResetAfterSeconds
+	}
+	return a.email < b.email
+}
+
+func claudeUsageRowLess(a, b srUsageRow) bool {
+	if (a.err != nil) != (b.err != nil) {
+		return a.err == nil
+	}
+	if a.active != b.active {
+		return a.active
+	}
+	au, bu := usableForNewSession(a.score), usableForNewSession(b.score)
+	if au != bu {
+		return au
+	}
+	if a.score.Headroom != b.score.Headroom {
+		return a.score.Headroom > b.score.Headroom
+	}
+	if a.score.ShortResetAfterSeconds != b.score.ShortResetAfterSeconds {
+		if a.score.ShortResetAfterSeconds == 0 {
+			return false
+		}
+		if b.score.ShortResetAfterSeconds == 0 {
+			return true
+		}
+		return a.score.ShortResetAfterSeconds < b.score.ShortResetAfterSeconds
+	}
+	return a.email < b.email
+}
+
+func usageProvider(row srUsageRow) accounts.Provider {
+	if row.provider == "" {
+		return accounts.ProviderCodex
+	}
+	return row.provider
+}
+
+func usageProviderOrder(row srUsageRow) int {
+	switch usageProvider(row) {
+	case accounts.ProviderCodex:
+		return 0
+	case accounts.ProviderClaude:
+		return 1
+	default:
+		return 2
+	}
+}
+
+func usageProviderLabel(row srUsageRow) string {
+	switch usageProvider(row) {
+	case accounts.ProviderCodex:
+		return "Codex accounts"
+	case accounts.ProviderClaude:
+		return "Claude profiles"
+	default:
+		return strings.Title(string(usageProvider(row))) + " accounts"
+	}
+}
+
 func usageRowTier(row srUsageRow) int {
+	if row.provider != "" && row.provider != accounts.ProviderCodex {
+		return 5
+	}
 	if row.authMode == accounts.AuthModeOAuth && usableForNewSession(row.score) {
 		return 0
 	}
@@ -1268,6 +1414,9 @@ func usageRowTier(row srUsageRow) int {
 }
 
 func recommendedForNewSession(row srUsageRow) bool {
+	if row.provider != "" && row.provider != accounts.ProviderCodex {
+		return false
+	}
 	if row.err != nil || row.cooked || row.tempCooked {
 		return false
 	}
@@ -1314,121 +1463,24 @@ func displayUsageRows(out io.Writer, rows []srUsageRow, numbered bool) {
 		return
 	}
 	colored := colorEnabled(out)
-	if shouldDisplayUsageGrid(out) {
-		displayUsageRowsGrid(out, rows, numbered, colored)
-		return
-	}
-	displayUsageRowsDetailed(out, rows, numbered, colored)
-}
-
-func shouldDisplayUsageGrid(out io.Writer) bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv("SR_USAGE_GRID"))) {
-	case "1", "true", "yes", "on":
-		return true
-	case "0", "false", "no", "off":
-		return false
-	}
-	switch strings.ToLower(strings.TrimSpace(os.Getenv("CX_USAGE_GRID"))) {
-	case "1", "true", "yes", "on":
-		return true
-	case "0", "false", "no", "off":
-		return false
-	}
-	return terminalColumns(out) >= srUsageGridMinWidth
-}
-
-func displayUsageRowsDetailed(out io.Writer, rows []srUsageRow, numbered bool, colored bool) {
-	width := 0
-	for _, row := range rows {
-		if row.gtoReason != "" {
-			width = max(width, len("pick"))
-		}
-		if row.cookedReason != "" {
-			width = max(width, len("cooked"))
-		}
-		if row.tempCookedReason != "" {
-			width = max(width, len("temporarily cooked"))
-		}
-		for _, window := range row.windows {
-			width = max(width, len(windowLabel(window)))
-		}
-		if row.credits != nil {
-			width = max(width, len("Credits"))
-		}
-		if row.apiKeySpend != nil {
-			width = max(width, len("top model"))
-		}
-	}
-	fmt.Fprintln(out)
-	for i, row := range rows {
-		prefix := ""
-		if numbered {
-			prefix = fmt.Sprintf("%d) ", i+1)
-		}
-		active := ""
-		if row.active {
-			active = " " + style(colored, ansiCyan, "(active)")
-		}
-		recommended := ""
-		if row.gtoRecommended {
-			recommended = " " + style(colored, ansiGreen, "[recommended]")
-		}
-		cooked := ""
-		if row.cooked {
-			cooked = " " + style(colored, ansiRed, "[cooked]")
-		} else if row.tempCooked {
-			cooked = " " + style(colored, ansiYellow, "[temporarily cooked]")
-		}
-		plan := ""
-		if row.planType != "" {
-			plan = " " + style(colored, ansiDim, "["+row.planType+"]")
-		}
-		fmt.Fprintf(out, "%s%s%s%s%s%s\n", style(colored, ansiDim, prefix), style(colored, ansiBold+ansiWhite, displayAccountName(row.email)), plan, active, recommended, cooked)
-		if row.err != nil {
-			fmt.Fprintf(out, "  %s\n\n", style(colored, ansiRed, "Error: "+row.err.Error()))
-			continue
-		}
-		if row.gtoReason != "" {
-			fmt.Fprintf(out, "  %s: %s\n", style(colored, ansiDim, pad("pick", width)), row.gtoReason)
-		}
-		if row.cookedReason != "" {
-			fmt.Fprintf(out, "  %s: %s\n", style(colored, ansiDim, pad("cooked", width)), row.cookedReason)
-		}
-		if row.tempCookedReason != "" {
-			fmt.Fprintf(out, "  %s: %s\n", style(colored, ansiDim, pad("temporarily cooked", width)), row.tempCookedReason)
-		}
-		for _, window := range row.windows {
-			left := formatPercentLeft(window.UsedPercent)
-			fmt.Fprintf(out, "  %s: %s %s", style(colored, ansiDim, pad(windowLabel(window), width)), renderBar(window.UsedPercent, colored), style(colored, usageColor(window.UsedPercent), left+" left"))
-			if window.ResetAfterSeconds > 0 {
-				fmt.Fprintf(out, " %s", style(colored, ansiDim, "resets in "+formatDuration(window.ResetAfterSeconds)))
-			}
-			fmt.Fprintln(out)
-		}
-		if row.credits != nil {
-			if row.credits.Unlimited {
-				fmt.Fprintf(out, "  %s: %s\n", style(colored, ansiDim, pad("Credits", width)), style(colored, ansiGreen, "Unlimited"))
-			} else if row.credits.Balance != "" {
-				fmt.Fprintf(out, "  %s: $%s\n", style(colored, ansiDim, pad("Credits", width)), row.credits.Balance)
-			}
-		}
-		if row.apiKeySpend != nil {
-			displayAPIKeySpend(out, row.apiKeySpend, width, colored)
-		} else if row.apiKeyHint != "" {
-			fmt.Fprintf(out, "  %s\n", style(colored, ansiDim, row.apiKeyHint))
-		}
-		fmt.Fprintln(out)
-	}
+	displayUsageRowsGrid(out, rows, numbered, colored)
 }
 
 func displayUsageRowsGrid(out io.Writer, rows []srUsageRow, numbered bool, colored bool) {
-	columns := usageGridColumns(out)
+	columns := usageGridColumns(out, numbered)
 	fmt.Fprintln(out)
 	printUsageGridLine(out, columns, func(col usageGridColumn) usageGridCell {
 		return usageGridCell{Text: col.Title, Style: ansiDim}
 	}, colored, "")
 	printUsageGridSeparator(out, columns, colored)
+	currentGroup := ""
+	accountRowIndex := 0
 	for i, row := range rows {
+		group := usageProviderLabel(row)
+		if group != currentGroup {
+			printUsageGridGroup(out, columns, group, colored)
+			currentGroup = group
+		}
 		rowIndex := ""
 		if numbered {
 			rowIndex = strconv.Itoa(i + 1)
@@ -1446,8 +1498,9 @@ func displayUsageRowsGrid(out io.Writer, rows []srUsageRow, numbered bool, color
 			"Credits":  usageGridCreditsCell(row),
 		}
 		printUsageGridLine(out, columns, func(col usageGridColumn) usageGridCell {
-			return values[col.Title]
-		}, colored, usageGridRowStyle(i))
+			return values[col.Key]
+		}, colored, usageGridRowStyle(accountRowIndex))
+		accountRowIndex++
 	}
 	fmt.Fprintln(out)
 	if usageRowsHaveErrors(rows) {
@@ -1460,32 +1513,57 @@ func displayUsageRowsGrid(out io.Writer, rows []srUsageRow, numbered bool, color
 	}
 }
 
-func usageGridColumns(out io.Writer) []usageGridColumn {
-	columns := []usageGridColumn{
-		{Title: "#", Width: 3},
-		{Title: "Account", Width: 24},
-		{Title: "Plan", Width: 7},
-		{Title: "State", Width: 18},
-		{Title: "Pick", Width: 30},
-		{Title: "5h", Width: 10},
-		{Title: "7d", Width: 10},
-		{Title: "Spark", Width: 10},
-		{Title: "Spark wk", Width: 11},
-		{Title: "Credits", Width: 8},
+func printUsageGridGroup(out io.Writer, columns []usageGridColumn, label string, colored bool) {
+	fmt.Fprintln(out, style(colored, ansiBold+ansiDim, fitCell(label, usageGridWidth(columns))))
+}
+
+func usageGridColumns(out io.Writer, numbered bool) []usageGridColumn {
+	termWidth := terminalColumns(out)
+	accountWidth := 22
+	planWidth := 6
+	stateWidth := 10
+	pickWidth := 22
+	windowWidth := 9
+	creditsWidth := 7
+	sparkWidth := 8
+	if termWidth < 100 {
+		accountWidth = 20
+		planWidth = 4
+		stateWidth = 14
+		pickWidth = 16
+		windowWidth = 7
 	}
-	extra := terminalColumns(out) - usageGridWidth(columns)
+
+	columns := []usageGridColumn{}
+	if numbered {
+		columns = append(columns, usageGridColumn{Key: "#", Title: "#", Width: 3})
+	}
+	columns = append(columns,
+		usageGridColumn{Key: "Account", Title: "Account", Width: accountWidth},
+		usageGridColumn{Key: "Plan", Title: "Plan", Width: planWidth},
+		usageGridColumn{Key: "State", Title: "State", Width: stateWidth},
+		usageGridColumn{Key: "Pick", Title: "Use", Width: pickWidth},
+		usageGridColumn{Key: "5h", Title: "5h", Width: windowWidth},
+		usageGridColumn{Key: "7d", Title: "7d", Width: windowWidth},
+	)
+	columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Credits", Title: "$", Width: creditsWidth}, termWidth)
+	columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Spark", Title: "Spark", Width: sparkWidth}, termWidth)
+	columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Spark wk", Title: "Spark wk", Width: sparkWidth}, termWidth)
+
+	extra := termWidth - usageGridWidth(columns)
 	if extra <= 0 {
 		return columns
 	}
 	extra = widenUsageGridColumn(columns, "Account", extra, 36)
-	extra = widenUsageGridColumn(columns, "Pick", extra, 42)
-	extra = widenUsageGridColumn(columns, "State", extra, 22)
-	extra = widenUsageGridColumn(columns, "Spark wk", extra, 13)
+	extra = widenUsageGridColumn(columns, "Pick", extra, 34)
+	extra = widenUsageGridColumn(columns, "State", extra, 14)
+	extra = widenUsageGridColumn(columns, "Spark wk", extra, 10)
 	_ = widenUsageGridColumn(columns, "7d", extra, 12)
 	return columns
 }
 
 type usageGridColumn struct {
+	Key   string
 	Title string
 	Width int
 }
@@ -1506,12 +1584,20 @@ func usageGridWidth(columns []usageGridColumn) int {
 	return width
 }
 
+func appendUsageGridColumnIfFits(columns []usageGridColumn, column usageGridColumn, termWidth int) []usageGridColumn {
+	next := append(append([]usageGridColumn{}, columns...), column)
+	if usageGridWidth(next) <= termWidth {
+		return next
+	}
+	return columns
+}
+
 func widenUsageGridColumn(columns []usageGridColumn, title string, extra int, maxWidth int) int {
 	if extra <= 0 {
 		return 0
 	}
 	for i := range columns {
-		if columns[i].Title != title {
+		if columns[i].Key != title {
 			continue
 		}
 		add := min(extra, maxWidth-columns[i].Width)
@@ -1565,13 +1651,13 @@ func usageGridState(row srUsageRow) string {
 			states = append(states, "active")
 		}
 		if row.gtoRecommended {
-			states = append(states, "recommended")
+			states = append(states, "rec")
 		}
 	}
 	if row.cooked {
 		states = append(states, "cooked")
 	} else if row.tempCooked {
-		states = append(states, "temp cooked")
+		states = append(states, "temp")
 	}
 	if row.err != nil {
 		states = append(states, "error")
@@ -1599,6 +1685,9 @@ func usageGridPickColor(row srUsageRow) string {
 	case row.err != nil || row.cooked:
 		return ansiRed
 	case row.tempCooked || !recommendedForNewSession(row):
+		if usageProvider(row) == accounts.ProviderClaude {
+			return ""
+		}
 		return ansiYellow
 	case row.gtoRecommended:
 		return ansiGreen
@@ -1626,6 +1715,9 @@ func compactPickReason(row srUsageRow) string {
 	}
 	if row.authMode == accounts.AuthModeAPIKey {
 		return "API key fallback"
+	}
+	if usageProvider(row) == accounts.ProviderClaude && len(row.windows) == 0 {
+		return "Claude profile"
 	}
 	left := fmt.Sprintf("%d%% left", int(row.score.Headroom*100+0.5))
 	if !usableForNewSession(row.score) {

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -1520,11 +1520,43 @@ func displayUsageRowsGrid(out io.Writer, rows []srUsageRow, numbered bool, color
 	if usageRowsHaveErrors(rows) {
 		for _, row := range rows {
 			if row.err != nil {
-				fmt.Fprintf(out, "  %s: %s\n", style(colored, ansiBold+ansiWhite, displayAccountName(row.email)), style(colored, ansiRed, row.err.Error()))
+				fmt.Fprintf(out, "  %s %s: %s%s\n",
+					style(colored, ansiBold+ansiWhite, displayAccountName(row.email)),
+					style(colored, ansiDim, "["+string(usageProvider(row))+"]"),
+					style(colored, ansiRed, row.err.Error()),
+					style(colored, ansiDim, usageRowErrorHint(row)))
 			}
 		}
 		fmt.Fprintln(out)
 	}
+}
+
+func usageRowErrorHint(row srUsageRow) string {
+	if row.err == nil || !authErrorNeedsReadd(row.err) {
+		return ""
+	}
+	return " (re-add with: " + providerReaddCommand(usageProvider(row)) + ")"
+}
+
+func providerReaddCommand(provider accounts.Provider) string {
+	switch provider {
+	case accounts.ProviderClaude:
+		return "sr claude add"
+	case "gemini":
+		return "sr gemini add"
+	default:
+		return "sr add"
+	}
+}
+
+func authErrorNeedsReadd(err error) bool {
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{"401", "unauthorized", "invalid_grant", "reauth", "refresh failed", "access_expired"} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func printUsageGridGroup(out io.Writer, columns []usageGridColumn, label string, colored bool) {

--- a/cmd/subrouter/sr_claude.go
+++ b/cmd/subrouter/sr_claude.go
@@ -26,6 +26,7 @@ Usage:
   sr claude remove <name>       Remove a profile
   sr claude env                 Print export CLAUDE_CONFIG_DIR=...
   sr claude run [name] [...]    Launch Claude with a specific profile
+  sr claude --flag [...]        Launch Claude with the active profile
   sr claude <name> [...]        Shorthand for 'sr claude run <name>'
   sr claude help                Show this help
 `
@@ -90,6 +91,9 @@ func (r claudeRunner) run(ctx context.Context, args []string) error {
 		fmt.Fprint(r.out, srClaudeHelp)
 		return nil
 	default:
+		if strings.HasPrefix(args[0], "-") {
+			return r.runClaude(ctx, "", args)
+		}
 		if _, ok := r.store.FindProfile(args[0]); ok {
 			return r.runClaude(ctx, args[0], args[1:])
 		}

--- a/cmd/subrouter/sr_claude_test.go
+++ b/cmd/subrouter/sr_claude_test.go
@@ -73,3 +73,42 @@ func TestClaudeSwitchSupportsPartialProfile(t *testing.T) {
 		t.Fatalf("switch output = %q", out.String())
 	}
 }
+
+func TestClaudeFlagsRunActiveProfile(t *testing.T) {
+	home := t.TempDir()
+	store := claude.Store{Dir: filepath.Join(home, ".subrouter", "codex")}
+	if _, err := store.CreateProfile("work"); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := filepath.Join(home, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	recordPath := filepath.Join(home, "claude-run.txt")
+	claudePath := filepath.Join(binDir, "claude")
+	script := "#!/bin/sh\nprintf 'config=%s\\nargs=%s\\n' \"$CLAUDE_CONFIG_DIR\" \"$*\" > " + shellQuote(recordPath) + "\n"
+	if err := os.WriteFile(claudePath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var out bytes.Buffer
+	runner := claudeRunner{store: store, in: strings.NewReader(""), out: &out, errOut: &out}
+	err := runner.run(context.Background(), []string{"--dangerously-skip-permissions", "--resume", "1721c0ce-b3bd-4d73-8b33-b3d02b677074"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := os.ReadFile(recordPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "config="+store.ClaudeConfigDir("work")) {
+		t.Fatalf("Claude did not receive active config dir:\n%s", got)
+	}
+	if !strings.Contains(got, "args=--dangerously-skip-permissions --resume 1721c0ce-b3bd-4d73-8b33-b3d02b677074") {
+		t.Fatalf("Claude did not receive flags:\n%s", got)
+	}
+}

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -817,9 +817,6 @@ func (r srRunner) fetchServerUsageStatuses(ctx context.Context, server srServerC
 func usageRowsFromServerUsageStatuses(statuses []remoteServerUsageStatus) []srUsageRow {
 	rows := make([]srUsageRow, 0, len(statuses))
 	for _, status := range statuses {
-		if status.Provider != "" && status.Provider != accounts.ProviderCodex {
-			continue
-		}
 		email := accountEmail(status.ID, status.Email)
 		if email == "" {
 			if status.Error == "" {
@@ -834,6 +831,10 @@ func usageRowsFromServerUsageStatuses(statuses []remoteServerUsageStatus) []srUs
 			planType: status.PlanType,
 			windows:  status.Windows,
 			credits:  status.Credits,
+			provider: status.Provider,
+		}
+		if status.Provider == accounts.ProviderClaude && row.planType == "" {
+			row.planType = "claude"
 		}
 		if status.Error != "" {
 			row.err = errors.New(status.Error)
@@ -1221,8 +1222,9 @@ func (r srRunner) serverLoginOne(ctx context.Context, server srServerConfig, dev
 		return err
 	}
 	restored = true
-	fmt.Fprintf(r.out, "Added server-owned account %s to %s\n", account.Email, server.Name)
-	fmt.Fprintln(r.out, "Local auth was restored, so only the server owns the new refresh-token chain.")
+	fmt.Fprintf(r.out, "Uploaded %s to server %s.\n", account.Email, server.Name)
+	fmt.Fprintln(r.out, "Your local Codex login is back to the account you were using before this command.")
+	fmt.Fprintf(r.out, "The new %s refresh token is stored on %s, not kept as your local active login.\n", account.Email, server.Name)
 	return nil
 }
 
@@ -1337,8 +1339,28 @@ func (r srRunner) uploadServerAccountSSH(ctx context.Context, server srServerCon
 	}
 	uploadCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
 	defer cancel()
-	if err := r.commandRunner().Run(uploadCtx, "ssh", args, bytes.NewReader(archive), r.out, r.errOut); err != nil {
-		return fmt.Errorf("install account on server over ssh: %w", err)
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		if err := r.commandRunner().Run(uploadCtx, "ssh", args, bytes.NewReader(archive), r.out, r.errOut); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		if attempt < 3 {
+			if r.errOut != nil {
+				fmt.Fprintf(r.errOut, "server ssh upload failed, retrying (%d/3): %v\n", attempt, lastErr)
+			}
+			timer := time.NewTimer(time.Duration(attempt) * time.Second)
+			select {
+			case <-uploadCtx.Done():
+				timer.Stop()
+				return fmt.Errorf("install account on server over ssh: %w", uploadCtx.Err())
+			case <-timer.C:
+			}
+		}
+	}
+	if lastErr != nil {
+		return fmt.Errorf("install account on server over ssh: %w", lastErr)
 	}
 	return nil
 }

--- a/cmd/subrouter/sr_server_test.go
+++ b/cmd/subrouter/sr_server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -359,7 +360,7 @@ func TestSRAddUsesDefaultRemoteServer(t *testing.T) {
 	if strings.Contains(out.String(), "Added account:") {
 		t.Fatalf("top-level add should not add to local account store when a server is selected:\n%s", out.String())
 	}
-	if !strings.Contains(out.String(), "Added server-owned account fresh@example.com to team") {
+	if !strings.Contains(out.String(), "Uploaded fresh@example.com to server team.") {
 		t.Fatalf("missing server add confirmation:\n%s", out.String())
 	}
 }
@@ -661,8 +662,11 @@ func TestSRServerLoginUploadsFreshAuthAndRestoresLocalChain(t *testing.T) {
 	if strings.Contains(uploadCommand, "/var/lib/subrouter/.codex-accounts") {
 		t.Fatalf("upload should not use legacy account path:\n%s", uploadCommand)
 	}
-	if !strings.Contains(out.String(), "server owns the new refresh-token chain") {
+	if !strings.Contains(out.String(), "Your local Codex login is back to the account you were using before this command.") {
 		t.Fatalf("missing ownership message:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "The new bob@example.com refresh token is stored on community, not kept as your local active login.") {
+		t.Fatalf("missing server token ownership message:\n%s", out.String())
 	}
 }
 
@@ -1021,15 +1025,64 @@ func TestSRServerInstallUsesPublicInstallerAndSystemdCommand(t *testing.T) {
 	}
 }
 
+func TestSRServerLoginRetriesTransientSSHUploadFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	store := accounts.DefaultCodexStore()
+	serverStore := defaultSRServerStore(store)
+	if err := serverStore.save(srServerFile{
+		Default: "team",
+		Servers: []srServerConfig{{
+			Name: "team",
+			URL:  "http://subrouter-team:31415",
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	fake := &recordingSRCommandRunner{
+		loginAuth: testCodexAuth("fresh@example.com", "fresh-refresh"),
+		failCommandPrefixes: []failCommandPrefix{{
+			prefix: []string{"ssh", "-o", "BatchMode=yes"},
+			times:  1,
+			err:    errors.New("ssh: connect to host subrouter-team port 22: Connection refused"),
+		}},
+	}
+	var out bytes.Buffer
+	runner := srRunner{program: "sr", store: store, in: strings.NewReader(""), out: &out, errOut: &out, cmd: fake}
+
+	if err := runner.run(context.Background(), []string{"add"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if count := fake.countCommandPrefix("ssh", "-o", "BatchMode=yes"); count != 2 {
+		t.Fatalf("ssh upload attempts = %d, want 2; commands: %#v", count, fake.commands)
+	}
+	if !strings.Contains(out.String(), "server ssh upload failed, retrying (1/3)") {
+		t.Fatalf("missing retry message:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Uploaded fresh@example.com to server team.") {
+		t.Fatalf("missing success message after retry:\n%s", out.String())
+	}
+}
+
 type recordingSRCommandRunner struct {
-	loginAuth  accounts.CodexAuthFile
-	loginAuths []accounts.CodexAuthFile
-	commands   [][]string
+	loginAuth           accounts.CodexAuthFile
+	loginAuths          []accounts.CodexAuthFile
+	commands            [][]string
+	failCommandPrefixes []failCommandPrefix
 }
 
 func (r *recordingSRCommandRunner) Run(_ context.Context, name string, args []string, _ io.Reader, _ io.Writer, _ io.Writer) error {
 	command := append([]string{name}, args...)
 	r.commands = append(r.commands, command)
+	for i := range r.failCommandPrefixes {
+		failure := &r.failCommandPrefixes[i]
+		if failure.times > 0 && commandHasPrefix(command, failure.prefix) {
+			failure.times--
+			return failure.err
+		}
+	}
 	if name == "codex" && len(args) > 0 && args[0] == "login" {
 		loginAuth := r.loginAuth
 		if len(r.loginAuths) > 0 {
@@ -1047,6 +1100,12 @@ func (r *recordingSRCommandRunner) Run(_ context.Context, name string, args []st
 		return os.WriteFile(path, body, 0o600)
 	}
 	return nil
+}
+
+type failCommandPrefix struct {
+	prefix []string
+	times  int
+	err    error
 }
 
 func (r *recordingSRCommandRunner) Output(context.Context, string, []string) ([]byte, error) {
@@ -1094,21 +1153,33 @@ func (r *recordingSRCommandRunner) countCommand(parts ...string) int {
 
 func (r *recordingSRCommandRunner) hasCommandPrefix(parts ...string) bool {
 	for _, command := range r.commands {
-		if len(command) < len(parts) {
-			continue
-		}
-		matches := true
-		for i := range parts {
-			if command[i] != parts[i] {
-				matches = false
-				break
-			}
-		}
-		if matches {
+		if commandHasPrefix(command, parts) {
 			return true
 		}
 	}
 	return false
+}
+
+func (r *recordingSRCommandRunner) countCommandPrefix(parts ...string) int {
+	count := 0
+	for _, command := range r.commands {
+		if commandHasPrefix(command, parts) {
+			count++
+		}
+	}
+	return count
+}
+
+func commandHasPrefix(command []string, parts []string) bool {
+	if len(command) < len(parts) {
+		return false
+	}
+	for i := range parts {
+		if command[i] != parts[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func jsonMarshalIndent(value any) ([]byte, error) {

--- a/cmd/subrouter/sr_test.go
+++ b/cmd/subrouter/sr_test.go
@@ -9,9 +9,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 	"github.com/manaflow-ai/subrouter/internal/selectacct"
@@ -543,7 +545,7 @@ func TestSRDefaultShowsCookedAccountAndDoesNotPromptWhenAllCooked(t *testing.T) 
 	if !strings.Contains(got, "All of your OAuth accounts are cooked") {
 		t.Fatalf("missing all-cooked warning:\n%s", got)
 	}
-	if !strings.Contains(got, "[cooked]") || !strings.Contains(got, "cooked") {
+	if !strings.Contains(got, "active, cooked") || !strings.Contains(got, "cooked, canno") {
 		t.Fatalf("missing cooked row state:\n%s", got)
 	}
 	if strings.Contains(got, "Switch to (#):") {
@@ -584,16 +586,16 @@ func TestSRDefaultShowsTemporarilyCookedAccountWhenShortWindowConsumed(t *testin
 	}
 
 	got := out.String()
-	if !strings.Contains(got, "[temporarily cooked]") {
+	if !strings.Contains(got, "active, temp") {
 		t.Fatalf("missing temporarily cooked marker:\n%s", got)
 	}
-	if !strings.Contains(got, "temporarily cooked") || !strings.Contains(got, "5h limit fully consumed") {
+	if !strings.Contains(got, "temp cooked") {
 		t.Fatalf("missing temporarily cooked reason:\n%s", got)
 	}
-	if strings.Contains(got, "[cooked]") || strings.Contains(got, "All of your OAuth accounts are cooked") {
+	if strings.Contains(got, "active, cooked") || strings.Contains(got, "All of your OAuth accounts are cooked") {
 		t.Fatalf("short-window saturation should not be treated as permanently cooked:\n%s", got)
 	}
-	if strings.Contains(got, "[recommended]") {
+	if strings.Contains(got, "recommended") {
 		t.Fatalf("temporarily cooked account should not be recommended:\n%s", got)
 	}
 	if strings.Contains(got, "Switch to (#):") {
@@ -870,6 +872,50 @@ func TestSRRankRowsKeepsTemporarilyCookedAboveCooked(t *testing.T) {
 	}
 }
 
+func TestSRRankRowsGroupsProvidersSeparately(t *testing.T) {
+	rows := []srUsageRow{
+		{
+			email:    "claude-inactive@example.com",
+			authMode: accounts.AuthModeOAuth,
+			provider: accounts.ProviderClaude,
+			score:    selectacct.Score{AccountID: "claude-inactive@example.com", Headroom: 1, ShortHeadroom: 1},
+		},
+		{
+			email:    "codex-low@example.com",
+			authMode: accounts.AuthModeOAuth,
+			provider: accounts.ProviderCodex,
+			score:    selectacct.Score{AccountID: "codex-low@example.com", Headroom: 0.3, ShortHeadroom: 0.3},
+		},
+		{
+			email:    "claude-active@example.com",
+			active:   true,
+			authMode: accounts.AuthModeOAuth,
+			provider: accounts.ProviderClaude,
+			score:    selectacct.Score{AccountID: "claude-active@example.com", Headroom: 0.5, ShortHeadroom: 0.5},
+		},
+		{
+			email:    "codex-high@example.com",
+			authMode: accounts.AuthModeOAuth,
+			provider: accounts.ProviderCodex,
+			score:    selectacct.Score{AccountID: "codex-high@example.com", Headroom: 0.9, ShortHeadroom: 0.9},
+		},
+	}
+
+	rankUsageRows(rows)
+
+	got := []string{rows[0].email, rows[1].email, rows[2].email, rows[3].email}
+	want := []string{"codex-high@example.com", "codex-low@example.com", "claude-active@example.com", "claude-inactive@example.com"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("ranked rows = %#v, want %#v", got, want)
+	}
+	if !rows[0].gtoRecommended {
+		t.Fatal("best Codex row should still be recommended")
+	}
+	if rows[2].gtoRecommended || rows[3].gtoRecommended {
+		t.Fatalf("Claude rows should not be marked as Codex recommendations: %#v", rows)
+	}
+}
+
 func TestScoreFromWindowsUsesAllDisplayedRateLimits(t *testing.T) {
 	score := scoreFromWindows("a@example.com", []accounts.UsageWindow{
 		{Name: "primary", UsedPercent: 10, LimitWindowSeconds: int64((5 * time.Hour) / time.Second), ResetAfterSeconds: int64((3 * time.Hour) / time.Second)},
@@ -895,7 +941,6 @@ func TestRenderBarSupportsANSIColors(t *testing.T) {
 }
 
 func TestDisplayUsageRowsGridWhenForced(t *testing.T) {
-	t.Setenv("SR_USAGE_GRID", "1")
 	t.Setenv("COLUMNS", "200")
 	var out bytes.Buffer
 	displayUsageRows(&out, []srUsageRow{
@@ -929,6 +974,91 @@ func TestDisplayUsageRowsGridWhenForced(t *testing.T) {
 	lines := strings.Split(got, "\n")
 	if len(lines) < 3 || !strings.Contains(lines[2], "───") || strings.Contains(lines[2], "===") || strings.Contains(lines[2], "---") {
 		t.Fatalf("grid separator should be a thin Unicode rule:\n%s", got)
+	}
+}
+
+func TestDisplayUsageRowsGridGroupsProviders(t *testing.T) {
+	t.Setenv("COLUMNS", "200")
+	var out bytes.Buffer
+	displayUsageRows(&out, []srUsageRow{
+		{
+			email:    "codex@example.com",
+			planType: "pro",
+			authMode: accounts.AuthModeOAuth,
+			provider: accounts.ProviderCodex,
+			score:    selectacct.Score{AccountID: "codex@example.com", Headroom: 0.9, ShortHeadroom: 0.9},
+		},
+		{
+			email:    "claude@example.com",
+			planType: "claude",
+			authMode: accounts.AuthModeOAuth,
+			provider: accounts.ProviderClaude,
+			score:    selectacct.Score{AccountID: "claude@example.com", Headroom: 0.8, ShortHeadroom: 0.8},
+		},
+	}, true)
+
+	got := out.String()
+	codexGroup := strings.Index(got, "Codex accounts")
+	codexRow := strings.Index(got, "codex@example.com")
+	claudeGroup := strings.Index(got, "Claude profiles")
+	claudeRow := strings.Index(got, "claude@example.com")
+	if codexGroup < 0 || codexRow < 0 || claudeGroup < 0 || claudeRow < 0 {
+		t.Fatalf("grouped rows missing labels or accounts:\n%s", got)
+	}
+	if !(codexGroup < codexRow && codexRow < claudeGroup && claudeGroup < claudeRow) {
+		t.Fatalf("provider grouping order is unclear:\n%s", got)
+	}
+}
+
+func TestDisplayUsageRowsGridCompactsForNarrowTerminals(t *testing.T) {
+	t.Setenv("COLUMNS", "80")
+	var out bytes.Buffer
+	displayUsageRows(&out, []srUsageRow{
+		{
+			email:          "lawrencechen2002@gmail.com",
+			planType:       "pro",
+			gtoRecommended: true,
+			authMode:       accounts.AuthModeOAuth,
+			provider:       accounts.ProviderCodex,
+			score:          selectacct.Score{AccountID: "lawrencechen2002@gmail.com", Headroom: 0.67, ShortHeadroom: 0.96, ShortResetAfterSeconds: int64(time.Minute / time.Second)},
+			windows: []accounts.UsageWindow{
+				{Name: "primary", UsedPercent: 4, LimitWindowSeconds: int64((5 * time.Hour) / time.Second), ResetAfterSeconds: int64(time.Minute / time.Second)},
+				{Name: "secondary", UsedPercent: 33, LimitWindowSeconds: int64((7 * 24 * time.Hour) / time.Second), ResetAfterSeconds: int64((5 * 24 * time.Hour) / time.Second)},
+				{Name: "GPT-5.3-Codex-Spark/primary", UsedPercent: 0, LimitWindowSeconds: int64((5 * time.Hour) / time.Second)},
+				{Name: "GPT-5.3-Codex-Spark/secondary", UsedPercent: 0, LimitWindowSeconds: int64((7 * 24 * time.Hour) / time.Second)},
+			},
+			credits: &accounts.CreditsInfo{Balance: "0"},
+		},
+		{
+			email:    "austin@manaflow.ai",
+			planType: "claude",
+			authMode: accounts.AuthModeOAuth,
+			provider: accounts.ProviderClaude,
+			score:    selectacct.Score{AccountID: "austin@manaflow.ai", Headroom: 0.95, ShortHeadroom: 0.95},
+			windows: []accounts.UsageWindow{
+				{Name: "5h", UsedPercent: 5, ResetAfterSeconds: int64((4 * time.Hour) / time.Second)},
+				{Name: "7d", UsedPercent: 1, ResetAfterSeconds: int64((2 * 24 * time.Hour) / time.Second)},
+			},
+		},
+	}, false)
+
+	got := out.String()
+	if strings.Contains(got, "Spark") || strings.Contains(got, "Spark wk") {
+		t.Fatalf("narrow grid should omit Spark columns:\n%s", got)
+	}
+	if strings.HasPrefix(strings.TrimLeft(got, "\n"), "#") {
+		t.Fatalf("non-numbered grid should not render blank # column:\n%s", got)
+	}
+	if !strings.Contains(got, "Use") || !strings.Contains(got, "Claude profiles") {
+		t.Fatalf("narrow grid missing core columns or groups:\n%s", got)
+	}
+	for _, line := range strings.Split(got, "\n") {
+		if line == "" {
+			continue
+		}
+		if width := utf8.RuneCountInString(line); width > 80 {
+			t.Fatalf("line width = %d, want <= 80:\n%s\nfull output:\n%s", width, line, got)
+		}
 	}
 }
 
@@ -1018,8 +1148,9 @@ func TestUsageGridSuppressesShortWindowsByQuotaFamily(t *testing.T) {
 	}
 }
 
-func TestDisplayUsageRowsDetailedCanBeForced(t *testing.T) {
+func TestDisplayUsageRowsIgnoresDetailedModeEnv(t *testing.T) {
 	t.Setenv("SR_USAGE_GRID", "0")
+	t.Setenv("CX_USAGE_GRID", "0")
 	t.Setenv("COLUMNS", "200")
 	var out bytes.Buffer
 	displayUsageRows(&out, []srUsageRow{
@@ -1031,8 +1162,11 @@ func TestDisplayUsageRowsDetailedCanBeForced(t *testing.T) {
 	}, true)
 
 	got := out.String()
-	if !strings.Contains(got, "1) a@example.com") || !strings.Contains(got, "pick") {
-		t.Fatalf("forced detailed output missing expected labels:\n%s", got)
+	if !strings.Contains(got, "Account") || !strings.Contains(got, "a@example.com") {
+		t.Fatalf("grid output missing expected row:\n%s", got)
+	}
+	if strings.Contains(got, "1) a@example.com") || strings.Contains(got, "pick:") {
+		t.Fatalf("detailed output should never be rendered:\n%s", got)
 	}
 }
 

--- a/cmd/subrouter/sr_test.go
+++ b/cmd/subrouter/sr_test.go
@@ -972,7 +972,14 @@ func TestDisplayUsageRowsGridWhenForced(t *testing.T) {
 		t.Fatalf("forced grid should not render detailed pick label:\n%s", got)
 	}
 	lines := strings.Split(got, "\n")
-	if len(lines) < 3 || !strings.Contains(lines[2], "───") || strings.Contains(lines[2], "===") || strings.Contains(lines[2], "---") {
+	separator := ""
+	for _, line := range lines {
+		if strings.Contains(line, "───") {
+			separator = line
+			break
+		}
+	}
+	if separator == "" || strings.Contains(separator, "===") || strings.Contains(separator, "---") {
 		t.Fatalf("grid separator should be a thin Unicode rule:\n%s", got)
 	}
 }
@@ -1007,6 +1014,37 @@ func TestDisplayUsageRowsGridGroupsProviders(t *testing.T) {
 	}
 	if !(codexGroup < codexRow && codexRow < claudeGroup && claudeGroup < claudeRow) {
 		t.Fatalf("provider grouping order is unclear:\n%s", got)
+	}
+}
+
+func TestDisplayUsageRowsGridUsesClaudeLimitLabels(t *testing.T) {
+	t.Setenv("COLUMNS", "160")
+	var out bytes.Buffer
+	displayUsageRows(&out, []srUsageRow{
+		{
+			email:    "lawrence@manaflow.ai",
+			planType: "claude",
+			authMode: accounts.AuthModeOAuth,
+			provider: accounts.ProviderClaude,
+			score:    selectacct.Score{AccountID: "lawrence@manaflow.ai", Headroom: 0.46, ShortHeadroom: 0.89, ShortResetAfterSeconds: int64((3 * time.Hour) / time.Second)},
+			windows: []accounts.UsageWindow{
+				{Name: "5h", UsedPercent: 11, ResetAfterSeconds: int64((3 * time.Hour) / time.Second)},
+				{Name: "7d", UsedPercent: 54, ResetAfterSeconds: int64((5 * 24 * time.Hour) / time.Second)},
+				{Name: "opus-weekly", UsedPercent: 100, ResetAfterSeconds: int64((5 * 24 * time.Hour) / time.Second)},
+				{Name: "sonnet-weekly", UsedPercent: 0, ResetAfterSeconds: int64((5 * 24 * time.Hour) / time.Second)},
+			},
+		},
+	}, false)
+
+	got := out.String()
+	if !strings.Contains(got, "Session") || !strings.Contains(got, "Weekly") || !strings.Contains(got, "Opus wk") || !strings.Contains(got, "Sonnet wk") {
+		t.Fatalf("Claude grid missing Claude-specific labels:\n%s", got)
+	}
+	if strings.Contains(got, "  5h  ") || strings.Contains(got, "  7d  ") || strings.Contains(got, "Spark") {
+		t.Fatalf("Claude grid should not use Codex labels:\n%s", got)
+	}
+	if !strings.Contains(got, "session reset") {
+		t.Fatalf("Claude pick reason should use session terminology:\n%s", got)
 	}
 }
 

--- a/cmd/subrouter/sr_test.go
+++ b/cmd/subrouter/sr_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -1311,5 +1312,40 @@ func usageResponseWindows(primaryUsedPercent, secondaryUsedPercent float64) *htt
 		StatusCode: http.StatusOK,
 		Header:     make(http.Header),
 		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+}
+
+func TestUsageErrorFootnoteShowsProviderAndReaddCommand(t *testing.T) {
+	t.Setenv("COLUMNS", "200")
+	var out bytes.Buffer
+	displayUsageRows(&out, []srUsageRow{
+		{
+			email:    "codex-broken@example.com",
+			authMode: accounts.AuthModeOAuth,
+			err:      errors.New("usage fetch failed: 401 Unauthorized"),
+		},
+		{
+			email:    "claude-broken@example.com",
+			provider: accounts.ProviderClaude,
+			err:      errors.New("Claude OAuth refresh failed: 400 Bad Request: invalid_grant"),
+		},
+		{
+			email:    "codex-flaky@example.com",
+			authMode: accounts.AuthModeOAuth,
+			err:      errors.New("usage fetch failed: connection refused"),
+		},
+	}, false)
+	text := out.String()
+	if !strings.Contains(text, "codex-broken@example.com [codex]: usage fetch failed: 401 Unauthorized (re-add with: sr add)") {
+		t.Fatalf("codex 401 footnote missing provider/re-add hint:\n%s", text)
+	}
+	if !strings.Contains(text, "claude-broken@example.com [claude]: Claude OAuth refresh failed: 400 Bad Request: invalid_grant (re-add with: sr claude add)") {
+		t.Fatalf("claude invalid_grant footnote missing provider/re-add hint:\n%s", text)
+	}
+	if strings.Contains(text, "codex-flaky@example.com [codex]: usage fetch failed: connection refused (re-add") {
+		t.Fatalf("transient error should not suggest re-add:\n%s", text)
+	}
+	if !strings.Contains(text, "codex-flaky@example.com [codex]: usage fetch failed: connection refused") {
+		t.Fatalf("transient error footnote should still show provider:\n%s", text)
 	}
 }

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -1,6 +1,7 @@
 package claude
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -25,6 +26,10 @@ const (
 	usageURL        = "https://api.anthropic.com/api/oauth/usage"
 	oauthBetaHeader = "oauth-2025-04-20"
 )
+
+var oauthTokenURL = "https://platform.claude.com/v1/oauth/token"
+
+const oauthClientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 
 var reservedNames = map[string]bool{
 	"add": true, "login": true, "list": true, "ls": true, "switch": true,
@@ -60,6 +65,7 @@ type AuthStatus struct {
 
 type CredentialInfo struct {
 	AccessToken      string `json:"accessToken,omitempty"`
+	RefreshToken     string `json:"refreshToken,omitempty"`
 	SubscriptionType string `json:"subscriptionType,omitempty"`
 	RateLimitTier    string `json:"rateLimitTier,omitempty"`
 	ExpiresAt        int64  `json:"expiresAt,omitempty"`
@@ -161,24 +167,11 @@ func (s Store) ListAccounts(ctx context.Context) ([]accounts.Account, error) {
 		if err != nil {
 			return nil, err
 		}
-		if credential == nil || credential.AccessToken == "" {
+		account, ok := profileAccount(profile, configDir, credential)
+		if !ok {
 			continue
 		}
-		addedAt, _ := time.Parse(time.RFC3339, profile.CreatedAt)
-		email := ""
-		if strings.Contains(profile.Name, "@") {
-			email = profile.Name
-		}
-		out = append(out, accounts.Account{
-			ID:       profile.Name,
-			Provider: accounts.ProviderClaude,
-			AuthMode: accounts.AuthModeOAuth,
-			Label:    profile.Name,
-			Email:    email,
-			AddedAt:  addedAt,
-			Token:    credential.AccessToken,
-			Source:   configDir,
-		})
+		out = append(out, account)
 	}
 	sort.Slice(out, func(i, j int) bool {
 		return out[i].ID < out[j].ID
@@ -506,6 +499,68 @@ func (s Store) ReadCredential(ctx context.Context, instancePath string) (*Creden
 	return parseCredentialPayload(body)
 }
 
+func (s Store) RefreshCredentialIfExpired(ctx context.Context, client *http.Client, profile Profile) (accounts.Account, bool, error) {
+	configDir := s.ClaudeConfigDir(profile.Name)
+	credential, err := s.ReadCredential(ctx, configDir)
+	if err != nil {
+		return accounts.Account{}, false, err
+	}
+	if credential == nil || credential.AccessToken == "" {
+		return accounts.Account{}, false, fmt.Errorf("Claude profile %q has no access token", profile.Name)
+	}
+	didRefresh := false
+	if credential.RefreshToken != "" && credentialExpired(credential, 60*time.Second) {
+		refreshed, err := RefreshCredential(ctx, client, *credential)
+		if err != nil {
+			return accounts.Account{}, false, err
+		}
+		credential = &refreshed
+		if err := s.WriteCredential(ctx, configDir, *credential); err != nil {
+			return accounts.Account{}, false, err
+		}
+		didRefresh = true
+	}
+	account, ok := profileAccount(profile, configDir, credential)
+	if !ok {
+		return accounts.Account{}, false, fmt.Errorf("Claude profile %q has no usable credential", profile.Name)
+	}
+	return account, didRefresh, nil
+}
+
+func (s Store) RefreshAccountIfExpired(ctx context.Context, client *http.Client, account accounts.Account) (accounts.Account, bool, error) {
+	profile, ok := s.FindProfile(account.ID)
+	if !ok {
+		return account, false, fmt.Errorf("Claude profile %q not found", account.ID)
+	}
+	return s.RefreshCredentialIfExpired(ctx, client, profile)
+}
+
+func (s Store) WriteCredential(ctx context.Context, instancePath string, credential CredentialInfo) error {
+	body, err := credentialPayload(credential)
+	if err != nil {
+		return err
+	}
+	filePath := filepath.Join(instancePath, ".credentials.json")
+	if _, err := os.Stat(filePath); err == nil {
+		return os.WriteFile(filePath, body, 0o600)
+	}
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("Claude credential persistence is only supported for .credentials.json files on %s", runtime.GOOS)
+	}
+	u, err := user.Current()
+	if err != nil {
+		return err
+	}
+	service := "Claude Code-credentials-" + keychainHash(instancePath)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "security", "add-generic-password", "-U", "-s", service, "-a", u.Username, "-w", string(body))
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("write Claude credential to keychain: %w", err)
+	}
+	return nil
+}
+
 func readCredentialFile(instancePath string) (*CredentialInfo, bool) {
 	body, err := os.ReadFile(filepath.Join(instancePath, ".credentials.json"))
 	if err != nil {
@@ -523,6 +578,99 @@ func parseCredentialPayload(body []byte) (*CredentialInfo, error) {
 		return nil, err
 	}
 	return raw.ClaudeAIOAuth, nil
+}
+
+func credentialPayload(credential CredentialInfo) ([]byte, error) {
+	body, err := json.MarshalIndent(map[string]CredentialInfo{
+		"claudeAiOauth": credential,
+	}, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	body = append(body, '\n')
+	return body, nil
+}
+
+func credentialExpired(credential *CredentialInfo, skew time.Duration) bool {
+	if credential == nil || credential.ExpiresAt <= 0 {
+		return false
+	}
+	expiresAt := time.UnixMilli(credential.ExpiresAt)
+	return !time.Now().Add(skew).Before(expiresAt)
+}
+
+func RefreshCredential(ctx context.Context, client *http.Client, credential CredentialInfo) (CredentialInfo, error) {
+	if credential.RefreshToken == "" {
+		return credential, nil
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	payload := map[string]string{
+		"client_id":     oauthClientID,
+		"grant_type":    "refresh_token",
+		"refresh_token": credential.RefreshToken,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return credential, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, oauthTokenURL, bytes.NewReader(body))
+	if err != nil {
+		return credential, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("anthropic-beta", oauthBetaHeader)
+	res, err := client.Do(req)
+	if err != nil {
+		return credential, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(res.Body)
+		return credential, fmt.Errorf("Claude OAuth refresh failed: %s: %s", res.Status, strings.TrimSpace(buf.String()))
+	}
+	var refreshed struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int64  `json:"expires_in"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&refreshed); err != nil {
+		return credential, err
+	}
+	if refreshed.AccessToken == "" {
+		return credential, fmt.Errorf("Claude OAuth refresh response missing access_token")
+	}
+	credential.AccessToken = refreshed.AccessToken
+	if refreshed.RefreshToken != "" {
+		credential.RefreshToken = refreshed.RefreshToken
+	}
+	if refreshed.ExpiresIn > 0 {
+		credential.ExpiresAt = time.Now().Add(time.Duration(refreshed.ExpiresIn) * time.Second).UnixMilli()
+	}
+	return credential, nil
+}
+
+func profileAccount(profile Profile, configDir string, credential *CredentialInfo) (accounts.Account, bool) {
+	if credential == nil || credential.AccessToken == "" {
+		return accounts.Account{}, false
+	}
+	addedAt, _ := time.Parse(time.RFC3339, profile.CreatedAt)
+	email := ""
+	if strings.Contains(profile.Name, "@") {
+		email = profile.Name
+	}
+	return accounts.Account{
+		ID:       profile.Name,
+		Provider: accounts.ProviderClaude,
+		AuthMode: accounts.AuthModeOAuth,
+		Label:    profile.Name,
+		Email:    email,
+		AddedAt:  addedAt,
+		Token:    credential.AccessToken,
+		Source:   configDir,
+	}, true
 }
 
 func keychainHash(instancePath string) string {

--- a/internal/agents/claude/store_test.go
+++ b/internal/agents/claude/store_test.go
@@ -2,9 +2,14 @@ package claude
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 )
@@ -87,7 +92,7 @@ func TestClaudeConfigDirFallsBackWhenAliasMissing(t *testing.T) {
 
 func TestReadCredentialFile(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(`{"claudeAiOauth":{"accessToken":"tok","subscriptionType":"pro"}}`), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(`{"claudeAiOauth":{"accessToken":"tok","refreshToken":"refresh","subscriptionType":"pro"}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	credential, ok := readCredentialFile(dir)
@@ -96,6 +101,66 @@ func TestReadCredentialFile(t *testing.T) {
 	}
 	if credential.AccessToken != "tok" {
 		t.Fatalf("access token = %q, want tok", credential.AccessToken)
+	}
+	if credential.RefreshToken != "refresh" {
+		t.Fatalf("refresh token = %q, want refresh", credential.RefreshToken)
+	}
+}
+
+func TestRefreshCredentialPostsClaudeOAuthRefresh(t *testing.T) {
+	originalURL := oauthTokenURL
+	defer func() { oauthTokenURL = originalURL }()
+
+	var sawRequest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRequest = true
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("anthropic-beta"); got != oauthBetaHeader {
+			t.Fatalf("anthropic-beta = %q, want %q", got, oauthBetaHeader)
+		}
+		if got := r.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+			t.Fatalf("Content-Type = %q, want JSON", got)
+		}
+		var payload map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		if got := payload["client_id"]; got != oauthClientID {
+			t.Fatalf("client_id = %q, want %q", got, oauthClientID)
+		}
+		if got := payload["grant_type"]; got != "refresh_token" {
+			t.Fatalf("grant_type = %q, want refresh_token", got)
+		}
+		if got := payload["refresh_token"]; got != "old-refresh" {
+			t.Fatalf("refresh_token = %q, want old-refresh", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "new-access",
+			"refresh_token": "new-refresh",
+			"expires_in":    3600,
+		})
+	}))
+	defer server.Close()
+	oauthTokenURL = server.URL
+
+	got, err := RefreshCredential(context.Background(), server.Client(), CredentialInfo{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		ExpiresAt:    time.Now().Add(-time.Hour).UnixMilli(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sawRequest {
+		t.Fatal("refresh endpoint was not called")
+	}
+	if got.AccessToken != "new-access" || got.RefreshToken != "new-refresh" {
+		t.Fatalf("tokens = %q/%q, want new-access/new-refresh", got.AccessToken, got.RefreshToken)
+	}
+	if got.ExpiresAt <= time.Now().UnixMilli() {
+		t.Fatalf("ExpiresAt = %d, want future", got.ExpiresAt)
 	}
 }
 

--- a/internal/proxy/lifecycle_test.go
+++ b/internal/proxy/lifecycle_test.go
@@ -148,3 +148,51 @@ func TestAdminTokenRequiredForNonLoopbackAdminEndpoint(t *testing.T) {
 		t.Fatalf("status with token = %d, body = %s", recorder.Code, recorder.Body.String())
 	}
 }
+
+func TestPromoteUsableClaudeStatusSkipsErroredActiveProfile(t *testing.T) {
+	statuses := []AccountUsageStatus{
+		{
+			AccountStatus: AccountStatus{
+				ID:        "austin@manaflow.ai",
+				Provider:  accounts.ProviderClaude,
+				AuthValid: false,
+				Error:     "invalid_grant",
+			},
+			Active: true,
+		},
+		{
+			AccountStatus: AccountStatus{
+				ID:        "lawrence@manaflow.ai",
+				Provider:  accounts.ProviderClaude,
+				AuthValid: true,
+			},
+			Windows: []accounts.UsageWindow{
+				{Name: "5h", UsedPercent: 30},
+				{Name: "7d", UsedPercent: 20},
+			},
+		},
+		{
+			AccountStatus: AccountStatus{
+				ID:        "lc+0@cmux.com",
+				Provider:  accounts.ProviderClaude,
+				AuthValid: true,
+			},
+			Windows: []accounts.UsageWindow{
+				{Name: "5h", UsedPercent: 100},
+				{Name: "7d", UsedPercent: 31},
+			},
+		},
+	}
+
+	promoteUsableClaudeStatus(statuses)
+
+	if statuses[0].Active {
+		t.Fatal("errored Claude profile stayed active")
+	}
+	if !statuses[1].Active {
+		t.Fatal("usable Claude profile was not promoted to active")
+	}
+	if statuses[2].Active {
+		t.Fatal("cooked Claude profile was promoted to active")
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -929,7 +929,7 @@ func (s Server) proxyHandler() http.Handler {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 			return
 		}
-		account, err = s.refreshAccount(r.Context(), account)
+		account, err = s.refreshSelectedAccount(r.Context(), agentType, sessionID, userEmail, r, account)
 		if err != nil {
 			http.Error(w, "refresh selected account: "+err.Error(), http.StatusServiceUnavailable)
 			return
@@ -1831,6 +1831,76 @@ func (s Server) refreshAccount(ctx context.Context, account accounts.Account) (a
 		return account, nil
 	}
 	return s.AccountRef.Refresh(ctx, account)
+}
+
+func (s Server) refreshSelectedAccount(ctx context.Context, agentType, sessionID, userEmail string, r *http.Request, account accounts.Account) (accounts.Account, error) {
+	refreshed, err := s.refreshAccount(ctx, account)
+	if err == nil {
+		return refreshed, nil
+	}
+	provider := providerForAgent(agentType)
+	if provider != accounts.ProviderClaude || session.ExtractAccountID(r) != "" {
+		return account, err
+	}
+	if s.Logger != nil {
+		s.Logger.Warn("selected Claude account refresh failed, trying another account", "account", account.ID, "error", err)
+	}
+	tried := map[string]struct{}{account.ID: {}}
+	s.markAccountExhausted(account.ID)
+	lastErr := err
+	for {
+		next, pickErr := s.retryAccount(ctx, provider, agentType, sessionID, userEmail, tried)
+		if pickErr != nil {
+			return account, lastErr
+		}
+		tried[next.ID] = struct{}{}
+		refreshed, err = s.refreshAccount(ctx, next)
+		if err == nil {
+			return refreshed, nil
+		}
+		lastErr = err
+		s.markAccountExhausted(next.ID)
+		if s.Logger != nil {
+			s.Logger.Warn("retry Claude account refresh failed", "account", next.ID, "error", err)
+		}
+	}
+}
+
+func (s Server) retryAccount(ctx context.Context, provider accounts.Provider, agentType, sessionID, userEmail string, tried map[string]struct{}) (accounts.Account, error) {
+	candidates := filterAccountsForProvider(s.accountList(), provider)
+	if len(candidates) == 0 {
+		return accounts.Account{}, fmt.Errorf("no %s accounts available", provider)
+	}
+	untried := make([]accounts.Account, 0, len(candidates))
+	for _, account := range candidates {
+		if _, ok := tried[account.ID]; ok {
+			continue
+		}
+		untried = append(untried, account)
+	}
+	if len(untried) == 0 {
+		return accounts.Account{}, fmt.Errorf("no untried %s accounts available", provider)
+	}
+	if provider == accounts.ProviderCodex {
+		s.refreshUsageScoresIfStale(ctx, candidates)
+	}
+	scheduler := s.scheduler()
+	if s.Sessions != nil {
+		scheduler = scheduler.WithSessionCounts(s.Sessions.CountByAccount())
+	}
+	account, err := scheduler.Pick(untried)
+	if err != nil {
+		return accounts.Account{}, err
+	}
+	if scheduler.Exhausted(account.ID) {
+		return accounts.Account{}, fmt.Errorf("no non-exhausted %s accounts available", provider)
+	}
+	if s.Sessions != nil {
+		if _, err := s.Sessions.Put(agentType, sessionID, account.ID, userEmail); err != nil {
+			return accounts.Account{}, err
+		}
+	}
+	return account, nil
 }
 
 const replayablePostMaxBodyBytes = 128 << 20

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/manaflow-ai/subrouter/internal/accounts"
+	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
 	"github.com/manaflow-ai/subrouter/internal/selectacct"
 	"github.com/manaflow-ai/subrouter/internal/session"
 	"github.com/manaflow-ai/subrouter/internal/transcript"
@@ -140,10 +141,11 @@ func (l *Lifecycle) Status() map[string]any {
 }
 
 type AccountRef struct {
-	mu       sync.RWMutex
-	accounts []accounts.Account
-	store    accounts.CodexStore
-	client   *http.Client
+	mu          sync.RWMutex
+	accounts    []accounts.Account
+	store       accounts.CodexStore
+	claudeStore agentclaude.Store
+	client      *http.Client
 }
 
 type AccountStatus struct {
@@ -168,9 +170,10 @@ type AccountUsageStatus struct {
 
 func NewAccountRef(store accounts.CodexStore, initial []accounts.Account, client *http.Client) *AccountRef {
 	return &AccountRef{
-		accounts: append([]accounts.Account(nil), initial...),
-		store:    store,
-		client:   client,
+		accounts:    append([]accounts.Account(nil), initial...),
+		store:       store,
+		claudeStore: agentclaude.DefaultStore(),
+		client:      client,
 	}
 }
 
@@ -191,6 +194,11 @@ func (r *AccountRef) Reload() ([]accounts.Account, error) {
 	if err != nil {
 		return nil, err
 	}
+	claudeAccounts, err := r.claudeStore.ListAccounts(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	loaded = append(loaded, claudeAccounts...)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.accounts = append([]accounts.Account(nil), loaded...)
@@ -198,7 +206,18 @@ func (r *AccountRef) Reload() ([]accounts.Account, error) {
 }
 
 func (r *AccountRef) Refresh(ctx context.Context, account accounts.Account) (accounts.Account, error) {
-	if r == nil || account.AuthMode != accounts.AuthModeOAuth || (account.Provider != "" && account.Provider != accounts.ProviderCodex) {
+	if r == nil || account.AuthMode != accounts.AuthModeOAuth {
+		return account, nil
+	}
+	if account.Provider == accounts.ProviderClaude {
+		refreshed, _, err := r.claudeStore.RefreshAccountIfExpired(ctx, r.client, account)
+		if err != nil {
+			return account, err
+		}
+		r.replace(refreshed)
+		return refreshed, nil
+	}
+	if account.Provider != "" && account.Provider != accounts.ProviderCodex {
 		return account, nil
 	}
 	if accounts.CodexRefreshReason(ctx) == "" {
@@ -285,6 +304,36 @@ func (r *AccountRef) Statuses(ctx context.Context, forceRefresh bool) []AccountS
 		}
 		out = append(out, status)
 	}
+	for _, profile := range r.claudeStore.ListProfiles() {
+		status := AccountStatus{
+			ID:          profile.Name,
+			Provider:    accounts.ProviderClaude,
+			AuthMode:    accounts.AuthModeOAuth,
+			Email:       claudeProfileEmail(profile.Name),
+			Source:      r.claudeStore.ClaudeConfigDir(profile.Name),
+			AuthChecked: true,
+		}
+		account, didRefresh, err := r.claudeStore.RefreshCredentialIfExpired(ctx, r.client, profile)
+		if err != nil {
+			status.AuthValid = false
+			status.Error = err.Error()
+			out = append(out, status)
+			continue
+		}
+		if forceRefresh {
+			account, didRefresh, err = r.forceRefreshClaude(ctx, profile)
+			if err != nil {
+				status.AuthValid = false
+				status.Error = err.Error()
+				out = append(out, status)
+				continue
+			}
+		}
+		status.AuthValid = true
+		status.Refreshed = didRefresh
+		r.replace(account)
+		out = append(out, status)
+	}
 	return out
 }
 
@@ -360,7 +409,190 @@ func (r *AccountRef) UsageStatuses(ctx context.Context) []AccountUsageStatus {
 		}()
 	}
 	wg.Wait()
+	claudeProfiles := r.claudeStore.ListProfiles()
+	claudeOffset := len(out)
+	out = append(out, make([]AccountUsageStatus, len(claudeProfiles))...)
+	activeClaude := r.claudeStore.ActiveProfile()
+	for i, profile := range claudeProfiles {
+		i, profile := claudeOffset+i, profile
+		status := AccountUsageStatus{
+			AccountStatus: AccountStatus{
+				ID:          profile.Name,
+				Provider:    accounts.ProviderClaude,
+				AuthMode:    accounts.AuthModeOAuth,
+				Email:       claudeProfileEmail(profile.Name),
+				Source:      r.claudeStore.ClaudeConfigDir(profile.Name),
+				AuthChecked: true,
+			},
+			Active: profile.Name == activeClaude,
+		}
+		out[i] = status
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			account, didRefresh, err := r.claudeStore.RefreshCredentialIfExpired(ctx, r.client, profile)
+			next := out[i]
+			next.Refreshed = didRefresh
+			if err != nil {
+				next.AuthValid = false
+				next.Error = err.Error()
+				out[i] = next
+				return
+			}
+			next.AuthValid = true
+			r.replace(account)
+			usage, err := agentclaude.FetchUsage(ctx, r.client, account.Token)
+			if err != nil {
+				next.Error = err.Error()
+				out[i] = next
+				return
+			}
+			next.PlanType = "claude"
+			next.Windows = claudeUsageWindows(usage)
+			out[i] = next
+		}()
+	}
+	wg.Wait()
+	promoteUsableClaudeStatus(out[claudeOffset:])
 	return out
+}
+
+func (r *AccountRef) forceRefreshClaude(ctx context.Context, profile agentclaude.Profile) (accounts.Account, bool, error) {
+	configDir := r.claudeStore.ClaudeConfigDir(profile.Name)
+	credential, err := r.claudeStore.ReadCredential(ctx, configDir)
+	if err != nil {
+		return accounts.Account{}, false, err
+	}
+	if credential == nil || credential.RefreshToken == "" {
+		return accounts.Account{}, false, fmt.Errorf("Claude profile %q has no refresh token", profile.Name)
+	}
+	refreshed, err := agentclaude.RefreshCredential(ctx, r.client, *credential)
+	if err != nil {
+		return accounts.Account{}, false, err
+	}
+	if err := r.claudeStore.WriteCredential(ctx, configDir, refreshed); err != nil {
+		return accounts.Account{}, false, err
+	}
+	return claudeAccountFromCredential(profile, configDir, &refreshed), true, nil
+}
+
+func claudeAccountFromCredential(profile agentclaude.Profile, configDir string, credential *agentclaude.CredentialInfo) accounts.Account {
+	addedAt, _ := time.Parse(time.RFC3339, profile.CreatedAt)
+	return accounts.Account{
+		ID:       profile.Name,
+		Provider: accounts.ProviderClaude,
+		AuthMode: accounts.AuthModeOAuth,
+		Label:    profile.Name,
+		Email:    claudeProfileEmail(profile.Name),
+		AddedAt:  addedAt,
+		Token:    credential.AccessToken,
+		Source:   configDir,
+	}
+}
+
+func claudeProfileEmail(name string) string {
+	if strings.Contains(name, "@") {
+		return name
+	}
+	return ""
+}
+
+func claudeUsageWindows(usage *agentclaude.UsageResponse) []accounts.UsageWindow {
+	if usage == nil {
+		return nil
+	}
+	var windows []accounts.UsageWindow
+	add := func(name string, limit *agentclaude.RateLimit) {
+		if limit == nil || limit.Utilization == nil {
+			return
+		}
+		window := accounts.UsageWindow{
+			Name:        name,
+			UsedPercent: *limit.Utilization,
+		}
+		if reset, err := time.Parse(time.RFC3339, limit.ResetsAt); err == nil {
+			seconds := int64(time.Until(reset).Seconds())
+			if seconds < 0 {
+				seconds = 0
+			}
+			window.ResetAfterSeconds = seconds
+		}
+		windows = append(windows, window)
+	}
+	add("5h", usage.FiveHour)
+	add("7d", usage.SevenDay)
+	add("opus-weekly", usage.SevenDayOpus)
+	add("sonnet-weekly", usage.SevenDaySonnet)
+	if usage.ExtraUsage != nil && usage.ExtraUsage.IsEnabled && usage.ExtraUsage.Utilization != nil {
+		windows = append(windows, accounts.UsageWindow{Name: "extra", UsedPercent: *usage.ExtraUsage.Utilization})
+	}
+	return windows
+}
+
+func promoteUsableClaudeStatus(statuses []AccountUsageStatus) {
+	activeUsable := false
+	bestIdx := -1
+	var best selectacct.Score
+	for i := range statuses {
+		status := &statuses[i]
+		if status.Provider != accounts.ProviderClaude {
+			continue
+		}
+		usable := false
+		if status.AuthValid && status.Error == "" {
+			score := scoreFromUsageWindows(status.ID, status.Windows)
+			usable = scoreUsableForNewSession(score)
+			if usable && (bestIdx == -1 || betterClaudeActiveCandidate(score, best)) {
+				bestIdx = i
+				best = score
+			}
+		}
+		if status.Active && usable {
+			activeUsable = true
+		}
+	}
+	if activeUsable {
+		return
+	}
+	for i := range statuses {
+		if statuses[i].Provider == accounts.ProviderClaude {
+			statuses[i].Active = false
+		}
+	}
+	if bestIdx >= 0 {
+		statuses[bestIdx].Active = true
+	}
+}
+
+func betterClaudeActiveCandidate(left, right selectacct.Score) bool {
+	if left.Headroom != right.Headroom {
+		return left.Headroom > right.Headroom
+	}
+	if left.ShortHeadroom != right.ShortHeadroom {
+		return left.ShortHeadroom > right.ShortHeadroom
+	}
+	if left.ShortResetAfterSeconds != right.ShortResetAfterSeconds {
+		return left.ShortResetAfterSeconds > right.ShortResetAfterSeconds
+	}
+	return left.AccountID < right.AccountID
+}
+
+func scoreUsableForNewSession(score selectacct.Score) bool {
+	return score.Headroom >= selectacct.MinNewSessionHeadroom && score.ShortHeadroom >= selectacct.MinNewSessionHeadroom
+}
+
+func scoreFromUsageWindows(accountID string, windows []accounts.UsageWindow) selectacct.Score {
+	limitWindows := make([]selectacct.LimitWindow, 0, len(windows))
+	for _, window := range windows {
+		limitWindows = append(limitWindows, selectacct.LimitWindow{
+			Name:               window.Name,
+			UsedPercent:        window.UsedPercent,
+			LimitWindowSeconds: window.LimitWindowSeconds,
+			ResetAfterSeconds:  window.ResetAfterSeconds,
+			Feature:            window.Feature,
+		})
+	}
+	return selectacct.ScoreFromLimitWindows(accountID, 0, limitWindows)
 }
 
 func (r *AccountRef) replace(account accounts.Account) {
@@ -599,7 +831,7 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 			setZeroScore(scores, scoreByID, account.ID)
 			continue
 		}
-		windows, err := accounts.FetchCodexUsage(ctx, client, refreshed)
+		windows, err := s.fetchAccountUsageWindows(ctx, client, refreshed)
 		if err != nil {
 			if s.Logger != nil {
 				s.Logger.Warn("account reload usage fetch failed", "account", account.ID, "error", err)
@@ -607,22 +839,23 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 			setZeroScore(scores, scoreByID, account.ID)
 			continue
 		}
-		limitWindows := make([]selectacct.LimitWindow, 0, len(windows))
-		for _, window := range windows {
-			limitWindows = append(limitWindows, selectacct.LimitWindow{
-				Name:               window.Name,
-				UsedPercent:        window.UsedPercent,
-				LimitWindowSeconds: window.LimitWindowSeconds,
-				ResetAfterSeconds:  window.ResetAfterSeconds,
-				Feature:            window.Feature,
-			})
-		}
 		if idx, ok := scoreByID[account.ID]; ok {
-			scores[idx] = selectacct.ScoreFromLimitWindows(account.ID, 0, limitWindows)
+			scores[idx] = scoreFromUsageWindows(account.ID, windows)
 			scored++
 		}
 	}
 	return scores, scored
+}
+
+func (s Server) fetchAccountUsageWindows(ctx context.Context, client *http.Client, account accounts.Account) ([]accounts.UsageWindow, error) {
+	if account.Provider == accounts.ProviderClaude {
+		usage, err := agentclaude.FetchUsage(ctx, client, account.Token)
+		if err != nil {
+			return nil, err
+		}
+		return claudeUsageWindows(usage), nil
+	}
+	return accounts.FetchCodexUsage(ctx, client, account)
 }
 
 const defaultUsageFetchTimeout = 10 * time.Second
@@ -1594,7 +1827,7 @@ func (s Server) accountList() []accounts.Account {
 }
 
 func (s Server) refreshAccount(ctx context.Context, account accounts.Account) (accounts.Account, error) {
-	if s.AccountRef == nil || (account.Provider != "" && account.Provider != accounts.ProviderCodex) {
+	if s.AccountRef == nil {
 		return account, nil
 	}
 	return s.AccountRef.Refresh(ctx, account)

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/manaflow-ai/subrouter/internal/accounts"
+	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
 	"github.com/manaflow-ai/subrouter/internal/selectacct"
 	"github.com/manaflow-ai/subrouter/internal/session"
 	"github.com/manaflow-ai/subrouter/internal/transcript"
@@ -391,6 +392,103 @@ func TestHandlerKeepsClaudeConversationOnSameAccount(t *testing.T) {
 	}
 	if third != "Bearer claude-b-token" {
 		t.Fatalf("new Claude session Authorization = %q, want claude-b", third)
+	}
+}
+
+func TestHandlerReroutesClaudeWhenStickyAccountRefreshFails(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer good-token" {
+			t.Fatalf("Authorization = %q, want good token", got)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+	claudeUpstream, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claudeStore := agentclaude.Store{Dir: t.TempDir()}
+	badDir, err := claudeStore.CreateProfile("bad-profile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	goodDir, err := claudeStore.CreateProfile("good-profile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeClaudeCredential(t, badDir, agentclaude.CredentialInfo{
+		AccessToken:  "bad-token",
+		RefreshToken: "bad-refresh",
+		ExpiresAt:    time.Now().Add(-time.Hour).UnixMilli(),
+	})
+	writeClaudeCredential(t, goodDir, agentclaude.CredentialInfo{
+		AccessToken:  "good-token",
+		RefreshToken: "good-refresh",
+		ExpiresAt:    time.Now().Add(time.Hour).UnixMilli(),
+	})
+
+	refreshClient := &http.Client{Transport: proxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Status:     "400 Bad Request",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"error":"invalid_grant","error_description":"Refresh token not found or invalid"}`)),
+			Request:    req,
+		}, nil
+	})}
+	accountRef := NewAccountRef(accounts.CodexStore{Dir: t.TempDir()}, nil, refreshClient)
+	accountRef.claudeStore = claudeStore
+	loaded, err := claudeStore.ListAccounts(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	accountRef.accounts = loaded
+
+	sessionStore, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sessionStore.Put("claude", "claude-session", "bad-profile", ""); err != nil {
+		t.Fatal(err)
+	}
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+		{AccountID: "bad-profile", Headroom: 0.9, ShortHeadroom: 0.9},
+		{AccountID: "good-profile", Headroom: 0.8, ShortHeadroom: 0.8},
+	}))
+	handler := Server{
+		ClaudeUpstream: claudeUpstream,
+		AccountRef:     accountRef,
+		Sessions:       sessionStore,
+		SchedulerRef:   schedulerRef,
+		MaxBodyBytes:   1024,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	req, err := http.NewRequest(http.MethodPost, subrouter.URL+"/v1/messages", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Subrouter-Agent", "claude")
+	req.Header.Set("X-Claude-Code-Session-Id", "claude-session")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if _, err := io.Copy(io.Discard, response.Body); err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", response.StatusCode)
+	}
+	assignment, ok := sessionStore.Get("claude", "claude-session")
+	if !ok {
+		t.Fatal("missing Claude session assignment")
+	}
+	if assignment.AccountID != "good-profile" {
+		t.Fatalf("sticky AccountID = %q, want good-profile", assignment.AccountID)
 	}
 }
 
@@ -1241,6 +1339,17 @@ type proxyRoundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f proxyRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+func writeClaudeCredential(t *testing.T, dir string, credential agentclaude.CredentialInfo) {
+	t.Helper()
+	body, err := json.Marshal(map[string]agentclaude.CredentialInfo{"claudeAiOauth": credential})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func proxyStoredOAuthAccount(email, tokenPrefix string, exp time.Time) accounts.StoredCodexAccount {


### PR DESCRIPTION
Stacked on feat-claude-pooling (includes its 4 commits) plus one new commit.

**New in this PR:** error footnotes under the usage grids now say which provider the broken account belongs to and print the exact re-add command for auth-shaped errors:

```
austin+1@cmux.com [codex]: usage fetch failed: 401 Unauthorized (re-add with: sr add)
austin@manaflow.ai [claude]: Claude OAuth refresh failed: 400 Bad Request: invalid_grant (re-add with: sr claude add)
```

Transient errors (network, 5xx) keep the provider label but get no re-add hint. Covered by TestUsageErrorFootnoteShowsProviderAndReaddCommand.

**From feat-claude-pooling:** Claude pooling status in sr, Claude flag forwarding, Claude-specific usage labels, and rerouting Claude sessions when the selected account's OAuth refresh fails (the fix for pooled sessions getting stuck on a dead account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783643897&installation_id=133855650&pr_number=4&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F4&signature=499b288d8035ece81fb8a5e4641c2efe53fd78136bd8e978382af530a7496439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Claude profiles to `sr status` with provider-grouped grids and provider-labeled error footnotes that include a re-add command for auth errors. Also reroutes Claude sessions when the selected profile’s refresh fails.

- **New Features**
  - `sr status` shows Codex and Claude usage side-by-side, grouped by provider with provider-specific columns (Codex: 5h/7d/Spark; Claude: Session/Weekly/Opus wk/Sonnet wk/Extra). Errors now include the provider label and a re-add hint for auth-shaped failures, e.g., “(re-add with: sr add)” or “(re-add with: sr claude add)”.
  - Claude profiles are fully integrated: OAuth refresh on expiry, usage fetched via `internal/agents/claude`, and windows mapped to Session/Weekly tiers. Sorting and recommendations are provider-aware (recommendations remain Codex-only).
  - `sr claude --flags ...` forwards flags to Claude using the active profile.
  - Server and proxy include Claude in account/usage statuses, promote a usable Claude profile if the active one errors, and pool/reroute Claude sessions when the selected profile’s refresh fails.

- **Bug Fixes**
  - Fix pooled Claude sessions getting stuck on a dead profile by retrying with another Claude account.
  - Server SSH upload during `sr add` now retries transient failures (3 attempts with backoff) and clarifies token ownership in messages (“Uploaded X to server Y. Your local Codex login is back... The new X refresh token is stored on Y.”).
  - Usage view is always a compact grid with adaptive columns for narrow terminals; help text updated to reflect Codex and Claude support.

<sup>Written for commit f670233d368d21838cdbd7cf568de0cdb4a39820. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude profile support alongside Codex accounts in account management
  * Usage display now groups and shows both Codex and Claude accounts by provider
  * New `sr claude` command with flag support for launching Claude

* **Improvements**
  * Server account uploads now retry on transient failures
  * Updated login messaging to clarify token storage location on server

<!-- end of auto-generated comment: release notes by coderabbit.ai -->