### PR TITLE
Fail Claude sessions over to accounts with quota

### DIFF
--- a/internal/proxy/claude_failover_test.go
+++ b/internal/proxy/claude_failover_test.go
@@ -1,0 +1,201 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/internal/selectacct"
+	"github.com/manaflow-ai/subrouter/internal/session"
+)
+
+func TestRetryableUpstreamPostRequestClaudeMessages(t *testing.T) {
+	post := func(path string) *http.Request {
+		req, err := http.NewRequest(http.MethodPost, "http://example.com"+path, strings.NewReader("{}"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return req
+	}
+	if !retryableUpstreamPostRequest(accounts.ProviderClaude, post("/v1/messages")) {
+		t.Fatal("claude POST /v1/messages should be retryable")
+	}
+	if !retryableUpstreamPostRequest(accounts.ProviderClaude, post("/messages")) {
+		t.Fatal("claude POST /messages should be retryable")
+	}
+	if retryableUpstreamPostRequest(accounts.ProviderClaude, post("/v1/messages/count_tokens")) {
+		t.Fatal("count_tokens should not be retryable")
+	}
+	if !retryableUpstreamPostRequest(accounts.ProviderCodex, post("/v1/responses")) {
+		t.Fatal("codex POST /v1/responses should stay retryable")
+	}
+	if retryableUpstreamPostRequest(accounts.ProviderCodex, post("/v1/messages")) {
+		t.Fatal("codex POST /v1/messages should not be retryable")
+	}
+}
+
+type stubRoundTripper struct {
+	calls     int
+	responses func(req *http.Request) *http.Response
+}
+
+func (s *stubRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.calls++
+	return s.responses(req), nil
+}
+
+func claudeFailoverServer(t *testing.T) (Server, *session.Store) {
+	t.Helper()
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: "cooked@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-cooked"},
+			{ID: "fresh@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-fresh"},
+		},
+		Sessions:     store,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler(nil)),
+		ScoreAccounts: func(ctx context.Context, available []accounts.Account) ([]selectacct.Score, int) {
+			scores := make([]selectacct.Score, 0, len(available))
+			for _, account := range available {
+				headroom := 1.0
+				if account.ID == "cooked@example.com" {
+					headroom = 0
+				}
+				scores = append(scores, selectacct.Score{AccountID: account.ID, Headroom: headroom, ShortHeadroom: headroom})
+			}
+			return scores, len(scores)
+		},
+	}
+	return server, store
+}
+
+func TestUsageLimitRetryTransportClaudeFailsOverOn429(t *testing.T) {
+	server, store := claudeFailoverServer(t)
+	if _, err := store.Put("claude", "session-1", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		auth := req.Header.Get("Authorization")
+		if strings.Contains(auth, "tok-cooked") {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"You've hit your session limit"}}`)),
+				Header:     http.Header{},
+			}
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":"msg_1"}`)),
+			Header:     http.Header{},
+		}
+	}}
+	transport := usageLimitRetryTransport{
+		base:        stub,
+		server:      &server,
+		provider:    accounts.ProviderClaude,
+		agent:       "claude",
+		session:     "session-1",
+		account:     "cooked@example.com",
+		method:      http.MethodPost,
+		path:        "/v1/messages",
+		maxAttempts: 3,
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader([]byte(`{"model":"claude-opus-4-8"}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after failover", response.StatusCode)
+	}
+	if stub.calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2 (429 then retry)", stub.calls)
+	}
+	if !server.SchedulerRef.Get().Exhausted("cooked@example.com") {
+		t.Fatal("429 should mark the cooked account exhausted")
+	}
+	assignment, ok := store.Get("claude", "session-1")
+	if !ok || assignment.AccountID != "fresh@example.com" {
+		t.Fatalf("sticky assignment = %+v, want moved to fresh@example.com", assignment)
+	}
+}
+
+func TestReuseStickyAssignmentClaudeExhausted(t *testing.T) {
+	server, _ := claudeFailoverServer(t)
+	cooked := accounts.Account{ID: "cooked@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth}
+	scheduler := selectacct.NewScheduler([]selectacct.Score{
+		{AccountID: "cooked@example.com", Headroom: 0, ShortHeadroom: 0},
+		{AccountID: "fresh@example.com", Headroom: 1, ShortHeadroom: 1},
+	})
+	if server.reuseStickyAssignment("claude", "session-1", cooked, scheduler) {
+		t.Fatal("exhausted claude account should not keep its sticky session")
+	}
+	fresh := accounts.Account{ID: "fresh@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth}
+	if !server.reuseStickyAssignment("claude", "session-1", fresh, scheduler) {
+		t.Fatal("healthy claude account should keep its sticky session")
+	}
+}
+
+func TestCaptureResponseBodyClaude429MarksExhausted(t *testing.T) {
+	server, _ := claudeFailoverServer(t)
+	response := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error"}}`)),
+		Header:     http.Header{},
+	}
+	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "/v1/messages")
+	if !server.SchedulerRef.Get().Exhausted("cooked@example.com") {
+		t.Fatal("claude 429 should mark the account exhausted via passive inspection")
+	}
+}
+
+func TestRefreshUsageScoresCoversAllProviders(t *testing.T) {
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var captured []accounts.Account
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: "codex@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth},
+			{ID: "claude@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth},
+			{ID: "apikey", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeAPIKey},
+		},
+		Sessions:      store,
+		SchedulerRef:  selectacct.NewSchedulerRef(selectacct.NewScheduler(nil)),
+		UsageScoreTTL: time.Minute,
+		ScoreAccounts: func(ctx context.Context, available []accounts.Account) ([]selectacct.Score, int) {
+			captured = available
+			return []selectacct.Score{{AccountID: "claude@example.com", Headroom: 0, ShortHeadroom: 0}}, 1
+		},
+	}
+	server.SchedulerRef.SetUpdatedAt(time.Now().Add(-time.Hour))
+	server.refreshUsageScoresIfStale(context.Background())
+	ids := make(map[string]bool, len(captured))
+	for _, account := range captured {
+		ids[account.ID] = true
+	}
+	if !ids["codex@example.com"] || !ids["claude@example.com"] {
+		t.Fatalf("refresh scored %v, want both codex and claude OAuth accounts", ids)
+	}
+	if ids["apikey"] {
+		t.Fatal("API-key accounts should not be usage-scored")
+	}
+	if !server.SchedulerRef.Get().Exhausted("claude@example.com") {
+		t.Fatal("claude usage scores should make Exhausted() real")
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -963,7 +963,8 @@ func (s Server) proxyHandler() http.Handler {
 		proxyRequest.URL.Path = s.pathForUpstream(proxyRequest.URL.Path, account)
 		proxyRequest.URL.RawPath = ""
 		session.StripSubrouterHeaders(proxyRequest.Header)
-		retryPost := retryableResponsesPostRequest(proxyRequest)
+		requestProvider := providerForAgent(agentType)
+		retryPost := retryableUpstreamPostRequest(requestProvider, proxyRequest)
 		postReplayable := false
 		if retryPost {
 			var replayErr error
@@ -985,11 +986,14 @@ func (s Server) proxyHandler() http.Handler {
 
 		rp := httputil.NewSingleHostReverseProxy(upstream)
 		transport := s.transport()
-		if retryPost && postReplayable && providerForAgent(agentType) == accounts.ProviderCodex && account.AuthMode == accounts.AuthModeOAuth {
+		if retryPost && postReplayable &&
+			(requestProvider == accounts.ProviderCodex || requestProvider == accounts.ProviderClaude) &&
+			account.AuthMode == accounts.AuthModeOAuth {
 			transport = usageLimitRetryTransport{
 				base:        transport,
 				server:      &s,
 				logger:      s.Logger,
+				provider:    requestProvider,
 				agent:       agentType,
 				session:     sessionID,
 				userEmail:   userEmail,
@@ -1021,7 +1025,7 @@ func (s Server) proxyHandler() http.Handler {
 			r.Host = upstream.Host
 		}
 		rp.ModifyResponse = func(response *http.Response) error {
-			s.captureResponseBody(response, agentType, sessionID, account.ID, proxyRequest.URL.Path)
+			s.captureResponseBody(response, agentType, sessionID, account.ID, account.Provider, proxyRequest.URL.Path)
 			return nil
 		}
 		if s.Logger != nil {
@@ -1318,7 +1322,12 @@ func (s Server) recordReplayableRequestBody(r *http.Request, agentType, sessionI
 	s.Transcripts.RecordPayloadSummary(agentType, sessionID, "http_body", "client_to_upstream", streamID, bytesRead, hex.EncodeToString(hasher.Sum(nil)), chunks, nil)
 }
 
-func (s Server) captureResponseBody(response *http.Response, agentType, sessionID, accountID, path string) {
+func (s Server) captureResponseBody(response *http.Response, agentType, sessionID, accountID string, provider accounts.Provider, path string) {
+	// Anthropic signals subscription exhaustion with a plain 429, with no
+	// codex-style usage-limit body to inspect.
+	if provider == accounts.ProviderClaude && accountID != "" && response.StatusCode == http.StatusTooManyRequests {
+		s.markAccountExhausted(accountID)
+	}
 	inspectUsageLimit := s.SchedulerRef != nil && accountID != "" && responseStatusCanExhaust(response.StatusCode)
 	if response.Body == nil || (s.Transcripts == nil && s.Logger == nil && !inspectUsageLimit) {
 		return
@@ -1627,8 +1636,8 @@ func (s Server) accountForSession(agentType, sessionID string, r *http.Request) 
 	if provider == accounts.ProviderCodex && chatGPTBackendPath(r.URL.Path) {
 		availableAccounts = oauthAccounts(availableAccounts)
 	}
-	if provider == accounts.ProviderCodex {
-		s.refreshUsageScoresIfStale(r.Context(), availableAccounts)
+	if provider == accounts.ProviderCodex || provider == accounts.ProviderClaude {
+		s.refreshUsageScoresIfStale(r.Context())
 	}
 	base := s.scheduler()
 	if model != "" && s.Logger != nil && base.HasModelPool(model) {
@@ -1750,10 +1759,16 @@ func codexResponsePath(path string) bool {
 	}
 }
 
-func (s Server) refreshUsageScoresIfStale(ctx context.Context, availableAccounts []accounts.Account) {
+// refreshUsageScoresIfStale rebuilds the scheduler from every OAuth account's
+// usage, across all providers. Scoring the full list (not just the requesting
+// provider's accounts) matters because FinishRefresh replaces the scheduler
+// wholesale: a codex-triggered refresh must not wipe claude scores or vice
+// versa.
+func (s Server) refreshUsageScoresIfStale(ctx context.Context) {
 	if s.SchedulerRef == nil || !s.SchedulerRef.BeginRefreshIfStale(s.UsageScoreTTL) {
 		return
 	}
+	availableAccounts := oauthAccounts(s.accountList())
 	scoreAccounts := s.ScoreAccounts
 	if scoreAccounts == nil {
 		scoreAccounts = s.scoreAccounts
@@ -1881,8 +1896,8 @@ func (s Server) retryAccount(ctx context.Context, provider accounts.Provider, ag
 	if len(untried) == 0 {
 		return accounts.Account{}, fmt.Errorf("no untried %s accounts available", provider)
 	}
-	if provider == accounts.ProviderCodex {
-		s.refreshUsageScoresIfStale(ctx, candidates)
+	if provider == accounts.ProviderCodex || provider == accounts.ProviderClaude {
+		s.refreshUsageScoresIfStale(ctx)
 	}
 	scheduler := s.scheduler()
 	if s.Sessions != nil {
@@ -1918,6 +1933,17 @@ func retryableResponsesPostRequest(r *http.Request) bool {
 		path == "/v1/responses" ||
 		path == "/responses/compact" ||
 		path == "/v1/responses/compact"
+}
+
+func retryableUpstreamPostRequest(provider accounts.Provider, r *http.Request) bool {
+	if provider == accounts.ProviderClaude {
+		if r == nil || r.Method != http.MethodPost {
+			return false
+		}
+		path := r.URL.Path
+		return path == "/v1/messages" || path == "/messages"
+	}
+	return retryableResponsesPostRequest(r)
 }
 
 func makeRequestBodyReplayable(r *http.Request, maxBytes int64) (bool, error) {
@@ -1968,6 +1994,7 @@ type usageLimitRetryTransport struct {
 	base        http.RoundTripper
 	server      *Server
 	logger      *slog.Logger
+	provider    accounts.Provider
 	agent       string
 	session     string
 	userEmail   string
@@ -1976,6 +2003,17 @@ type usageLimitRetryTransport struct {
 	path        string
 	upstream    string
 	maxAttempts int
+}
+
+// responseUsageLimited reports whether the upstream response means the current
+// account is out of quota. Anthropic signals subscription exhaustion with a
+// plain 429 (no codex-style "usage_limit_reached" body), so claude is detected
+// by status alone.
+func (t usageLimitRetryTransport) responseUsageLimited(response *http.Response) (bool, error) {
+	if t.provider == accounts.ProviderClaude {
+		return response != nil && response.StatusCode == http.StatusTooManyRequests, nil
+	}
+	return responseUsageLimit(response)
 }
 
 func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -1998,7 +2036,7 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 		if err != nil || req.GetBody == nil || req.Context().Err() != nil {
 			return response, err
 		}
-		usageLimited, inspectErr := responseUsageLimit(response)
+		usageLimited, inspectErr := t.responseUsageLimited(response)
 		if inspectErr != nil {
 			if t.logger != nil {
 				t.logger.Warn("usage-limit response inspection failed", "agent", t.agent, "session", t.session, "account", accountID, "method", t.method, "path", t.path, "upstream", t.upstream, "error", inspectErr)
@@ -2014,7 +2052,7 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 		if attempt == maxAttempts || t.server == nil {
 			return response, nil
 		}
-		nextAccount, pickErr := t.server.codexOAuthRetryAccount(req.Context(), t.agent, t.session, t.userEmail, tried)
+		nextAccount, pickErr := t.server.oauthRetryAccount(req.Context(), t.provider, t.agent, t.session, t.userEmail, tried)
 		if pickErr != nil {
 			if t.logger != nil {
 				t.logger.Warn("usage-limit retry has no alternate account", "agent", t.agent, "session", t.session, "account", accountID, "method", t.method, "path", t.path, "upstream", t.upstream, "error", pickErr)
@@ -2046,10 +2084,10 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 	return base.RoundTrip(req)
 }
 
-func (s Server) codexOAuthRetryAccount(ctx context.Context, agentType, sessionID, userEmail string, tried map[string]struct{}) (accounts.Account, error) {
-	allCandidates := oauthAccounts(filterAccountsForProvider(s.accountList(), accounts.ProviderCodex))
+func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provider, agentType, sessionID, userEmail string, tried map[string]struct{}) (accounts.Account, error) {
+	allCandidates := oauthAccounts(filterAccountsForProvider(s.accountList(), provider))
 	if len(allCandidates) == 0 {
-		return accounts.Account{}, fmt.Errorf("no OAuth Codex accounts available")
+		return accounts.Account{}, fmt.Errorf("no OAuth %s accounts available", provider)
 	}
 	candidates := make([]accounts.Account, 0, len(allCandidates))
 	for _, account := range allCandidates {
@@ -2059,9 +2097,9 @@ func (s Server) codexOAuthRetryAccount(ctx context.Context, agentType, sessionID
 		candidates = append(candidates, account)
 	}
 	if len(candidates) == 0 {
-		return accounts.Account{}, fmt.Errorf("no untried OAuth Codex accounts available")
+		return accounts.Account{}, fmt.Errorf("no untried OAuth %s accounts available", provider)
 	}
-	s.refreshUsageScoresIfStale(ctx, allCandidates)
+	s.refreshUsageScoresIfStale(ctx)
 	scheduler := s.scheduler()
 	if s.Sessions != nil {
 		scheduler = scheduler.WithSessionCounts(s.Sessions.CountByAccount())
@@ -2071,10 +2109,10 @@ func (s Server) codexOAuthRetryAccount(ctx context.Context, agentType, sessionID
 		return accounts.Account{}, err
 	}
 	if scheduler.Exhausted(account.ID) {
-		return accounts.Account{}, fmt.Errorf("no non-exhausted OAuth Codex accounts available")
+		return accounts.Account{}, fmt.Errorf("no non-exhausted OAuth %s accounts available", provider)
 	}
 	if !scheduler.UsableForNewSession(account.ID) && s.Logger != nil {
-		s.Logger.Warn("usage-limit retry selected OAuth Codex account below new-session headroom threshold", "account", account.ID, "threshold", selectacct.MinNewSessionHeadroom)
+		s.Logger.Warn("usage-limit retry selected OAuth account below new-session headroom threshold", "provider", provider, "account", account.ID, "threshold", selectacct.MinNewSessionHeadroom)
 	}
 	refreshed, err := s.refreshAccount(ctx, account)
 	if err != nil {


### PR DESCRIPTION
Starting or resuming a Claude session on an account that hit its subscription limit ("You've hit your session limit") previously 429'd forever. Three gaps, all fixed:

1. **Proactive**: the scheduler only ever scored Codex accounts, so `Exhausted()` was permanently false for Claude. Now `refreshUsageScoresIfStale` scores every OAuth account across providers (the full list, since `FinishRefresh` replaces the scheduler wholesale) and runs for Claude selections too. New sessions avoid cooked accounts; sticky sessions on cooked accounts reroute.
2. **Reactive**: Claude `POST /v1/messages` is now wrapped in `usageLimitRetryTransport`. Anthropic signals exhaustion with a plain 429 (no codex-style body), so for Claude the status alone marks the account exhausted, the request replays on the next healthy account, and the sticky assignment moves with it. The client sees a 200, not the 429.
3. **Passive**: non-replayable Claude requests that 429 mark the account exhausted so the session's next request reroutes.

Covered by 5 new tests in `internal/proxy/claude_failover_test.go`, including the end-to-end transport failover (429 → mark exhausted → retry on alternate → sticky moved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783655729&installation_id=133855650&pr_number=5&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F5&signature=e03a825689b30b8890bddd41a78307be01abbcff98b13d6a42820be1f18deb0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Claude sessions now fail over to another OAuth account with quota instead of returning 429s, so requests keep working and sticky sessions move to healthy accounts. This prevents sessions from getting stuck when an account hits its subscription limit.

- **Bug Fixes**
  - Score usage for all OAuth accounts across providers during refresh, and trigger it for Claude selections.
  - Retry Claude POST /v1/messages on 429: mark the account exhausted, pick the next healthy account, and move the sticky assignment.
  - Mark Claude accounts exhausted on plain 429 during response capture so non-replayable requests reroute on the next call.
  - Added tests covering retryability, failover, sticky reuse, and cross-provider scoring.

<sup>Written for commit 214da96df495c759aa16d97925bd3e69ecf6a192. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for account failover behavior and usage-limit detection.

* **Refactor**
  * Improved proxy resilience by generalizing failover logic to consistently handle usage limits and account exhaustion across multiple providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->