### PR TITLE
CI on PRs + non-blocking startup + pull-based VM auto-deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Build, vet, test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: CGO_ENABLED=0 go test ./...

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -216,16 +216,23 @@ func serve(args []string) error {
 		slog.Warn("Claude accounts skipped", "error", err)
 		claudeAccounts = nil
 	}
-	scores := fallbackScores(codexAccounts)
+	// Start with optimistic fallback scores so the proxy begins accepting
+	// connections immediately. Blocking startup on a synchronous usage fetch
+	// (an OAuth refresh per account) stalls socket-activated connections during
+	// a deploy restart, so the real scores are fetched in the background and
+	// swapped in once ready. Per-request 401/429 failover covers the brief
+	// window before fresh scores land.
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler(fallbackScores(codexAccounts)))
 	if *fetchUsage {
-		fetchedScores, successful := fetchCodexScoresWithStore(context.Background(), codexStore, codexAccounts)
-		if successful > 0 {
-			scores = fetchedScores
-		} else {
-			slog.Warn("initial usage score fetch skipped", "reason", "no fresh OAuth usage scores")
-		}
+		go func() {
+			fetchedScores, successful := fetchCodexScoresWithStore(context.Background(), codexStore, codexAccounts)
+			if successful > 0 {
+				schedulerRef.Set(selectacct.NewScheduler(fetchedScores))
+			} else {
+				slog.Warn("initial usage score fetch skipped", "reason", "no fresh OAuth usage scores")
+			}
+		}()
 	}
-	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler(scores))
 	outboundTransport := proxy.NewOutboundTransport()
 	initialAccounts := append([]accounts.Account(nil), codexAccounts...)
 	initialAccounts = append(initialAccounts, claudeAccounts...)

--- a/deploy/gcp/subrouter-autoupdate.service
+++ b/deploy/gcp/subrouter-autoupdate.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Subrouter auto-update from latest GitHub release
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/subrouter-autoupdate.sh

--- a/deploy/gcp/subrouter-autoupdate.sh
+++ b/deploy/gcp/subrouter-autoupdate.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Pull-based auto-updater for the Subrouter VM.
+#
+# Polls the latest published GitHub release and, when it differs from the
+# installed version, downloads the matching binary, verifies its checksum,
+# swaps it in, and restarts the service. Restarts are zero-interruption: the
+# listening socket is owned by systemd (subrouter.socket), the old process
+# drains in-flight requests on SIGTERM (TimeoutStopSec=10min), and the new
+# process starts accepting immediately (it no longer blocks startup on usage
+# fetches). A release only exists after CI ran `go test`, so this never deploys
+# untested code.
+set -euo pipefail
+
+REPO="${SUBROUTER_REPO:-manaflow-ai/subrouter}"
+BIN="${SUBROUTER_BIN:-/usr/local/bin/subrouter}"
+VERSION_FILE="${SUBROUTER_VERSION_FILE:-/etc/subrouter-version}"
+SERVICE="${SUBROUTER_SERVICE:-subrouter.service}"
+
+log() { echo "subrouter-autoupdate: $*"; }
+
+case "$(uname -m)" in
+  x86_64|amd64) arch="amd64" ;;
+  aarch64|arm64) arch="arm64" ;;
+  *) log "unsupported arch $(uname -m)"; exit 1 ;;
+esac
+
+latest_tag="$(curl -fsSL -H 'Accept: application/vnd.github+json' \
+  "https://api.github.com/repos/${REPO}/releases/latest" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])')"
+if [ -z "${latest_tag}" ]; then
+  log "could not resolve latest release tag"; exit 1
+fi
+
+installed=""
+[ -f "${VERSION_FILE}" ] && installed="$(cat "${VERSION_FILE}" 2>/dev/null || true)"
+
+if [ "${latest_tag}" = "${installed}" ]; then
+  exit 0
+fi
+
+version="${latest_tag#v}"
+asset="subrouter_${version}_linux_${arch}"
+base="https://github.com/${REPO}/releases/download/${latest_tag}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+log "updating ${installed:-none} -> ${latest_tag} (${asset})"
+curl -fsSL -o "${tmp}/${asset}" "${base}/${asset}"
+curl -fsSL -o "${tmp}/SHA256SUMS" "${base}/SHA256SUMS"
+( cd "${tmp}" && grep " ${asset}\$" SHA256SUMS | sha256sum -c - )
+
+cp -p "${BIN}" "${BIN}.bak-$(date +%Y%m%d-%H%M%S)" 2>/dev/null || true
+install -m 0755 -o root -g root "${tmp}/${asset}" "${BIN}"
+systemctl restart "${SERVICE}"
+
+i=0
+until curl -fsS http://127.0.0.1:31415/_subrouter/health >/dev/null 2>&1; do
+  i=$((i + 1))
+  if [ "${i}" -ge 30 ]; then
+    log "health check failed after restart; leaving new binary in place"
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "${latest_tag}" > "${VERSION_FILE}"
+log "updated to ${latest_tag} and healthy"

