### PR TITLE
Provider-scope account-list mutations so Codex accounts aren't shadowed

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -302,7 +302,7 @@ func (r *AccountRef) Refresh(ctx context.Context, account accounts.Account) (acc
 	defer r.mu.Unlock()
 	replaced := false
 	for i := range r.accounts {
-		if accountMatches(r.accounts[i], account.ID) {
+		if sameProvider(r.accounts[i].Provider, account.Provider) && accountMatches(r.accounts[i], account.ID) {
 			r.accounts[i] = next
 			replaced = true
 			break
@@ -726,7 +726,7 @@ func (r *AccountRef) replace(account accounts.Account) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for i := range r.accounts {
-		if accountMatches(r.accounts[i], account.ID) {
+		if sameProvider(r.accounts[i].Provider, account.Provider) && accountMatches(r.accounts[i], account.ID) {
 			r.accounts[i] = account
 			return
 		}
@@ -2492,6 +2492,22 @@ func findAccount(haystack []accounts.Account, id string) (accounts.Account, bool
 		}
 	}
 	return accounts.Account{}, false
+}
+
+// sameProvider reports whether two providers refer to the same upstream,
+// treating the empty provider as Codex (its historical default). Account-list
+// mutations must compare provider too: a Codex account and a Claude account
+// routinely share the same ID (a Codex email equals a Claude profile name), so
+// matching by ID alone let one provider's refresh overwrite the other's entry,
+// dropping the Codex account from selection entirely.
+func sameProvider(a, b accounts.Provider) bool {
+	if a == "" {
+		a = accounts.ProviderCodex
+	}
+	if b == "" {
+		b = accounts.ProviderCodex
+	}
+	return a == b
 }
 
 func accountMatches(account accounts.Account, id string) bool {

--- a/internal/proxy/scoreaccounts_test.go
+++ b/internal/proxy/scoreaccounts_test.go
@@ -52,3 +52,41 @@ func TestScoreAccountsPreservesHealthyScoreWhenUsageIsStale(t *testing.T) {
 		t.Fatalf("healthy account clobbered to exhausted by stale usage: %+v", scores[0])
 	}
 }
+
+// Regression: a Codex account and a Claude account routinely share the same ID
+// (a Codex email equals a Claude profile name). Mutating the account list
+// (refresh/replace) must match provider too, or one provider's update silently
+// overwrites the other's entry, dropping it from selection. This is exactly
+// what hid the best Codex accounts (e.g. aziz@cmux.com) behind their Claude
+// namesakes so Codex never routed to them.
+func TestAccountRefReplaceDoesNotClobberAcrossProviders(t *testing.T) {
+	ref := &AccountRef{
+		accounts: []accounts.Account{
+			{ID: "shared@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "codex-tok"},
+			{ID: "shared@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "claude-tok"},
+		},
+	}
+
+	// A Claude-side refresh must update only the Claude entry.
+	ref.replace(accounts.Account{ID: "shared@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "claude-tok-2"})
+
+	all := ref.All()
+	var codex, claude *accounts.Account
+	for i := range all {
+		switch all[i].Provider {
+		case accounts.ProviderCodex:
+			codex = &all[i]
+		case accounts.ProviderClaude:
+			claude = &all[i]
+		}
+	}
+	if codex == nil {
+		t.Fatal("Codex account was clobbered by a same-ID Claude replace")
+	}
+	if codex.Token != "codex-tok" {
+		t.Fatalf("Codex token = %q, want untouched codex-tok", codex.Token)
+	}
+	if claude == nil || claude.Token != "claude-tok-2" {
+		t.Fatalf("Claude entry not updated: %+v", claude)
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subrouter",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Routes AI coding-agent traffic across subscription accounts and API keys.",
   "license": "MIT",
   "homepage": "https://github.com/manaflow-ai/subrouter#readme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "subrouter"
-version = "0.1.19"
+version = "0.1.20"
 description = "Routes AI coding-agent traffic across subscription accounts and API keys."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Symptom

Codex hit usage limits / routed to a dead account while healthy Codex accounts
had quota. The daemon's best Codex account (`aziz@cmux.com`, 100% quota) was
invisible to Codex selection.

## Root cause (found via runtime logging on the VM)

The account list (`AccountRef`) matched accounts by ID alone when
refreshing/replacing. A Codex account's ID equals a same-named Claude profile,
so a Claude refresh overwrote the Codex entry with the same ID, dropping the
Codex account from the list. Diagnostic logs showed `aziz@cmux.com` and
`austin@manaflow.com` present only as `provider=claude` — their Codex entries
had been clobbered, so Codex never routed to them.

## Fix

Match provider too (empty treated as Codex) in both `AccountRef` refresh and
`replace` paths. Adds `TestAccountRefReplaceDoesNotClobberAcrossProviders`.

This is the account-store analog of the earlier scheduler provider-scoping fix;
together with the optimistic-routing and seed-and-preserve scoring fixes, Codex
selection now sees and uses all healthy accounts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784164861&installation_id=133855650&pr_number=21&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F21&signature=408415401bd246d939ce75f8fadbc952b1fccf2eb91fd9590bdfe077281d2c56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope account-list mutations by provider to prevent Codex accounts from being overwritten by same-ID Claude entries. This restores correct Codex routing by keeping all healthy Codex accounts visible.

- **Bug Fixes**
  - In `AccountRef.Refresh` and `replace`, match by provider + ID; empty provider treated as Codex via `sameProvider`.
  - Added `TestAccountRefReplaceDoesNotClobberAcrossProviders` to prevent cross-provider clobbering.

- **Dependencies**
  - Bump `subrouter` version to `0.1.20` in `package.json` and `pyproject.toml`.

<sup>Written for commit 1977fb22e0403daf5b510a3693e64f3db8dead55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

