### PR TITLE
Add sr claude pick

### DIFF
--- a/cmd/subrouter/sr_claude.go
+++ b/cmd/subrouter/sr_claude.go
@@ -27,6 +27,7 @@ Usage:
   sr claude remove <name>       Remove a profile
   sr claude env                 Print export CLAUDE_CONFIG_DIR=...
   sr claude push [name]         Upload a profile to the default Subrouter server pool
+  sr claude pick                Switch to the profile with the most quota left
   sr claude run [name] [...]    Launch Claude with a specific profile
   sr claude --flag [...]        Launch Claude with the active profile
   sr claude <name> [...]        Shorthand for 'sr claude run <name>'
@@ -45,6 +46,7 @@ type claudeRunner struct {
 	// when no default server is configured.
 	pushToServer func(ctx context.Context, name string) error
 	pushAfterAdd func(ctx context.Context, name string) error
+	pick         func(ctx context.Context) error
 }
 
 func (r srRunner) claude(ctx context.Context, args []string) error {
@@ -56,6 +58,7 @@ func (r srRunner) claude(ctx context.Context, args []string) error {
 		client:       r.client,
 		pushToServer: r.pushClaudeProfileToServer,
 		pushAfterAdd: r.pushClaudeProfileAfterAdd,
+		pick:         r.pickClaudeProfile,
 	}
 	return cr.run(ctx, args)
 }
