### PR TITLE
sr claude: pass args through to Claude and route via the server pool by default

### DIFF
--- a/cmd/subrouter/sr_claude.go
+++ b/cmd/subrouter/sr_claude.go
@@ -3,11 +3,13 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -17,21 +19,23 @@ import (
 	"github.com/manaflow-ai/subrouter/internal/agents/claude"
 )
 
-const srClaudeHelp = `sr claude - Manage multiple Claude Code profiles
+const srClaudeHelp = `sr claude - Run Claude Code through Subrouter and manage profiles
 
 Usage:
-  sr claude                     Show profiles and switch interactively
+  sr claude [args...]           Launch Claude with the active profile; args pass through
   sr claude add [name]          Add account (opens OAuth login, infers email)
   sr claude list                List all profiles with auth status
-  sr claude switch [name]       Switch active profile
+  sr claude switch [name]       Switch active profile (interactive picker without name)
   sr claude remove <name>       Remove a profile
   sr claude env                 Print export CLAUDE_CONFIG_DIR=...
   sr claude push [name]         Upload a profile to the default Subrouter server pool
   sr claude pick                Switch to the profile with the most quota left
   sr claude run [name] [...]    Launch Claude with a specific profile
-  sr claude --flag [...]        Launch Claude with the active profile
   sr claude <name> [...]        Shorthand for 'sr claude run <name>'
   sr claude help                Show this help
