### PR TITLE
sr claude: migrate resumed sessions across profiles

### DIFF
--- a/cmd/subrouter/sr_claude.go
+++ b/cmd/subrouter/sr_claude.go
@@ -323,6 +323,14 @@ func (r claudeRunner) runClaude(ctx context.Context, name string, extra []string
 	if err := r.store.SetActiveProfile(profile.Name); err != nil {
 		return err
 	}
+	if sessionID := claude.ResumeSessionID(extra); sessionID != "" {
+		from, migrateErr := r.store.MigrateSession(profile.Name, sessionID)
+		if migrateErr != nil {
+			fmt.Fprintf(r.errOut, "warning: could not migrate session %s: %v\n", sessionID, migrateErr)
+		} else if from != "" {
+			fmt.Fprintf(r.errOut, "Copied session %s from profile %q.\n", sessionID, from)
+		}
+	}
 	cmd := exec.CommandContext(ctx, claudePath, extra...)
 	cmd.Stdin = r.in
 	cmd.Stdout = r.out

--- a/internal/agents/claude/migrate.go
+++ b/internal/agents/claude/migrate.go
@@ -1,0 +1,136 @@
+package claude
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var sessionIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// ResumeSessionID extracts the session UUID from Claude CLI args when they
+// request a resume (`--resume <id>`, `-r <id>`, or `--resume=<id>`). Returns
+// "" when the args do not name a concrete session.
+func ResumeSessionID(args []string) string {
+	for i, arg := range args {
+		if arg == "--resume" || arg == "-r" {
+			if i+1 < len(args) && sessionIDPattern.MatchString(args[i+1]) {
+				return args[i+1]
+			}
+			continue
+		}
+		for _, prefix := range []string{"--resume=", "-r="} {
+			if strings.HasPrefix(arg, prefix) {
+				candidate := strings.TrimPrefix(arg, prefix)
+				if sessionIDPattern.MatchString(candidate) {
+					return candidate
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// MigrateSession copies a conversation (transcript, topic dir, file history,
+// session env) into the target profile's config dir when another profile owns
+// it. Claude Code stores conversations per CLAUDE_CONFIG_DIR, so resuming a
+// session started under a different profile fails with "No conversation found"
+// unless the files move with it. Returns the source profile name when a copy
+// happened, "" when the target already had the session or nobody has it.
+func (s Store) MigrateSession(targetProfile, sessionID string) (string, error) {
+	if !sessionIDPattern.MatchString(sessionID) {
+		return "", fmt.Errorf("invalid session id %q", sessionID)
+	}
+	targetDir := s.ClaudeConfigDir(targetProfile)
+	if len(sessionTranscripts(targetDir, sessionID)) > 0 {
+		return "", nil
+	}
+	for _, profile := range s.ListProfiles() {
+		if profile.Name == targetProfile {
+			continue
+		}
+		sourceDir := s.ClaudeConfigDir(profile.Name)
+		transcripts := sessionTranscripts(sourceDir, sessionID)
+		if len(transcripts) == 0 {
+			continue
+		}
+		for _, transcript := range transcripts {
+			projectDir := filepath.Base(filepath.Dir(transcript))
+			destProject := filepath.Join(targetDir, "projects", projectDir)
+			if err := os.MkdirAll(destProject, 0o700); err != nil {
+				return "", err
+			}
+			if err := copyPath(transcript, filepath.Join(destProject, filepath.Base(transcript))); err != nil {
+				return "", err
+			}
+			// Topic/metadata dir sharing the session id, when present.
+			topicDir := strings.TrimSuffix(transcript, ".jsonl")
+			if info, err := os.Stat(topicDir); err == nil && info.IsDir() {
+				if err := copyPath(topicDir, filepath.Join(destProject, sessionID)); err != nil {
+					return "", err
+				}
+			}
+		}
+		for _, sub := range []string{"file-history", "session-env"} {
+			source := filepath.Join(sourceDir, sub, sessionID)
+			if _, err := os.Stat(source); err != nil {
+				continue
+			}
+			if err := os.MkdirAll(filepath.Join(targetDir, sub), 0o700); err != nil {
+				return "", err
+			}
+			if err := copyPath(source, filepath.Join(targetDir, sub, sessionID)); err != nil {
+				return "", err
+			}
+		}
+		return profile.Name, nil
+	}
+	return "", nil
+}
+
+func sessionTranscripts(configDir, sessionID string) []string {
+	matches, err := filepath.Glob(filepath.Join(configDir, "projects", "*", sessionID+".jsonl"))
+	if err != nil {
+		return nil
+	}
+	return matches
+}
+
+func copyPath(source, dest string) error {
+	info, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		entries, err := os.ReadDir(source)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(dest, 0o700); err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			if err := copyPath(filepath.Join(source, entry.Name()), filepath.Join(dest, entry.Name())); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	in, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/internal/agents/claude/migrate_test.go
+++ b/internal/agents/claude/migrate_test.go
@@ -1,0 +1,109 @@
+package claude
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResumeSessionID(t *testing.T) {
+	id := "6452edd8-ba4e-4ba7-b585-4f10d03b1bb4"
+	cases := []struct {
+		args []string
+		want string
+	}{
+		{[]string{"--resume", id}, id},
+		{[]string{"--dangerously-skip-permissions", "--chrome", "--resume", id}, id},
+		{[]string{"-r", id}, id},
+		{[]string{"--resume=" + id}, id},
+		{[]string{"--resume"}, ""},
+		{[]string{"--resume", "not-a-uuid"}, ""},
+		{[]string{"-p", "hello"}, ""},
+	}
+	for _, tc := range cases {
+		if got := ResumeSessionID(tc.args); got != tc.want {
+			t.Fatalf("ResumeSessionID(%v) = %q, want %q", tc.args, got, tc.want)
+		}
+	}
+}
+
+func migrateTestStore(t *testing.T) (Store, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	store := Store{Dir: dir}
+	profiles := profilesFile{
+		Active: "target@example.com",
+		Profiles: map[string]Profile{
+			"source@example.com": {Name: "source@example.com", Dir: "_psource"},
+			"target@example.com": {Name: "target@example.com", Dir: "_ptarget"},
+		},
+	}
+	body, err := json.Marshal(profiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "claude.json"), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sourceDir := store.ClaudeConfigDir("source@example.com")
+	targetDir := store.ClaudeConfigDir("target@example.com")
+	return store, sourceDir, targetDir
+}
+
+func TestMigrateSessionCopiesConversation(t *testing.T) {
+	store, sourceDir, targetDir := migrateTestStore(t)
+	id := "6452edd8-ba4e-4ba7-b585-4f10d03b1bb4"
+	project := "-Users-someone-fun-repo"
+	for _, path := range []string{
+		filepath.Join(sourceDir, "projects", project, id+".jsonl"),
+		filepath.Join(sourceDir, "projects", project, id, "topic.json"),
+		filepath.Join(sourceDir, "file-history", id, "f0.txt"),
+		filepath.Join(sourceDir, "session-env", id, "env.json"),
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("data"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	from, err := store.MigrateSession("target@example.com", id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if from != "source@example.com" {
+		t.Fatalf("from = %q, want source@example.com", from)
+	}
+	for _, path := range []string{
+		filepath.Join(targetDir, "projects", project, id+".jsonl"),
+		filepath.Join(targetDir, "projects", project, id, "topic.json"),
+		filepath.Join(targetDir, "file-history", id, "f0.txt"),
+		filepath.Join(targetDir, "session-env", id, "env.json"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected migrated file %s: %v", path, err)
+		}
+	}
+
+	// Second call is a no-op: the target already has the session.
+	from, err = store.MigrateSession("target@example.com", id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if from != "" {
+		t.Fatalf("second migrate from = %q, want no-op", from)
+	}
+}
+
+func TestMigrateSessionMissingEverywhere(t *testing.T) {
+	store, _, _ := migrateTestStore(t)
+	from, err := store.MigrateSession("target@example.com", "11111111-2222-3333-4444-555555555555")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if from != "" {
+		t.Fatalf("from = %q, want empty when no profile has the session", from)
+	}
+}


### PR DESCRIPTION
`sr claude --resume <id>` failed with "No conversation found" when the session was created under a different profile, because Claude Code keys conversations by CLAUDE_CONFIG_DIR and every sr claude profile is a separate config dir. Profile switches (e.g. an `sr claude add` making the new account active) stranded all prior sessions.

`sr claude run` now detects `--resume`/`-r <session-id>` and, when the target profile lacks the conversation, copies the transcript, topic dir, file-history, and session-env from whichever profile owns it, then launches. No-op when the target already has it or nobody does.

Tested in `internal/agents/claude/migrate_test.go` (arg parsing, full copy, idempotent second run, missing-everywhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783658266&installation_id=133855650&pr_number=6&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F6&signature=3d789f01575dbb9745b6c7e4102e7df698f2f4fac273a330a2c333e346f72d67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes resuming Claude sessions across profiles by auto-migrating the session when `sr claude --resume <id>` points to a session in another profile. Prevents the “No conversation found” error after profile switches.

- **Bug Fixes**
  - Detects `--resume`/`-r <id>` in `sr claude run`.
  - If the target profile is missing the session, copies the transcript, topic dir, `file-history`, and `session-env` from the source profile.
  - No-op if already present or missing everywhere; warns on migration errors and notes the source profile when a copy occurs.
  - Added tests for arg parsing, full copy, idempotency, and missing-session cases.

<sup>Written for commit dc1a24fee2480e26aaf0eed0eab7368285379d95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

