### PR TITLE
sr claude add auto-close + usage-status cache against rate-limit bursts

### DIFF
--- a/cmd/subrouter/sr_claude.go
+++ b/cmd/subrouter/sr_claude.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/manaflow-ai/subrouter/internal/agents/claude"
@@ -124,7 +125,7 @@ func (r claudeRunner) add(ctx context.Context, name string) error {
 	claudeConfigDir := r.store.PreferredInstancePath(instancePath)
 
 	fmt.Fprintln(r.out, "Starting Claude Code...")
-	fmt.Fprintln(r.out, "Complete the OAuth login in your browser, then exit Claude to finish setup.")
+	fmt.Fprintln(r.out, "Complete the OAuth login in your browser; Claude closes automatically once the login lands.")
 	fmt.Fprintln(r.out)
 
 	cmd := exec.CommandContext(ctx, claudePath)
@@ -132,13 +133,14 @@ func (r claudeRunner) add(ctx context.Context, name string) error {
 	cmd.Stdout = r.out
 	cmd.Stderr = r.errOut
 	cmd.Env = append(os.Environ(), "CLAUDE_CONFIG_DIR="+claudeConfigDir)
-	if err := cmd.Run(); err != nil {
+	exitErr, autoClosed := r.runClaudeUntilCredential(ctx, cmd, claudeConfigDir)
+	if exitErr != nil && !autoClosed {
 		if name != "" {
 			_, _ = r.store.RemoveProfile(name)
 		} else {
 			_ = r.store.CleanupInstance(tempDir)
 		}
-		return fmt.Errorf("Claude login did not complete: %w", err)
+		return fmt.Errorf("Claude login did not complete: %w", exitErr)
 	}
 
 	status, err := claude.AuthStatusForPath(ctx, claudePath, claudeConfigDir)
@@ -300,6 +302,76 @@ func (r claudeRunner) env() error {
 	}
 	fmt.Fprintf(r.out, "export CLAUDE_CONFIG_DIR=%s\n", r.store.ClaudeConfigDir(active))
 	return nil
+}
+
+// runClaudeUntilCredential runs the interactive Claude login and polls for the
+// OAuth credential landing in the profile's config dir. As soon as it appears,
+// the Claude process is closed automatically so the user does not have to exit
+// by hand. Returns the process exit error and whether we initiated the close
+// (in which case a non-nil exit error is expected and not a failure).
+func (r claudeRunner) runClaudeUntilCredential(ctx context.Context, cmd *exec.Cmd, claudeConfigDir string) (error, bool) {
+	if err := cmd.Start(); err != nil {
+		return err, false
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case err := <-done:
+			return err, false
+		case <-ctx.Done():
+			err := closeInteractiveProcess(cmd, done)
+			return err, true
+		case <-ticker.C:
+			credential, _ := r.store.ReadCredential(ctx, claudeConfigDir)
+			if credential == nil || credential.AccessToken == "" {
+				continue
+			}
+			fmt.Fprintln(r.errOut, "\nLogin detected; closing Claude...")
+			err := closeInteractiveProcess(cmd, done)
+			r.restoreTerminal()
+			return err, true
+		}
+	}
+}
+
+// closeInteractiveProcess ends an interactive TUI process: SIGINT twice (Claude
+// requires a double Ctrl-C), then SIGTERM, then SIGKILL, waiting briefly after
+// each signal.
+func closeInteractiveProcess(cmd *exec.Cmd, done <-chan error) error {
+	if cmd.Process == nil {
+		return <-done
+	}
+	for i := 0; i < 2; i++ {
+		_ = cmd.Process.Signal(os.Interrupt)
+		select {
+		case err := <-done:
+			return err
+		case <-time.After(750 * time.Millisecond):
+		}
+	}
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(2 * time.Second):
+	}
+	_ = cmd.Process.Kill()
+	return <-done
+}
+
+// restoreTerminal best-effort resets the controlling terminal in case the
+// closed TUI left it in raw mode.
+func (r claudeRunner) restoreTerminal() {
+	stdin, ok := r.in.(*os.File)
+	if !ok {
+		return
+	}
+	cmd := exec.Command("stty", "sane")
+	cmd.Stdin = stdin
+	_ = cmd.Run()
 }
 
 func (r claudeRunner) runClaude(ctx context.Context, name string, extra []string) error {

--- a/cmd/subrouter/sr_claude_autoclose_test.go
+++ b/cmd/subrouter/sr_claude_autoclose_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestCloseInteractiveProcessEndsRunningProcess(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	start := time.Now()
+	_ = closeInteractiveProcess(cmd, done)
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("close took %v, want fast termination", elapsed)
+	}
+	if cmd.ProcessState == nil {
+		t.Fatal("process state missing after close")
+	}
+	if cmd.ProcessState.Success() {
+		t.Fatal("process should have been signaled, not exited cleanly")
+	}
+}

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -698,7 +698,7 @@ func FetchUsage(ctx context.Context, client *http.Client, accessToken string) (*
 	}
 	defer res.Body.Close()
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		return nil, nil
+		return nil, fmt.Errorf("usage fetch failed: %s", res.Status)
 	}
 	var usage UsageResponse
 	if err := json.NewDecoder(res.Body).Decode(&usage); err != nil {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -146,6 +146,16 @@ type AccountRef struct {
 	store       accounts.CodexStore
 	claudeStore agentclaude.Store
 	client      *http.Client
+
+	usageStatusMu    sync.Mutex
+	usageStatusCache []AccountUsageStatus
+	usageStatusAt    time.Time
+	lastGoodUsage    map[string]usageStatusSnapshot
+}
+
+type usageStatusSnapshot struct {
+	status AccountUsageStatus
+	at     time.Time
 }
 
 type AccountStatus struct {
@@ -337,10 +347,72 @@ func (r *AccountRef) Statuses(ctx context.Context, forceRefresh bool) []AccountS
 	return out
 }
 
+const usageStatusCacheTTL = 30 * time.Second
+const usageStatusLastGoodTTL = 15 * time.Minute
+
+// UsageStatuses serves a cached sweep when one is fresh, and backfills
+// accounts whose live usage fetch transiently failed (the upstream usage
+// endpoints rate-limit bursts) with their last-known-good windows, so brief
+// 429s do not blank a healthy account's quota display.
 func (r *AccountRef) UsageStatuses(ctx context.Context) []AccountUsageStatus {
 	if r == nil {
 		return nil
 	}
+	r.usageStatusMu.Lock()
+	defer r.usageStatusMu.Unlock()
+	if !r.usageStatusAt.IsZero() && time.Since(r.usageStatusAt) < usageStatusCacheTTL && r.usageStatusCache != nil {
+		return append([]AccountUsageStatus(nil), r.usageStatusCache...)
+	}
+	out := r.usageStatusesLive(ctx)
+	now := time.Now()
+	if r.lastGoodUsage == nil {
+		r.lastGoodUsage = map[string]usageStatusSnapshot{}
+	}
+	for i := range out {
+		status := out[i]
+		key := status.ID + "\x00" + string(status.Provider)
+		if len(status.Windows) > 0 {
+			r.lastGoodUsage[key] = usageStatusSnapshot{status: status, at: now}
+			continue
+		}
+		if authLikeUsageError(status.Error) {
+			continue
+		}
+		snapshot, ok := r.lastGoodUsage[key]
+		if !ok || now.Sub(snapshot.at) > usageStatusLastGoodTTL {
+			continue
+		}
+		restored := snapshot.status
+		restored.Active = status.Active
+		restored.Refreshed = status.Refreshed
+		restored.Error = ""
+		out[i] = restored
+	}
+	r.usageStatusCache = append([]AccountUsageStatus(nil), out...)
+	r.usageStatusAt = now
+	return out
+}
+
+func (r *AccountRef) InvalidateUsageStatusCache() {
+	if r == nil {
+		return
+	}
+	r.usageStatusMu.Lock()
+	defer r.usageStatusMu.Unlock()
+	r.usageStatusAt = time.Time{}
+}
+
+func authLikeUsageError(message string) bool {
+	lower := strings.ToLower(message)
+	for _, marker := range []string{"401", "403", "unauthorized", "forbidden", "invalid_grant", "no access token", "no usable credential"} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus {
 	storedAccounts, err := r.store.ListStored()
 	if err != nil {
 		return []AccountUsageStatus{{
@@ -761,6 +833,7 @@ func (s Server) handleReloadAccounts(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	s.AccountRef.InvalidateUsageStatusCache()
 	writeJSON(w, map[string]any{
 		"ok":              true,
 		"accounts":        loaded,

--- a/internal/proxy/usage_status_cache_test.go
+++ b/internal/proxy/usage_status_cache_test.go
@@ -1,0 +1,112 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
+)
+
+type usageRoundTripper struct {
+	calls     int
+	responses []*http.Response
+}
+
+func (u *usageRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	u.calls++
+	if len(u.responses) == 0 {
+		return &http.Response{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(strings.NewReader("")), Header: http.Header{}}, nil
+	}
+	res := u.responses[0]
+	if len(u.responses) > 1 {
+		u.responses = u.responses[1:]
+	}
+	return res, nil
+}
+
+func usageOKResponse() *http.Response {
+	body := `{"five_hour":{"utilization":10.0,"resets_at":"2030-01-01T00:00:00+00:00"},"seven_day":{"utilization":5.0,"resets_at":"2030-01-02T00:00:00+00:00"}}`
+	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: http.Header{}}
+}
+
+func usage429Response() *http.Response {
+	return &http.Response{StatusCode: http.StatusTooManyRequests, Status: "429 Too Many Requests", Body: io.NopCloser(strings.NewReader(`{"type":"error"}`)), Header: http.Header{}}
+}
+
+func cacheTestAccountRef(t *testing.T, transport http.RoundTripper) *AccountRef {
+	t.Helper()
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".subrouter", "codex")
+	profileDir := filepath.Join(claudeDir, "claude", "_ptest")
+	if err := os.MkdirAll(profileDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	profiles := map[string]any{
+		"profiles": map[string]any{
+			"claude@example.com": map[string]any{"name": "claude@example.com", "dir": "_ptest"},
+		},
+	}
+	body, err := json.Marshal(profiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "claude.json"), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	expires := time.Now().Add(time.Hour).UnixMilli()
+	credential := fmt.Sprintf(`{"claudeAiOauth":{"accessToken":"tok","refreshToken":"ref","expiresAt":%d,"subscriptionType":"max"}}`, expires)
+	if err := os.WriteFile(filepath.Join(profileDir, ".credentials.json"), []byte(credential), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return &AccountRef{
+		store:       accounts.CodexStore{Dir: filepath.Join(dir, "codex-accounts")},
+		claudeStore: agentclaude.Store{Dir: claudeDir},
+		client:      &http.Client{Transport: transport},
+	}
+}
+
+func TestUsageStatusesCachesWithinTTL(t *testing.T) {
+	transport := &usageRoundTripper{responses: []*http.Response{usageOKResponse()}}
+	ref := cacheTestAccountRef(t, transport)
+	first := ref.UsageStatuses(context.Background())
+	callsAfterFirst := transport.calls
+	second := ref.UsageStatuses(context.Background())
+	if transport.calls != callsAfterFirst {
+		t.Fatalf("second call within TTL hit upstream (%d -> %d calls)", callsAfterFirst, transport.calls)
+	}
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("statuses = %d/%d, want 1/1", len(first), len(second))
+	}
+	if len(second[0].Windows) == 0 {
+		t.Fatal("cached status lost usage windows")
+	}
+}
+
+func TestUsageStatusesRestoresLastGoodOnTransientFailure(t *testing.T) {
+	transport := &usageRoundTripper{responses: []*http.Response{usageOKResponse(), usage429Response()}}
+	ref := cacheTestAccountRef(t, transport)
+	first := ref.UsageStatuses(context.Background())
+	if len(first) != 1 || len(first[0].Windows) == 0 {
+		t.Fatalf("first sweep should have windows, got %+v", first)
+	}
+	ref.InvalidateUsageStatusCache()
+	second := ref.UsageStatuses(context.Background())
+	if len(second) != 1 {
+		t.Fatalf("statuses = %d, want 1", len(second))
+	}
+	if len(second[0].Windows) == 0 {
+		t.Fatalf("429 sweep should serve last-known-good windows, got %+v", second[0])
+	}
+	if second[0].Error != "" {
+		t.Fatalf("transient failure with last-good backfill should not surface an error, got %q", second[0].Error)
+	}
+}


### PR DESCRIPTION
Two related fixes:

**`sr claude add` auto-closes Claude after OAuth.** The add flow now polls the new profile's config dir for the OAuth credential while the interactive Claude runs, and closes Claude automatically (double SIGINT to match the required double Ctrl-C, escalating to SIGTERM/SIGKILL, plus a best-effort `stty sane`) the moment the login lands. No more manually exiting Claude to finish `sr claude add`.

**Claude usage no longer blanks under rate-limit bursts.** `claude.FetchUsage` swallowed any non-2xx as 'no usage', so when Anthropic rate-limited the usage endpoint (live sweeps from sr status + the scheduler's 30s scoring), healthy pooled accounts rendered as a bare 'Claude profile' placeholder that flapped between consecutive calls. Now: FetchUsage returns an error on non-2xx; `/_subrouter/usage-status` caches sweeps for 30s (single-flight) and backfills transient failures with the account's last-known-good windows (15 min retention); auth-shaped errors (401/403/invalid_grant) are never masked so the re-add footnote still fires; reload-accounts invalidates the cache.

Tests: auto-close process termination, cache-within-TTL, last-good backfill on 429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783660768&installation_id=133855650&pr_number=7&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F7&signature=787e45fabbfb2e113db6ecf9f0695796dee372b984749e2833f35977d4f0b364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-closes Claude after OAuth in `sr claude add` and adds a short-term usage cache to prevent blanked quotas during rate-limit bursts.

- **New Features**
  - `sr claude add` now auto-closes Claude when the OAuth credential lands (polls config dir; sends double SIGINT, then SIGTERM/SIGKILL if needed).
  - Restores terminal state on exit (`stty sane`); adds a termination test.

- **Bug Fixes**
  - Prevents usage display from blanking when Anthropic rate-limits the usage endpoint.
  - `claude.FetchUsage` now errors on non-2xx; `/_subrouter/usage-status` caches for 30s and backfills transient failures with last-known-good windows (15 min).
  - Auth-shaped errors (401/403/invalid_grant) still surface; `reload-accounts` invalidates the cache.

<sup>Written for commit 12ef0fcb149ed409c52a3459ea08da82d4ccb9fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude login process now automatically closes after credentials are obtained.
  * Account usage status now caches results and falls back to previously cached data during transient failures.

* **Bug Fixes**
  * Improved error handling for credential fetch failures.

* **Tests**
  * Added tests for usage status caching behavior and fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->