### PR TITLE
Shared usage-windows cache; no score-zeroing on transient failures

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -152,11 +152,57 @@ type AccountRef struct {
 	usageStatusCache []AccountUsageStatus
 	usageStatusAt    time.Time
 	lastGoodUsage    map[string]usageStatusSnapshot
+
+	usageWindowsMu sync.Mutex
+	usageWindows   map[string]usageWindowsEntry
 }
 
 type usageStatusSnapshot struct {
 	status AccountUsageStatus
 	at     time.Time
+}
+
+type usageWindowsEntry struct {
+	windows []accounts.UsageWindow
+	at      time.Time
+}
+
+const usageWindowsTTL = 2 * time.Minute
+const usageWindowsLastGoodTTL = 15 * time.Minute
+
+// FetchUsageWindowsCached is the single path for reading an account's usage
+// windows. Every consumer (scheduler scoring, the usage-status sweep,
+// auto-switch) used to fetch live, and with many pooled accounts the combined
+// rate tripped the upstream usage endpoints' per-IP limits, which then
+// cascaded: failed fetches zeroed scores and made healthy accounts look
+// exhausted. Fresh-within-TTL returns the cache; a transient fetch failure
+// falls back to the last-known-good windows instead of erroring.
+func (r *AccountRef) FetchUsageWindowsCached(ctx context.Context, client *http.Client, account accounts.Account) ([]accounts.UsageWindow, error) {
+	if r == nil {
+		return fetchAccountUsageWindowsLive(ctx, client, account)
+	}
+	key := account.ID + "\x00" + string(account.Provider)
+	now := time.Now()
+	r.usageWindowsMu.Lock()
+	entry, ok := r.usageWindows[key]
+	r.usageWindowsMu.Unlock()
+	if ok && now.Sub(entry.at) < usageWindowsTTL {
+		return append([]accounts.UsageWindow(nil), entry.windows...), nil
+	}
+	windows, err := fetchAccountUsageWindowsLive(ctx, client, account)
+	if err == nil {
+		r.usageWindowsMu.Lock()
+		if r.usageWindows == nil {
+			r.usageWindows = map[string]usageWindowsEntry{}
+		}
+		r.usageWindows[key] = usageWindowsEntry{windows: append([]accounts.UsageWindow(nil), windows...), at: now}
+		r.usageWindowsMu.Unlock()
+		return windows, nil
+	}
+	if !authLikeUsageError(err.Error()) && ok && now.Sub(entry.at) < usageWindowsLastGoodTTL {
+		return append([]accounts.UsageWindow(nil), entry.windows...), nil
+	}
+	return nil, err
 }
 
 type AccountStatus struct {
@@ -514,14 +560,14 @@ func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus
 			}
 			next.AuthValid = true
 			r.replace(account)
-			usage, err := agentclaude.FetchUsage(ctx, r.client, account.Token)
+			windows, err := r.FetchUsageWindowsCached(ctx, r.client, account)
 			if err != nil {
 				next.Error = err.Error()
 				out[i] = next
 				return
 			}
 			next.PlanType = "claude"
-			next.Windows = claudeUsageWindows(usage)
+			next.Windows = windows
 			out[i] = next
 		}()
 	}
@@ -913,7 +959,15 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 			if s.Logger != nil {
 				s.Logger.Warn("account reload usage fetch failed", "account", account.ID, "error", err)
 			}
