### PR TITLE
Fail over Claude requests on 401, not just 429

### DIFF
--- a/internal/proxy/claude_failover_test.go
+++ b/internal/proxy/claude_failover_test.go
@@ -134,6 +134,77 @@ func TestUsageLimitRetryTransportClaudeFailsOverOn429(t *testing.T) {
 	}
 }
 
+func TestUsageLimitRetryTransportClaudeFailsOverOn401(t *testing.T) {
+	server, store := claudeFailoverServer(t)
+	if _, err := store.Put("claude", "session-1", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	// A dead/expired Claude OAuth token yields a plain 401 authentication_error.
+	// subrouter must fail over to a healthy account instead of returning 401.
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		auth := req.Header.Get("Authorization")
+		if strings.Contains(auth, "tok-cooked") {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"}}`)),
+				Header:     http.Header{},
+			}
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":"msg_1"}`)),
+			Header:     http.Header{},
+		}
+	}}
+	transport := usageLimitRetryTransport{
+		base:        stub,
+		server:      &server,
+		provider:    accounts.ProviderClaude,
+		agent:       "claude",
+		session:     "session-1",
+		account:     "cooked@example.com",
+		method:      http.MethodPost,
+		path:        "/v1/messages",
+		maxAttempts: 3,
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader([]byte(`{"model":"claude-opus-4-8"}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after 401 failover", response.StatusCode)
+	}
+	if stub.calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2 (401 then retry)", stub.calls)
+	}
+	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
+		t.Fatal("401 should drop the dead-token account from selection")
+	}
+	assignment, ok := store.Get("claude", "session-1")
+	if !ok || assignment.AccountID != "fresh@example.com" {
+		t.Fatalf("sticky assignment = %+v, want moved to fresh@example.com", assignment)
+	}
+}
+
+func TestCaptureResponseBodyClaude401MarksExhausted(t *testing.T) {
+	server, _ := claudeFailoverServer(t)
+	response := &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"authentication_error"}}`)),
+		Header:     http.Header{},
+	}
+	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "/v1/messages")
+	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
+		t.Fatal("claude 401 should mark the account exhausted via passive inspection")
+	}
+}
+
 func TestReuseStickyAssignmentClaudeExhausted(t *testing.T) {
 	server, _ := claudeFailoverServer(t)
 	cooked := accounts.Account{ID: "cooked@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1505,9 +1505,11 @@ func (s Server) recordReplayableRequestBody(r *http.Request, agentType, sessionI
 }
 
 func (s Server) captureResponseBody(response *http.Response, agentType, sessionID, accountID string, provider accounts.Provider, path string) {
-	// Anthropic signals subscription exhaustion with a plain 429, with no
-	// codex-style usage-limit body to inspect.
-	if provider == accounts.ProviderClaude && accountID != "" && response.StatusCode == http.StatusTooManyRequests {
+	// Anthropic signals subscription exhaustion with a plain 429 and a dead or
+	// expired OAuth token with a plain 401, neither with a codex-style
+	// usage-limit body to inspect. Both mean this account can't serve the
+	// request, so drop it from selection and let failover pick another.
+	if provider == accounts.ProviderClaude && accountID != "" && claudeAccountUnusableStatus(response.StatusCode) {
 		s.markAccountExhausted(provider, accountID)
 	}
 	inspectUsageLimit := s.SchedulerRef != nil && accountID != "" && responseStatusCanExhaust(response.StatusCode)
@@ -2193,9 +2195,19 @@ type usageLimitRetryTransport struct {
 // by status alone.
 func (t usageLimitRetryTransport) responseUsageLimited(response *http.Response) (bool, error) {
 	if t.provider == accounts.ProviderClaude {
-		return response != nil && response.StatusCode == http.StatusTooManyRequests, nil
+		return response != nil && claudeAccountUnusableStatus(response.StatusCode), nil
 	}
 	return responseUsageLimit(response)
+}
+
+// claudeAccountUnusableStatus reports whether an upstream status means the
+// selected Claude account cannot serve this request and subrouter should fail
+// over to another account. 429 is quota exhaustion; 401 is a dead or expired
+// OAuth token (Anthropic returns authentication_error). Both are
+// account-specific, so replaying the same request on a different account is the
+// correct response instead of surfacing the failure to the client.
+func claudeAccountUnusableStatus(code int) bool {
+	return code == http.StatusTooManyRequests || code == http.StatusUnauthorized
 }
 
 func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subrouter",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Routes AI coding-agent traffic across subscription accounts and API keys.",
   "license": "MIT",
   "homepage": "https://github.com/manaflow-ai/subrouter#readme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "subrouter"
-version = "0.1.14"
+version = "0.1.15"
 description = "Routes AI coding-agent traffic across subscription accounts and API keys."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Why

After the provider-scoping fix, Codex routed fine but Claude still 401'd for
clients. Root cause isolated live: subrouter routing is sound (forcing a
healthy account returns 200), but account selection sometimes lands on an
account whose OAuth token is dead/expired (e.g. `austin@manaflow.ai` returns
`invalid_grant` on refresh; sticky sessions can pin to an unhealthy account).
Anthropic returns a plain **401 authentication_error** for those, and
subrouter only failed over on **429**, so the client got the 401 with no
retry even though healthy Claude accounts were available.

Direct-to-Anthropic with a healthy token returns 404 (model) not 401, proving
the token path is fine; the failure is purely "selected a bad account + no
failover".

## What

- Treat a Claude `401` like a `429`: mark the account unusable and replay the
  request on another account. Applied in both the active replay transport
  (`responseUsageLimited`) and the passive inspector (`captureResponseBody`).
- Tests: `TestUsageLimitRetryTransportClaudeFailsOverOn401`,
  `TestCaptureResponseBodyClaude401MarksExhausted`.
- Bump to v0.1.15.

## Verification

- `go test ./internal/proxy/...` green, including the new 401 tests.
- Pre-fix, an end-to-end `claude -p` through subrouter 401'd; post-deploy it
  returns 200 (verified after release).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784152036&installation_id=133855650&pr_number=16&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F16&signature=020648ae375981aaf20c609dfd56f684265495add2698c174f4fc715da3b0601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail over Claude requests on 401 as well as 429 to prevent client-facing 401s from dead OAuth tokens. We now drop the bad account and retry on a healthy one.

- **Bug Fixes**
  - Treat Anthropic 401 authentication_error as an account-level failure for Claude (same as 429).
  - Apply in both the retry transport and passive response inspector; centralized via `claudeAccountUnusableStatus`.
  - Added tests: `TestUsageLimitRetryTransportClaudeFailsOverOn401`, `TestCaptureResponseBodyClaude401MarksExhausted`. Version bumped to 0.1.15.

<sup>Written for commit 56ba59d9c7669a7e84eca1160d453e95b396031e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

