### PR TITLE
Don't let stale usage data clobber known-good scores

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -177,9 +177,15 @@ const usageWindowsLastGoodTTL = 15 * time.Minute
 // cascaded: failed fetches zeroed scores and made healthy accounts look
 // exhausted. Fresh-within-TTL returns the cache; a transient fetch failure
 // falls back to the last-known-good windows instead of erroring.
-func (r *AccountRef) FetchUsageWindowsCached(ctx context.Context, client *http.Client, account accounts.Account) ([]accounts.UsageWindow, error) {
+//
+// The returned bool reports whether the windows are FRESH (a recent successful
+// fetch) versus a STALE last-known-good fallback. Callers must not treat stale
+// windows as a confident exhaustion signal: stale cooked data was overwriting
+// healthy accounts' scores and routing traffic to dead accounts.
+func (r *AccountRef) FetchUsageWindowsCached(ctx context.Context, client *http.Client, account accounts.Account) ([]accounts.UsageWindow, bool, error) {
 	if r == nil {
-		return fetchAccountUsageWindowsLive(ctx, client, account)
+		windows, err := fetchAccountUsageWindowsLive(ctx, client, account)
+		return windows, err == nil, err
 	}
 	key := account.ID + "\x00" + string(account.Provider)
 	now := time.Now()
@@ -187,7 +193,7 @@ func (r *AccountRef) FetchUsageWindowsCached(ctx context.Context, client *http.C
 	entry, ok := r.usageWindows[key]
 	r.usageWindowsMu.Unlock()
 	if ok && now.Sub(entry.at) < usageWindowsTTL {
-		return append([]accounts.UsageWindow(nil), entry.windows...), nil
+		return append([]accounts.UsageWindow(nil), entry.windows...), true, nil
 	}
 	windows, err := fetchAccountUsageWindowsLive(ctx, client, account)
 	if err == nil {
@@ -197,12 +203,12 @@ func (r *AccountRef) FetchUsageWindowsCached(ctx context.Context, client *http.C
 		}
 		r.usageWindows[key] = usageWindowsEntry{windows: append([]accounts.UsageWindow(nil), windows...), at: now}
 		r.usageWindowsMu.Unlock()
-		return windows, nil
+		return windows, true, nil
 	}
 	if !authLikeUsageError(err.Error()) && ok && now.Sub(entry.at) < usageWindowsLastGoodTTL {
-		return append([]accounts.UsageWindow(nil), entry.windows...), nil
+		return append([]accounts.UsageWindow(nil), entry.windows...), false, nil
 	}
-	return nil, err
+	return nil, false, err
 }
 
 type AccountStatus struct {
@@ -560,7 +566,7 @@ func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus
 			}
 			next.AuthValid = true
 			r.replace(account)
-			windows, err := r.FetchUsageWindowsCached(ctx, r.client, account)
+			windows, _, err := r.FetchUsageWindowsCached(ctx, r.client, account)
 			if err != nil {
 				next.Error = err.Error()
 				out[i] = next
@@ -920,20 +926,26 @@ func (s Server) reloadAccounts(ctx context.Context) (int, int, error) {
 }
 
 func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account) ([]selectacct.Score, int) {
+	// Seed each account from the scheduler's current score so a refresh that
+	// can't get FRESH usage data for an account preserves its last known score
+	// instead of overwriting it. Previously a refresh built every score from
+	// scratch and, when the usage cache served stale "last good" cooked data
+	// (the upstream usage endpoint rate-limits under load), it clobbered
+	// healthy accounts to exhausted and the router then routed traffic to dead
+	// accounts. A score is only overwritten on confident, fresh evidence.
+	current := s.scheduler()
 	scores := make([]selectacct.Score, 0, len(available))
 	scoreByID := make(map[string]int, len(available))
 	for _, account := range available {
-		headroom := 1.0
+		seed := current.ScoreFor(account.Provider, account.ID)
+		seed.AccountID = account.ID
+		seed.Provider = account.Provider
 		if account.AuthMode == accounts.AuthModeAPIKey {
-			headroom = 0.01
+			seed.Headroom = 0.01
+			seed.ShortHeadroom = 0.01
 		}
 		scoreByID[selectacct.ScoreKey(account.Provider, account.ID)] = len(scores)
-		scores = append(scores, selectacct.Score{
-			AccountID:     account.ID,
-			Provider:      account.Provider,
-			Headroom:      headroom,
-			ShortHeadroom: headroom,
-		})
+		scores = append(scores, seed)
 	}
 
 	client := (*http.Client)(nil)
@@ -954,23 +966,28 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 			if s.Logger != nil {
 				s.Logger.Warn("account reload refresh failed", "account", account.ID, "error", err)
 			}
-			setZeroScore(scores, scoreByID, account.Provider, account.ID)
+			// Only zero on a confident auth failure (dead/invalid token).
+			// Transient refresh errors preserve the seed.
+			if authLikeUsageError(err.Error()) {
+				setZeroScore(scores, scoreByID, account.Provider, account.ID)
+			}
 			continue
 		}
-		windows, err := s.fetchAccountUsageWindows(ctx, client, refreshed)
+		windows, fresh, err := s.fetchAccountUsageWindows(ctx, client, refreshed)
 		if err != nil {
 			if s.Logger != nil {
 				s.Logger.Warn("account reload usage fetch failed", "account", account.ID, "error", err)
 			}
 			// Auth failures mean the account is unusable; zero it so the
-			// scheduler avoids it. Transient failures (rate limits, network)
-			// keep the optimistic default score: treating unknown as
-			// exhausted herds every session away from healthy accounts, and
-			// per-request usage-limit failover already handles true
-			// exhaustion.
+			// scheduler avoids it. Transient failures preserve the seed.
 			if authLikeUsageError(err.Error()) {
 				setZeroScore(scores, scoreByID, account.Provider, account.ID)
 			}
+			continue
+		}
+		if !fresh {
+			// Stale last-known-good windows are not a confident signal. Keep
+			// the seeded score rather than risk demoting a healthy account.
 			continue
 		}
 		if idx, ok := scoreByID[selectacct.ScoreKey(account.Provider, account.ID)]; ok {
@@ -981,11 +998,14 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 	return scores, scored
 }
 
-func (s Server) fetchAccountUsageWindows(ctx context.Context, client *http.Client, account accounts.Account) ([]accounts.UsageWindow, error) {
+// fetchAccountUsageWindows returns an account's usage windows and whether they
+// are fresh (a recent successful fetch) versus a stale last-known-good fallback.
+func (s Server) fetchAccountUsageWindows(ctx context.Context, client *http.Client, account accounts.Account) ([]accounts.UsageWindow, bool, error) {
 	if s.AccountRef != nil {
 		return s.AccountRef.FetchUsageWindowsCached(ctx, client, account)
 	}
-	return fetchAccountUsageWindowsLive(ctx, client, account)
+	windows, err := fetchAccountUsageWindowsLive(ctx, client, account)
+	return windows, err == nil, err
 }
 
 func fetchAccountUsageWindowsLive(ctx context.Context, client *http.Client, account accounts.Account) ([]accounts.UsageWindow, error) {

--- a/internal/proxy/scoreaccounts_test.go
+++ b/internal/proxy/scoreaccounts_test.go
@@ -1,0 +1,54 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/internal/selectacct"
+)
+
+// Regression: a usage-score refresh must never demote a healthy account to
+// exhausted using stale data. The upstream usage endpoint rate-limits under
+// load, so the per-request re-score read stale "last good" cooked windows and
+// overwrote the scheduler's healthy scores with zeros, after which the router
+// routed traffic to dead accounts. scoreAccounts must preserve the last known
+// score when it cannot fetch FRESH usage.
+func TestScoreAccountsPreservesHealthyScoreWhenUsageIsStale(t *testing.T) {
+	transport := &usageRoundTripper{responses: []*http.Response{usage429Response()}}
+	ref := cacheTestAccountRef(t, transport)
+	account := accounts.Account{ID: "claude@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok"}
+
+	// Seed a STALE, cooked last-known-good usage entry so the live (rate-limited
+	// 429) fetch falls back to it and reports fresh=false.
+	key := account.ID + "\x00" + string(account.Provider)
+	ref.usageWindowsMu.Lock()
+	if ref.usageWindows == nil {
+		ref.usageWindows = map[string]usageWindowsEntry{}
+	}
+	ref.usageWindows[key] = usageWindowsEntry{
+		windows: []accounts.UsageWindow{{Name: "5h", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60}},
+		at:      time.Now().Add(-usageWindowsTTL - time.Minute),
+	}
+	ref.usageWindowsMu.Unlock()
+
+	server := Server{
+		AccountRef: ref,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+			{AccountID: "claude@example.com", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+		})),
+	}
+
+	scores, scored := server.scoreAccounts(context.Background(), []accounts.Account{account})
+	if scored != 0 {
+		t.Fatalf("scored = %d, want 0 (stale usage must not count as a fresh score)", scored)
+	}
+	if len(scores) != 1 {
+		t.Fatalf("scores = %d, want 1", len(scores))
+	}
+	if scores[0].Headroom <= 0 || scores[0].ShortHeadroom <= 0 {
+		t.Fatalf("healthy account clobbered to exhausted by stale usage: %+v", scores[0])
+	}
+}

--- a/internal/proxy/usage_windows_cache_test.go
+++ b/internal/proxy/usage_windows_cache_test.go
@@ -37,9 +37,12 @@ func TestFetchUsageWindowsCachedServesFromCacheWithinTTL(t *testing.T) {
 	client := &http.Client{Transport: transport}
 	account := accounts.Account{ID: "a@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok"}
 	for i := 0; i < 3; i++ {
-		windows, err := ref.FetchUsageWindowsCached(context.Background(), client, account)
+		windows, fresh, err := ref.FetchUsageWindowsCached(context.Background(), client, account)
 		if err != nil || len(windows) == 0 {
 			t.Fatalf("call %d: windows=%v err=%v", i, windows, err)
+		}
+		if !fresh {
+			t.Fatalf("call %d: within-TTL cache should report fresh", i)
 		}
 	}
 	if transport.calls != 1 {
@@ -52,7 +55,7 @@ func TestFetchUsageWindowsCachedFallsBackToLastGoodOn429(t *testing.T) {
 	ref := &AccountRef{}
 	client := &http.Client{Transport: transport}
 	account := accounts.Account{ID: "a@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok"}
-	if _, err := ref.FetchUsageWindowsCached(context.Background(), client, account); err != nil {
+	if _, _, err := ref.FetchUsageWindowsCached(context.Background(), client, account); err != nil {
 		t.Fatal(err)
 	}
 	// Expire the freshness window but keep the entry as last-good.
@@ -63,12 +66,15 @@ func TestFetchUsageWindowsCachedFallsBackToLastGoodOn429(t *testing.T) {
 	ref.usageWindows[key] = entry
 	ref.usageWindowsMu.Unlock()
 	transport.responses = claudeUsage429
-	windows, err := ref.FetchUsageWindowsCached(context.Background(), client, account)
+	windows, fresh, err := ref.FetchUsageWindowsCached(context.Background(), client, account)
 	if err != nil {
 		t.Fatalf("transient 429 should serve last-good, got error %v", err)
 	}
 	if len(windows) == 0 {
 		t.Fatal("last-good windows missing")
+	}
+	if fresh {
+		t.Fatal("stale last-good fallback must report fresh=false so scoring does not trust it")
 	}
 }
 
@@ -79,7 +85,7 @@ func TestFetchUsageWindowsCachedPropagatesAuthErrors(t *testing.T) {
 	ref := &AccountRef{}
 	client := &http.Client{Transport: transport}
 	account := accounts.Account{ID: "a@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok"}
-	if _, err := ref.FetchUsageWindowsCached(context.Background(), client, account); err == nil {
+	if _, _, err := ref.FetchUsageWindowsCached(context.Background(), client, account); err == nil {
 		t.Fatal("auth error should propagate, not be masked")
 	}
 }

--- a/internal/selectacct/scheduler.go
+++ b/internal/selectacct/scheduler.go
@@ -169,6 +169,17 @@ func selectionTier(account accounts.Account, score Score) int {
 	return 4
 }
 
+// ScoreFor returns the stored score for an account, or an optimistic default
+// (treated as fully healthy) when none is known. Callers use it to seed a
+// refresh so accounts whose fresh usage could not be fetched preserve their
+// last known score instead of being clobbered with low-confidence data.
+func (s Scheduler) ScoreFor(provider accounts.Provider, accountID string) Score {
+	if score, ok := s.scores[ScoreKey(provider, accountID)]; ok {
+		return score
+	}
+	return Score{AccountID: accountID, Provider: provider, Headroom: 1, ShortHeadroom: 1}
+}
+
 func (s Scheduler) score(provider accounts.Provider, accountID string) Score {
 	score, ok := s.scores[ScoreKey(provider, accountID)]
 	if !ok {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subrouter",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Routes AI coding-agent traffic across subscription accounts and API keys.",
   "license": "MIT",
   "homepage": "https://github.com/manaflow-ai/subrouter#readme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "subrouter"
-version = "0.1.18"
+version = "0.1.19"
 description = "Routes AI coding-agent traffic across subscription accounts and API keys."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Symptom

Codex hit "you've hit your usage limit" / 503 while 6+ accounts had real
quota. The router was sending every request to a genuinely cooked account.

## Root cause

The per-request usage re-score (`scoreAccounts`) rebuilt all scores from
scratch each time. Under load the upstream usage endpoint rate-limits, so the
usage cache served stale "last good" cooked windows, and the re-score
overwrote the scheduler's healthy scores with zeros. The 10-minute auto-switch
set fresh healthy scores; the 30-second per-request refresh clobbered them.
With every account scored exhausted, the (correctly non-refusing) router
routed to a dead account.

Evidence from the VM: auto-switch logged 7 accounts at `headroom=1`, then five
minutes later routing logs showed every pick landing on exhausted `lc+3`.

## Fix

`scoreAccounts` now seeds each account from the scheduler's current score and
only overwrites it on FRESH, confident evidence. `FetchUsageWindowsCached`
reports whether windows are fresh or a stale last-good fallback; stale data and
transient refresh/fetch errors preserve the prior score. Only confident signals
(fresh usage, auth failure, or a real upstream usage-limit via failover) change
a score.

## Tests

- `TestScoreAccountsPreservesHealthyScoreWhenUsageIsStale`: drives the real
  `scoreAccounts` through a rate-limited stale-cache path and asserts the
  healthy score survives (fails on old code).
- Cache tests assert the new fresh/stale flag.
- Combined with `TestRouterDoesNotRefuseWhenScoresAreStaleExhausted` (route,
  don't refuse) from the prior PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784164117&installation_id=133855650&pr_number=20&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F20&signature=76d7a6a346b57e251dd0971ba2ad28c47c6870458f0e9628f0502b1ac1cff43e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent stale usage data from overwriting healthy account scores during per-request re-scoring, so we don’t route traffic to exhausted accounts when the usage endpoint rate-limits.

- **Bug Fixes**
  - Seed per-request scoring from the scheduler’s current scores; only update on fresh usage, auth failure, or a confirmed upstream limit.
  - `FetchUsageWindowsCached` now returns a fresh/stale flag; stale last-known-good windows and transient fetch errors no longer demote or zero scores.
  - Added `Scheduler.ScoreFor` to preserve an account’s last known score (or a healthy default) when fresh usage can’t be fetched.

- **Dependencies**
  - Bumped version to 0.1.19 in `package.json` and `pyproject.toml`.

<sup>Written for commit 6541f15af1d82291dff00883ac75fedfcd5dc543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