+
+With no local profiles, launching creates a proxy-only profile that routes
+through the default Subrouter server's account pool (no local login needed).
 `
 
 type claudeRunner struct {
@@ -47,25 +51,29 @@ type claudeRunner struct {
 	pushToServer func(ctx context.Context, name string) error
 	pushAfterAdd func(ctx context.Context, name string) error
 	pick         func(ctx context.Context) error
+	// defaultServer reports the default remote Subrouter server, used to
+	// synthesize a proxy-only profile when no local profile exists.
+	defaultServer func() (srServerConfig, bool, error)
 }
 
 func (r srRunner) claude(ctx context.Context, args []string) error {
 	cr := claudeRunner{
-		store:        claude.DefaultStore(),
-		in:           r.in,
-		out:          r.out,
-		errOut:       r.errOut,
-		client:       r.client,
-		pushToServer: r.pushClaudeProfileToServer,
-		pushAfterAdd: r.pushClaudeProfileAfterAdd,
-		pick:         r.pickClaudeProfile,
+		store:         claude.DefaultStore(),
+		in:            r.in,
+		out:           r.out,
+		errOut:        r.errOut,
+		client:        r.client,
+		pushToServer:  r.pushClaudeProfileToServer,
+		pushAfterAdd:  r.pushClaudeProfileAfterAdd,
+		pick:          r.pickClaudeProfile,
+		defaultServer: r.defaultRemoteServer,
 	}
 	return cr.run(ctx, args)
 }
 
 func (r claudeRunner) run(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		return r.defaultInteractive(ctx)
+		return r.runClaude(ctx, "", nil)
 	}
 	switch args[0] {
 	case "add", "login":
@@ -130,7 +138,9 @@ func (r claudeRunner) run(ctx context.Context, args []string) error {
 		if _, ok := r.store.FindProfile(args[0]); ok {
 			return r.runClaude(ctx, args[0], args[1:])
 		}
-		return fmt.Errorf("unknown command: sr claude %s\n%s", args[0], srClaudeHelp)
+		// Codex parity: anything that is not a subcommand or profile name is
+		// a Claude CLI argument (e.g. a positional prompt) — pass it through.
+		return r.runClaude(ctx, "", args)
 	}
 }
 
@@ -417,7 +427,11 @@ func (r claudeRunner) runClaude(ctx context.Context, name string, extra []string
 		name = r.store.ActiveProfile()
 	}
 	if name == "" {
-		return fmt.Errorf("no profile specified and no active profile set")
+		fallback, err := r.ensureServerProfile()
+		if err != nil {
+			return err
+		}
+		name = fallback
 	}
 	profile, ok, err := r.store.MatchProfile(name)
 	if err != nil {
@@ -447,6 +461,67 @@ func (r claudeRunner) runClaude(ctx context.Context, name string, extra []string
 	cmd.Stderr = r.errOut
 	cmd.Env = append(os.Environ(), "CLAUDE_CONFIG_DIR="+r.store.ClaudeConfigDir(profile.Name))
 	return cmd.Run()
+}
+
+// serverProfileName is the implicit proxy-only profile used when no local
+// Claude profile exists. It carries no OAuth login of its own; every request
+// routes through the default Subrouter server's account pool.
+const serverProfileName = "server"
+
+// ensureServerProfile creates (or refreshes) the proxy-only profile against
+// the default Subrouter server so 'sr claude' works with zero local logins,
+// matching how 'sr codex' uses the server pool directly.
+func (r claudeRunner) ensureServerProfile() (string, error) {
+	if r.defaultServer == nil {
+		return "", fmt.Errorf("no profile specified and no active profile set")
+	}
+	server, ok, err := r.defaultServer()
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("no Claude profiles and no default Subrouter server; run 'sr claude add' to log in locally or 'sr server use <name>' to route through a server pool")
+	}
+	if _, exists := r.store.FindProfile(serverProfileName); !exists {
+		if _, err := r.store.CreateProfile(serverProfileName); err != nil {
+			return "", err
+		}
+		fmt.Fprintf(r.errOut, "Created proxy-only Claude profile %q routed through server %s.\n", serverProfileName, server.Name)
+	}
+	configDir := r.store.ClaudeConfigDir(serverProfileName)
+	if err := writeClaudeProxyEnv(configDir, server.URL); err != nil {
+		return "", err
+	}
+	if err := ensureClaudeOnboarded(configDir); err != nil {
+		return "", err
+	}
+	return serverProfileName, nil
+}
+
+// ensureClaudeOnboarded seeds the config dir's .claude.json so a proxy-only
+// profile skips Claude Code's first-run onboarding wizard (there is no local
+// login step that would otherwise complete it).
+func ensureClaudeOnboarded(configDir string) error {
+	path := filepath.Join(configDir, ".claude.json")
+	state := map[string]any{}
+	if body, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(body, &state); err != nil {
+			return fmt.Errorf("parse %s: %w", path, err)
+		}
+	}
+	if onboarded, _ := state["hasCompletedOnboarding"].(bool); onboarded {
+		return nil
+	}
+	state["hasCompletedOnboarding"] = true
+	out, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	out = append(out, '\n')
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0o600)
 }
 
 type claudeRow struct {

--- a/cmd/subrouter/sr_claude_test.go
+++ b/cmd/subrouter/sr_claude_test.go
@@ -112,3 +112,171 @@ func TestClaudeFlagsRunActiveProfile(t *testing.T) {
 		t.Fatalf("Claude did not receive flags:\n%s", got)
 	}
 }
+
+// installFakeClaude puts a fake claude binary on PATH that records its
+// CLAUDE_CONFIG_DIR and argv, and returns the record file path.
+func installFakeClaude(t *testing.T, home string) string {
+	t.Helper()
+	binDir := filepath.Join(home, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	recordPath := filepath.Join(home, "claude-run.txt")
+	script := "#!/bin/sh\nprintf 'config=%s\\nargs=%s\\n' \"$CLAUDE_CONFIG_DIR\" \"$*\" > " + shellQuote(recordPath) + "\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return recordPath
+}
+
+func TestClaudeBareLaunchesActiveProfile(t *testing.T) {
+	home := t.TempDir()
+	store := claude.Store{Dir: filepath.Join(home, ".subrouter", "codex")}
+	if _, err := store.CreateProfile("work"); err != nil {
+		t.Fatal(err)
+	}
+	recordPath := installFakeClaude(t, home)
+
+	var out bytes.Buffer
+	runner := claudeRunner{store: store, in: strings.NewReader(""), out: &out, errOut: &out}
+	if err := runner.run(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := os.ReadFile(recordPath)
+	if err != nil {
+		t.Fatalf("bare 'sr claude' did not launch Claude: %v", err)
+	}
+	if !strings.Contains(string(body), "config="+store.ClaudeConfigDir("work")) {
+		t.Fatalf("Claude did not receive active config dir:\n%s", body)
+	}
+}
+
+func TestClaudePositionalPromptPassesThrough(t *testing.T) {
+	home := t.TempDir()
+	store := claude.Store{Dir: filepath.Join(home, ".subrouter", "codex")}
+	if _, err := store.CreateProfile("work"); err != nil {
+		t.Fatal(err)
+	}
+	recordPath := installFakeClaude(t, home)
+
+	var out bytes.Buffer
+	runner := claudeRunner{store: store, in: strings.NewReader(""), out: &out, errOut: &out}
+	if err := runner.run(context.Background(), []string{"fix the flaky test", "-p"}); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := os.ReadFile(recordPath)
+	if err != nil {
+		t.Fatalf("positional prompt did not launch Claude: %v", err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "config="+store.ClaudeConfigDir("work")) {
+		t.Fatalf("Claude did not receive active config dir:\n%s", got)
+	}
+	if !strings.Contains(got, "args=fix the flaky test -p") {
+		t.Fatalf("Claude did not receive the positional prompt:\n%s", got)
+	}
+}
+
+func TestClaudeProfileNameStillRunsThatProfile(t *testing.T) {
+	home := t.TempDir()
+	store := claude.Store{Dir: filepath.Join(home, ".subrouter", "codex")}
+	if _, err := store.CreateProfile("work"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateProfile("personal"); err != nil {
+		t.Fatal(err)
+	}
+	recordPath := installFakeClaude(t, home)
+
+	var out bytes.Buffer
+	runner := claudeRunner{store: store, in: strings.NewReader(""), out: &out, errOut: &out}
+	if err := runner.run(context.Background(), []string{"personal", "-p"}); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := os.ReadFile(recordPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "config="+store.ClaudeConfigDir("personal")) {
+		t.Fatalf("Claude did not receive the named profile config dir:\n%s", got)
+	}
+	if !strings.Contains(got, "args=-p") || strings.Contains(got, "args=personal") {
+		t.Fatalf("profile name leaked into Claude args:\n%s", got)
+	}
+}
+
+func TestClaudeNoProfilesFallsBackToServerPool(t *testing.T) {
+	home := t.TempDir()
+	store := claude.Store{Dir: filepath.Join(home, ".subrouter", "codex")}
+	recordPath := installFakeClaude(t, home)
+
+	var out bytes.Buffer
+	runner := claudeRunner{
+		store:  store,
+		in:     strings.NewReader(""),
+		out:    &out,
+		errOut: &out,
+		defaultServer: func() (srServerConfig, bool, error) {
+			return srServerConfig{Name: "team", URL: "http://subrouter-team:31415"}, true, nil
+		},
+	}
+	if err := runner.run(context.Background(), []string{"-p", "hello"}); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := os.ReadFile(recordPath)
+	if err != nil {
+		t.Fatalf("fallback did not launch Claude: %v", err)
+	}
+	configDir := store.ClaudeConfigDir(serverProfileName)
+	if !strings.Contains(string(body), "config="+configDir) {
+		t.Fatalf("Claude did not receive server profile config dir:\n%s", body)
+	}
+
+	settings, err := os.ReadFile(filepath.Join(configDir, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(settings), `"ANTHROPIC_BASE_URL": "http://subrouter-team:31415"`) {
+		t.Fatalf("server profile settings missing proxy env:\n%s", settings)
+	}
+	state, err := os.ReadFile(filepath.Join(configDir, ".claude.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(state), `"hasCompletedOnboarding": true`) {
+		t.Fatalf("server profile missing onboarding seed:\n%s", state)
+	}
+	if active := store.ActiveProfile(); active != serverProfileName {
+		t.Fatalf("active profile = %q, want %q", active, serverProfileName)
+	}
+}
+
+func TestClaudeNoProfilesNoServerErrors(t *testing.T) {
+	home := t.TempDir()
+	store := claude.Store{Dir: filepath.Join(home, ".subrouter", "codex")}
+	installFakeClaude(t, home)
+
+	var out bytes.Buffer
+	runner := claudeRunner{
+		store:  store,
+		in:     strings.NewReader(""),
+		out:    &out,
+		errOut: &out,
+		defaultServer: func() (srServerConfig, bool, error) {
+			return srServerConfig{}, false, nil
+		},
+	}
+	err := runner.run(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error with no profiles and no default server")
+	}
+	if !strings.Contains(err.Error(), "sr claude add") || !strings.Contains(err.Error(), "sr server use") {
+		t.Fatalf("error should point at both setup paths, got: %v", err)
+	}
+}


### PR DESCRIPTION
`sr claude "$(cat prompt.txt)"` previously failed with `unknown command: sr claude <prompt>` because every non-flag first arg was parsed as a profile subcommand. That broke the codex-style dispatch pattern (`sr codex --model ... "$(cat prompt.txt)"` vs claude).

Changes:
- Bare `sr claude` launches Claude with the active profile (the interactive picker moves to `sr claude switch`, which already had that path).
- Args that are not a known subcommand or profile name pass through to the Claude CLI, so positional prompts work like they do with `sr codex`.
- With no local profiles, launching creates a proxy-only `server` profile wired to the default Subrouter server (`ANTHROPIC_BASE_URL` + dummy `ANTHROPIC_AUTH_TOKEN` in its settings.json, onboarding pre-seeded), so the server account pool needs zero local OAuth logins.

Verified live: `sr claude "Reply with exactly: subrouter-pool-ok" -p` launches Claude, and the request shows up in the subrouter-team journal as a pooled `agent=claude` session. Also confirmed Claude Code 2.1.173 sends `Bearer subrouter` (env auth token) even when an OAuth credential exists in the profile, so proxy-mode profiles route correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783813139&installation_id=133855650&pr_number=12&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F12&signature=8b662d658ef79b96f912b560e8afbba89b8615d90551398685859e333d84b1bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `sr claude` match `sr codex`: pass args through to the Claude CLI and, if no local profile exists, route via the default Subrouter server pool. Fixes “unknown command” errors for positional prompts and reduces setup by using the server automatically.

- **New Features**
  - Bare `sr claude` now launches Claude with the active profile; the interactive picker moves to `sr claude switch`.
  - Any first arg that isn’t a subcommand or profile name is forwarded to the Claude CLI (positional prompts work).
  - When no profiles exist, auto-creates a proxy-only `server` profile wired to the default Subrouter server, seeds onboarding, and sets `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN` so requests use the server account pool.

- **Migration**
  - Use `sr claude switch` to pick profiles interactively. If you want server routing, ensure a default server is set with `sr server use <name>`.

<sup>Written for commit a7cee980468dee434b8a738bac9bd2fe8f835c3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `sr claude` now launches directly when invoked with no arguments
  * Positional arguments are passed through to Claude
  * Automatic fallback to default server profile when no local profiles exist

* **Tests**
  * Added comprehensive test coverage for Claude invocation and fallback behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->