### PR TITLE
Stop auto-publishing npm/PyPI; tags only ship the GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,26 @@
 name: Release
 
+# A pushed tag builds + tests, then publishes a GitHub release with the binary.
+# The VM auto-updater pulls that release; that is the only deploy path we care
+# about. npm/PyPI are NOT published on a tag; they are manual opt-in only via
+# the workflow_dispatch toggles below.
+
 on:
   push:
     tags:
       - "v*"
   workflow_dispatch:
     inputs:
-      create_github_release:
-        description: "Create or update the GitHub release"
-        required: true
-        type: boolean
-        default: false
       publish_npm:
-        description: "Publish to npm through trusted publishing"
+        description: "Also publish to npm (manual opt-in)"
         required: true
         type: boolean
         default: false
       publish_pypi:
-        description: "Publish to PyPI through trusted publishing"
+        description: "Also publish to PyPI (manual opt-in)"
         required: true
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read
@@ -43,17 +43,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
       - name: Determine release version
         id: version
         shell: bash
@@ -62,17 +51,8 @@ jobs:
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             version="${GITHUB_REF_NAME#v}"
           else
-            version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+            version="$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
           fi
-
-          package_version="$(node -p "require('./package.json').version")"
-          python_version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
-
-          if [[ "${version}" != "${package_version}" || "${version}" != "${python_version}" ]]; then
-            echo "version mismatch: release=${version} package.json=${package_version} pyproject.toml=${python_version}" >&2
-            exit 1
-          fi
-
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
       - name: Test Go packages
@@ -84,15 +64,6 @@ jobs:
       - name: Copy shell installer into release assets
         run: cp install.sh dist/release/install.sh
 
-      - name: Check npm package
-        run: npm pack --dry-run
-
-      - name: Build Python package
-        run: |
-          python -m pip install --upgrade build twine
-          python -m build
-          python -m twine check dist/subrouter-*.tar.gz dist/subrouter-*.whl
-
       - name: Upload Go release artifacts
         uses: actions/upload-artifact@v5
         with:
@@ -100,20 +71,11 @@ jobs:
           path: dist/release/*
           if-no-files-found: error
 
-      - name: Upload Python distributions
-        uses: actions/upload-artifact@v5
-        with:
-          name: python-dist
-          path: |
-            dist/subrouter-*.tar.gz
-            dist/subrouter-*.whl
-          if-no-files-found: error
-
   github-release:
     name: Publish GitHub release
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.inputs.create_github_release == 'true' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: write
     steps:
@@ -138,11 +100,13 @@ jobs:
               --notes "Subrouter ${TAG_NAME}"
           fi
 
+  # Manual opt-in only. These never run on a tag push; trigger this workflow via
+  # the Actions "Run workflow" button with the toggle enabled to publish.
   npm-publish:
-    name: Publish npm package
+    name: Publish npm package (manual)
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.inputs.publish_npm == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_npm }}
     environment: npm
     permissions:
       contents: read
@@ -161,20 +125,28 @@ jobs:
         run: npm publish --access public
 
   pypi-publish:
-    name: Publish PyPI package
+    name: Publish PyPI package (manual)
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.inputs.publish_pypi == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_pypi }}
     environment: pypi
     permissions:
       contents: read
       id-token: write
     steps:
-      - name: Download Python distributions
-        uses: actions/download-artifact@v5
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          name: python-dist
-          path: dist
+          python-version: "3.12"
+
+      - name: Build Python package
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+          python -m twine check dist/subrouter-*.tar.gz dist/subrouter-*.whl
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Per request: the only deploy we care about is the VM pulling the GitHub release
binary. A tag push now runs build + test + GitHub release only. npm/PyPI are
manual opt-in via workflow_dispatch toggles (default off), so nothing publishes
to the public registries during normal CI/CD.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784153220&installation_id=133855650&pr_number=18&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F18&signature=638ae79fe1ef0ca5a4bee1a02c34ab875a27fe23bda33059206d9e6df223381b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stopped auto-publishing to `npm` and `PyPI`. Tag pushes now only build/test and publish a GitHub release with binaries, which the VM pulls as the sole deploy path.

- **Migration**
  - To publish to `npm` or `PyPI`, run the Release workflow manually and enable `publish_npm` and/or `publish_pypi` (defaults off).

<sup>Written for commit 17a4ae36b57a7c259e6f5de3e6d027df96d1b2f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

