### PR TITLE
Shared Claude session store: --resume works across profiles

### DIFF
--- a/cmd/subrouter/sr_claude.go
+++ b/cmd/subrouter/sr_claude.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -26,6 +27,7 @@ Usage:
   sr claude switch [name]       Switch active profile
   sr claude remove <name>       Remove a profile
   sr claude env                 Print export CLAUDE_CONFIG_DIR=...
+  sr claude consolidate         Move all profiles' sessions into one shared store (resume works across profiles)
   sr claude push [name]         Upload a profile to the default Subrouter server pool
   sr claude pick                Switch to the profile with the most quota left
   sr claude run [name] [...]    Launch Claude with a specific profile
@@ -47,18 +49,24 @@ type claudeRunner struct {
 	pushToServer func(ctx context.Context, name string) error
 	pushAfterAdd func(ctx context.Context, name string) error
 	pick         func(ctx context.Context) error
+	// defaultClaudeDir is the config dir a bare `claude` uses when
+	// CLAUDE_CONFIG_DIR is unset (~/.claude). Consolidation folds it into the
+	// shared store too so sessions started outside any profile stay resumable.
+	// Empty in tests to keep them off the real home dir.
+	defaultClaudeDir string
 }
 
 func (r srRunner) claude(ctx context.Context, args []string) error {
 	cr := claudeRunner{
-		store:        claude.DefaultStore(),
-		in:           r.in,
-		out:          r.out,
-		errOut:       r.errOut,
-		client:       r.client,
-		pushToServer: r.pushClaudeProfileToServer,
-		pushAfterAdd: r.pushClaudeProfileAfterAdd,
-		pick:         r.pickClaudeProfile,
+		store:            claude.DefaultStore(),
+		in:               r.in,
+		out:              r.out,
+		errOut:           r.errOut,
+		client:           r.client,
+		pushToServer:     r.pushClaudeProfileToServer,
+		pushAfterAdd:     r.pushClaudeProfileAfterAdd,
+		pick:             r.pickClaudeProfile,
+		defaultClaudeDir: defaultClaudeConfigDir(),
 	}
 	return cr.run(ctx, args)
 }
@@ -88,6 +96,8 @@ func (r claudeRunner) run(ctx context.Context, args []string) error {
 		return r.remove(args[1])
 	case "env":
 		return r.env()
+	case "consolidate":
+		return r.consolidate()
 	case "pick":
 		if r.pick == nil {
 			return fmt.Errorf("pick is not available")
@@ -338,8 +348,74 @@ func (r claudeRunner) env() error {
 	if active == "" {
 		return nil
 	}
-	fmt.Fprintf(r.out, "export CLAUDE_CONFIG_DIR=%s\n", r.store.ClaudeConfigDir(active))
+	configDir := r.store.ClaudeConfigDir(active)
+	r.convergeShared(configDir)
+	fmt.Fprintf(r.out, "export CLAUDE_CONFIG_DIR=%s\n", configDir)
 	return nil
+}
+
+func (r claudeRunner) consolidate() error {
+	report, err := r.store.ConsolidateSharedState()
+	if err != nil {
+		return err
+	}
+	if dir := r.existingDefaultClaudeDir(); dir != "" {
+		defaultReport, err := r.store.EnsureSharedLayout(dir)
+		if err != nil {
+			return fmt.Errorf("default Claude dir %s: %w", dir, err)
+		}
+		report.Profiles++
+		report.Moved += defaultReport.Moved
+		report.Conflicts = append(report.Conflicts, defaultReport.Conflicts...)
+	}
+	fmt.Fprintln(r.out, claude.FormatSharedStateReport(report))
+	fmt.Fprintf(r.out, "Shared store: %s\n", r.store.SharedDir())
+	fmt.Fprintln(r.out, "Sessions are now resumable from every profile; new profiles join automatically.")
+	return nil
+}
+
+// defaultClaudeConfigDir resolves the config dir a bare `claude` falls back to
+// when CLAUDE_CONFIG_DIR is unset.
+func defaultClaudeConfigDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".claude")
+}
+
+// existingDefaultClaudeDir returns the default Claude dir only when it already
+// exists, so consolidation never materializes ~/.claude for users who only
+// ever run Claude through profiles.
+func (r claudeRunner) existingDefaultClaudeDir() string {
+	if r.defaultClaudeDir == "" {
+		return ""
+	}
+	info, err := os.Stat(r.defaultClaudeDir)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+	return r.defaultClaudeDir
+}
+
+// convergeShared repairs a profile's shared-store symlinks before handing the
+// config dir to Claude (Claude recreates real dirs when a symlink goes
+// missing). No-op until `sr claude consolidate` has created the shared store;
+// best-effort because launching Claude matters more than the repair.
+func (r claudeRunner) convergeShared(configDir string) {
+	if !r.store.SharedStoreEnabled() {
+		return
+	}
+	if _, err := r.store.EnsureSharedLayout(configDir); err != nil {
+		fmt.Fprintf(r.errOut, "warning: shared session store converge failed: %v\n", err)
+	}
+	// Bare `claude` (no CLAUDE_CONFIG_DIR) recreates real dirs in ~/.claude
+	// when its symlinks go missing; repair it on the same occasions.
+	if dir := r.existingDefaultClaudeDir(); dir != "" {
+		if _, err := r.store.EnsureSharedLayout(dir); err != nil {
+			fmt.Fprintf(r.errOut, "warning: default Claude dir converge failed: %v\n", err)
+		}
+	}
 }
 
 // runClaudeUntilCredential runs the interactive Claude login and polls for the
