### PR TITLE
Isolate codex and claude scheduler state by provider

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -489,8 +489,8 @@ func fetchCodexScoresWithStore(ctx context.Context, store accounts.CodexStore, c
 			} else if refreshed, _, err := store.RefreshStoredIfExpired(accounts.WithCodexRefreshReason(ctx, "serve.fetch-usage"), client, stored); err != nil {
 				slog.Warn("account refresh failed", "account", account.ID, "error", err)
 				mu.Lock()
-				if idx, ok := scoreByID[account.ID]; ok {
-					scores[idx] = selectacct.Score{AccountID: account.ID, Headroom: 0, ShortHeadroom: 0}
+				if idx, ok := scoreByID[account.SchedulerKey()]; ok {
+					scores[idx] = selectacct.Score{AccountID: account.SchedulerKey(), Headroom: 0, ShortHeadroom: 0}
 				}
 				mu.Unlock()
 				return
@@ -501,8 +501,8 @@ func fetchCodexScoresWithStore(ctx context.Context, store accounts.CodexStore, c
 			if err != nil {
 				slog.Warn("usage fetch failed", "account", account.ID, "error", err)
 				mu.Lock()
-				if idx, ok := scoreByID[account.ID]; ok {
-					scores[idx] = selectacct.Score{AccountID: account.ID, Headroom: 0}
+				if idx, ok := scoreByID[account.SchedulerKey()]; ok {
+					scores[idx] = selectacct.Score{AccountID: account.SchedulerKey(), Headroom: 0}
 				}
 				mu.Unlock()
 				return
@@ -517,9 +517,9 @@ func fetchCodexScoresWithStore(ctx context.Context, store accounts.CodexStore, c
 					Feature:            window.Feature,
 				})
 			}
-			score := selectacct.ScoreFromLimitWindows(account.ID, 0, limitWindows)
+			score := selectacct.ScoreFromLimitWindows(account.SchedulerKey(), 0, limitWindows)
 			mu.Lock()
-			if idx, ok := scoreByID[account.ID]; ok {
+			if idx, ok := scoreByID[account.SchedulerKey()]; ok {
 				scores[idx] = score
 				successful++
 			}
@@ -541,7 +541,7 @@ func fallbackScores(codexAccounts []accounts.Account) []selectacct.Score {
 		if account.AuthMode == accounts.AuthModeAPIKey {
 			headroom = 0.01
 		}
-		scores = append(scores, selectacct.Score{AccountID: account.ID, Headroom: headroom, ShortHeadroom: headroom})
+		scores = append(scores, selectacct.Score{AccountID: account.SchedulerKey(), Headroom: headroom, ShortHeadroom: headroom})
 	}
 	return scores
 }

--- a/cmd/subrouter/sr_auto_switch.go
+++ b/cmd/subrouter/sr_auto_switch.go
@@ -107,8 +107,8 @@ func srAutoSwitchOnce(ctx context.Context, cfg srAutoSwitchConfig) (string, erro
 	if err != nil {
 		return "", err
 	}
-	if !scheduler.UsableForNewSession(picked.ID) {
-		if scheduler.Exhausted(picked.ID) {
+	if !scheduler.UsableForNewSession(picked.SchedulerKey()) {
+		if scheduler.Exhausted(picked.SchedulerKey()) {
 			return "", fmt.Errorf("no usable OAuth Codex accounts available")
 		}
 		logSRAutoSwitch(cfg.Logger, slog.LevelWarn, "sr auto-switch selected account below new-session headroom threshold", "account", picked.ID, "threshold", selectacct.MinNewSessionHeadroom)

--- a/internal/accounts/scheduler_key_test.go
+++ b/internal/accounts/scheduler_key_test.go
@@ -1,0 +1,28 @@
+package accounts
+
+import "testing"
+
+func TestSchedulerKeyProviderScoped(t *testing.T) {
+	codex := Account{ID: "user@example.com", Provider: ProviderCodex}
+	claude := Account{ID: "user@example.com", Provider: ProviderClaude}
+
+	if codex.SchedulerKey() == claude.SchedulerKey() {
+		t.Fatalf("codex and claude accounts with the same ID share a scheduler key: %q", codex.SchedulerKey())
+	}
+	if got, want := codex.SchedulerKey(), "codex:user@example.com"; got != want {
+		t.Fatalf("codex SchedulerKey = %q, want %q", got, want)
+	}
+	if got, want := claude.SchedulerKey(), "claude:user@example.com"; got != want {
+		t.Fatalf("claude SchedulerKey = %q, want %q", got, want)
+	}
+}
+
+func TestSchedulerKeyLegacyEmptyProviderFallsBackToID(t *testing.T) {
+	legacy := Account{ID: "user@example.com"}
+	if got, want := legacy.SchedulerKey(), "user@example.com"; got != want {
+		t.Fatalf("legacy SchedulerKey = %q, want bare ID %q", got, want)
+	}
+	if got := SchedulerKey("", "user@example.com"); got != "user@example.com" {
+		t.Fatalf("SchedulerKey with empty provider = %q, want bare ID", got)
+	}
+}

--- a/internal/accounts/types.go
+++ b/internal/accounts/types.go
@@ -34,3 +34,21 @@ func (a Account) AuthorizationHeader() string {
 	}
 	return "Bearer " + a.Token
 }
+
+// SchedulerKey returns a provider-scoped identity for use as the account
+// scheduler's map key. A codex account and a claude profile for the same person
+// share Account.ID (the email), so keying the scheduler by the bare ID lets one
+// provider's exhausted score clobber the other's. Qualifying by provider keeps
+// the two pools isolated. Legacy accounts with an empty Provider fall back to
+// the bare ID so existing single-provider keys are unchanged.
+func SchedulerKey(provider Provider, id string) string {
+	if provider == "" {
+		return id
+	}
+	return string(provider) + ":" + id
+}
+
+// SchedulerKey returns the provider-scoped scheduler key for this account.
+func (a Account) SchedulerKey() string {
+	return SchedulerKey(a.Provider, a.ID)
+}

--- a/internal/proxy/claude_failover_test.go
+++ b/internal/proxy/claude_failover_test.go
@@ -70,7 +70,7 @@ func claudeFailoverServer(t *testing.T) (Server, *session.Store) {
 				if account.ID == "cooked@example.com" {
 					headroom = 0
 				}
-				scores = append(scores, selectacct.Score{AccountID: account.ID, Headroom: headroom, ShortHeadroom: headroom})
+				scores = append(scores, selectacct.Score{AccountID: account.SchedulerKey(), Headroom: headroom, ShortHeadroom: headroom})
 			}
 			return scores, len(scores)
 		},
@@ -125,7 +125,7 @@ func TestUsageLimitRetryTransportClaudeFailsOverOn429(t *testing.T) {
 	if stub.calls != 2 {
 		t.Fatalf("upstream calls = %d, want 2 (429 then retry)", stub.calls)
 	}
-	if !server.SchedulerRef.Get().Exhausted("cooked@example.com") {
+	if !server.SchedulerRef.Get().Exhausted(accounts.SchedulerKey(accounts.ProviderClaude, "cooked@example.com")) {
 		t.Fatal("429 should mark the cooked account exhausted")
 	}
 	assignment, ok := store.Get("claude", "session-1")
@@ -138,8 +138,8 @@ func TestReuseStickyAssignmentClaudeExhausted(t *testing.T) {
 	server, _ := claudeFailoverServer(t)
 	cooked := accounts.Account{ID: "cooked@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth}
 	scheduler := selectacct.NewScheduler([]selectacct.Score{
-		{AccountID: "cooked@example.com", Headroom: 0, ShortHeadroom: 0},
-		{AccountID: "fresh@example.com", Headroom: 1, ShortHeadroom: 1},
+		{AccountID: accounts.SchedulerKey(accounts.ProviderClaude, "cooked@example.com"), Headroom: 0, ShortHeadroom: 0},
+		{AccountID: accounts.SchedulerKey(accounts.ProviderClaude, "fresh@example.com"), Headroom: 1, ShortHeadroom: 1},
 	})
 	if server.reuseStickyAssignment("claude", "session-1", cooked, scheduler) {
 		t.Fatal("exhausted claude account should not keep its sticky session")
@@ -158,7 +158,7 @@ func TestCaptureResponseBodyClaude429MarksExhausted(t *testing.T) {
 		Header:     http.Header{},
 	}
 	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "/v1/messages")
-	if !server.SchedulerRef.Get().Exhausted("cooked@example.com") {
+	if !server.SchedulerRef.Get().Exhausted(accounts.SchedulerKey(accounts.ProviderClaude, "cooked@example.com")) {
 		t.Fatal("claude 429 should mark the account exhausted via passive inspection")
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -925,9 +925,9 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 		if account.AuthMode == accounts.AuthModeAPIKey {
 			headroom = 0.01
 		}
-		scoreByID[account.ID] = len(scores)
+		scoreByID[account.SchedulerKey()] = len(scores)
 		scores = append(scores, selectacct.Score{
-			AccountID:     account.ID,
+			AccountID:     account.SchedulerKey(),
 			Headroom:      headroom,
 			ShortHeadroom: headroom,
 		})
@@ -951,7 +951,7 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 			if s.Logger != nil {
 				s.Logger.Warn("account reload refresh failed", "account", account.ID, "error", err)
 			}
-			setZeroScore(scores, scoreByID, account.ID)
+			setZeroScore(scores, scoreByID, account.SchedulerKey())
 			continue
 		}
 		windows, err := s.fetchAccountUsageWindows(ctx, client, refreshed)
@@ -966,12 +966,12 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 			// per-request usage-limit failover already handles true
 			// exhaustion.
 			if authLikeUsageError(err.Error()) {
-				setZeroScore(scores, scoreByID, account.ID)
+				setZeroScore(scores, scoreByID, account.SchedulerKey())
 			}
 			continue
 		}
-		if idx, ok := scoreByID[account.ID]; ok {
-			scores[idx] = scoreFromUsageWindows(account.ID, windows)
+		if idx, ok := scoreByID[account.SchedulerKey()]; ok {
+			scores[idx] = scoreFromUsageWindows(account.SchedulerKey(), windows)
 			scored++
 		}
 	}
@@ -1331,7 +1331,7 @@ func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, direction
 			})
 		}
 		if direction == "upstream_to_client" && messageType == websocket.TextMessage && usageLimitJSON(body) {
-			s.markAccountExhausted(accountID)
+			s.markAccountExhausted(providerForAgent(agentType), accountID)
 		}
 		if err := dst.WriteMessage(messageType, body); err != nil {
 			return
@@ -1339,9 +1339,9 @@ func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, direction
 	}
 }
 
-func (s Server) markAccountExhausted(accountID string) {
+func (s Server) markAccountExhausted(provider accounts.Provider, accountID string) {
 	if s.SchedulerRef != nil {
-		s.SchedulerRef.MarkExhausted(accountID)
+		s.SchedulerRef.MarkExhausted(accounts.SchedulerKey(provider, accountID))
 	}
 }
 
@@ -1505,7 +1505,7 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 	// Anthropic signals subscription exhaustion with a plain 429, with no
 	// codex-style usage-limit body to inspect.
 	if provider == accounts.ProviderClaude && accountID != "" && response.StatusCode == http.StatusTooManyRequests {
-		s.markAccountExhausted(accountID)
+		s.markAccountExhausted(provider, accountID)
 	}
 	inspectUsageLimit := s.SchedulerRef != nil && accountID != "" && responseStatusCanExhaust(response.StatusCode)
 	if response.Body == nil || (s.Transcripts == nil && s.Logger == nil && !inspectUsageLimit) {
@@ -1516,7 +1516,7 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 	if inspectUsageLimit {
 		inspect = func(body []byte) {
 			if usageLimitJSON(body) {
-				s.markAccountExhausted(accountID)
+				s.markAccountExhausted(provider, accountID)
 			}
 		}
 	}
@@ -1845,8 +1845,8 @@ func (s Server) accountForSession(agentType, sessionID string, r *http.Request) 
 					"session", sessionID,
 					"account", account.ID,
 					"active", s.activeSession(agentType, sessionID),
-					"usable_for_new_session", scheduler.UsableForNewSession(account.ID),
-					"exhausted", scheduler.Exhausted(account.ID),
+					"usable_for_new_session", scheduler.UsableForNewSession(account.SchedulerKey()),
+					"exhausted", scheduler.Exhausted(account.SchedulerKey()),
 				)
 			}
 		}
@@ -1856,8 +1856,8 @@ func (s Server) accountForSession(agentType, sessionID string, r *http.Request) 
 	if err != nil {
 		return accounts.Account{}, sessionID, userEmail, err
 	}
-	if account.AuthMode == accounts.AuthModeOAuth && !scheduler.UsableForNewSession(account.ID) {
-		if scheduler.Exhausted(account.ID) {
+	if account.AuthMode == accounts.AuthModeOAuth && !scheduler.UsableForNewSession(account.SchedulerKey()) {
+		if scheduler.Exhausted(account.SchedulerKey()) {
 			return accounts.Account{}, sessionID, userEmail, fmt.Errorf("no usable OAuth %s accounts available", provider)
 		}
 		if provider == accounts.ProviderCodex && s.Logger != nil {
@@ -1875,7 +1875,7 @@ func (s Server) logStickyReuse(agentType, sessionID string, account accounts.Acc
 	if s.Logger == nil || providerForAgent(agentType) != accounts.ProviderCodex || account.AuthMode != accounts.AuthModeOAuth {
 		return
 	}
-	if scheduler.UsableForNewSession(account.ID) || scheduler.Exhausted(account.ID) || !s.activeSession(agentType, sessionID) {
+	if scheduler.UsableForNewSession(account.SchedulerKey()) || scheduler.Exhausted(account.SchedulerKey()) || !s.activeSession(agentType, sessionID) {
 		return
 	}
 	s.Logger.Info("keeping active sticky session on constrained account",
@@ -1888,14 +1888,14 @@ func (s Server) logStickyReuse(agentType, sessionID string, account accounts.Acc
 }
 
 func (s Server) reuseStickyAssignment(agentType, sessionID string, account accounts.Account, scheduler selectacct.Scheduler) bool {
-	if scheduler.Exhausted(account.ID) {
+	if scheduler.Exhausted(account.SchedulerKey()) {
 		return false
 	}
 	if s.activeSession(agentType, sessionID) {
 		return true
 	}
 	if providerForAgent(agentType) == accounts.ProviderCodex && account.AuthMode == accounts.AuthModeOAuth {
-		return scheduler.UsableForNewSession(account.ID)
+		return scheduler.UsableForNewSession(account.SchedulerKey())
 	}
 	return true
 }
@@ -2040,7 +2040,7 @@ func (s Server) refreshSelectedAccount(ctx context.Context, agentType, sessionID
 		s.Logger.Warn("selected Claude account refresh failed, trying another account", "account", account.ID, "error", err)
 	}
 	tried := map[string]struct{}{account.ID: {}}
-	s.markAccountExhausted(account.ID)
+	s.markAccountExhausted(provider, account.ID)
 	lastErr := err
 	for {
 		next, pickErr := s.retryAccount(ctx, provider, agentType, sessionID, userEmail, tried)
@@ -2053,7 +2053,7 @@ func (s Server) refreshSelectedAccount(ctx context.Context, agentType, sessionID
 			return refreshed, nil
 		}
 		lastErr = err
-		s.markAccountExhausted(next.ID)
+		s.markAccountExhausted(provider, next.ID)
 		if s.Logger != nil {
 			s.Logger.Warn("retry Claude account refresh failed", "account", next.ID, "error", err)
 		}
@@ -2086,7 +2086,7 @@ func (s Server) retryAccount(ctx context.Context, provider accounts.Provider, ag
 	if err != nil {
 		return accounts.Account{}, err
 	}
-	if scheduler.Exhausted(account.ID) {
+	if scheduler.Exhausted(account.SchedulerKey()) {
 		return accounts.Account{}, fmt.Errorf("no non-exhausted %s accounts available", provider)
 	}
 	if s.Sessions != nil {
@@ -2226,7 +2226,7 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			return response, nil
 		}
 		if t.server != nil {
-			t.server.markAccountExhausted(accountID)
+			t.server.markAccountExhausted(t.provider, accountID)
 		}
 		if attempt == maxAttempts || t.server == nil {
 			return response, nil
@@ -2287,10 +2287,10 @@ func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provide
 	if err != nil {
 		return accounts.Account{}, err
 	}
-	if scheduler.Exhausted(account.ID) {
+	if scheduler.Exhausted(account.SchedulerKey()) {
 		return accounts.Account{}, fmt.Errorf("no non-exhausted OAuth %s accounts available", provider)
 	}
-	if !scheduler.UsableForNewSession(account.ID) && s.Logger != nil {
+	if !scheduler.UsableForNewSession(account.SchedulerKey()) && s.Logger != nil {
 		s.Logger.Warn("usage-limit retry selected OAuth account below new-session headroom threshold", "provider", provider, "account", account.ID, "threshold", selectacct.MinNewSessionHeadroom)
 	}
 	refreshed, err := s.refreshAccount(ctx, account)

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -2783,14 +2783,14 @@ func TestHandlerMarksWebSocketUsageLimitAccountExhausted(t *testing.T) {
 		t.Fatal(err)
 	}
 	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
-		{AccountID: "empty@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
-		{AccountID: "healthy@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
+		{AccountID: accounts.SchedulerKey(accounts.ProviderCodex, "empty@example.com"), Headroom: 0.80, ShortHeadroom: 0.80},
+		{AccountID: accounts.SchedulerKey(accounts.ProviderCodex, "healthy@example.com"), Headroom: 0.80, ShortHeadroom: 0.80},
 	}))
 	handler := Server{
 		Upstream: upstreamURL,
 		Accounts: []accounts.Account{
-			{ID: "empty@example.com", AuthMode: accounts.AuthModeOAuth, Token: "empty-token"},
-			{ID: "healthy@example.com", AuthMode: accounts.AuthModeOAuth, Token: "healthy-token"},
+			{ID: "empty@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "empty-token"},
+			{ID: "healthy@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "healthy-token"},
 		},
 		Sessions:     store,
 		SchedulerRef: schedulerRef,
@@ -2871,14 +2871,14 @@ func TestHandlerRetriesHTTPUsageLimitOnAlternateOAuthAccount(t *testing.T) {
 		t.Fatal(err)
 	}
 	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
-		{AccountID: "empty@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
-		{AccountID: "healthy@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
+		{AccountID: accounts.SchedulerKey(accounts.ProviderCodex, "empty@example.com"), Headroom: 0.80, ShortHeadroom: 0.80},
+		{AccountID: accounts.SchedulerKey(accounts.ProviderCodex, "healthy@example.com"), Headroom: 0.80, ShortHeadroom: 0.80},
 	}))
 	handler := Server{
 		Upstream: upstreamURL,
 		Accounts: []accounts.Account{
-			{ID: "empty@example.com", AuthMode: accounts.AuthModeOAuth, Token: "empty-token"},
-			{ID: "healthy@example.com", AuthMode: accounts.AuthModeOAuth, Token: "healthy-token"},
+			{ID: "empty@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "empty-token"},
+			{ID: "healthy@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "healthy-token"},
 		},
 		Sessions:     store,
 		SchedulerRef: schedulerRef,

--- a/internal/proxy/scheduler_provider_collision_test.go
+++ b/internal/proxy/scheduler_provider_collision_test.go
@@ -1,0 +1,48 @@
+package proxy
+
+import (
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/internal/selectacct"
+	"github.com/manaflow-ai/subrouter/internal/session"
+)
+
+// TestAccountForSessionCodexNotExhaustedByCollidingClaudeScore guards against
+// codex and claude accounts that share an email colliding in the single shared
+// scheduler. A claude profile and a codex account for the same person both have
+// Account.ID == "user@example.com"; before the fix the scheduler map was keyed
+// by the bare ID, so an exhausted claude score marked the healthy codex account
+// exhausted and codex requests 503'd with "no usable OAuth codex accounts
+// available". The scheduler entry below simulates that collided/poisoned bare
+// key. A codex request must not be blocked by it.
+func TestAccountForSessionCodexNotExhaustedByCollidingClaudeScore(t *testing.T) {
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const email = "user@example.com"
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: email, Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "tok-codex"},
+			{ID: email, Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-claude"},
+		},
+		Sessions: store,
+		// Poisoned bare-email entry: the claude side exhausted the shared key.
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+			{AccountID: email, Headroom: 0, ShortHeadroom: 0},
+		})),
+	}
+
+	req := httptest.NewRequest("POST", "/v1/responses", strings.NewReader("{}"))
+	account, _, _, err := server.accountForSession("codex", "session-new", req)
+	if err != nil {
+		t.Fatalf("codex request was blocked by colliding claude score: %v", err)
+	}
+	if account.Provider != accounts.ProviderCodex || account.ID != email {
+		t.Fatalf("selected account = %s/%s, want codex/%s", account.Provider, account.ID, email)
+	}
+}

--- a/internal/selectacct/scheduler.go
+++ b/internal/selectacct/scheduler.go
@@ -104,8 +104,8 @@ func (s Scheduler) Pick(candidates []accounts.Account) (accounts.Account, error)
 
 	sorted := append([]accounts.Account(nil), candidates...)
 	sort.SliceStable(sorted, func(i, j int) bool {
-		left := s.score(sorted[i].ID)
-		right := s.score(sorted[j].ID)
+		left := s.scoreFor(sorted[i])
+		right := s.scoreFor(sorted[j])
 		leftTier := selectionTier(sorted[i], left)
 		rightTier := selectionTier(sorted[j], right)
 		if leftTier != rightTier {
@@ -161,6 +161,23 @@ func (s Scheduler) score(accountID string) Score {
 	}
 	if s.sessionCounts != nil {
 		score.Sessions = s.sessionCounts[accountID]
+	}
+	return score
+}
+
+// scoreFor resolves an account's score for selection. Headroom/exhaustion are
+// keyed by the provider-scoped SchedulerKey so a codex account and a claude
+// profile sharing an email never clobber each other. The session-count
+// tiebreaker is keyed by the bare account ID, since session counts are
+// provider-agnostic load and the session store records bare account IDs.
+func (s Scheduler) scoreFor(account accounts.Account) Score {
+	key := account.SchedulerKey()
+	score, ok := s.scores[key]
+	if !ok {
+		score = Score{AccountID: key, Headroom: 1, ShortHeadroom: 1}
+	}
+	if s.sessionCounts != nil {
+		score.Sessions = s.sessionCounts[account.ID]
 	}
 	return score
 }


### PR DESCRIPTION
## Problem

The team subrouter returned `503 no usable OAuth codex accounts available` for every codex request while its own `/_subrouter/usage-status` showed roughly half the codex pool with full headroom. Reproduced directly against the running server (loopback and Tailscale): `/_subrouter/health` was 200, but `/healthz` and `POST /v1/responses` were 503. Forcing a request onto one of the "exhausted" codex accounts (`X-Subrouter-Account-ID`) routed to OpenAI and returned a normal `400 {"detail":"Instructions are required"}`, so the accounts were healthy and the scheduler's exhaustion gate was the only blocker.

## Root cause

The proxy serves codex and claude through one shared `SchedulerRef` (`cmd/subrouter/main.go`), and the scheduler's score map is keyed by `Account.ID`. A codex account and a claude profile for the same person share that ID (the email): codex sets `ID = email` (`internal/accounts/codex_store.go`), claude sets `ID = profile.Name` (`internal/agents/claude/store.go`). `scoreAccounts` iterates every OAuth account across both providers and writes `scores[account.ID]`, so the two collide and the last writer wins. A constrained or errored claude profile (in production: one profile with `invalid_grant`, another at 12% weekly) clobbered its healthy codex twin to exhausted, and once enough twins were poisoned the pre-flight check 503'd the whole codex pool. Claude routing was unaffected because claude selection uses a separate path, which is why only codex went down.

## Fix

Key the scheduler's headroom/exhaustion scores by a provider-scoped `Account.SchedulerKey()` (`"codex:<id>"` / `"claude:<id>"`) at every write (`scoreAccounts`, the startup score builders in `main.go`, `MarkExhausted`) and every read (`Pick`, the `UsableForNewSession`/`Exhausted` gates, `sr` auto-switch). Codex and claude scores now occupy distinct map slots and cannot clobber each other. Candidate lists were already filtered per provider, so no cross-provider interference remains.

The session-count tiebreaker stays keyed by the bare account ID via a new `Scheduler.scoreFor`, because session load is provider-agnostic and the session store records bare account IDs. Legacy accounts with an empty `Provider` fall back to the bare key, so single-provider deployments are unchanged.

A missed read site degrades to fail-open (unknown key defaults to full headroom), never to false exhaustion, so the change cannot reintroduce the 503 through an oversight.

## Tests

Two-commit red/green:
- Commit 1 adds `TestAccountForSessionCodexNotExhaustedByCollidingClaudeScore` (proxy), which injects a poisoned bare-email score and asserts a codex request still routes. It fails on `main` with the exact production error and passes with the fix.
- Commit 2 adds the provider-scoping plus `TestSchedulerKeyProviderScoped` / `TestSchedulerKeyLegacyEmptyProviderFallsBackToID` (accounts).

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

## Deploy

Not deployed. The running `subrouter-team` build must be rebuilt and rolled out to clear the live 503; that is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784151012&installation_id=133855650&pr_number=15&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F15&signature=32c5bea0e74bbc139f3fe10e4f75a8f66bb88b1ed4ce8feaa4b51c38cd945d3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a scheduler key collision between codex and claude that was causing codex 503s by isolating scheduler state per provider. Codex and Claude now use provider-scoped keys so one cannot mark the other exhausted.

- **Bug Fixes**
  - Key scheduler scores by provider-scoped `Account.SchedulerKey()` (`"codex:<id>"` / `"claude:<id>"`) across writes and reads, including `scoreAccounts`, startup score builders, `Pick`, `UsableForNewSession`/`Exhausted`, `MarkExhausted`, sr auto-switch, and usage-limit inspectors.
  - Keep session-count tiebreaker on the bare account ID via `Scheduler.scoreFor`.
  - Unknown keys fail open (full headroom). Legacy accounts with empty `Provider` fall back to the bare ID.

- **Tests**
  - Added regression test to ensure a claude score cannot exhaust a codex account with the same email.
  - Updated existing tests to use provider-scoped scheduler keys.

<sup>Written for commit 0ee74c4359e4c84c288ae1d2db93ca2caa89717f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota and usage-limit tracking for accounts from different providers. Accounts sharing the same email across providers are now properly tracked independently, preventing cross-provider interference.

* **Tests**
  * Added test coverage for provider-scoped account tracking and scheduler key behavior to ensure proper isolation between accounts across different providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->