### PR TITLE
sr claude add auto-uploads profiles to the default server

### DIFF
--- a/cmd/subrouter/sr_claude.go
+++ b/cmd/subrouter/sr_claude.go
@@ -26,6 +26,7 @@ Usage:
   sr claude switch [name]       Switch active profile
   sr claude remove <name>       Remove a profile
   sr claude env                 Print export CLAUDE_CONFIG_DIR=...
+  sr claude push [name]         Upload a profile to the default Subrouter server pool
   sr claude run [name] [...]    Launch Claude with a specific profile
   sr claude --flag [...]        Launch Claude with the active profile
   sr claude <name> [...]        Shorthand for 'sr claude run <name>'
@@ -38,15 +39,23 @@ type claudeRunner struct {
 	out    io.Writer
 	errOut io.Writer
 	client *http.Client
+	// pushToServer uploads a profile to the default Subrouter server, when
+	// one is configured. nil when the claude runner is built without server
+	// support (tests). pushAfterAdd is the same upload but no-ops silently
+	// when no default server is configured.
+	pushToServer func(ctx context.Context, name string) error
+	pushAfterAdd func(ctx context.Context, name string) error
 }
 
 func (r srRunner) claude(ctx context.Context, args []string) error {
 	cr := claudeRunner{
-		store:  claude.DefaultStore(),
-		in:     r.in,
-		out:    r.out,
-		errOut: r.errOut,
-		client: r.client,
+		store:        claude.DefaultStore(),
+		in:           r.in,
+		out:          r.out,
+		errOut:       r.errOut,
+		client:       r.client,
+		pushToServer: r.pushClaudeProfileToServer,
+		pushAfterAdd: r.pushClaudeProfileAfterAdd,
 	}
 	return cr.run(ctx, args)
 }
