### PR TITLE
Never refuse traffic on stale exhaustion scores; route optimistically

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1861,13 +1861,21 @@ func (s Server) accountForSession(agentType, sessionID string, r *http.Request) 
 	if err != nil {
 		return accounts.Account{}, sessionID, userEmail, err
 	}
-	if account.AuthMode == accounts.AuthModeOAuth && !scheduler.UsableForNewSession(account.Provider, account.ID) {
-		if scheduler.Exhausted(account.Provider, account.ID) {
-			return accounts.Account{}, sessionID, userEmail, fmt.Errorf("no usable OAuth %s accounts available", provider)
-		}
-		if provider == accounts.ProviderCodex && s.Logger != nil {
-			s.Logger.Warn("selected OAuth Codex account below new-session headroom threshold", "account", account.ID, "threshold", selectacct.MinNewSessionHeadroom)
-		}
+	if account.AuthMode == accounts.AuthModeOAuth && !scheduler.UsableForNewSession(account.Provider, account.ID) && s.Logger != nil {
+		// Never refuse here based on the scheduler's view. Usage scores can be
+		// stale: the per-request re-score reads usage through a cache that falls
+		// back to stale "last good" data when the upstream usage endpoint
+		// rate-limits, which made healthy accounts look exhausted and produced
+		// bogus "no usable accounts" 503s while real quota existed. The
+		// scheduler is a load-balancing hint, not a hard gate. Route the best
+		// account and let the real upstream response drive per-request
+		// usage-limit failover; a genuinely exhausted account surfaces the
+		// upstream's own 429 instead of a premature rejection.
+		s.Logger.Warn("selected OAuth account below new-session headroom; routing optimistically",
+			"provider", provider,
+			"account", account.ID,
+			"exhausted", scheduler.Exhausted(account.Provider, account.ID),
+			"threshold", selectacct.MinNewSessionHeadroom)
 	}
 	assignment, err := s.Sessions.Put(agentType, sessionID, account.ID, userEmail)
 	if err != nil {
@@ -2302,11 +2310,16 @@ func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provide
 	if err != nil {
 		return accounts.Account{}, err
 	}
-	if scheduler.Exhausted(account.Provider, account.ID) {
-		return accounts.Account{}, fmt.Errorf("no non-exhausted OAuth %s accounts available", provider)
-	}
+	// Do not stop failover when the best untried account looks exhausted: scores
+	// can be stale, so trying it (the retry loop is bounded by maxAttempts and
+	// the tried set) is strictly better than refusing an account that may have
+	// quota. A truly exhausted account just returns the upstream's own limit.
 	if !scheduler.UsableForNewSession(account.Provider, account.ID) && s.Logger != nil {
-		s.Logger.Warn("usage-limit retry selected OAuth account below new-session headroom threshold", "provider", provider, "account", account.ID, "threshold", selectacct.MinNewSessionHeadroom)
+		s.Logger.Warn("usage-limit retry selecting OAuth account below new-session headroom; trying anyway",
+			"provider", provider,
+			"account", account.ID,
+			"exhausted", scheduler.Exhausted(account.Provider, account.ID),
+			"threshold", selectacct.MinNewSessionHeadroom)
 	}
 	refreshed, err := s.refreshAccount(ctx, account)
 	if err != nil {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -2991,7 +2991,11 @@ func TestHandlerRetriesHTTPUsageLimitToBelowThresholdFallback(t *testing.T) {
 	}
 }
 
-func TestHandlerDoesNotAssignNewSessionToExhaustedOAuthAccount(t *testing.T) {
+// When every OAuth account is scored exhausted, the router must still route
+// optimistically and let the upstream decide, rather than refusing with a 503.
+// Scores can be stale (cached usage behind a rate-limited upstream), and a hard
+// refusal here caused real outages where healthy accounts looked exhausted.
+func TestHandlerRoutesOptimisticallyWhenAllOAuthScoredExhausted(t *testing.T) {
 	var auths []string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		auths = append(auths, r.Header.Get("Authorization"))
@@ -3036,14 +3040,17 @@ func TestHandlerDoesNotAssignNewSessionToExhaustedOAuthAccount(t *testing.T) {
 	if _, err := io.Copy(io.Discard, response.Body); err != nil {
 		t.Fatal(err)
 	}
-	if response.StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want 503", response.StatusCode)
+	if response.StatusCode == http.StatusServiceUnavailable {
+		t.Fatal("router refused with 503 instead of routing optimistically on stale-exhausted scores")
 	}
-	if len(auths) != 0 {
-		t.Fatalf("upstream auths = %#v, want no upstream request", auths)
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204 (forwarded upstream)", response.StatusCode)
 	}
-	if _, ok := store.Get("codex", "session-1"); ok {
-		t.Fatal("exhausted account should not be assigned to new session")
+	if len(auths) != 1 {
+		t.Fatalf("upstream auths = %#v, want exactly one forwarded request", auths)
+	}
+	if _, ok := store.Get("codex", "session-1"); !ok {
+		t.Fatal("session should be assigned after optimistic routing")
 	}
 }
 

--- a/internal/proxy/scheduler_staleness_test.go
+++ b/internal/proxy/scheduler_staleness_test.go
@@ -1,0 +1,87 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/internal/selectacct"
+	"github.com/manaflow-ai/subrouter/internal/session"
+)
+
+// Regression: the scheduler is a load-balancing hint, not a hard gate. Usage
+// scores can go stale (the per-request re-score reads usage through a cache
+// that falls back to stale "last good" data when the upstream usage endpoint
+// rate-limits), which made healthy accounts look exhausted and produced bogus
+// "no usable OAuth accounts" 503s while real quota existed. The router must
+// route to the best account regardless of stale exhaustion scores and let the
+// real upstream response decide.
+func TestRouterDoesNotRefuseWhenScoresAreStaleExhausted(t *testing.T) {
+	var upstreamHits int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"resp_1"}`))
+	}))
+	defer upstream.Close()
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Every OAuth Codex account is scored fully exhausted, simulating stale
+	// cached scores. UsageScoreTTL=0 disables the pre-selection refresh so the
+	// stale scores stick, exactly reproducing the stuck-scheduler state.
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+		{AccountID: "a@example.com", Provider: accounts.ProviderCodex, Headroom: 0, ShortHeadroom: 0},
+		{AccountID: "b@example.com", Provider: accounts.ProviderCodex, Headroom: 0, ShortHeadroom: 0},
+	}))
+
+	handler := Server{
+		Upstream: upstreamURL,
+		Accounts: []accounts.Account{
+			{ID: "a@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "a-token"},
+			{ID: "b@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "b-token"},
+		},
+		Sessions:      store,
+		SchedulerRef:  schedulerRef,
+		UsageScoreTTL: 0,
+		MaxBodyBytes:  1024,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	req, err := http.NewRequest(http.MethodPost, subrouter.URL+"/v1/responses", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Subrouter-Session", "codex-session:stale")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+
+	if response.StatusCode == http.StatusServiceUnavailable {
+		t.Fatalf("router refused with 503 on stale-exhausted scores: %s", string(body))
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (routed despite stale exhaustion); body=%s", response.StatusCode, string(body))
+	}
+	if upstreamHits == 0 {
+		t.Fatal("request was not forwarded upstream; router refused instead of routing")
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subrouter",
-  "version": "0.1.16",
+  "version": "0.1.18",
   "description": "Routes AI coding-agent traffic across subscription accounts and API keys.",
   "license": "MIT",
   "homepage": "https://github.com/manaflow-ai/subrouter#readme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "subrouter"
-version = "0.1.16"
+version = "0.1.18"
 description = "Routes AI coding-agent traffic across subscription accounts and API keys."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Symptom

Codex (and earlier Claude) clients got `503 no usable OAuth accounts` from the
VM while `sr status` showed 6+ accounts with real quota. Restarting fixed it
briefly, then it recurred within minutes.

## Root cause

The daemon's scheduler held stale "exhausted" scores. The per-request re-score
(`scoreAccounts`) reads usage through a 2m/15m cache that falls back to stale
"last good" windows when the upstream usage endpoint rate-limits. After the 5h
quota window reset, accounts were healthy, but the cache kept serving the old
cooked windows, so the scheduler scored them exhausted. The selection path then
*hard-refused* based on those stale scores. Boot and `sr status` use fresh
(uncached) fetches, which is why they looked healthy.

## Fix

The scheduler is a load-balancing hint, not a hard gate. The router now routes
the best account even if it's scored exhausted, and lets the real upstream
response drive per-request usage-limit/401/429 failover. A genuinely exhausted
fleet surfaces the upstream's own 429 instead of a premature rejection. Applied
to both primary selection and the usage-limit retry path.

## Test

- `TestRouterDoesNotRefuseWhenScoresAreStaleExhausted`: seeds the scheduler
  all-exhausted with a healthy upstream and asserts the request routes (200),
  not 503. Fails on the old code, passes now.
- Updated the old hard-gate test to assert the new optimistic-routing contract.

Verified live after deploy: repeated `codex`/`claude` runs route through the VM
and stay working.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784162428&installation_id=133855650&pr_number=19&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F19&signature=e7e75290d01e2b6c3bb85cc46fb1b427f63076f3b06e0d20badf63f4334ce2f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop returning 503 “no usable OAuth accounts” when scheduler scores go stale. We now route the best OAuth account even if scored exhausted and let upstream 401/429 drive failover, for both primary selection and usage-limit retries.

- **Bug Fixes**
  - Treat scheduler scores as hints, not gates; remove hard refusal on “exhausted” in selection and retry paths and add warning logs when routing below headroom.
  - Add `TestRouterDoesNotRefuseWhenScoresAreStaleExhausted` and update the websocket test to assert optimistic routing.

- **Dependencies**
  - Bump project version to `0.1.18` in `package.json` and `pyproject.toml`.

<sup>Written for commit 60913c17acfcb572d4556c85146998e63c74afd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account selection to avoid prematurely rejecting requests based on potentially stale scheduler data; requests now proceed to upstream services for actual quota and failover handling.
  * Updated OAuth retry logic to optimistically route requests when exhaustion signals may be outdated.

* **Tests**
  * Added regression test verifying correct behavior with stale exhaustion data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->