@@ -433,6 +509,8 @@ func (r claudeRunner) runClaude(ctx context.Context, name string, extra []string
 	if err := r.store.SetActiveProfile(profile.Name); err != nil {
 		return err
 	}
+	configDir := r.store.ClaudeConfigDir(profile.Name)
+	r.convergeShared(configDir)
 	if sessionID := claude.ResumeSessionID(extra); sessionID != "" {
 		from, migrateErr := r.store.MigrateSession(profile.Name, sessionID)
 		if migrateErr != nil {
@@ -445,7 +523,7 @@ func (r claudeRunner) runClaude(ctx context.Context, name string, extra []string
 	cmd.Stdin = r.in
 	cmd.Stdout = r.out
 	cmd.Stderr = r.errOut
-	cmd.Env = append(os.Environ(), "CLAUDE_CONFIG_DIR="+r.store.ClaudeConfigDir(profile.Name))
+	cmd.Env = append(os.Environ(), "CLAUDE_CONFIG_DIR="+configDir)
 	return cmd.Run()
 }
 

--- a/cmd/subrouter/sr_claude_test.go
+++ b/cmd/subrouter/sr_claude_test.go
@@ -112,3 +112,56 @@ func TestClaudeFlagsRunActiveProfile(t *testing.T) {
 		t.Fatalf("Claude did not receive flags:\n%s", got)
 	}
 }
+
+func TestClaudeConsolidateIncludesDefaultClaudeDir(t *testing.T) {
+	store := claude.Store{Dir: t.TempDir()}
+	if _, err := store.CreateProfile("work"); err != nil {
+		t.Fatal(err)
+	}
+	defaultDir := filepath.Join(t.TempDir(), ".claude")
+	id := "99999999-9999-9999-9999-999999999999"
+	transcript := filepath.Join(defaultDir, "projects", "-proj", id+".jsonl")
+	if err := os.MkdirAll(filepath.Dir(transcript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(transcript, []byte("bare-session"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	runner := claudeRunner{store: store, in: strings.NewReader(""), out: &out, errOut: &out, defaultClaudeDir: defaultDir}
+	if err := runner.run(context.Background(), []string{"consolidate"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The bare-claude session is now visible from the profile.
+	fromProfile := filepath.Join(store.ClaudeConfigDir("work"), "projects", "-proj", id+".jsonl")
+	if _, err := os.Stat(fromProfile); err != nil {
+		t.Fatalf("bare session not visible from profile: %v", err)
+	}
+	// And ~/.claude itself is converged onto the shared store.
+	info, err := os.Lstat(filepath.Join(defaultDir, "projects"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("default Claude dir projects should be a symlink after consolidate")
+	}
+}
+
+func TestClaudeConsolidateSkipsMissingDefaultClaudeDir(t *testing.T) {
+	store := claude.Store{Dir: t.TempDir()}
+	if _, err := store.CreateProfile("work"); err != nil {
+		t.Fatal(err)
+	}
+	defaultDir := filepath.Join(t.TempDir(), ".claude")
+
+	var out bytes.Buffer
+	runner := claudeRunner{store: store, in: strings.NewReader(""), out: &out, errOut: &out, defaultClaudeDir: defaultDir}
+	if err := runner.run(context.Background(), []string{"consolidate"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(defaultDir); !os.IsNotExist(err) {
+		t.Fatalf("consolidate must not materialize %s, lstat err = %v", defaultDir, err)
+	}
+}

--- a/internal/agents/claude/shared.go
+++ b/internal/agents/claude/shared.go
@@ -1,0 +1,286 @@
+package claude
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// sharedStateDirNames are the per-profile Claude Code state dirs that hold
+// conversation state keyed by session UUID (or referenced from transcripts):
+// transcripts, per-session env, file history, todos, shell snapshots, task
+// lists, and plans. Sharing them across profiles makes every session
+// resumable from every profile; only credentials and account identity (the
+// keychain entry and .claude.json) stay per-profile.
+var sharedStateDirNames = []string{
+	"projects",
+	"session-env",
+	"file-history",
+	"todos",
+	"shell-snapshots",
+	"tasks",
+	"plans",
+}
+
+const (
+	sharedDirName       = "_shared"
+	sharedConflictsName = ".conflicts"
+)
+
+// SharedStateReport summarizes a consolidation or layout-repair pass.
+type SharedStateReport struct {
+	Profiles  int
+	Moved     int
+	Conflicts []string
+}
+
+func (r *SharedStateReport) merge(other SharedStateReport) {
+	r.Profiles += other.Profiles
+	r.Moved += other.Moved
+	r.Conflicts = append(r.Conflicts, other.Conflicts...)
+}
+
+// SharedDir returns the shared session store directory, a sibling of the
+// profile config dirs. It lives under the same root the profile config dirs
+// resolve to (the legacy ~/.codex-accounts location when that is still the
+// preferred home of the instance dirs), so `ls` next to the profiles shows it.
+func (s Store) SharedDir() string {
+	return filepath.Join(s.preferredInstancesRoot(), sharedDirName)
+}
+
+// preferredInstancesRoot mirrors PreferredInstancePath for the instances root
+// itself: when the store lives in ~/.subrouter/codex but the legacy
+// ~/.codex-accounts tree is still the preferred home of instance dirs, the
+// shared store must live there too, next to the dirs it is linked from.
+func (s Store) preferredInstancesRoot() string {
+	instances := s.InstancesDir()
+	cleanDir := filepath.Clean(s.Dir)
+	if filepath.Base(cleanDir) != "codex" || filepath.Base(filepath.Dir(cleanDir)) != ".subrouter" {
+		return instances
+	}
+	home := filepath.Dir(filepath.Dir(cleanDir))
+	candidate := filepath.Join(home, ".codex-accounts", "claude")
+	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+		return candidate
+	}
+	return instances
+}
+
+// SharedStoreEnabled reports whether the shared session store has been
+// created (via `sr claude consolidate`). Until then profiles keep fully
+// isolated state and nothing changes.
+func (s Store) SharedStoreEnabled() bool {
+	info, err := os.Stat(s.SharedDir())
+	return err == nil && info.IsDir()
+}
+
+// ConsolidateSharedState creates the shared session store and converges every
+// instance dir onto it: per-instance session state moves (renames, same
+// volume) into the shared store and each instance dir gets symlinks in its
+// place. Besides registered profiles this sweeps every other dir in the
+// instances root (temp instances from `sr claude add`, dirs orphaned by
+// removed profiles), since those hold resumable sessions too. Re-running is a
+// cheap no-op for already-converged dirs. When the same file exists in two
+// instances with different content, the newer copy wins and the older one is
+// quarantined under _shared/.conflicts/<instance-dir>/ rather than deleted.
+func (s Store) ConsolidateSharedState() (SharedStateReport, error) {
+	var report SharedStateReport
+	if err := os.MkdirAll(s.SharedDir(), 0o700); err != nil {
+		return report, err
+	}
+	seen := map[string]bool{}
+	for _, profile := range s.ListProfiles() {
+		configDir := filepath.Clean(s.ClaudeConfigDir(profile.Name))
+		profileReport, err := s.EnsureSharedLayout(configDir)
+		if err != nil {
+			return report, fmt.Errorf("profile %q: %w", profile.Name, err)
+		}
+		seen[configDir] = true
+		report.merge(profileReport)
+		report.Profiles++
+	}
+	for _, root := range []string{s.preferredInstancesRoot(), s.InstancesDir()} {
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() || entry.Name() == sharedDirName || strings.HasPrefix(entry.Name(), ".") {
+				continue
+			}
+			configDir := filepath.Clean(filepath.Join(root, entry.Name()))
+			if seen[configDir] {
+				continue
+			}
+			instanceReport, err := s.EnsureSharedLayout(configDir)
+			if err != nil {
+				return report, fmt.Errorf("instance %s: %w", configDir, err)
+			}
+			seen[configDir] = true
+			report.merge(instanceReport)
+			report.Profiles++
+		}
+	}
+	return report, nil
+}
+
+// EnsureSharedLayout converges one profile config dir onto the shared store:
+// for each shared state dir, a missing entry becomes a symlink, an existing
+// real dir is merged into the shared store (then replaced by a symlink), and
+// an existing symlink is left alone. Safe to call on every launch; when the
+// profile is already converged this is a handful of lstats.
+func (s Store) EnsureSharedLayout(configDir string) (SharedStateReport, error) {
+	var report SharedStateReport
+	sharedDir := s.SharedDir()
+	cleanConfig := filepath.Clean(configDir)
+	if cleanConfig == filepath.Clean(sharedDir) || filepath.Base(cleanConfig) == sharedDirName {
+		return report, fmt.Errorf("refusing to converge the shared store onto itself: %s", configDir)
+	}
+	if err := os.MkdirAll(cleanConfig, 0o700); err != nil {
+		return report, err
+	}
+	for _, name := range sharedStateDirNames {
+		target := filepath.Join(sharedDir, name)
+		if err := os.MkdirAll(target, 0o700); err != nil {
+			return report, err
+		}
+		link := filepath.Join(configDir, name)
+		info, err := os.Lstat(link)
+		if os.IsNotExist(err) {
+			if err := symlinkIdempotent(target, link); err != nil {
+				return report, err
+			}
+			continue
+		}
+		if err != nil {
+			return report, err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+		if !info.IsDir() {
+			return report, fmt.Errorf("%s exists and is not a directory", link)
+		}
+		conflictDir := filepath.Join(sharedDir, sharedConflictsName, filepath.Base(cleanConfig), name)
+		moved, conflicts, err := mergeMoveDir(link, target, conflictDir)
+		report.Moved += moved
+		report.Conflicts = append(report.Conflicts, conflicts...)
+		if err != nil {
+			return report, err
+		}
+		if err := os.Remove(link); err != nil {
+			return report, fmt.Errorf("replace %s with symlink: %w", link, err)
+		}
+		if err := symlinkIdempotent(target, link); err != nil {
+			return report, err
+		}
+	}
+	return report, nil
+}
+
+// symlinkIdempotent creates link -> target, tolerating a concurrent process
+// having already created an equivalent symlink.
+func symlinkIdempotent(target, link string) error {
+	err := os.Symlink(target, link)
+	if err == nil || !os.IsExist(err) {
+		return err
+	}
+	info, lerr := os.Lstat(link)
+	if lerr == nil && info.Mode()&os.ModeSymlink != 0 {
+		return nil
+	}
+	return err
+}
+
+// mergeMoveDir moves the contents of src into dst, merging directories.
+// Files move by rename (no data copies). When dst already has an entry with
+// the same name and either side is not a directory, the entry with the newer
+// mtime ends up in dst and the older one moves under conflictDir. Returns the
+// number of renamed entries and the quarantined conflict paths.
+func mergeMoveDir(src, dst, conflictDir string) (int, []string, error) {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return 0, nil, err
+	}
+	moved := 0
+	var conflicts []string
+	for _, entry := range entries {
+		name := entry.Name()
+		srcPath := filepath.Join(src, name)
+		dstPath := filepath.Join(dst, name)
+		dstInfo, err := os.Lstat(dstPath)
+		if os.IsNotExist(err) {
+			if renameErr := os.Rename(srcPath, dstPath); renameErr == nil {
+				moved++
+				continue
+			}
+			// A concurrent converge may have landed the entry between the
+			// lstat and the rename; re-check before treating it as fatal.
+			dstInfo, err = os.Lstat(dstPath)
+		}
+		if err != nil {
+			return moved, conflicts, err
+		}
+		srcInfo, err := os.Lstat(srcPath)
+		if err != nil {
+			return moved, conflicts, err
+		}
+		if srcInfo.IsDir() && dstInfo.IsDir() {
+			subMoved, subConflicts, err := mergeMoveDir(srcPath, dstPath, filepath.Join(conflictDir, name))
+			moved += subMoved
+			conflicts = append(conflicts, subConflicts...)
+			if err != nil {
+				return moved, conflicts, err
+			}
+			if err := os.Remove(srcPath); err != nil {
+				return moved, conflicts, fmt.Errorf("remove merged dir %s: %w", srcPath, err)
+			}
+			continue
+		}
+		if srcInfo.ModTime().After(dstInfo.ModTime()) {
+			quarantined, err := quarantine(dstPath, filepath.Join(conflictDir, name))
+			if err != nil {
+				return moved, conflicts, err
+			}
+			if err := os.Rename(srcPath, dstPath); err != nil {
+				return moved, conflicts, err
+			}
+			moved++
+			conflicts = append(conflicts, quarantined)
+		} else {
+			quarantined, err := quarantine(srcPath, filepath.Join(conflictDir, name))
+			if err != nil {
+				return moved, conflicts, err
+			}
+			conflicts = append(conflicts, quarantined)
+		}
+	}
+	return moved, conflicts, nil
+}
+
+// quarantine moves path under the conflicts dir, suffixing the name when a
+// previous run already quarantined an entry with the same name. Returns the
+// final quarantined path.
+func quarantine(path, dest string) (string, error) {
+	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+		return "", err
+	}
+	candidate := dest
+	for i := 1; ; i++ {
+		if _, err := os.Lstat(candidate); os.IsNotExist(err) {
+			break
+		}
+		candidate = fmt.Sprintf("%s.%d", dest, i)
+	}
+	return candidate, os.Rename(path, candidate)
+}
+
+// FormatSharedStateReport renders a one-line human summary.
+func FormatSharedStateReport(report SharedStateReport) string {
+	line := fmt.Sprintf("Converged %d profile(s), moved %d entr(ies) into the shared store.", report.Profiles, report.Moved)
+	if len(report.Conflicts) > 0 {
+		line += fmt.Sprintf(" %d conflict(s) quarantined under %s.", len(report.Conflicts), filepath.Join(sharedDirName, sharedConflictsName))
+	}
+	return line
+}

--- a/internal/agents/claude/shared_test.go
+++ b/internal/agents/claude/shared_test.go
@@ -1,0 +1,234 @@
+package claude
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func sharedTestStore(t *testing.T) Store {
+	t.Helper()
+	dir := t.TempDir()
+	store := Store{Dir: dir}
+	profiles := profilesFile{
+		Active: "b@example.com",
+		Profiles: map[string]Profile{
+			"a@example.com": {Name: "a@example.com", Dir: "_pa"},
+			"b@example.com": {Name: "b@example.com", Dir: "_pb"},
+		},
+	}
+	body, err := json.Marshal(profiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "claude.json"), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func writeFileAt(t *testing.T, path, content string, mtime time.Time) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !mtime.IsZero() {
+		if err := os.Chtimes(path, mtime, mtime); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func assertSymlinkTo(t *testing.T, link, target string) {
+	t.Helper()
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat %s: %v", link, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s is not a symlink", link)
+	}
+	got, err := os.Readlink(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != target {
+		t.Fatalf("%s -> %s, want %s", link, got, target)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(body)
+}
+
+func TestConsolidateSharedStateMergesAndSymlinks(t *testing.T) {
+	store := sharedTestStore(t)
+	dirA := store.ClaudeConfigDir("a@example.com")
+	dirB := store.ClaudeConfigDir("b@example.com")
+	project := "-Users-someone-fun-repo"
+	idA := "11111111-1111-1111-1111-111111111111"
+	idB := "22222222-2222-2222-2222-222222222222"
+
+	old := time.Now().Add(-time.Hour)
+	writeFileAt(t, filepath.Join(dirA, "projects", project, idA+".jsonl"), "a-transcript", time.Time{})
+	writeFileAt(t, filepath.Join(dirA, "session-env", idA, "env.json"), "a-env", time.Time{})
+	writeFileAt(t, filepath.Join(dirA, "file-history", idA, "f0@v2"), "a-hist", time.Time{})
+	writeFileAt(t, filepath.Join(dirB, "projects", project, idB+".jsonl"), "b-transcript", time.Time{})
+	// Same session in both profiles (e.g. from an old copy-based migration):
+	// the newer copy must win and the older one must be quarantined.
+	writeFileAt(t, filepath.Join(dirA, "projects", project, idB+".jsonl"), "stale-copy", old)
+
+	report, err := store.ConsolidateSharedState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Profiles != 2 {
+		t.Fatalf("profiles = %d, want 2", report.Profiles)
+	}
+	if len(report.Conflicts) != 1 {
+		t.Fatalf("conflicts = %v, want exactly 1", report.Conflicts)
+	}
+
+	shared := store.SharedDir()
+	for _, name := range sharedStateDirNames {
+		assertSymlinkTo(t, filepath.Join(dirA, name), filepath.Join(shared, name))
+		assertSymlinkTo(t, filepath.Join(dirB, name), filepath.Join(shared, name))
+	}
+	if got := readFile(t, filepath.Join(shared, "projects", project, idA+".jsonl")); got != "a-transcript" {
+		t.Fatalf("shared transcript A = %q", got)
+	}
+	if got := readFile(t, filepath.Join(shared, "projects", project, idB+".jsonl")); got != "b-transcript" {
+		t.Fatalf("shared transcript B = %q, want winner b-transcript", got)
+	}
+	if got := readFile(t, report.Conflicts[0]); got != "stale-copy" {
+		t.Fatalf("quarantined conflict = %q, want stale-copy", got)
+	}
+	// Both profiles now see both sessions through the symlinks.
+	for _, dir := range []string{dirA, dirB} {
+		for _, id := range []string{idA, idB} {
+			if _, err := os.Stat(filepath.Join(dir, "projects", project, id+".jsonl")); err != nil {
+				t.Fatalf("session %s not visible from %s: %v", id, dir, err)
+			}
+		}
+	}
+
+	// Idempotent re-run: nothing moves, no conflicts.
+	report, err = store.ConsolidateSharedState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Moved != 0 || len(report.Conflicts) != 0 {
+		t.Fatalf("re-run moved=%d conflicts=%v, want 0 and none", report.Moved, report.Conflicts)
+	}
+}
+
+func TestEnsureSharedLayoutRepairsRecreatedRealDir(t *testing.T) {
+	store := sharedTestStore(t)
+	if _, err := store.ConsolidateSharedState(); err != nil {
+		t.Fatal(err)
+	}
+	dirB := store.ClaudeConfigDir("b@example.com")
+	project := "-Users-someone-fun-repo"
+	id := "33333333-3333-3333-3333-333333333333"
+
+	// Simulate Claude recreating a real projects dir after the symlink was
+	// deleted, then writing a new session into it.
+	if err := os.Remove(filepath.Join(dirB, "projects")); err != nil {
+		t.Fatal(err)
+	}
+	writeFileAt(t, filepath.Join(dirB, "projects", project, id+".jsonl"), "fresh", time.Time{})
+
+	if _, err := store.EnsureSharedLayout(dirB); err != nil {
+		t.Fatal(err)
+	}
+	assertSymlinkTo(t, filepath.Join(dirB, "projects"), filepath.Join(store.SharedDir(), "projects"))
+	if got := readFile(t, filepath.Join(store.SharedDir(), "projects", project, id+".jsonl")); got != "fresh" {
+		t.Fatalf("merged transcript = %q", got)
+	}
+}
+
+func TestCreateProfileAfterConsolidationGetsSymlinks(t *testing.T) {
+	store := sharedTestStore(t)
+	if _, err := store.ConsolidateSharedState(); err != nil {
+		t.Fatal(err)
+	}
+	instancePath, err := store.CreateProfile("fresh-profile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range sharedStateDirNames {
+		assertSymlinkTo(t, filepath.Join(instancePath, name), filepath.Join(store.SharedDir(), name))
+	}
+}
+
+func TestCreateProfileWithoutSharedStoreKeepsRealDirs(t *testing.T) {
+	store := sharedTestStore(t)
+	instancePath, err := store.CreateProfile("isolated-profile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"session-env", "todos", "file-history"} {
+		info, err := os.Lstat(filepath.Join(instancePath, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			t.Fatalf("%s should be a real dir before consolidation", name)
+		}
+	}
+	if store.SharedStoreEnabled() {
+		t.Fatal("shared store should not exist before consolidation")
+	}
+}
+
+func TestMigrateSessionNoopWhenShared(t *testing.T) {
+	store := sharedTestStore(t)
+	dirA := store.ClaudeConfigDir("a@example.com")
+	id := "44444444-4444-4444-4444-444444444444"
+	writeFileAt(t, filepath.Join(dirA, "projects", "-proj", id+".jsonl"), "x", time.Time{})
+	if _, err := store.ConsolidateSharedState(); err != nil {
+		t.Fatal(err)
+	}
+	from, err := store.MigrateSession("b@example.com", id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if from != "" {
+		t.Fatalf("MigrateSession copied from %q, want shared-store no-op", from)
+	}
+}
+
+func TestEnsureSharedLayoutRefusesSharedDir(t *testing.T) {
+	store := sharedTestStore(t)
+	if _, err := store.ConsolidateSharedState(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.EnsureSharedLayout(store.SharedDir()); err == nil {
+		t.Fatal("expected error converging the shared store onto itself")
+	}
+}
+
+func TestConsolidateSweepsUnregisteredInstanceDirs(t *testing.T) {
+	store := sharedTestStore(t)
+	id := "55555555-5555-5555-5555-555555555555"
+	tempInstance := filepath.Join(store.InstancesDir(), "_p1234567890")
+	writeFileAt(t, filepath.Join(tempInstance, "projects", "-proj", id+".jsonl"), "temp-session", time.Time{})
+
+	if _, err := store.ConsolidateSharedState(); err != nil {
+		t.Fatal(err)
+	}
+	assertSymlinkTo(t, filepath.Join(tempInstance, "projects"), filepath.Join(store.SharedDir(), "projects"))
+	if got := readFile(t, filepath.Join(store.SharedDir(), "projects", "-proj", id+".jsonl")); got != "temp-session" {
+		t.Fatalf("temp instance session = %q", got)
+	}
+}

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -351,6 +351,11 @@ func (s Store) initInstanceDir(instancePath string) error {
 			return err
 		}
 	}
+	if s.SharedStoreEnabled() {
+		if _, err := s.EnsureSharedLayout(s.PreferredInstancePath(instancePath)); err != nil {
+			return err
+		}
+	}
 	return s.syncMCPServers(instancePath)
 }
 


### PR DESCRIPTION
`claude --resume <id>` failed with "No conversation found" whenever the session was started under a different profile (or under bare `~/.claude`), because Claude Code keys all session state to CLAUDE_CONFIG_DIR.

`sr claude consolidate` moves the session-state dirs (`projects`, `session-env`, `file-history`, `todos`, `shell-snapshots`, `tasks`, `plans`) from every instance dir into one `_shared` store and replaces them with symlinks. It sweeps registered profiles, unregistered temp instances, and the bare `~/.claude` default dir. Moves are same-volume renames, no data copies. When two instances hold the same file, the newer mtime wins and the older copy is quarantined under `_shared/.conflicts/<instance>/`, never deleted.

`sr claude env` and `sr claude run` re-converge the symlinks on every invocation (Claude recreates real dirs if a symlink goes missing) and new profiles get symlinks at creation, so the store stays converged without further manual steps. Credentials and account identity stay per-profile.

Verified on the real store (41 instance dirs, ~44k entries, 4 conflicts quarantined): a session that previously failed to resume from a fresh login shell now resumes from the active profile and from a different profile's config dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783814430&installation_id=133855650&pr_number=13&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F13&signature=7591d351fc70073309f36989b3dbac844ec6c0758e041b9a4a6939ddb0132582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared Claude session store so `claude --resume <id>` works across profiles and from the default `~/.claude`. Sessions started anywhere are now resumable anywhere; credentials stay per-profile.

- **New Features**
  - `sr claude consolidate` moves session-state dirs into one `_shared` store and replaces per-profile dirs with symlinks.
  - Sweeps registered profiles, unregistered temp instances, and the default `~/.claude` dir (if it exists).
  - `sr claude env` and `sr claude run` re-converge symlinks on every call; new profiles get symlinks at creation.
  - Conflict handling: newer mtime wins; older copy is quarantined under `_shared/.conflicts/<instance>/`.

- **Migration**
  - Run `sr claude consolidate` once. It prints a summary and the shared store path.
  - After that, no manual steps needed; convergence is automatic on `env`/`run`.

<sup>Written for commit eb1e3ffbf7652e4bc52b82d49fa653c85bf98720. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `consolidate` command to consolidate Claude sessions into a shared store accessible across profiles.
  * Shared session storage now enables unified session access and automatic symlink management for profiles.
  * Automatic session repair and migration when initializing profile instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->