@@ -76,6 +85,21 @@ func (r claudeRunner) run(ctx context.Context, args []string) error {
 		return r.remove(args[1])
 	case "env":
 		return r.env()
+	case "push", "upload":
+		if r.pushToServer == nil {
+			return fmt.Errorf("server push is not available")
+		}
+		name := ""
+		if len(args) > 1 {
+			name = args[1]
+		}
+		if name == "" {
+			name = r.store.ActiveProfile()
+		}
+		if name == "" {
+			return fmt.Errorf("usage: sr claude push <name>")
+		}
+		return r.pushToServer(ctx, name)
 	case "run":
 		name := ""
 		extra := []string{}
@@ -176,6 +200,12 @@ func (r claudeRunner) add(ctx context.Context, name string) error {
 		email = " (" + status.Email + ")"
 	}
 	fmt.Fprintf(r.out, "\nAdded Claude profile %q.%s%s\n", profileName, email, plan)
+	if r.pushAfterAdd != nil {
+		if err := r.pushAfterAdd(ctx, profileName); err != nil {
+			fmt.Fprintf(r.errOut, "warning: server upload failed (profile stays local-only): %v\n", err)
+			fmt.Fprintf(r.errOut, "Retry with: sr claude push %s\n", profileName)
+		}
+	}
 	fmt.Fprintf(r.out, "\n  sr claude switch %s\n", profileName)
 	fmt.Fprintf(r.out, "  sr claude run %s\n", profileName)
 	return nil

--- a/cmd/subrouter/sr_claude_upload.go
+++ b/cmd/subrouter/sr_claude_upload.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/agents/claude"
+)
+
+// pushClaudeProfileToServer uploads a local Claude profile's credential to the
+// default remote server, registers it in the server's claude.json, hot-reloads
+// accounts, and switches the local profile to proxy-mode env so the server
+// becomes the single owner of the rotating OAuth refresh token. Anthropic
+// rotates refresh tokens on use, so a credential refreshed from two places
+// invalidates one of them; after the push, local runs route through the proxy
+// instead of refreshing directly.
+func (r srRunner) pushClaudeProfileToServer(ctx context.Context, name string) error {
+	return r.pushClaudeProfile(ctx, name, true)
+}
+
+// pushClaudeProfileAfterAdd is the auto-upload hook for 'sr claude add': a
+// missing default server is a silent no-op (purely local setups stay local).
+func (r srRunner) pushClaudeProfileAfterAdd(ctx context.Context, name string) error {
+	return r.pushClaudeProfile(ctx, name, false)
+}
+
+func (r srRunner) pushClaudeProfile(ctx context.Context, name string, requireServer bool) error {
+	server, ok, err := r.defaultRemoteServer()
+	if err != nil {
+		return err
+	}
+	if !ok {
+		if !requireServer {
+			return nil
+		}
+		return fmt.Errorf("no default Subrouter server configured; run '%s server use <name>'", r.programOrSubrouter())
+	}
+	store := claude.DefaultStore()
+	profile, ok, err := store.MatchProfile(name)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("Claude profile %q not found", name)
+	}
+	configDir := store.ClaudeConfigDir(profile.Name)
+	credential, err := store.ReadCredential(ctx, configDir)
+	if err != nil {
+		return err
+	}
+	if credential == nil || credential.AccessToken == "" {
+		return fmt.Errorf("Claude profile %q has no credential to upload", profile.Name)
+	}
+	if err := r.uploadServerClaudeProfile(ctx, server, store, profile, *credential); err != nil {
+		return err
+	}
+	if err := writeClaudeProxyEnv(configDir, server.URL); err != nil {
+		return fmt.Errorf("profile uploaded, but writing proxy env to settings.json failed: %w", err)
+	}
+	fmt.Fprintf(r.out, "Uploaded Claude profile %s to server %s and switched local runs to the server pool.\n", profile.Name, server.Name)
+	return nil
+}
+
+func (r srRunner) uploadServerClaudeProfile(ctx context.Context, server srServerConfig, store claude.Store, profile claude.Profile, credential claude.CredentialInfo) error {
+	dir := filepath.Base(store.InstancePath(profile.Name))
+	if dir == "" || dir == "." || dir == string(os.PathSeparator) {
+		return fmt.Errorf("could not determine instance dir for profile %q", profile.Name)
+	}
+	body, err := json.MarshalIndent(map[string]claude.CredentialInfo{"claudeAiOauth": credential}, "", "  ")
+	if err != nil {
+		return err
+	}
+	body = append(body, '\n')
+	archive, err := buildClaudeCredentialArchive(dir, body)
+	if err != nil {
+		return err
+	}
+	host := sshHostForServer(server)
+	if host == "" {
+		return fmt.Errorf("server %s has no SSH-able host in its URL", server.Name)
+	}
+	remoteCommand := claudeUploadRemoteCommand(server, profile.Name, dir)
+	args := []string{
+		"-o", "BatchMode=yes",
+		"-o", "ConnectTimeout=15",
+		"-o", "LogLevel=ERROR",
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		host,
+		remoteCommand,
+	}
+	uploadCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		if err := r.commandRunner().Run(uploadCtx, "ssh", args, bytes.NewReader(archive), r.out, r.errOut); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		if attempt < 3 {
+			if r.errOut != nil {
+				fmt.Fprintf(r.errOut, "claude profile upload failed, retrying (%d/3): %v\n", attempt, lastErr)
+			}
+			timer := time.NewTimer(time.Duration(attempt) * time.Second)
+			select {
+			case <-uploadCtx.Done():
+				timer.Stop()
+				return fmt.Errorf("upload claude profile over ssh: %w", uploadCtx.Err())
+			case <-timer.C:
+			}
+		}
+	}
+	return fmt.Errorf("upload claude profile over ssh: %w", lastErr)
+}
+
+func buildClaudeCredentialArchive(dir string, credentialJSON []byte) ([]byte, error) {
+	var archive bytes.Buffer
+	gz := gzip.NewWriter(&archive)
+	tw := tar.NewWriter(gz)
+	relPath := filepath.Join("codex", "claude", dir, ".credentials.json")
+	if err := tw.WriteHeader(&tar.Header{Name: relPath, Mode: 0o600, Size: int64(len(credentialJSON))}); err != nil {
+		return nil, err
+	}
+	if _, err := tw.Write(credentialJSON); err != nil {
+		return nil, err
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	return archive.Bytes(), nil
+}
+
+func claudeUploadRemoteCommand(server srServerConfig, profileName, dir string) string {
+	createdAt := time.Now().UTC().Format(time.RFC3339)
+	// The registration merge keeps any existing createdAt and other profiles
+	// intact; only this profile's name/dir are overwritten.
+	jqProgram := `.profiles[$name] = {name: $name, createdAt: (.profiles[$name].createdAt // $created), dir: $dir}`
+	remotePath := fmt.Sprintf("/tmp/sr-claude-cred-%d.tgz", time.Now().UnixNano())
+	registryPath := "/var/lib/subrouter/codex/claude.json"
+	return strings.Join([]string{
+		"set -euo pipefail",
+		"cat > " + shellQuote(remotePath),
+		"reload_status=$(curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:31415/_subrouter/reload-accounts || true)",
+		"if [ \"$reload_status\" != \"405\" ]; then echo " + shellQuote("Subrouter server is too old for hot account reload; run sr server install "+server.Name+" first.") + " >&2; exit 1; fi",
+		"command -v jq >/dev/null || { echo 'jq is required on the server for claude profile registration' >&2; exit 1; }",
+		"sudo install -d -o subrouter -g subrouter -m 0700 /var/lib/subrouter/codex/claude",
+		"sudo tar -C /var/lib/subrouter -xzf " + shellQuote(remotePath),
+		"sudo rm -f " + shellQuote(remotePath),
+		"sudo chmod 700 " + shellQuote("/var/lib/subrouter/codex/claude/"+dir),
+		"sudo chmod 600 " + shellQuote("/var/lib/subrouter/codex/claude/"+dir+"/.credentials.json"),
+		"sudo sh -c " + shellQuote("test -s "+registryPath+" || printf '{\"profiles\":{}}' > "+registryPath),
+		"sudo jq --arg name " + shellQuote(profileName) + " --arg dir " + shellQuote(dir) + " --arg created " + shellQuote(createdAt) + " " + shellQuote(jqProgram) + " " + registryPath + " | sudo tee " + registryPath + ".new >/dev/null",
+		"sudo mv " + registryPath + ".new " + registryPath,
+		"sudo chown -R subrouter:subrouter /var/lib/subrouter/codex/claude " + registryPath,
+		"curl -fsS -X POST http://127.0.0.1:31415/_subrouter/reload-accounts >/dev/null",
+	}, " && ")
+}
+
+// writeClaudeProxyEnv merges the Subrouter proxy env into the profile's
+// settings.json, preserving unrelated settings. The dummy auth token satisfies
+// Claude Code's auth requirement; the server replaces it with pooled
+// credentials.
+func writeClaudeProxyEnv(configDir, serverURL string) error {
+	settingsPath := filepath.Join(configDir, "settings.json")
+	settings := map[string]any{}
+	if body, err := os.ReadFile(settingsPath); err == nil {
+		if err := json.Unmarshal(body, &settings); err != nil {
+			return fmt.Errorf("parse %s: %w", settingsPath, err)
+		}
+	}
+	env, _ := settings["env"].(map[string]any)
+	if env == nil {
+		env = map[string]any{}
+	}
+	env["ANTHROPIC_BASE_URL"] = strings.TrimRight(serverURL, "/")
+	if _, ok := env["ANTHROPIC_AUTH_TOKEN"]; !ok {
+		env["ANTHROPIC_AUTH_TOKEN"] = "subrouter"
+	}
+	settings["env"] = env
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	out = append(out, '\n')
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(settingsPath, out, 0o600)
+}

--- a/cmd/subrouter/sr_claude_upload_test.go
+++ b/cmd/subrouter/sr_claude_upload_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildClaudeCredentialArchive(t *testing.T) {
+	payload := []byte(`{"claudeAiOauth":{"accessToken":"tok"}}`)
+	archive, err := buildClaudeCredentialArchive("_p123", payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gz, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := tar.NewReader(gz)
+	header, err := tr.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if header.Name != filepath.Join("codex", "claude", "_p123", ".credentials.json") {
+		t.Fatalf("archive path = %q", header.Name)
+	}
+	if header.Mode != 0o600 {
+		t.Fatalf("mode = %o, want 600", header.Mode)
+	}
+	body, err := io.ReadAll(tr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(body, payload) {
+		t.Fatalf("archive body = %q", body)
+	}
+}
+
+func TestClaudeUploadRemoteCommand(t *testing.T) {
+	command := claudeUploadRemoteCommand(srServerConfig{Name: "team", URL: "http://subrouter-team:31415"}, "lc9@example.com", "_p999")
+	for _, want := range []string{
+		"sudo tar -C /var/lib/subrouter",
+		"/var/lib/subrouter/codex/claude.json",
+		"'lc9@example.com'",
+		"'_p999'",
+		"reload-accounts",
+		"command -v jq",
+		"chown -R subrouter:subrouter",
+	} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("remote command missing %q:\n%s", want, command)
+		}
+	}
+}
+
+func TestWriteClaudeProxyEnvMergesSettings(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(`{"theme":"dark","env":{"FOO":"bar"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeClaudeProxyEnv(dir, "http://subrouter-team:31415/"); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(body, &settings); err != nil {
+		t.Fatal(err)
+	}
+	if settings["theme"] != "dark" {
+		t.Fatalf("theme clobbered: %v", settings["theme"])
+	}
+	env := settings["env"].(map[string]any)
+	if env["FOO"] != "bar" {
+		t.Fatalf("unrelated env clobbered: %v", env["FOO"])
+	}
+	if env["ANTHROPIC_BASE_URL"] != "http://subrouter-team:31415" {
+		t.Fatalf("base url = %v (trailing slash should be trimmed)", env["ANTHROPIC_BASE_URL"])
+	}
+	if env["ANTHROPIC_AUTH_TOKEN"] != "subrouter" {
+		t.Fatalf("auth token = %v", env["ANTHROPIC_AUTH_TOKEN"])
+	}
+
+	// Second write is idempotent and keeps a custom token if one exists.
+	env["ANTHROPIC_AUTH_TOKEN"] = "custom"
+	body, _ = json.Marshal(settings)
+	if err := os.WriteFile(settingsPath, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeClaudeProxyEnv(dir, "http://subrouter-team:31415"); err != nil {
+		t.Fatal(err)
+	}
+	body, _ = os.ReadFile(settingsPath)
+	if err := json.Unmarshal(body, &settings); err != nil {
+		t.Fatal(err)
+	}
+	if got := settings["env"].(map[string]any)["ANTHROPIC_AUTH_TOKEN"]; got != "custom" {
+		t.Fatalf("custom token clobbered: %v", got)
+	}
+}
+
+func TestWriteClaudeProxyEnvCreatesSettings(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "fresh")
+	if err := writeClaudeProxyEnv(dir, "http://subrouter-team:31415"); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(body, &settings); err != nil {
+		t.Fatal(err)
+	}
+	env := settings["env"].(map[string]any)
+	if env["ANTHROPIC_BASE_URL"] != "http://subrouter-team:31415" {
+		t.Fatalf("base url = %v", env["ANTHROPIC_BASE_URL"])
+	}
+}


### PR DESCRIPTION
Codex accounts already auto-upload on `sr add`; Claude profiles required a manual server-side credential push every time (this bit us on 4 accounts in one night).

`sr claude add` now auto-uploads when a default server is configured:
1. tars the profile credential and ships it over BatchMode SSH (same transport as the codex upload, 3 retries),
2. extracts to `/var/lib/subrouter/codex/claude/<dir>/.credentials.json` with subrouter ownership and tight modes,
3. jq-merges the registration into the server's `claude.json` (other profiles and existing createdAt preserved),
4. hot-reloads accounts,
5. switches the local profile to proxy-mode env (`ANTHROPIC_BASE_URL` + dummy token, merged into settings.json without clobbering other keys) so the server becomes the single owner of the rotating refresh token (Anthropic rotates on use; dual-owner credentials kill each other).

`sr claude push [name]` does the same for existing profiles. With no default server configured, add stays silently local-only. Upload failure downgrades to a warning with the retry command; the add itself still succeeds.

Tests: archive layout, remote-command contents, settings.json merge (preserves unrelated keys + custom tokens, trims trailing slash, creates fresh file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783669821&installation_id=133855650&pr_number=9&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F9&signature=0b71b640ab911bad8512cf7ed28af1e23ed240b40b155e11f20c81de468c7278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-uploads Claude profiles to the default Subrouter server on `sr claude add`, and adds `sr claude push [name]` to upload existing profiles. This removes manual credential pushes and routes local runs through the server pool.

- **New Features**
  - `sr claude add` now uploads the new profile to the default server (SSH with 3 retries) and registers it.
  - Server steps: extract to `/var/lib/subrouter/codex/claude/<dir>/.credentials.json`, merge into `claude.json` (preserves others and `createdAt`), then hot-reload accounts.
  - Local steps: switch the profile to proxy mode by writing `ANTHROPIC_BASE_URL` (trailing slash trimmed) and a dummy `ANTHROPIC_AUTH_TOKEN` into `settings.json` without clobbering other keys.
  - `sr claude push [name]` (alias: `upload`) performs the same for existing profiles. No default server => add stays local; upload failures warn and show a retry command.

- **Migration**
  - Requires a configured default server. The server must have `jq` and support `/_subrouter/reload-accounts`; if outdated, run `sr server install <name>`.

<sup>Written for commit 37b3b7ee0e62fa94b538d4ca7783dc0f531a87de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