-			setZeroScore(scores, scoreByID, account.ID)
+			// Auth failures mean the account is unusable; zero it so the
+			// scheduler avoids it. Transient failures (rate limits, network)
+			// keep the optimistic default score: treating unknown as
+			// exhausted herds every session away from healthy accounts, and
+			// per-request usage-limit failover already handles true
+			// exhaustion.
+			if authLikeUsageError(err.Error()) {
+				setZeroScore(scores, scoreByID, account.ID)
+			}
 			continue
 		}
 		if idx, ok := scoreByID[account.ID]; ok {
@@ -925,6 +979,13 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 }
 
 func (s Server) fetchAccountUsageWindows(ctx context.Context, client *http.Client, account accounts.Account) ([]accounts.UsageWindow, error) {
+	if s.AccountRef != nil {
+		return s.AccountRef.FetchUsageWindowsCached(ctx, client, account)
+	}
+	return fetchAccountUsageWindowsLive(ctx, client, account)
+}
+
+func fetchAccountUsageWindowsLive(ctx context.Context, client *http.Client, account accounts.Account) ([]accounts.UsageWindow, error) {
 	if account.Provider == accounts.ProviderClaude {
 		usage, err := agentclaude.FetchUsage(ctx, client, account.Token)
 		if err != nil {

--- a/internal/proxy/usage_windows_cache_test.go
+++ b/internal/proxy/usage_windows_cache_test.go
@@ -1,0 +1,109 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/internal/selectacct"
+)
+
+type countingTransport struct {
+	calls     int
+	responses func() *http.Response
+}
+
+func (c *countingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	c.calls++
+	return c.responses(), nil
+}
+
+func claudeUsageOK() *http.Response {
+	body := `{"five_hour":{"utilization":40.0,"resets_at":"2030-01-01T00:00:00+00:00"},"seven_day":{"utilization":10.0,"resets_at":"2030-01-02T00:00:00+00:00"}}`
+	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: http.Header{}}
+}
+
+func claudeUsage429() *http.Response {
+	return &http.Response{StatusCode: http.StatusTooManyRequests, Status: "429 Too Many Requests", Body: io.NopCloser(strings.NewReader("{}")), Header: http.Header{}}
+}
+
+func TestFetchUsageWindowsCachedServesFromCacheWithinTTL(t *testing.T) {
+	transport := &countingTransport{responses: claudeUsageOK}
+	ref := &AccountRef{}
+	client := &http.Client{Transport: transport}
+	account := accounts.Account{ID: "a@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok"}
+	for i := 0; i < 3; i++ {
+		windows, err := ref.FetchUsageWindowsCached(context.Background(), client, account)
+		if err != nil || len(windows) == 0 {
+			t.Fatalf("call %d: windows=%v err=%v", i, windows, err)
+		}
+	}
+	if transport.calls != 1 {
+		t.Fatalf("upstream calls = %d, want 1 (cache should absorb repeats)", transport.calls)
+	}
+}
+
+func TestFetchUsageWindowsCachedFallsBackToLastGoodOn429(t *testing.T) {
+	transport := &countingTransport{responses: claudeUsageOK}
+	ref := &AccountRef{}
+	client := &http.Client{Transport: transport}
+	account := accounts.Account{ID: "a@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok"}
+	if _, err := ref.FetchUsageWindowsCached(context.Background(), client, account); err != nil {
+		t.Fatal(err)
+	}
+	// Expire the freshness window but keep the entry as last-good.
+	key := account.ID + "\x00" + string(account.Provider)
+	ref.usageWindowsMu.Lock()
+	entry := ref.usageWindows[key]
+	entry.at = entry.at.Add(-usageWindowsTTL - 1)
+	ref.usageWindows[key] = entry
+	ref.usageWindowsMu.Unlock()
+	transport.responses = claudeUsage429
+	windows, err := ref.FetchUsageWindowsCached(context.Background(), client, account)
+	if err != nil {
+		t.Fatalf("transient 429 should serve last-good, got error %v", err)
+	}
+	if len(windows) == 0 {
+		t.Fatal("last-good windows missing")
+	}
+}
+
+func TestFetchUsageWindowsCachedPropagatesAuthErrors(t *testing.T) {
+	transport := &countingTransport{responses: func() *http.Response {
+		return &http.Response{StatusCode: http.StatusUnauthorized, Status: "401 Unauthorized", Body: io.NopCloser(strings.NewReader("{}")), Header: http.Header{}}
+	}}
+	ref := &AccountRef{}
+	client := &http.Client{Transport: transport}
+	account := accounts.Account{ID: "a@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok"}
+	if _, err := ref.FetchUsageWindowsCached(context.Background(), client, account); err == nil {
+		t.Fatal("auth error should propagate, not be masked")
+	}
+}
+
+func TestScoreAccountsKeepsOptimisticScoreOnTransientFailure(t *testing.T) {
+	server := Server{
+		ScoreAccounts: nil,
+		Logger:        nil,
+	}
+	scores := []selectacct.Score{{AccountID: "a@example.com", Headroom: 1, ShortHeadroom: 1}}
+	scoreByID := map[string]int{"a@example.com": 0}
+	// Simulate the error-handling branch directly: transient errors must not
+	// zero, auth errors must.
+	transientErr := errors.New("usage fetch failed: 429 Too Many Requests")
+	if authLikeUsageError(transientErr.Error()) {
+		t.Fatal("429 must not classify as auth error")
+	}
+	authErr := errors.New("usage fetch failed: 401 Unauthorized")
+	if !authLikeUsageError(authErr.Error()) {
+		t.Fatal("401 must classify as auth error")
+	}
+	setZeroScore(scores, scoreByID, "a@example.com")
+	if scores[0].Headroom != 0 {
+		t.Fatal("setZeroScore should zero")
+	}
+	_ = server
+}


### PR DESCRIPTION
Tonight's failure: with 10 pooled Claude accounts, the usage-status sweeps plus the 30s scheduler scoring pass fetched live usage per account and tripped Anthropic's per-IP rate limit, then the cascade made it worse — a failed usage fetch zeroed the account's score, so rate limiting alone marked the whole healthy pool exhausted, and the deploy restart had wiped the status-level last-good cache so every row rendered 'usage fetch failed: 429'.

Fixes:
1. `AccountRef.FetchUsageWindowsCached` is now the single usage-window read path for scheduler scoring and the usage-status sweep: 2-minute fresh TTL (callers hitting every 30s get cache), 15-minute last-known-good fallback on transient errors. Auth-shaped errors always propagate so dead credentials still surface.
2. `scoreAccounts` no longer zeroes an account's score on transient fetch failure — unknown ≠ exhausted; the optimistic default keeps routing alive and per-request usage-limit failover (PR #5) handles true exhaustion. Auth failures still zero.

Steady-state Anthropic usage-endpoint load drops from ~20 req/min to ~5 req/min with 10 accounts.

Tests: cache-within-TTL, last-good fallback on 429, auth-error propagation, 429-vs-401 classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783722560&installation_id=133855650&pr_number=11&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F11&signature=9fe63010e1c9975206173556006c7a996c35cff85008de532dcff86feeee786c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shared a cached usage-window reader across scheduler scoring and status sweeps, and stopped zeroing scores on transient failures. This cuts Anthropic usage calls and prevents healthy pools from being marked exhausted.

- **Bug Fixes**
  - Added `AccountRef.FetchUsageWindowsCached` as the single read path with a 2‑min fresh TTL and a 15‑min last‑good fallback on transient errors; auth errors still propagate.
  - Updated `scoreAccounts` to keep the optimistic default on transient fetch failures; only auth failures zero the score.
  - Reduced Anthropic usage-endpoint load from ~20 req/min to ~5 req/min with 10 accounts.
  - Added tests for cache hits, 429 fallback, auth error propagation, and 429 vs 401 classification.

<sup>Written for commit 5261c2fc3ac0e6ce09f66c1b63aca29bfc86aa70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added caching with automatic fallback for account usage status data, reducing repeated upstream requests.

* **Bug Fixes**
  * Modified error handling to distinguish between authentication failures and temporary service disruptions, improving resilience during outages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->