--- a/deploy/gcp/subrouter-autoupdate.timer
+++ b/deploy/gcp/subrouter-autoupdate.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Poll for new Subrouter releases and auto-update
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=2min
+RandomizedDelaySec=30
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subrouter",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Routes AI coding-agent traffic across subscription accounts and API keys.",
   "license": "MIT",
   "homepage": "https://github.com/manaflow-ai/subrouter#readme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "subrouter"
-version = "0.1.15"
+version = "0.1.16"
 description = "Routes AI coding-agent traffic across subscription accounts and API keys."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Why

Two gaps the team hit: the buggy build reached the VM via manual deploys of
unreleased code (no CI gate, no automated deploy), and a deploy restart could
stall new connections.

## What

- **CI on PRs** (`.github/workflows/ci.yml`): every PR and main push runs
  `go build`, `go vet`, `go test`. `release.yml` already runs the full suite
  before publishing, so a release only exists if tests passed -> deploys are
  gated on tests.
- **Non-blocking startup** (`cmd/subrouter/main.go`): serve immediately with
  optimistic fallback scores and fetch usage in the background instead of
  blocking boot on ~18 OAuth refreshes. With the existing systemd socket
  activation (listener survives restarts) + graceful drain (in-flight requests
  finish, `TimeoutStopSec=10min`), the new process now also accepts instantly,
  so deploy restarts don't interrupt connected or new traffic.
- **Pull-based auto-deploy** (`deploy/gcp/subrouter-autoupdate.{sh,service,timer}`):
  the VM polls the latest published release, checksum-verifies the binary, and
  restarts via the zero-interruption path. No inbound access, stored secrets,
  or IAM changes (the VM is Tailscale-locked).

## Verified

- Deploy restart with an in-flight streaming request: request completes 200,
  rapid health pinger stays 200 across the restart (after the startup fix).
- `codex` and `claude` CLIs route through the VM end to end.

OIDC push (GCP Workload Identity Federation + IAP) is the alternative if we
want GitHub Actions to push instead of the VM pulling; noted but not required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784152680&installation_id=133855650&pr_number=17&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F17&signature=ff97764ac9c931472ed24793620c57c4eb52c139bf9252b07dcaa2b18af96774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CI on PRs, makes startup non-blocking, and adds a pull-based VM auto-deploy for zero-downtime releases. Deploys are now gated by tests and restarts no longer interrupt traffic.

- **New Features**
  - CI on PRs and `main`: runs `go build`, `go vet`, `go test`; releases only publish after tests pass.
  - Non-blocking startup: serve immediately with fallback scores; fetch usage in the background; works with systemd socket activation and graceful drain.
  - Pull-based auto-deploy: systemd timer/service + script polls latest GitHub release, verifies checksum, installs, restarts, and health-checks; no inbound access or stored secrets.

- **Migration**
  - On the VM, install `deploy/gcp/subrouter-autoupdate.{sh,service,timer}`; put the script at `/usr/local/bin/subrouter-autoupdate.sh`.
  - Run: `sudo systemctl daemon-reload && sudo systemctl enable --now subrouter-autoupdate.timer`.
  - Ensure `subrouter.service` and `subrouter.socket` are active; optional envs: `SUBROUTER_REPO`, `SUBROUTER_BIN`, `SUBROUTER_VERSION_FILE`, `SUBROUTER_SERVICE`.

<sup>Written for commit 5229be2d26d6715fc3ce2e2300c3e8a440a94e17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