@@ -85,6 +88,11 @@ func (r claudeRunner) run(ctx context.Context, args []string) error {
 		return r.remove(args[1])
 	case "env":
 		return r.env()
+	case "pick":
+		if r.pick == nil {
+			return fmt.Errorf("pick is not available")
+		}
+		return r.pick(ctx)
 	case "push", "upload":
 		if r.pushToServer == nil {
 			return fmt.Errorf("server push is not available")

--- a/cmd/subrouter/sr_claude_pick.go
+++ b/cmd/subrouter/sr_claude_pick.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/internal/agents/claude"
+)
+
+// pickClaudeProfile switches the active Claude profile to the one with the
+// most quota headroom. Usage comes from the default server's pool view when
+// one is configured (the same data `sr` renders), falling back to local
+// per-profile usage fetches otherwise.
+func (r srRunner) pickClaudeProfile(ctx context.Context) error {
+	rows, err := r.claudeUsageRowsForPick(ctx)
+	if err != nil {
+		return err
+	}
+	store := claude.DefaultStore()
+	localProfiles := map[string]bool{}
+	for _, profile := range store.ListProfiles() {
+		localProfiles[profile.Name] = true
+	}
+	candidates := make([]srUsageRow, 0, len(rows))
+	for _, row := range rows {
+		if localProfiles[row.email] {
+			candidates = append(candidates, row)
+		}
+	}
+	if len(candidates) == 0 {
+		return fmt.Errorf("no Claude profiles configured. Run 'sr claude add' first")
+	}
+	target := bestClaudeUsageRow(candidates)
+	if target == nil {
+		displayUsageRows(r.out, candidates, false)
+		return fmt.Errorf("no Claude profile has quota for a new session")
+	}
+	active := store.ActiveProfile()
+	displayUsageRows(r.out, []srUsageRow{*target}, false)
+	if target.email == active {
+		fmt.Fprintf(r.out, "Already using recommended Claude profile: %s\n", target.email)
+		return nil
+	}
+	if err := store.SetActiveProfile(target.email); err != nil {
+		return err
+	}
+	fmt.Fprintf(r.out, "Picked recommended Claude profile: %s\n", target.email)
+	return nil
+}
+
+func (r srRunner) claudeUsageRowsForPick(ctx context.Context) ([]srUsageRow, error) {
+	if server, ok, err := r.defaultRemoteServer(); err != nil {
+		return nil, err
+	} else if ok {
+		usage, available, err := r.fetchServerUsageStatuses(ctx, server)
+		if err == nil && available {
+			rows := usageRowsFromServerUsageStatuses(usage)
+			claudeRows := make([]srUsageRow, 0, len(rows))
+			for _, row := range rows {
+				if row.provider == accounts.ProviderClaude {
+					claudeRows = append(claudeRows, row)
+				}
+			}
+			if len(claudeRows) > 0 {
+				return claudeRows, nil
+			}
+		}
+		// Server missing/old/empty: fall through to local usage.
+	}
+	all, err := r.fetchUsageRows(ctx)
+	if err != nil {
+		return nil, err
+	}
+	claudeRows := make([]srUsageRow, 0, len(all))
+	for _, row := range all {
+		if row.provider == accounts.ProviderClaude {
+			claudeRows = append(claudeRows, row)
+		}
+	}
+	return claudeRows, nil
+}
+
+// bestClaudeUsageRow returns the healthy row with the most constrained-window
+// headroom, or nil when every profile is errored or exhausted. Claude rows
+// never get gtoRecommended (that flag is codex-only), so pick sorts directly.
+func bestClaudeUsageRow(rows []srUsageRow) *srUsageRow {
+	usable := make([]srUsageRow, 0, len(rows))
+	for _, row := range rows {
+		if row.err != nil || row.cooked || row.tempCooked {
+			continue
+		}
+		if row.score.Headroom <= 0 || row.score.ShortHeadroom <= 0 {
+			continue
+		}
+		usable = append(usable, row)
+	}
+	if len(usable) == 0 {
+		return nil
+	}
+	sort.SliceStable(usable, func(i, j int) bool {
+		left := minFloat(usable[i].score.Headroom, usable[i].score.ShortHeadroom)
+		right := minFloat(usable[j].score.Headroom, usable[j].score.ShortHeadroom)
+		if left != right {
+			return left > right
+		}
+		return usable[i].email < usable[j].email
+	})
+	return &usable[0]
+}
+
+func minFloat(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cmd/subrouter/sr_claude_pick_test.go
+++ b/cmd/subrouter/sr_claude_pick_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/internal/selectacct"
+)
+
+func claudePickRow(email string, headroom, short float64) srUsageRow {
+	return srUsageRow{
+		email:    email,
+		provider: accounts.ProviderClaude,
+		authMode: accounts.AuthModeOAuth,
+		planType: "claude",
+		score:    selectacct.Score{AccountID: email, Headroom: headroom, ShortHeadroom: short},
+	}
+}
+
+func TestBestClaudeUsageRowPicksMostHeadroom(t *testing.T) {
+	rows := []srUsageRow{
+		claudePickRow("half@example.com", 0.5, 0.5),
+		claudePickRow("fresh@example.com", 0.99, 0.97),
+		claudePickRow("weekly-tight@example.com", 0.1, 0.9),
+	}
+	target := bestClaudeUsageRow(rows)
+	if target == nil || target.email != "fresh@example.com" {
+		t.Fatalf("target = %+v, want fresh@example.com", target)
+	}
+}
+
+func TestBestClaudeUsageRowSkipsCookedErroredExhausted(t *testing.T) {
+	cooked := claudePickRow("cooked@example.com", 0.9, 0.9)
+	cooked.tempCooked = true
+	errored := claudePickRow("error@example.com", 1, 1)
+	errored.err = errors.New("usage fetch failed: 429")
+	exhausted := claudePickRow("exhausted@example.com", 0.8, 0)
+	ok := claudePickRow("ok@example.com", 0.3, 0.4)
+	target := bestClaudeUsageRow([]srUsageRow{cooked, errored, exhausted, ok})
+	if target == nil || target.email != "ok@example.com" {
+		t.Fatalf("target = %+v, want ok@example.com", target)
+	}
+}
+
+func TestBestClaudeUsageRowNilWhenAllUnusable(t *testing.T) {
+	cooked := claudePickRow("cooked@example.com", 0, 0)
+	if target := bestClaudeUsageRow([]srUsageRow{cooked}); target != nil {
+		t.Fatalf("target = %+v, want nil", target)
+	}
+}


### PR DESCRIPTION
`sr claude pick` switches the active Claude profile to the one with the most quota left, mirroring `sr pick` for Codex. Usage comes from the default server's pool view when configured (the same data `sr` renders), with a local-fetch fallback; candidates are limited to locally-present profiles; cooked/errored/exhausted rows are skipped; winner = largest min(session, weekly) headroom.

Tests cover the picker: most-headroom selection, skipping cooked/errored/exhausted rows, and nil when nothing is usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783674371&installation_id=133855650&pr_number=10&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F10&signature=4749f839d458c5fc3951f8fe07aeb45460958e92df11b1f7b744bb1eeabce953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `sr claude pick` to automatically switch to the Claude profile with the most remaining quota, mirroring `sr pick` for Codex. This chooses the profile with the largest min(session, weekly) headroom to reduce session failures.

- **New Features**
  - Adds `sr claude pick` that selects the recommended profile and sets it active (no-op if already selected).
  - Reads usage from the default server pool when available; falls back to local per-profile usage.
  - Only considers locally present profiles; skips cooked/errored/exhausted rows; shows usage and errors if none are usable.
  - Includes unit tests for most-headroom selection and skipping unusable rows.

<sup>Written for commit 7c07ac224bb481b15af8987a10db8c4963cfcf26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

