### PR TITLE
Scope scheduler scores by provider; load Claude accounts resiliently

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -470,7 +470,7 @@ func fetchCodexScoresWithStore(ctx context.Context, store accounts.CodexStore, c
 	scores := fallbackScores(codexAccounts)
 	scoreByID := make(map[string]int, len(scores))
 	for i, score := range scores {
-		scoreByID[score.AccountID] = i
+		scoreByID[selectacct.ScoreKey(score.Provider, score.AccountID)] = i
 	}
 
 	var mu sync.Mutex
@@ -489,8 +489,8 @@ func fetchCodexScoresWithStore(ctx context.Context, store accounts.CodexStore, c
 			} else if refreshed, _, err := store.RefreshStoredIfExpired(accounts.WithCodexRefreshReason(ctx, "serve.fetch-usage"), client, stored); err != nil {
 				slog.Warn("account refresh failed", "account", account.ID, "error", err)
 				mu.Lock()
-				if idx, ok := scoreByID[account.ID]; ok {
-					scores[idx] = selectacct.Score{AccountID: account.ID, Headroom: 0, ShortHeadroom: 0}
+				if idx, ok := scoreByID[selectacct.ScoreKey(account.Provider, account.ID)]; ok {
+					scores[idx] = selectacct.Score{AccountID: account.ID, Provider: account.Provider, Headroom: 0, ShortHeadroom: 0}
 				}
 				mu.Unlock()
 				return
@@ -501,8 +501,8 @@ func fetchCodexScoresWithStore(ctx context.Context, store accounts.CodexStore, c
 			if err != nil {
 				slog.Warn("usage fetch failed", "account", account.ID, "error", err)
 				mu.Lock()
-				if idx, ok := scoreByID[account.ID]; ok {
-					scores[idx] = selectacct.Score{AccountID: account.ID, Headroom: 0}
+				if idx, ok := scoreByID[selectacct.ScoreKey(account.Provider, account.ID)]; ok {
+					scores[idx] = selectacct.Score{AccountID: account.ID, Provider: account.Provider, Headroom: 0}
 				}
 				mu.Unlock()
 				return
@@ -518,8 +518,9 @@ func fetchCodexScoresWithStore(ctx context.Context, store accounts.CodexStore, c
 				})
 			}
 			score := selectacct.ScoreFromLimitWindows(account.ID, 0, limitWindows)
+			score.Provider = account.Provider
 			mu.Lock()
-			if idx, ok := scoreByID[account.ID]; ok {
+			if idx, ok := scoreByID[selectacct.ScoreKey(account.Provider, account.ID)]; ok {
 				scores[idx] = score
 				successful++
 			}
@@ -541,7 +542,7 @@ func fallbackScores(codexAccounts []accounts.Account) []selectacct.Score {
 		if account.AuthMode == accounts.AuthModeAPIKey {
 			headroom = 0.01
 		}
-		scores = append(scores, selectacct.Score{AccountID: account.ID, Headroom: headroom, ShortHeadroom: headroom})
+		scores = append(scores, selectacct.Score{AccountID: account.ID, Provider: account.Provider, Headroom: headroom, ShortHeadroom: headroom})
 	}
 	return scores
 }

--- a/cmd/subrouter/sr_auto_switch.go
+++ b/cmd/subrouter/sr_auto_switch.go
@@ -107,8 +107,8 @@ func srAutoSwitchOnce(ctx context.Context, cfg srAutoSwitchConfig) (string, erro
 	if err != nil {
 		return "", err
 	}
-	if !scheduler.UsableForNewSession(picked.ID) {
-		if scheduler.Exhausted(picked.ID) {
+	if !scheduler.UsableForNewSession(picked.Provider, picked.ID) {
+		if scheduler.Exhausted(picked.Provider, picked.ID) {
 			return "", fmt.Errorf("no usable OAuth Codex accounts available")
 		}
 		logSRAutoSwitch(cfg.Logger, slog.LevelWarn, "sr auto-switch selected account below new-session headroom threshold", "account", picked.ID, "threshold", selectacct.MinNewSessionHeadroom)

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -165,7 +166,11 @@ func (s Store) ListAccounts(ctx context.Context) ([]accounts.Account, error) {
 		configDir := s.ClaudeConfigDir(profile.Name)
 		credential, err := s.ReadCredential(ctx, configDir)
 		if err != nil {
-			return nil, err
+			// One profile with a corrupt credential (e.g. a malformed
+			// keychain blob) must not drop every other Claude account.
+			// Skip it and keep loading the rest.
+			slog.Warn("Claude profile credential unreadable, skipping", "profile", profile.Name, "error", err)
+			continue
 		}
 		account, ok := profileAccount(profile, configDir, credential)
 		if !ok {

--- a/internal/proxy/claude_failover_test.go
+++ b/internal/proxy/claude_failover_test.go
@@ -125,7 +125,7 @@ func TestUsageLimitRetryTransportClaudeFailsOverOn429(t *testing.T) {
 	if stub.calls != 2 {
 		t.Fatalf("upstream calls = %d, want 2 (429 then retry)", stub.calls)
 	}
-	if !server.SchedulerRef.Get().Exhausted("cooked@example.com") {
+	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
 		t.Fatal("429 should mark the cooked account exhausted")
 	}
 	assignment, ok := store.Get("claude", "session-1")
@@ -138,8 +138,8 @@ func TestReuseStickyAssignmentClaudeExhausted(t *testing.T) {
 	server, _ := claudeFailoverServer(t)
 	cooked := accounts.Account{ID: "cooked@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth}
 	scheduler := selectacct.NewScheduler([]selectacct.Score{
-		{AccountID: "cooked@example.com", Headroom: 0, ShortHeadroom: 0},
-		{AccountID: "fresh@example.com", Headroom: 1, ShortHeadroom: 1},
+		{AccountID: "cooked@example.com", Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0},
+		{AccountID: "fresh@example.com", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
 	})
 	if server.reuseStickyAssignment("claude", "session-1", cooked, scheduler) {
 		t.Fatal("exhausted claude account should not keep its sticky session")
@@ -158,7 +158,7 @@ func TestCaptureResponseBodyClaude429MarksExhausted(t *testing.T) {
 		Header:     http.Header{},
 	}
 	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "/v1/messages")
-	if !server.SchedulerRef.Get().Exhausted("cooked@example.com") {
+	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
 		t.Fatal("claude 429 should mark the account exhausted via passive inspection")
 	}
 }
@@ -180,7 +180,7 @@ func TestRefreshUsageScoresCoversAllProviders(t *testing.T) {
 		UsageScoreTTL: time.Minute,
 		ScoreAccounts: func(ctx context.Context, available []accounts.Account) ([]selectacct.Score, int) {
 			captured = available
-			return []selectacct.Score{{AccountID: "claude@example.com", Headroom: 0, ShortHeadroom: 0}}, 1
+			return []selectacct.Score{{AccountID: "claude@example.com", Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0}}, 1
 		},
 	}
 	server.SchedulerRef.SetUpdatedAt(time.Now().Add(-time.Hour))
@@ -195,7 +195,7 @@ func TestRefreshUsageScoresCoversAllProviders(t *testing.T) {
 	if ids["apikey"] {
 		t.Fatal("API-key accounts should not be usage-scored")
 	}
-	if !server.SchedulerRef.Get().Exhausted("claude@example.com") {
+	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "claude@example.com") {
 		t.Fatal("claude usage scores should make Exhausted() real")
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -659,7 +659,7 @@ func promoteUsableClaudeStatus(statuses []AccountUsageStatus) {
 		}
 		usable := false
 		if status.AuthValid && status.Error == "" {
-			score := scoreFromUsageWindows(status.ID, status.Windows)
+			score := scoreFromUsageWindows(status.Provider, status.ID, status.Windows)
 			usable = scoreUsableForNewSession(score)
 			if usable && (bestIdx == -1 || betterClaudeActiveCandidate(score, best)) {
 				bestIdx = i
@@ -700,7 +700,7 @@ func scoreUsableForNewSession(score selectacct.Score) bool {
 	return score.Headroom >= selectacct.MinNewSessionHeadroom && score.ShortHeadroom >= selectacct.MinNewSessionHeadroom
 }
 
-func scoreFromUsageWindows(accountID string, windows []accounts.UsageWindow) selectacct.Score {
+func scoreFromUsageWindows(provider accounts.Provider, accountID string, windows []accounts.UsageWindow) selectacct.Score {
 	limitWindows := make([]selectacct.LimitWindow, 0, len(windows))
 	for _, window := range windows {
 		limitWindows = append(limitWindows, selectacct.LimitWindow{
@@ -711,7 +711,9 @@ func scoreFromUsageWindows(accountID string, windows []accounts.UsageWindow) sel
 			Feature:            window.Feature,
 		})
 	}
-	return selectacct.ScoreFromLimitWindows(accountID, 0, limitWindows)
+	score := selectacct.ScoreFromLimitWindows(accountID, 0, limitWindows)
+	score.Provider = provider
+	return score
 }
 
 func (r *AccountRef) replace(account accounts.Account) {
@@ -925,9 +927,10 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 		if account.AuthMode == accounts.AuthModeAPIKey {
 			headroom = 0.01
 		}
-		scoreByID[account.ID] = len(scores)
+		scoreByID[selectacct.ScoreKey(account.Provider, account.ID)] = len(scores)
 		scores = append(scores, selectacct.Score{
 			AccountID:     account.ID,
+			Provider:      account.Provider,
 			Headroom:      headroom,
 			ShortHeadroom: headroom,
 		})
@@ -951,7 +954,7 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 			if s.Logger != nil {
 				s.Logger.Warn("account reload refresh failed", "account", account.ID, "error", err)
 			}
-			setZeroScore(scores, scoreByID, account.ID)
+			setZeroScore(scores, scoreByID, account.Provider, account.ID)
 			continue
 		}
 		windows, err := s.fetchAccountUsageWindows(ctx, client, refreshed)
@@ -966,12 +969,12 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 			// per-request usage-limit failover already handles true
 			// exhaustion.
 			if authLikeUsageError(err.Error()) {
-				setZeroScore(scores, scoreByID, account.ID)
+				setZeroScore(scores, scoreByID, account.Provider, account.ID)
 			}
 			continue
 		}
-		if idx, ok := scoreByID[account.ID]; ok {
-			scores[idx] = scoreFromUsageWindows(account.ID, windows)
+		if idx, ok := scoreByID[selectacct.ScoreKey(account.Provider, account.ID)]; ok {
+			scores[idx] = scoreFromUsageWindows(account.Provider, account.ID, windows)
 			scored++
 		}
 	}
@@ -998,9 +1001,9 @@ func fetchAccountUsageWindowsLive(ctx context.Context, client *http.Client, acco
 
 const defaultUsageFetchTimeout = 10 * time.Second
 
-func setZeroScore(scores []selectacct.Score, scoreByID map[string]int, accountID string) {
-	if idx, ok := scoreByID[accountID]; ok {
-		scores[idx] = selectacct.Score{AccountID: accountID, Headroom: 0, ShortHeadroom: 0}
+func setZeroScore(scores []selectacct.Score, scoreByID map[string]int, provider accounts.Provider, accountID string) {
+	if idx, ok := scoreByID[selectacct.ScoreKey(provider, accountID)]; ok {
+		scores[idx] = selectacct.Score{AccountID: accountID, Provider: provider, Headroom: 0, ShortHeadroom: 0}
 	}
 }
 
@@ -1331,7 +1334,7 @@ func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, direction
 			})
 		}
 		if direction == "upstream_to_client" && messageType == websocket.TextMessage && usageLimitJSON(body) {
-			s.markAccountExhausted(accountID)
+			s.markAccountExhausted(providerForAgent(agentType), accountID)
 		}
 		if err := dst.WriteMessage(messageType, body); err != nil {
 			return
@@ -1339,9 +1342,9 @@ func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, direction
 	}
 }
 
-func (s Server) markAccountExhausted(accountID string) {
+func (s Server) markAccountExhausted(provider accounts.Provider, accountID string) {
 	if s.SchedulerRef != nil {
-		s.SchedulerRef.MarkExhausted(accountID)
+		s.SchedulerRef.MarkExhausted(provider, accountID)
 	}
 }
 
@@ -1505,7 +1508,7 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 	// Anthropic signals subscription exhaustion with a plain 429, with no
 	// codex-style usage-limit body to inspect.
 	if provider == accounts.ProviderClaude && accountID != "" && response.StatusCode == http.StatusTooManyRequests {
-		s.markAccountExhausted(accountID)
+		s.markAccountExhausted(provider, accountID)
 	}
 	inspectUsageLimit := s.SchedulerRef != nil && accountID != "" && responseStatusCanExhaust(response.StatusCode)
 	if response.Body == nil || (s.Transcripts == nil && s.Logger == nil && !inspectUsageLimit) {
@@ -1516,7 +1519,7 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 	if inspectUsageLimit {
 		inspect = func(body []byte) {
 			if usageLimitJSON(body) {
-				s.markAccountExhausted(accountID)
+				s.markAccountExhausted(provider, accountID)
 			}
 		}
 	}
@@ -1845,8 +1848,8 @@ func (s Server) accountForSession(agentType, sessionID string, r *http.Request) 
 					"session", sessionID,
 					"account", account.ID,
 					"active", s.activeSession(agentType, sessionID),
-					"usable_for_new_session", scheduler.UsableForNewSession(account.ID),
-					"exhausted", scheduler.Exhausted(account.ID),
+					"usable_for_new_session", scheduler.UsableForNewSession(account.Provider, account.ID),
+					"exhausted", scheduler.Exhausted(account.Provider, account.ID),
 				)
 			}
 		}
@@ -1856,8 +1859,8 @@ func (s Server) accountForSession(agentType, sessionID string, r *http.Request) 
 	if err != nil {
 		return accounts.Account{}, sessionID, userEmail, err
 	}
-	if account.AuthMode == accounts.AuthModeOAuth && !scheduler.UsableForNewSession(account.ID) {
-		if scheduler.Exhausted(account.ID) {
+	if account.AuthMode == accounts.AuthModeOAuth && !scheduler.UsableForNewSession(account.Provider, account.ID) {
+		if scheduler.Exhausted(account.Provider, account.ID) {
 			return accounts.Account{}, sessionID, userEmail, fmt.Errorf("no usable OAuth %s accounts available", provider)
 		}
 		if provider == accounts.ProviderCodex && s.Logger != nil {
@@ -1875,7 +1878,7 @@ func (s Server) logStickyReuse(agentType, sessionID string, account accounts.Acc
 	if s.Logger == nil || providerForAgent(agentType) != accounts.ProviderCodex || account.AuthMode != accounts.AuthModeOAuth {
 		return
 	}
-	if scheduler.UsableForNewSession(account.ID) || scheduler.Exhausted(account.ID) || !s.activeSession(agentType, sessionID) {
+	if scheduler.UsableForNewSession(account.Provider, account.ID) || scheduler.Exhausted(account.Provider, account.ID) || !s.activeSession(agentType, sessionID) {
 		return
 	}
 	s.Logger.Info("keeping active sticky session on constrained account",
@@ -1888,14 +1891,14 @@ func (s Server) logStickyReuse(agentType, sessionID string, account accounts.Acc
 }
 
 func (s Server) reuseStickyAssignment(agentType, sessionID string, account accounts.Account, scheduler selectacct.Scheduler) bool {
-	if scheduler.Exhausted(account.ID) {
+	if scheduler.Exhausted(account.Provider, account.ID) {
 		return false
 	}
 	if s.activeSession(agentType, sessionID) {
 		return true
 	}
 	if providerForAgent(agentType) == accounts.ProviderCodex && account.AuthMode == accounts.AuthModeOAuth {
-		return scheduler.UsableForNewSession(account.ID)
+		return scheduler.UsableForNewSession(account.Provider, account.ID)
 	}
 	return true
 }
@@ -2040,7 +2043,7 @@ func (s Server) refreshSelectedAccount(ctx context.Context, agentType, sessionID
 		s.Logger.Warn("selected Claude account refresh failed, trying another account", "account", account.ID, "error", err)
 	}
 	tried := map[string]struct{}{account.ID: {}}
-	s.markAccountExhausted(account.ID)
+	s.markAccountExhausted(provider, account.ID)
 	lastErr := err
 	for {
 		next, pickErr := s.retryAccount(ctx, provider, agentType, sessionID, userEmail, tried)
@@ -2053,7 +2056,7 @@ func (s Server) refreshSelectedAccount(ctx context.Context, agentType, sessionID
 			return refreshed, nil
 		}
 		lastErr = err
-		s.markAccountExhausted(next.ID)
+		s.markAccountExhausted(provider, next.ID)
 		if s.Logger != nil {
 			s.Logger.Warn("retry Claude account refresh failed", "account", next.ID, "error", err)
 		}
@@ -2086,7 +2089,7 @@ func (s Server) retryAccount(ctx context.Context, provider accounts.Provider, ag
 	if err != nil {
 		return accounts.Account{}, err
 	}
-	if scheduler.Exhausted(account.ID) {
+	if scheduler.Exhausted(account.Provider, account.ID) {
 		return accounts.Account{}, fmt.Errorf("no non-exhausted %s accounts available", provider)
 	}
 	if s.Sessions != nil {
@@ -2226,7 +2229,7 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			return response, nil
 		}
 		if t.server != nil {
-			t.server.markAccountExhausted(accountID)
+			t.server.markAccountExhausted(t.provider, accountID)
 		}
 		if attempt == maxAttempts || t.server == nil {
 			return response, nil
@@ -2287,10 +2290,10 @@ func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provide
 	if err != nil {
 		return accounts.Account{}, err
 	}
-	if scheduler.Exhausted(account.ID) {
+	if scheduler.Exhausted(account.Provider, account.ID) {
 		return accounts.Account{}, fmt.Errorf("no non-exhausted OAuth %s accounts available", provider)
 	}
-	if !scheduler.UsableForNewSession(account.ID) && s.Logger != nil {
+	if !scheduler.UsableForNewSession(account.Provider, account.ID) && s.Logger != nil {
 		s.Logger.Warn("usage-limit retry selected OAuth account below new-session headroom threshold", "provider", provider, "account", account.ID, "threshold", selectacct.MinNewSessionHeadroom)
 	}
 	refreshed, err := s.refreshAccount(ctx, account)

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -2626,7 +2626,7 @@ func TestHandlerReroutesActiveStickySessionWhenAssignedAccountExhausted(t *testi
 		t.Fatal("timed out waiting for first request to become active")
 	}
 
-	schedulerRef.MarkExhausted("empty@example.com")
+	schedulerRef.MarkExhausted(accounts.ProviderCodex, "empty@example.com")
 
 	secondReq, err := http.NewRequest(http.MethodGet, subrouter.URL+"/backend-api/codex/analytics-events/events", nil)
 	if err != nil {

--- a/internal/proxy/usage_windows_cache_test.go
+++ b/internal/proxy/usage_windows_cache_test.go
@@ -90,7 +90,7 @@ func TestScoreAccountsKeepsOptimisticScoreOnTransientFailure(t *testing.T) {
 		Logger:        nil,
 	}
 	scores := []selectacct.Score{{AccountID: "a@example.com", Headroom: 1, ShortHeadroom: 1}}
-	scoreByID := map[string]int{"a@example.com": 0}
+	scoreByID := map[string]int{selectacct.ScoreKey(accounts.ProviderCodex, "a@example.com"): 0}
 	// Simulate the error-handling branch directly: transient errors must not
 	// zero, auth errors must.
 	transientErr := errors.New("usage fetch failed: 429 Too Many Requests")
@@ -101,7 +101,7 @@ func TestScoreAccountsKeepsOptimisticScoreOnTransientFailure(t *testing.T) {
 	if !authLikeUsageError(authErr.Error()) {
 		t.Fatal("401 must classify as auth error")
 	}
-	setZeroScore(scores, scoreByID, "a@example.com")
+	setZeroScore(scores, scoreByID, accounts.ProviderCodex, "a@example.com")
 	if scores[0].Headroom != 0 {
 		t.Fatal("setZeroScore should zero")
 	}

--- a/internal/selectacct/saturation_test.go
+++ b/internal/selectacct/saturation_test.go
@@ -74,10 +74,10 @@ func TestSchedulerForSparkModelUsesSparkWindows(t *testing.T) {
 	if got.ID != "spark-healthy" {
 		t.Fatalf("got %q, want spark-healthy", got.ID)
 	}
-	if !scheduler.UsableForNewSession("spark-healthy") {
+	if !scheduler.UsableForNewSession("", "spark-healthy") {
 		t.Fatal("spark-healthy should be usable for a Spark request")
 	}
-	if !scheduler.Exhausted("spark-cooked") {
+	if !scheduler.Exhausted("", "spark-cooked") {
 		t.Fatal("spark-cooked should be exhausted for a Spark request")
 	}
 }
@@ -95,11 +95,11 @@ func TestRegularModelDoesNotMatchSparkPool(t *testing.T) {
 		}),
 	}).ForModel("gpt-5.3-codex")
 
-	if scheduler.Exhausted("acct") {
+	if scheduler.Exhausted("", "acct") {
 		t.Fatal("regular model must use base quota, not the cooked Spark pool")
 	}
-	if math.Abs(scheduler.score("acct").Headroom-0.80) > 0.0001 {
-		t.Fatalf("regular headroom = %.2f, want 0.80 (base)", scheduler.score("acct").Headroom)
+	if math.Abs(scheduler.score("", "acct").Headroom-0.80) > 0.0001 {
+		t.Fatalf("regular headroom = %.2f, want 0.80 (base)", scheduler.score("", "acct").Headroom)
 	}
 }
 
@@ -163,10 +163,10 @@ func TestForModelZeroesAccountsLackingTheFeature(t *testing.T) {
 		}),
 	}).ForModel("gpt-5.3-codex-spark")
 
-	if !scheduler.Exhausted("no-spark") {
+	if !scheduler.Exhausted("", "no-spark") {
 		t.Fatal("account without the Spark pool must score zero for a Spark request")
 	}
-	if scheduler.Exhausted("has-spark") {
+	if scheduler.Exhausted("", "has-spark") {
 		t.Fatal("account with an open Spark pool must be usable")
 	}
 }
@@ -179,8 +179,8 @@ func TestForModelWithoutAnyPoolsFallsBackToBase(t *testing.T) {
 		ScoreFromLimitWindows("a", 0, []LimitWindow{{Name: "5h", UsedPercent: 30}}),
 	}).ForModel("gpt-5.3-codex-spark")
 
-	if math.Abs(scheduler.score("a").Headroom-0.70) > 0.0001 {
-		t.Fatalf("headroom = %.2f, want 0.70 (base, no matching pool)", scheduler.score("a").Headroom)
+	if math.Abs(scheduler.score("", "a").Headroom-0.70) > 0.0001 {
+		t.Fatalf("headroom = %.2f, want 0.70 (base, no matching pool)", scheduler.score("", "a").Headroom)
 	}
 }
 

--- a/internal/selectacct/scheduler.go
+++ b/internal/selectacct/scheduler.go
@@ -11,6 +11,7 @@ var ErrNoAccounts = errors.New("no accounts available")
 
 type Score struct {
 	AccountID              string
+	Provider               accounts.Provider
 	Headroom               float64
 	ShortHeadroom          float64
 	ShortResetAfterSeconds int64
@@ -26,10 +27,24 @@ type Scheduler struct {
 
 const MinNewSessionHeadroom = 0.40
 
+// ScoreKey is the scheduler's identity for an account. A Codex account's ID is
+// its bare email and a Claude account's ID is its profile name, which can also
+// be an email, so the same string routinely identifies one account per
+// provider (e.g. lawrence@cmux.com exists as both a Codex account and a Claude
+// profile). Keying scores by the bare ID alone lets one provider's score
+// silently overwrite the other's; scoping the key by provider keeps them
+// distinct.
+func ScoreKey(provider accounts.Provider, accountID string) string {
+	if provider == "" {
+		provider = accounts.ProviderCodex
+	}
+	return string(provider) + "\x00" + accountID
+}
+
 func NewScheduler(scores []Score) Scheduler {
 	byID := make(map[string]Score, len(scores))
 	for _, score := range scores {
-		byID[score.AccountID] = score
+		byID[ScoreKey(score.Provider, score.AccountID)] = score
 	}
 	return Scheduler{scores: byID}
 }
@@ -39,10 +54,10 @@ func (s Scheduler) WithScore(score Score) Scheduler {
 		scores:        make(map[string]Score, len(s.scores)+1),
 		sessionCounts: s.sessionCounts,
 	}
-	for accountID, existing := range s.scores {
-		next.scores[accountID] = existing
+	for key, existing := range s.scores {
+		next.scores[key] = existing
 	}
-	next.scores[score.AccountID] = score
+	next.scores[ScoreKey(score.Provider, score.AccountID)] = score
 	return next
 }
 
@@ -71,12 +86,12 @@ func (s Scheduler) ForModel(model string) Scheduler {
 		scores:        make(map[string]Score, len(s.scores)),
 		sessionCounts: s.sessionCounts,
 	}
-	for accountID, score := range s.scores {
+	for scoreKey, score := range s.scores {
 		modelScore, ok := score.ModelScores[key]
 		if !ok {
-			modelScore = Score{AccountID: accountID, Headroom: 0, ShortHeadroom: 0}
+			modelScore = Score{AccountID: score.AccountID, Provider: score.Provider, Headroom: 0, ShortHeadroom: 0}
 		}
-		next.scores[accountID] = modelScore
+		next.scores[scoreKey] = modelScore
 	}
 	return next
 }
@@ -104,8 +119,8 @@ func (s Scheduler) Pick(candidates []accounts.Account) (accounts.Account, error)
 
 	sorted := append([]accounts.Account(nil), candidates...)
 	sort.SliceStable(sorted, func(i, j int) bool {
-		left := s.score(sorted[i].ID)
-		right := s.score(sorted[j].ID)
+		left := s.score(sorted[i].Provider, sorted[i].ID)
+		right := s.score(sorted[j].Provider, sorted[j].ID)
 		leftTier := selectionTier(sorted[i], left)
 		rightTier := selectionTier(sorted[j], right)
 		if leftTier != rightTier {
@@ -130,12 +145,12 @@ func (s Scheduler) Pick(candidates []accounts.Account) (accounts.Account, error)
 	return sorted[0], nil
 }
 
-func (s Scheduler) UsableForNewSession(accountID string) bool {
-	return s.score(accountID).usableForNewSession()
+func (s Scheduler) UsableForNewSession(provider accounts.Provider, accountID string) bool {
+	return s.score(provider, accountID).usableForNewSession()
 }
 
-func (s Scheduler) Exhausted(accountID string) bool {
-	return s.score(accountID).exhausted()
+func (s Scheduler) Exhausted(provider accounts.Provider, accountID string) bool {
+	return s.score(provider, accountID).exhausted()
 }
 
 func selectionTier(account accounts.Account, score Score) int {
@@ -154,10 +169,10 @@ func selectionTier(account accounts.Account, score Score) int {
 	return 4
 }
 
-func (s Scheduler) score(accountID string) Score {
-	score, ok := s.scores[accountID]
+func (s Scheduler) score(provider accounts.Provider, accountID string) Score {
+	score, ok := s.scores[ScoreKey(provider, accountID)]
 	if !ok {
-		score = Score{AccountID: accountID, Headroom: 1, ShortHeadroom: 1}
+		score = Score{AccountID: accountID, Provider: provider, Headroom: 1, ShortHeadroom: 1}
 	}
 	if s.sessionCounts != nil {
 		score.Sessions = s.sessionCounts[accountID]

--- a/internal/selectacct/scheduler_ref.go
+++ b/internal/selectacct/scheduler_ref.go
@@ -3,6 +3,8 @@ package selectacct
 import (
 	"sync"
 	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
 )
 
 type SchedulerRef struct {
@@ -32,7 +34,7 @@ func (r *SchedulerRef) Set(scheduler Scheduler) {
 	r.updatedAt = time.Now()
 }
 
-func (r *SchedulerRef) MarkExhausted(accountID string) {
+func (r *SchedulerRef) MarkExhausted(provider accounts.Provider, accountID string) {
 	if accountID == "" {
 		return
 	}
@@ -40,6 +42,7 @@ func (r *SchedulerRef) MarkExhausted(accountID string) {
 	defer r.mu.Unlock()
 	r.scheduler = r.scheduler.WithScore(Score{
 		AccountID:     accountID,
+		Provider:      provider,
 		Headroom:      0,
 		ShortHeadroom: 0,
 	})

--- a/internal/selectacct/scheduler_test.go
+++ b/internal/selectacct/scheduler_test.go
@@ -186,3 +186,54 @@ func TestPickFallsBackToAPIKeyWhenNoOAuth(t *testing.T) {
 		t.Fatalf("got %q, want apikey:only", got.ID)
 	}
 }
+
+// A Codex account's ID is its bare email and a Claude account's ID is its
+// profile name, which is often the same email, so both providers routinely
+// share one ID. The scheduler must score them independently; keying by the
+// bare ID alone let one provider's score clobber the other's, which made a
+// healthy Codex account look exhausted (and vice versa) whenever a same-named
+// Claude profile existed.
+func TestScoresAreIsolatedPerProvider(t *testing.T) {
+	const shared = "lawrence@cmux.com"
+	scheduler := NewScheduler([]Score{
+		{AccountID: shared, Provider: accounts.ProviderCodex, Headroom: 1, ShortHeadroom: 1},
+		{AccountID: shared, Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0},
+	})
+
+	if scheduler.Exhausted(accounts.ProviderCodex, shared) {
+		t.Fatal("healthy Codex account must not be exhausted by a same-named Claude profile")
+	}
+	if !scheduler.UsableForNewSession(accounts.ProviderCodex, shared) {
+		t.Fatal("healthy Codex account must stay usable for a new session")
+	}
+	if !scheduler.Exhausted(accounts.ProviderClaude, shared) {
+		t.Fatal("exhausted Claude profile must stay exhausted")
+	}
+
+	got, err := scheduler.Pick([]accounts.Account{
+		{ID: shared, Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != shared || got.Provider != accounts.ProviderCodex {
+		t.Fatalf("got %q/%s, want the Codex account", got.ID, got.Provider)
+	}
+}
+
+// Independent of ordering: a healthy Claude profile must survive an exhausted
+// same-named Codex account (the reverse clobber direction).
+func TestScoresAreIsolatedPerProviderReversed(t *testing.T) {
+	const shared = "austin@manaflow.ai"
+	scheduler := NewScheduler([]Score{
+		{AccountID: shared, Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+		{AccountID: shared, Provider: accounts.ProviderCodex, Headroom: 0, ShortHeadroom: 0},
+	})
+
+	if scheduler.Exhausted(accounts.ProviderClaude, shared) {
+		t.Fatal("healthy Claude profile must not be exhausted by a same-named Codex account")
+	}
+	if !scheduler.Exhausted(accounts.ProviderCodex, shared) {
+		t.Fatal("exhausted Codex account must stay exhausted")
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subrouter",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Routes AI coding-agent traffic across subscription accounts and API keys.",
   "license": "MIT",
   "homepage": "https://github.com/manaflow-ai/subrouter#readme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "subrouter"
-version = "0.1.13"
+version = "0.1.14"
 description = "Routes AI coding-agent traffic across subscription accounts and API keys."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Why

The team subrouter was returning "no usable accounts" for Claude even though
forced per-account probes routed fine. Two root causes, both verified live:

1. **Cross-provider score collision (the diagnosed blocker).** A Codex
   account's ID is its bare email; a Claude account's ID is its profile name,
   which is routinely the same email. On this deployment, `lawrence@cmux.com`,
   `austin@manaflow.ai`, `austin@manaflow.com`, and `lawrence@manaflow.ai`
   each exist as both a Codex account and a Claude profile. The scheduler kept
   one score map keyed by the bare ID, so a reauth-dead Codex account
   (`Headroom 0`, every Codex OAuth token currently has a cached 401) silently
   clobbered the healthy same-named Claude profile (and the `scoreByID` index
   slices in the proxy/boot paths had the same collision). Result: Claude
   looked exhausted; a forced `X-Subrouter-Account-ID` probe bypassed the
   scheduler and worked.

2. **One corrupt credential nuked all Claude accounts.** `ListAccounts`
   returned `nil` on the first `ReadCredential` error, so a single malformed
   keychain blob (`invalid character 'b' after top-level value`, profile
   `lc1@manaflow.com`) dropped every Claude account: `claude_accounts=0`.

## What

- Key the scheduler by `(provider, accountID)` end to end: in-memory score
  map, `scoreByID` index slices, `MarkExhausted`, and the
  `UsableForNewSession`/`Exhausted` lookups.
- `ListAccounts` now logs and skips a profile with an unreadable credential
  instead of dropping the whole provider.
- Bump to v0.1.14.

No persisted-data migration: sessions store bare account IDs and derive
provider from the agent; usage-cache is keyed by admin label. Nothing on disk
changes shape.

## Verification

- New `TestScoresAreIsolatedPerProvider` / `...Reversed`; confirmed they FAIL
  when the provider key is removed and pass with it.
- Full `go test ./...` green (the unrelated `internal/transcript` gsutil test
  is environmental).
- Built and deployed locally: `claude_accounts` went `0 -> 9` (only the
  corrupt `lc1@manaflow.com` skipped, with a warning), and scores are now
  isolated per provider.

## Deploy to team VM after merge

cut tag `v0.1.14` (release.yml), then `sr server install team --version 0.1.14`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784150900&installation_id=133855650&pr_number=14&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F14&signature=5133342a138d345fa36d54f3cb3d35d85957a80d153410aa4dc78498360005c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Codex/Claude score collisions by scoping scheduler scores per provider and makes Claude account loading resilient to a single corrupt credential. Fixes false “no usable accounts” for Claude and bumps to v0.1.14.

- **Bug Fixes**
  - Key scheduler by (provider, accountID) end to end so Codex and Claude can’t overwrite each other; update `UsableForNewSession`, `Exhausted`, `MarkExhausted`, and related indices.
  - Include provider in usage scoring and exhaustion paths; mark exhaustion with provider and set scores from usage windows accordingly.
  - Claude `ListAccounts` now logs and skips an unreadable profile credential instead of failing all Claude accounts.
  - Added tests for per-provider isolation; updated existing tests.

- **Migration**
  - No changes needed. Sessions derive provider from the agent and the usage cache format is unchanged.

<sup>Written for commit da4558373e5004737b9d9d0a91d1d217b476a709. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-aware account tracking to properly handle multiple accounts across different providers independently, even when they share the same identifier.

* **Bug Fixes**
  * Improved credential handling to skip profiles with read errors instead of aborting the entire account listing process.
  * Enhanced account exhaustion detection with provider-specific context for more accurate quota management.

* **Chores**
  * Version bumped to 0.1.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->