### PR TITLE
Redeem ChatGPT rate-limit reset credits via subrouter

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -128,6 +128,7 @@ var directSRCommands = map[string]struct{}{
 	"pick":             {},
 	"remove":           {},
 	"remove-admin-key": {},
+	"reset":            {},
 	"rm":               {},
 	"server":           {},
 	"servers":          {},
@@ -592,6 +593,7 @@ Usage:
   %[1]s remove <email>     Remove a Codex account
   %[1]s status             Show Codex and Claude usage (non-interactive)
   %[1]s pick               Switch to the recommended account, failing if none has quota
+  %[1]s reset [email]      Redeem a rate-limit reset credit (best candidate, or --all, or --dry-run)
   %[1]s usage [days]       Refresh and show API-key spend
   %[1]s trace <email>      Show OAuth refresh breadcrumbs for an account
 

--- a/cmd/subrouter/main_test.go
+++ b/cmd/subrouter/main_test.go
@@ -175,6 +175,7 @@ func TestDirectSRCommandNames(t *testing.T) {
 		"pick",
 		"remove",
 		"remove-admin-key",
+		"reset",
 		"rm",
 		"server",
 		"servers",

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -56,6 +56,7 @@ Usage:
   sr remove <email>     Remove a Codex account
   sr status             Show Codex and Claude usage (non-interactive)
   sr pick               Switch to the recommended account, failing if none has quota
+  sr reset [email]      Redeem a rate-limit reset credit (pick best, or --all, or --dry-run)
   sr usage [days]       Refresh and show API-key spend
   sr trace <email>      Show OAuth refresh breadcrumbs for an account
 
@@ -94,23 +95,24 @@ type srSwitchOptions struct {
 }
 
 type srUsageRow struct {
-	email            string
-	active           bool
-	planType         string
-	windows          []accounts.UsageWindow
-	credits          *accounts.CreditsInfo
-	apiKeySpend      *accounts.APIKeyUsageSnapshot
-	apiKeyHint       string
-	err              error
-	score            selectacct.Score
-	gtoReason        string
-	gtoRecommended   bool
-	cooked           bool
-	cookedReason     string
-	tempCooked       bool
-	tempCookedReason string
-	authMode         accounts.AuthMode
-	provider         accounts.Provider
+	email              string
+	active             bool
+	planType           string
+	windows            []accounts.UsageWindow
+	credits            *accounts.CreditsInfo
+	complimentaryReset *accounts.ComplimentaryResetInfo
+	apiKeySpend        *accounts.APIKeyUsageSnapshot
+	apiKeyHint         string
+	err                error
+	score              selectacct.Score
+	gtoReason          string
+	gtoRecommended     bool
+	cooked             bool
+	cookedReason       string
+	tempCooked         bool
+	tempCookedReason   string
+	authMode           accounts.AuthMode
+	provider           accounts.Provider
 }
 
 func cxAlias(args []string) error {
@@ -176,6 +178,8 @@ func (r srRunner) run(ctx context.Context, args []string) error {
 		return r.status(ctx)
 	case "pick":
 		return r.pick(ctx, srSwitchOptions{})
+	case "reset":
+		return r.reset(ctx, args[1:])
 	case "usage":
 		days := 30
 		if len(args) > 1 {
@@ -257,6 +261,8 @@ func (r srRunner) runRemoteAccountCommand(ctx context.Context, server srServerCo
 		return r.serverStatus(ctx, defaultSRServerStore(r.store), server.Name)
 	case "pick":
 		return r.pickRemoteAccount(ctx, server)
+	case "reset":
+		return r.reset(ctx, args[1:])
 	case "switch", "use", "g", "gui", "gui-switch", "gui-use":
 		selector, _, err := parseSRSwitchArgs(args[1:], srSwitchOptions{})
 		if err != nil {
@@ -741,6 +747,7 @@ func (r srRunner) fetchUsageRows(ctx context.Context) ([]srUsageRow, error) {
 			rows[i].planType = details.PlanType
 			rows[i].windows = details.Windows
 			rows[i].credits = details.Credits
+			rows[i].complimentaryReset = details.ComplimentaryReset
 			rows[i].score = scoreFromWindows(account.Email, details.Windows)
 			rows[i].cooked, rows[i].cookedReason = cookedFromWindows(details.Windows)
 			rows[i].tempCooked, rows[i].tempCookedReason = tempCookedFromWindows(details.Windows)
@@ -1603,6 +1610,7 @@ func usageGridColumns(out io.Writer, numbered bool, provider accounts.Provider) 
 			usageGridColumn{Key: "5h", Title: "5h", Width: windowWidth},
 			usageGridColumn{Key: "7d", Title: "7d", Width: windowWidth},
 		)
+		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Reset", Title: "1x reset", Width: 8}, termWidth)
 		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Credits", Title: "$", Width: creditsWidth}, termWidth)
 		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Spark", Title: "Spark", Width: sparkWidth}, termWidth)
 		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Spark wk", Title: "Spark wk", Width: sparkWidth}, termWidth)
@@ -1631,6 +1639,7 @@ func usageGridValues(row srUsageRow, rowIndex string) map[string]usageGridCell {
 		"Pick":      {Text: compactPickReason(row), Style: usageGridPickColor(row)},
 		"5h":        usageGridShortWindowCell(row),
 		"7d":        usageGridWindowCell(row.windows, isLongQuotaWindow),
+		"Reset":     usageGridResetCell(row),
 		"Spark":     usageGridShortNamedWindowCell(row),
 		"Spark wk":  usageGridNamedWindowCell(row.windows, true),
 		"Credits":   usageGridCreditsCell(row),
@@ -1640,6 +1649,44 @@ func usageGridValues(row srUsageRow, rowIndex string) map[string]usageGridCell {
 		"Sonnet wk": usageGridWindowCell(row.windows, isClaudeSonnetWeeklyWindow),
 		"Extra":     usageGridWindowCell(row.windows, isClaudeExtraWindow),
 	}
+}
+
+func usageGridResetCell(row srUsageRow) usageGridCell {
+	if usageProvider(row) != accounts.ProviderCodex || row.authMode != accounts.AuthModeOAuth {
+		return usageGridCell{}
+	}
+	info := row.complimentaryReset
+	if info == nil || !info.Known {
+		return usageGridCell{Text: "unknown", Style: ansiDim}
+	}
+	if info.Eligible != nil && !*info.Eligible {
+		return usageGridCell{Text: "not elig", Style: ansiDim}
+	}
+	if info.Available {
+		return usageGridCell{Text: "avail", Style: ansiGreen}
+	}
+	if info.Consumed {
+		return usageGridCell{Text: "used", Style: ansiYellow}
+	}
+	if info.Remaining != nil {
+		if *info.Remaining > 0 {
+			return usageGridCell{Text: fmt.Sprintf("%d left", *info.Remaining), Style: ansiGreen}
+		}
+		return usageGridCell{Text: "used", Style: ansiYellow}
+	}
+	if strings.TrimSpace(info.Status) != "" {
+		return usageGridCell{Text: compactResetStatus(info.Status), Style: ansiDim}
+	}
+	return usageGridCell{Text: "unknown", Style: ansiDim}
+}
+
+func compactResetStatus(status string) string {
+	status = strings.ToLower(strings.TrimSpace(status))
+	status = strings.ReplaceAll(status, "_", " ")
+	if len(status) <= 8 {
+		return status
+	}
+	return status[:8]
 }
 
 type usageGridColumn struct {

--- a/cmd/subrouter/sr_reset.go
+++ b/cmd/subrouter/sr_reset.go
@@ -1,0 +1,348 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+// reset implements `subrouter reset`: redeem a ChatGPT Pro rate-limit reset
+// credit so a cooked account becomes usable again without waiting out the 7d
+// window. With no arguments it targets the single best candidate (cooked, has a
+// credit, longest natural reset remaining). --all sweeps every eligible
+// account. <email> targets one account. --dry-run lists candidates without
+// consuming a credit.
+func (r srRunner) reset(ctx context.Context, args []string) error {
+	flags := flag.NewFlagSet("reset", flag.ContinueOnError)
+	flags.SetOutput(r.errOut)
+	flags.Usage = func() {
+		fmt.Fprintln(r.errOut, "usage: subrouter reset [email] [--all] [--dry-run]")
+		fmt.Fprintln(r.errOut, "  Redeem a ChatGPT Pro rate-limit reset credit.")
+		fmt.Fprintln(r.errOut, "  No args: reset the best cooked account with a credit available.")
+		fmt.Fprintln(r.errOut, "  <email>: reset a specific account.")
+		fmt.Fprintln(r.errOut, "  --all: reset every cooked account that has a credit.")
+		fmt.Fprintln(r.errOut, "  --dry-run: list eligible accounts without redeeming.")
+	}
+	all := flags.Bool("all", false, "reset every cooked account that has an available credit")
+	dryRun := flags.Bool("dry-run", false, "list eligible accounts without redeeming a credit")
+	if err := flags.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return nil
+		}
+		return err
+	}
+	positional := flags.Args()
+	email := ""
+	if len(positional) > 0 {
+		email = strings.TrimSpace(positional[0])
+	}
+	if email != "" && *all {
+		return fmt.Errorf("pass either an email or --all, not both")
+	}
+
+	if server, ok, err := r.selectedRemoteServer(); err != nil {
+		return err
+	} else if ok {
+		return r.resetRemote(ctx, server, email, *all, *dryRun)
+	}
+	return r.resetLocal(ctx, email, *all, *dryRun)
+}
+
+// resetRemote talks to the team server, which holds the OAuth tokens and runs
+// the actual consume call against the wham API.
+func (r srRunner) resetRemote(ctx context.Context, server srServerConfig, email string, all, dryRun bool) error {
+	// No explicit target: pick the single smartest candidate from live usage so
+	// the user does not have to know which account has the worst 7d window.
+	if !all && email == "" {
+		candidate, err := r.pickSmartResetCandidateRemote(ctx, server)
+		if err != nil {
+			return err
+		}
+		if candidate == "" {
+			if dryRun {
+				return r.resetRemoteSweep(ctx, server, "", false, true)
+			}
+			return fmt.Errorf("no cooked account has a rate-limit reset credit available")
+		}
+		email = candidate
+	}
+
+	target := email
+	if all {
+		target = ""
+	}
+	return r.resetRemoteSweep(ctx, server, target, all, dryRun)
+}
+
+func (r srRunner) resetRemoteSweep(ctx context.Context, server srServerConfig, email string, all, dryRun bool) error {
+	u := server.URL + "/_subrouter/rate-limit-reset?"
+	q := url.Values{}
+	if all {
+		q.Set("all", "true")
+	}
+	if email != "" {
+		q.Set("email", email)
+	}
+	if dryRun {
+		q.Set("dry_run", "true")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u+q.Encode(), nil)
+	if err != nil {
+		return err
+	}
+	addServerAdminAuth(req, server)
+	client := r.client
+	if client == nil {
+		client = &http.Client{Timeout: 60 * time.Second}
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		if len(body) == 0 {
+			return fmt.Errorf("rate-limit reset failed: %s", res.Status)
+		}
+		return fmt.Errorf("rate-limit reset failed: %s\n%s", res.Status, bytes.TrimSpace(body))
+	}
+	var payload struct {
+		Reset   int                 `json:"reset"`
+		DryRun  bool                `json:"dry_run"`
+		Results []remoteResetResult `json:"results"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return fmt.Errorf("decode reset response: %w", err)
+	}
+	printResetResults(r.out, payload.DryRun, payload.Reset, payload.Results)
+	return nil
+}
+
+// pickSmartResetCandidateRemote fetches live usage from the server and returns
+// the email of the single best reset candidate: cooked on the 7d window, with a
+// credit available, and the longest natural reset remaining (biggest downtime
+// win from redeeming now). Returns "" when nothing is eligible.
+func (r srRunner) pickSmartResetCandidateRemote(ctx context.Context, server srServerConfig) (string, error) {
+	statuses, _, err := r.fetchServerUsageStatuses(ctx, server)
+	if err != nil {
+		return "", err
+	}
+	rows := usageRowsFromServerUsageStatuses(statuses)
+	type cand struct {
+		email      string
+		resetAfter int64
+	}
+	candidates := make([]cand, 0, len(rows))
+	for _, row := range rows {
+		if row.authMode != accounts.AuthModeOAuth || row.provider != accounts.ProviderCodex {
+			continue
+		}
+		if !row.cooked {
+			continue
+		}
+		if row.complimentaryReset == nil || !row.complimentaryReset.Available {
+			continue
+		}
+		var resetAfter int64
+		for _, w := range row.windows {
+			if isLongQuotaWindow(w) && w.ResetAfterSeconds > resetAfter {
+				resetAfter = w.ResetAfterSeconds
+			}
+		}
+		candidates = append(candidates, cand{email: row.email, resetAfter: resetAfter})
+	}
+	if len(candidates) == 0 {
+		return "", nil
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].resetAfter > candidates[j].resetAfter
+	})
+	return candidates[0].email, nil
+}
+
+// resetLocal runs the redeem directly against the wham API using the locally
+// stored OAuth token (no server).
+func (r srRunner) resetLocal(ctx context.Context, email string, all, dryRun bool) error {
+	storedAccounts, err := r.store.ListStored()
+	if err != nil {
+		return err
+	}
+	// Build candidates with a live usage fetch so local mode shares the same
+	// eligibility rules as the server path.
+	type cand struct {
+		account accounts.Account
+		before  []accounts.UsageWindow
+	}
+	candidates := make([]cand, 0, len(storedAccounts))
+	for _, stored := range storedAccounts {
+		if stored.IsAPIKey() {
+			continue
+		}
+		if email != "" && stored.Email != email {
+			continue
+		}
+		account, ok := stored.Account(stored.SourcePath(r.store))
+		if !ok || account.Token == "" {
+			continue
+		}
+		details, err := accounts.FetchCodexUsageDetails(ctx, r.client, account)
+		if err != nil {
+			if email != "" {
+				return fmt.Errorf("%s: %w", stored.Email, err)
+			}
+			continue
+		}
+		if !localRateLimitCooked(details) || !localRateLimitHasCredit(details) {
+			if email != "" {
+				return fmt.Errorf("%s is not eligible for a reset (cooked=%v, credit=%v)", stored.Email, localRateLimitCooked(details), localRateLimitHasCredit(details))
+			}
+			continue
+		}
+		candidates = append(candidates, cand{account: account, before: details.Windows})
+	}
+	if email != "" && len(candidates) == 0 {
+		return fmt.Errorf("account %s not found or not eligible", email)
+	}
+	if !all && email == "" && len(candidates) > 0 {
+		// Single best candidate by longest 7d reset remaining.
+		sort.Slice(candidates, func(i, j int) bool {
+			return longResetAfter(candidates[i].before) > longResetAfter(candidates[j].before)
+		})
+		candidates = candidates[:1]
+	}
+
+	results := make([]remoteResetResult, 0, len(candidates))
+	reset := 0
+	for _, c := range candidates {
+		res := remoteResetResult{Email: c.account.Email, Eligible: true, WindowsBefore: c.before, DryRun: dryRun}
+		if dryRun {
+			results = append(results, res)
+			continue
+		}
+		credit, err := accounts.RedeemRateLimitReset(ctx, r.client, c.account)
+		if err != nil {
+			res.Error = err.Error()
+			results = append(results, res)
+			continue
+		}
+		res.Credit = &credit
+		res.Reset = true
+		if after, err := accounts.FetchCodexUsageDetails(ctx, r.client, c.account); err == nil {
+			res.WindowsAfter = after.Windows
+		}
+		results = append(results, res)
+		if res.Reset {
+			reset++
+		}
+	}
+	printResetResults(r.out, dryRun, reset, results)
+	return nil
+}
+
+func longResetAfter(windows []accounts.UsageWindow) int64 {
+	var max int64
+	for _, w := range windows {
+		if isLongQuotaWindow(w) && w.ResetAfterSeconds > max {
+			max = w.ResetAfterSeconds
+		}
+	}
+	return max
+}
+
+func localRateLimitCooked(details accounts.CodexUsageDetails) bool {
+	if details.RawRateLimit.LimitReached {
+		return true
+	}
+	if sw := details.RawRateLimit.SecondaryWindow; sw != nil && sw.UsedPercent >= 100 {
+		return true
+	}
+	return false
+}
+
+func localRateLimitHasCredit(details accounts.CodexUsageDetails) bool {
+	return details.ComplimentaryReset != nil && details.ComplimentaryReset.Available
+}
+
+// remoteResetResult mirrors the server's RateLimitResetResult JSON.
+type remoteResetResult struct {
+	Email         string                         `json:"email"`
+	Eligible      bool                           `json:"eligible"`
+	Reset         bool                           `json:"reset"`
+	DryRun        bool                           `json:"dry_run,omitempty"`
+	Credit        *accounts.RateLimitResetCredit `json:"credit,omitempty"`
+	WindowsBefore []accounts.UsageWindow         `json:"windows_before,omitempty"`
+	WindowsAfter  []accounts.UsageWindow         `json:"windows_after,omitempty"`
+	Error         string                         `json:"error,omitempty"`
+}
+
+func printResetResults(out io.Writer, dryRun bool, resetCount int, results []remoteResetResult) {
+	if len(results) == 0 {
+		if dryRun {
+			fmt.Fprintln(out, "No accounts are eligible for a rate-limit reset.")
+		} else {
+			fmt.Fprintln(out, "No rate-limit resets performed (no eligible accounts).")
+		}
+		return
+	}
+	verb := "Reset"
+	if dryRun {
+		verb = "Would reset"
+	}
+	fmt.Fprintf(out, "%s %d/%d accounts:\n", verb, resetCount, len(results))
+	for _, res := range results {
+		fmt.Fprintln(out, resetResultLine(res))
+	}
+}
+
+func resetResultLine(res remoteResetResult) string {
+	var b strings.Builder
+	b.WriteString("  ")
+	b.WriteString(res.Email)
+	switch {
+	case res.Error != "":
+		b.WriteString(": ")
+		b.WriteString(res.Error)
+	case res.Reset:
+		before := longUsageSummary(res.WindowsBefore)
+		after := longUsageSummary(res.WindowsAfter)
+		if before != "" || after != "" {
+			fmt.Fprintf(&b, ": 7d %s -> %s", before, after)
+		} else {
+			b.WriteString(": reset")
+		}
+		if res.Credit != nil && res.Credit.Status != "" {
+			fmt.Fprintf(&b, " (credit %s)", res.Credit.Status)
+		}
+	case res.DryRun:
+		b.WriteString(": eligible ")
+		b.WriteString(longUsageSummary(res.WindowsBefore))
+	default:
+		b.WriteString(": no action")
+	}
+	return b.String()
+}
+
+// longUsageSummary renders the 7d (secondary) window as "used%/resets-in".
+func longUsageSummary(windows []accounts.UsageWindow) string {
+	for _, w := range windows {
+		if !isLongQuotaWindow(w) {
+			continue
+		}
+		if w.ResetAfterSeconds > 0 {
+			return fmt.Sprintf("%g%%/%s", w.UsedPercent, formatDuration(w.ResetAfterSeconds))
+		}
+		return fmt.Sprintf("%g%%", w.UsedPercent)
+	}
+	return "?"
+}

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -696,19 +696,20 @@ type remoteServerAccountStatus struct {
 }
 
 type remoteServerUsageStatus struct {
-	ID          string                 `json:"id"`
-	Provider    accounts.Provider      `json:"provider"`
-	AuthMode    accounts.AuthMode      `json:"auth_mode"`
-	Email       string                 `json:"email,omitempty"`
-	Source      string                 `json:"source"`
-	AuthChecked bool                   `json:"auth_checked"`
-	AuthValid   bool                   `json:"auth_valid"`
-	Refreshed   bool                   `json:"refreshed,omitempty"`
-	Error       string                 `json:"error,omitempty"`
-	Active      bool                   `json:"active,omitempty"`
-	PlanType    string                 `json:"plan_type,omitempty"`
-	Windows     []accounts.UsageWindow `json:"windows,omitempty"`
-	Credits     *accounts.CreditsInfo  `json:"credits,omitempty"`
+	ID                 string                           `json:"id"`
+	Provider           accounts.Provider                `json:"provider"`
+	AuthMode           accounts.AuthMode                `json:"auth_mode"`
+	Email              string                           `json:"email,omitempty"`
+	Source             string                           `json:"source"`
+	AuthChecked        bool                             `json:"auth_checked"`
+	AuthValid          bool                             `json:"auth_valid"`
+	Refreshed          bool                             `json:"refreshed,omitempty"`
+	Error              string                           `json:"error,omitempty"`
+	Active             bool                             `json:"active,omitempty"`
+	PlanType           string                           `json:"plan_type,omitempty"`
+	Windows            []accounts.UsageWindow           `json:"windows,omitempty"`
+	Credits            *accounts.CreditsInfo            `json:"credits,omitempty"`
+	ComplimentaryReset *accounts.ComplimentaryResetInfo `json:"complimentary_reset,omitempty"`
 }
 
 func (r srRunner) fetchServerAccountsResponse(ctx context.Context, server srServerConfig) (*http.Response, error) {
@@ -825,13 +826,14 @@ func usageRowsFromServerUsageStatuses(statuses []remoteServerUsageStatus) []srUs
 			email = "server"
 		}
 		row := srUsageRow{
-			email:    email,
-			active:   status.Active,
-			authMode: status.AuthMode,
-			planType: status.PlanType,
-			windows:  status.Windows,
-			credits:  status.Credits,
-			provider: status.Provider,
+			email:              email,
+			active:             status.Active,
+			authMode:           status.AuthMode,
+			planType:           status.PlanType,
+			windows:            status.Windows,
+			credits:            status.Credits,
+			complimentaryReset: status.ComplimentaryReset,
+			provider:           status.Provider,
 		}
 		if status.Provider == accounts.ProviderClaude && row.planType == "" {
 			row.planType = "claude"

--- a/cmd/subrouter/sr_server_test.go
+++ b/cmd/subrouter/sr_server_test.go
@@ -75,6 +75,7 @@ func TestSRServerAddStoresAdminTokenForRemoteAdminEndpoints(t *testing.T) {
 }
 
 func TestSRServerStatusSendsAdminToken(t *testing.T) {
+	t.Setenv("COLUMNS", "200")
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	store := accounts.DefaultCodexStore()
@@ -100,13 +101,14 @@ func TestSRServerStatusSendsAdminToken(t *testing.T) {
 				t.Fatalf("Authorization = %q", got)
 			}
 			body, _ := json.Marshal([]remoteServerUsageStatus{{
-				ID:        "acct@example.com",
-				Provider:  accounts.ProviderCodex,
-				AuthMode:  accounts.AuthModeOAuth,
-				Email:     "acct@example.com",
-				AuthValid: true,
-				PlanType:  "pro",
-				Windows:   []accounts.UsageWindow{{UsedPercent: 20, LimitWindowSeconds: int64((5 * time.Hour) / time.Second)}},
+				ID:                 "acct@example.com",
+				Provider:           accounts.ProviderCodex,
+				AuthMode:           accounts.AuthModeOAuth,
+				Email:              "acct@example.com",
+				AuthValid:          true,
+				PlanType:           "pro",
+				Windows:            []accounts.UsageWindow{{UsedPercent: 20, LimitWindowSeconds: int64((5 * time.Hour) / time.Second)}},
+				ComplimentaryReset: &accounts.ComplimentaryResetInfo{Known: true, Available: true},
 			}})
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -120,6 +122,9 @@ func TestSRServerStatusSendsAdminToken(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "acct@example.com") {
 		t.Fatalf("status did not render usage table:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "avail") {
+		t.Fatalf("status did not render complimentary reset status:\n%s", out.String())
 	}
 }
 
@@ -549,6 +554,24 @@ func TestUsageRowsFromServerUsageStatusesKeepsServerErrorWithoutEmail(t *testing
 	}
 	if rows[0].email != "server" || rows[0].err == nil || rows[0].err.Error() != "read account store: permission denied" {
 		t.Fatalf("row = %+v", rows[0])
+	}
+}
+
+func TestUsageRowsFromServerUsageStatusesPreservesComplimentaryReset(t *testing.T) {
+	rows := usageRowsFromServerUsageStatuses([]remoteServerUsageStatus{{
+		ID:                 "acct@example.com",
+		Email:              "acct@example.com",
+		Provider:           accounts.ProviderCodex,
+		AuthMode:           accounts.AuthModeOAuth,
+		PlanType:           "pro",
+		Windows:            []accounts.UsageWindow{{UsedPercent: 20, LimitWindowSeconds: int64((5 * time.Hour) / time.Second)}},
+		ComplimentaryReset: &accounts.ComplimentaryResetInfo{Known: true, Consumed: true},
+	}})
+	if len(rows) != 1 {
+		t.Fatalf("rows = %+v, want one row", rows)
+	}
+	if rows[0].complimentaryReset == nil || !rows[0].complimentaryReset.Consumed {
+		t.Fatalf("complimentary reset not preserved: %+v", rows[0].complimentaryReset)
 	}
 }
 

--- a/cmd/subrouter/sr_test.go
+++ b/cmd/subrouter/sr_test.go
@@ -958,15 +958,16 @@ func TestDisplayUsageRowsGridWhenForced(t *testing.T) {
 				{Name: "GPT-5.3-Codex-Spark/primary", UsedPercent: 8, LimitWindowSeconds: int64((5 * time.Hour) / time.Second), ResetAfterSeconds: int64((30 * time.Minute) / time.Second)},
 				{Name: "GPT-5.3-Codex-Spark/secondary", UsedPercent: 2, LimitWindowSeconds: int64((7 * 24 * time.Hour) / time.Second), ResetAfterSeconds: int64((6 * 24 * time.Hour) / time.Second)},
 			},
-			credits: &accounts.CreditsInfo{Balance: "0"},
+			credits:            &accounts.CreditsInfo{Balance: "0"},
+			complimentaryReset: &accounts.ComplimentaryResetInfo{Known: true, Consumed: true},
 		},
 	}, true)
 
 	got := out.String()
-	if !strings.Contains(got, "Account") || !strings.Contains(got, "Spark wk") {
+	if !strings.Contains(got, "Account") || !strings.Contains(got, "Spark wk") || !strings.Contains(got, "1x reset") {
 		t.Fatalf("grid header missing:\n%s", got)
 	}
-	if !strings.Contains(got, "lawrence@cmux.com") || !strings.Contains(got, "active rec") {
+	if !strings.Contains(got, "lawrence@cmux.com") || !strings.Contains(got, "active rec") || !strings.Contains(got, "used") {
 		t.Fatalf("grid row missing state:\n%s", got)
 	}
 	if strings.Contains(got, "pick") {
@@ -982,6 +983,64 @@ func TestDisplayUsageRowsGridWhenForced(t *testing.T) {
 	}
 	if separator == "" || strings.Contains(separator, "===") || strings.Contains(separator, "---") {
 		t.Fatalf("grid separator should be a thin Unicode rule:\n%s", got)
+	}
+}
+
+func TestUsageGridResetCellStates(t *testing.T) {
+	ineligible := false
+	cases := []struct {
+		name string
+		row  srUsageRow
+		want string
+	}{
+		{
+			name: "unknown",
+			row:  srUsageRow{authMode: accounts.AuthModeOAuth, provider: accounts.ProviderCodex},
+			want: "unknown",
+		},
+		{
+			name: "available",
+			row: srUsageRow{
+				authMode:           accounts.AuthModeOAuth,
+				provider:           accounts.ProviderCodex,
+				complimentaryReset: &accounts.ComplimentaryResetInfo{Known: true, Available: true},
+			},
+			want: "avail",
+		},
+		{
+			name: "consumed",
+			row: srUsageRow{
+				authMode:           accounts.AuthModeOAuth,
+				provider:           accounts.ProviderCodex,
+				complimentaryReset: &accounts.ComplimentaryResetInfo{Known: true, Consumed: true},
+			},
+			want: "used",
+		},
+		{
+			name: "ineligible",
+			row: srUsageRow{
+				authMode:           accounts.AuthModeOAuth,
+				provider:           accounts.ProviderCodex,
+				complimentaryReset: &accounts.ComplimentaryResetInfo{Known: true, Eligible: &ineligible},
+			},
+			want: "not elig",
+		},
+		{
+			name: "api key blank",
+			row: srUsageRow{
+				authMode:           accounts.AuthModeAPIKey,
+				provider:           accounts.ProviderCodex,
+				complimentaryReset: &accounts.ComplimentaryResetInfo{Known: true, Available: true},
+			},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := usageGridResetCell(tc.row).Text; got != tc.want {
+				t.Fatalf("reset cell = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/accounts/codex_reset.go
+++ b/internal/accounts/codex_reset.go
@@ -1,0 +1,207 @@
+package accounts
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	// codexRateLimitResetCreditsURL is the wham endpoint Codex.app uses to list
+	// and consume ChatGPT Pro rate-limit reset credits. It is a var (not a
+	// const) so tests can point it at an httptest server.
+	codexCLIUserAgent = "codex_cli_rs/0.0.0"
+)
+
+var (
+	codexRateLimitResetCreditsURL = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits"
+)
+
+// rateLimitResetConsumeURL derives the consume endpoint from the current
+// credits URL so tests only need to override codexRateLimitResetCreditsURL.
+func rateLimitResetConsumeURL() string {
+	return codexRateLimitResetCreditsURL + "/consume"
+}
+
+// RateLimitResetCredit is one redeemable rate-limit reset grant returned by
+// GET /wham/rate-limit-reset-credits. Status is "available" before redemption
+// and "redeemed" after.
+type RateLimitResetCredit struct {
+	ID              string `json:"id"`
+	ResetType       string `json:"reset_type,omitempty"`
+	Status          string `json:"status,omitempty"`
+	GrantedAt       string `json:"granted_at,omitempty"`
+	ExpiresAt       string `json:"expires_at,omitempty"`
+	RedeemStartedAt string `json:"redeem_started_at,omitempty"`
+	RedeemedAt      string `json:"redeemed_at,omitempty"`
+}
+
+// RateLimitResetCreditStatus reports a single account's reset-credit balance.
+// It is derived from wham/usage (rate_limit_reset_credits.available_count) so
+// callers can decide whether a redeem is possible without a second request.
+type RateLimitResetCreditStatus struct {
+	Known            bool
+	AvailableCount   int
+	AvailableCredits []RateLimitResetCredit
+}
+
+type rateLimitResetCreditsResponse struct {
+	Credits []RateLimitResetCredit `json:"credits"`
+}
+
+type rateLimitResetConsumeResponse struct {
+	Code   string               `json:"code,omitempty"`
+	Credit RateLimitResetCredit `json:"credit"`
+}
+
+// ListRateLimitResetCredits calls GET /wham/rate-limit-reset-credits for the
+// given account. Only OAuth accounts with an access token are eligible.
+func ListRateLimitResetCredits(ctx context.Context, client *http.Client, account Account) ([]RateLimitResetCredit, error) {
+	if account.AuthMode != AuthModeOAuth {
+		return nil, fmt.Errorf("rate-limit reset is only available for OAuth accounts")
+	}
+	if account.Token == "" {
+		return nil, fmt.Errorf("account has no access token")
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, codexRateLimitResetCreditsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	applyCodexWhamHeaders(req, account)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("list rate-limit reset credits failed: %s", res.Status)
+	}
+
+	var out rateLimitResetCreditsResponse
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out.Credits, nil
+}
+
+// ConsumeRateLimitResetCredit redeems a single credit by id via
+// POST /wham/rate-limit-reset-credits/consume. redeemRequestID is an
+// idempotency key generated client-side; pass a fresh UUID for a new redeem.
+func ConsumeRateLimitResetCredit(ctx context.Context, client *http.Client, account Account, creditID, redeemRequestID string) (RateLimitResetCredit, error) {
+	if creditID == "" {
+		return RateLimitResetCredit{}, fmt.Errorf("credit_id is required")
+	}
+	if redeemRequestID == "" {
+		redeemRequestID = newUUIDv4()
+	}
+	if account.AuthMode != AuthModeOAuth {
+		return RateLimitResetCredit{}, fmt.Errorf("rate-limit reset is only available for OAuth accounts")
+	}
+	if account.Token == "" {
+		return RateLimitResetCredit{}, fmt.Errorf("account has no access token")
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 20 * time.Second}
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"credit_id":         creditID,
+		"redeem_request_id": redeemRequestID,
+	})
+	if err != nil {
+		return RateLimitResetCredit{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rateLimitResetConsumeURL(), bytes.NewReader(body))
+	if err != nil {
+		return RateLimitResetCredit{}, err
+	}
+	applyCodexWhamHeaders(req, account)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return RateLimitResetCredit{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return RateLimitResetCredit{}, fmt.Errorf("consume rate-limit reset credit failed: %s", res.Status)
+	}
+
+	var out rateLimitResetConsumeResponse
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		return RateLimitResetCredit{}, err
+	}
+	return out.Credit, nil
+}
+
+// FirstAvailableRateLimitResetCredit lists the account's credits and returns
+// the first one whose status is "available". Returns ok=false (no error) when
+// the account has credits but none are redeemable right now.
+func FirstAvailableRateLimitResetCredit(ctx context.Context, client *http.Client, account Account) (RateLimitResetCredit, bool, error) {
+	credits, err := ListRateLimitResetCredits(ctx, client, account)
+	if err != nil {
+		return RateLimitResetCredit{}, false, err
+	}
+	for _, credit := range credits {
+		if credit.Status == "" || credit.Status == "available" {
+			return credit, true, nil
+		}
+	}
+	return RateLimitResetCredit{}, false, nil
+}
+
+// RedeemRateLimitReset finds the first available reset credit for the account
+// and consumes it. It returns the redeemed credit. This is the one-call path
+// for "un-cook this account now".
+func RedeemRateLimitReset(ctx context.Context, client *http.Client, account Account) (RateLimitResetCredit, error) {
+	credit, ok, err := FirstAvailableRateLimitResetCredit(ctx, client, account)
+	if err != nil {
+		return RateLimitResetCredit{}, err
+	}
+	if !ok {
+		return RateLimitResetCredit{}, fmt.Errorf("no available rate-limit reset credits for %s", account.Email)
+	}
+	return ConsumeRateLimitResetCredit(ctx, client, account, credit.ID, newUUIDv4())
+}
+
+// applyCodexWhamHeaders sets the headers Codex.app sends to the wham API
+// surface. The usage GET works with only Authorization, but the consume POST
+// is gated by the upstream's codex-client allowlist, so every reset request
+// carries the full identifying header set.
+func applyCodexWhamHeaders(req *http.Request, account Account) {
+	req.Header.Set("Authorization", account.AuthorizationHeader())
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("OAI-Client-Id", "codex")
+	req.Header.Set("OAI-Language", "en-US")
+	req.Header.Set("User-Agent", codexCLIUserAgent)
+	if account.AccountID != "" {
+		req.Header.Set("ChatGPT-Account-ID", account.AccountID)
+	}
+}
+
+// newUUIDv4 returns an RFC 4122 version 4 UUID string using crypto/rand so the
+// redeem idempotency key does not pull in a third-party dependency.
+func newUUIDv4() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand should never fail on macOS/Linux; fall back to a
+		// time-derived value so the redeem still proceeds with a unique key.
+		now := time.Now().UnixNano()
+		for i := range b {
+			b[i] = byte(now >> (i % 8 * 8))
+		}
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}

--- a/internal/accounts/codex_reset_test.go
+++ b/internal/accounts/codex_reset_test.go
@@ -1,0 +1,203 @@
+package accounts
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// useResetTestServer points the reset-credit package vars at srv for the
+// duration of the test and returns a restore func. Every test that exercises
+// the live reset endpoints calls this so the production chatgpt.com URL is
+// never hit.
+func useResetTestServer(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	orig := codexRateLimitResetCreditsURL
+	codexRateLimitResetCreditsURL = srv.URL + "/wham/rate-limit-reset-credits"
+	t.Cleanup(func() { codexRateLimitResetCreditsURL = orig })
+}
+
+func oauthAccountForTest() Account {
+	return Account{
+		Provider:  ProviderCodex,
+		AuthMode:  AuthModeOAuth,
+		Email:     "user@example.com",
+		Token:     "tok-123",
+		AccountID: "acct-1",
+	}
+}
+
+func TestListRateLimitResetCredits(t *testing.T) {
+	var gotAuth, gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"credits":[
+			{"id":"RateLimitResetCredit_abc","reset_type":"codex_rate_limits","status":"available"},
+			{"id":"RateLimitResetCredit_xyz","reset_type":"codex_rate_limits","status":"redeemed"}
+		]}`))
+	}))
+	defer srv.Close()
+	useResetTestServer(t, srv)
+
+	credits, err := ListRateLimitResetCredits(context.Background(), srv.Client(), oauthAccountForTest())
+	if err != nil {
+		t.Fatalf("ListRateLimitResetCredits: %v", err)
+	}
+	if gotAuth != "Bearer tok-123" {
+		t.Errorf("Authorization = %q, want Bearer tok-123", gotAuth)
+	}
+	if gotUA != codexCLIUserAgent {
+		t.Errorf("User-Agent = %q, want %q", gotUA, codexCLIUserAgent)
+	}
+	if len(credits) != 2 {
+		t.Fatalf("expected 2 credits, got %d", len(credits))
+	}
+	if credits[0].ID != "RateLimitResetCredit_abc" || credits[0].Status != "available" {
+		t.Errorf("credit[0] = %+v", credits[0])
+	}
+}
+
+func TestConsumeRateLimitResetCredit(t *testing.T) {
+	var gotMethod, gotContentType string
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":"reset","credit":{"id":"RateLimitResetCredit_abc","status":"redeemed"}}`))
+	}))
+	defer srv.Close()
+	useResetTestServer(t, srv)
+
+	credit, err := ConsumeRateLimitResetCredit(context.Background(), srv.Client(),
+		oauthAccountForTest(), "RateLimitResetCredit_abc", "req-7")
+	if err != nil {
+		t.Fatalf("Consume: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q", gotContentType)
+	}
+	if gotBody["credit_id"] != "RateLimitResetCredit_abc" {
+		t.Errorf("credit_id = %q", gotBody["credit_id"])
+	}
+	if gotBody["redeem_request_id"] != "req-7" {
+		t.Errorf("redeem_request_id = %q", gotBody["redeem_request_id"])
+	}
+	if credit.Status != "redeemed" {
+		t.Errorf("credit status = %q, want redeemed", credit.Status)
+	}
+}
+
+func TestFirstAvailableRateLimitResetCredit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"credits":[
+			{"id":"used-up","status":"redeemed"},
+			{"id":"good-one","status":"available"}
+		]}`))
+	}))
+	defer srv.Close()
+	useResetTestServer(t, srv)
+
+	credit, ok, err := FirstAvailableRateLimitResetCredit(context.Background(), srv.Client(), oauthAccountForTest())
+	if err != nil {
+		t.Fatalf("FirstAvailable: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected an available credit")
+	}
+	if credit.ID != "good-one" {
+		t.Errorf("got %q, want good-one", credit.ID)
+	}
+}
+
+func TestFirstAvailableRateLimitResetCreditNone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"credits":[{"id":"x","status":"redeemed"}]}`))
+	}))
+	defer srv.Close()
+	useResetTestServer(t, srv)
+	_, ok, err := FirstAvailableRateLimitResetCredit(context.Background(), srv.Client(), oauthAccountForTest())
+	if err != nil || ok {
+		t.Fatalf("expected no available credit, got ok=%v err=%v", ok, err)
+	}
+}
+
+func TestRedeemRateLimitResetListsThenConsumes(t *testing.T) {
+	var consumed bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/consume"):
+			consumed = true
+			_, _ = w.Write([]byte(`{"code":"reset","credit":{"id":"RateLimitResetCredit_abc","status":"redeemed"}}`))
+		default:
+			_, _ = w.Write([]byte(`{"credits":[{"id":"RateLimitResetCredit_abc","status":"available"}]}`))
+		}
+	}))
+	defer srv.Close()
+	useResetTestServer(t, srv)
+
+	credit, err := RedeemRateLimitReset(context.Background(), srv.Client(), oauthAccountForTest())
+	if err != nil {
+		t.Fatalf("Redeem: %v", err)
+	}
+	if !consumed {
+		t.Error("consume endpoint was never called")
+	}
+	if credit.Status != "redeemed" {
+		t.Errorf("status = %q", credit.Status)
+	}
+}
+
+func TestRedeemRateLimitResetNoCredits(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"credits":[{"id":"x","status":"redeemed"}]}`))
+	}))
+	defer srv.Close()
+	useResetTestServer(t, srv)
+	_, err := RedeemRateLimitReset(context.Background(), srv.Client(), oauthAccountForTest())
+	if err == nil {
+		t.Fatal("expected error when no credits available")
+	}
+	if !strings.Contains(err.Error(), "no available") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRateLimitResetRejectsAPIKeyAndEmptyToken(t *testing.T) {
+	if _, err := ListRateLimitResetCredits(context.Background(), nil, Account{AuthMode: AuthModeAPIKey}); err == nil {
+		t.Error("expected error for API-key account")
+	}
+	if _, err := ListRateLimitResetCredits(context.Background(), nil, Account{AuthMode: AuthModeOAuth, Token: ""}); err == nil {
+		t.Error("expected error for empty token")
+	}
+}
+
+func TestNewUUIDv4Shape(t *testing.T) {
+	u := newUUIDv4()
+	// 8-4-4-4-12 hex with the v4 and variant bits set.
+	if len(u) != 36 {
+		t.Fatalf("uuid len = %d (%q)", len(u), u)
+	}
+	if u[14] != '4' {
+		t.Errorf("expected version 4 at index 14, got %q", u[14])
+	}
+	if u[19] != '8' && u[19] != '9' && u[19] != 'a' && u[19] != 'b' {
+		t.Errorf("expected variant at index 19, got %q", u[19])
+	}
+	if newUUIDv4() == newUUIDv4() {
+		t.Error("expected unique uuids")
+	}
+}

--- a/internal/accounts/codex_usage.go
+++ b/internal/accounts/codex_usage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -23,11 +24,12 @@ type UsageWindow struct {
 }
 
 type CodexUsageDetails struct {
-	PlanType     string
-	Windows      []UsageWindow
-	BaseWindows  []UsageWindow
-	Credits      *CreditsInfo
-	RawRateLimit codexRateLimitDetails
+	PlanType           string
+	Windows            []UsageWindow
+	BaseWindows        []UsageWindow
+	Credits            *CreditsInfo
+	ComplimentaryReset *ComplimentaryResetInfo
+	RawRateLimit       codexRateLimitDetails
 }
 
 type CreditsInfo struct {
@@ -36,11 +38,25 @@ type CreditsInfo struct {
 	Balance    string
 }
 
+type ComplimentaryResetInfo struct {
+	Known     bool   `json:"known"`
+	Available bool   `json:"available,omitempty"`
+	Consumed  bool   `json:"consumed,omitempty"`
+	Eligible  *bool  `json:"eligible,omitempty"`
+	Remaining *int   `json:"remaining,omitempty"`
+	Used      *int   `json:"used,omitempty"`
+	Total     *int   `json:"total,omitempty"`
+	Status    string `json:"status,omitempty"`
+	ResetsAt  string `json:"resets_at,omitempty"`
+	Source    string `json:"source,omitempty"`
+}
+
 type codexUsageResponse struct {
 	PlanType             string                     `json:"plan_type"`
 	RateLimit            codexRateLimitDetails      `json:"rate_limit"`
 	Credits              *codexCreditsInfo          `json:"credits"`
 	AdditionalRateLimits []codexAdditionalRateLimit `json:"additional_rate_limits"`
+	ComplimentaryReset   *ComplimentaryResetInfo    `json:"-"`
 }
 
 type codexRateLimitDetails struct {
@@ -67,6 +83,17 @@ type codexAdditionalRateLimit struct {
 	MeteredFeature string                `json:"metered_feature"`
 	LimitName      string                `json:"limit_name"`
 	RateLimit      codexRateLimitDetails `json:"rate_limit"`
+}
+
+func (u *codexUsageResponse) UnmarshalJSON(data []byte) error {
+	type alias codexUsageResponse
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*u = codexUsageResponse(decoded)
+	u.ComplimentaryReset = parseComplimentaryResetInfo(data)
+	return nil
 }
 
 func FetchCodexUsage(ctx context.Context, client *http.Client, account Account) ([]UsageWindow, error) {
@@ -112,10 +139,11 @@ func FetchCodexUsageDetails(ctx context.Context, client *http.Client, account Ac
 		return CodexUsageDetails{}, err
 	}
 	details := CodexUsageDetails{
-		PlanType:     usage.PlanType,
-		Windows:      usage.displayWindows(),
-		BaseWindows:  usage.windows(),
-		RawRateLimit: usage.RateLimit,
+		PlanType:           usage.PlanType,
+		Windows:            usage.displayWindows(),
+		BaseWindows:        usage.windows(),
+		ComplimentaryReset: usage.ComplimentaryReset,
+		RawRateLimit:       usage.RateLimit,
 	}
 	if usage.Credits != nil {
 		details.Credits = &CreditsInfo{
@@ -125,6 +153,195 @@ func FetchCodexUsageDetails(ctx context.Context, client *http.Client, account Ac
 		}
 	}
 	return details, nil
+}
+
+func parseComplimentaryResetInfo(data []byte) *ComplimentaryResetInfo {
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil
+	}
+	return findComplimentaryResetInfo(root, "")
+}
+
+func findComplimentaryResetInfo(value any, path string) *ComplimentaryResetInfo {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	for key, child := range object {
+		childPath := key
+		if path != "" {
+			childPath = path + "." + key
+		}
+		if isComplimentaryResetKey(key) {
+			if info := parseComplimentaryResetCandidate(child, childPath); info != nil {
+				return info
+			}
+		}
+	}
+	for key, child := range object {
+		if isRateLimitResetKey(key) {
+			continue
+		}
+		childPath := key
+		if path != "" {
+			childPath = path + "." + key
+		}
+		if info := findComplimentaryResetInfo(child, childPath); info != nil {
+			return info
+		}
+	}
+	return nil
+}
+
+func isComplimentaryResetKey(key string) bool {
+	normalized := normalizeUsageKey(key)
+	return (strings.Contains(normalized, "complimentary") && strings.Contains(normalized, "reset")) ||
+		(strings.Contains(normalized, "onetime") && strings.Contains(normalized, "reset")) ||
+		strings.Contains(normalized, "resetcredit")
+}
+
+func isRateLimitResetKey(key string) bool {
+	normalized := normalizeUsageKey(key)
+	return normalized == "resetafterseconds" || normalized == "resetat" || normalized == "resetsat"
+}
+
+func normalizeUsageKey(value string) string {
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func parseComplimentaryResetCandidate(value any, source string) *ComplimentaryResetInfo {
+	info := &ComplimentaryResetInfo{Known: true, Source: source}
+	switch typed := value.(type) {
+	case bool:
+		normalizedSource := normalizeUsageKey(source)
+		if strings.Contains(normalizedSource, "used") ||
+			strings.Contains(normalizedSource, "consumed") ||
+			strings.Contains(normalizedSource, "redeemed") {
+			info.Consumed = typed
+			info.Available = !typed
+		} else {
+			info.Available = typed
+			info.Consumed = !typed
+		}
+	case string:
+		applyComplimentaryResetStatus(info, typed)
+	case map[string]any:
+		applyComplimentaryResetObject(info, typed)
+	default:
+		return nil
+	}
+	if info.Remaining != nil {
+		info.Available = *info.Remaining > 0
+		if *info.Remaining == 0 {
+			info.Consumed = true
+		}
+	}
+	if info.Total != nil && info.Used != nil && *info.Total > 0 {
+		info.Consumed = *info.Used >= *info.Total
+		info.Available = *info.Used < *info.Total
+	}
+	return info
+}
+
+func applyComplimentaryResetObject(info *ComplimentaryResetInfo, object map[string]any) {
+	if value, ok := stringField(object, "status", "state"); ok {
+		info.Status = value
+		applyComplimentaryResetStatus(info, value)
+	}
+	if value, ok := boolField(object, "available", "is_available", "can_reset", "can_use", "claimable"); ok {
+		info.Available = value
+	}
+	if value, ok := boolField(object, "consumed", "is_consumed", "used", "is_used", "redeemed", "is_redeemed"); ok {
+		info.Consumed = value
+	}
+	if value, ok := boolField(object, "eligible", "is_eligible"); ok {
+		info.Eligible = &value
+		if !value {
+			info.Available = false
+		}
+	}
+	if value, ok := intField(object, "remaining", "remaining_count", "available_count"); ok {
+		info.Remaining = &value
+	}
+	if value, ok := intField(object, "used_count", "uses", "redeemed_count"); ok {
+		info.Used = &value
+	}
+	if value, ok := intField(object, "total", "total_count", "limit"); ok {
+		info.Total = &value
+	}
+	if value, ok := stringField(object, "resets_at", "reset_at", "expires_at"); ok {
+		info.ResetsAt = value
+	}
+}
+
+func applyComplimentaryResetStatus(info *ComplimentaryResetInfo, status string) {
+	normalized := normalizeUsageKey(status)
+	switch normalized {
+	case "available", "eligible", "unused", "unclaimed", "claimable":
+		info.Available = true
+		info.Consumed = false
+	case "consumed", "used", "redeemed", "claimed":
+		info.Consumed = true
+		info.Available = false
+	case "ineligible", "unavailable", "disabled":
+		value := false
+		info.Eligible = &value
+		info.Available = false
+	}
+}
+
+func boolField(object map[string]any, names ...string) (bool, bool) {
+	for _, name := range names {
+		value, ok := object[name]
+		if !ok {
+			continue
+		}
+		if parsed, ok := value.(bool); ok {
+			return parsed, true
+		}
+	}
+	return false, false
+}
+
+func intField(object map[string]any, names ...string) (int, bool) {
+	for _, name := range names {
+		value, ok := object[name]
+		if !ok {
+			continue
+		}
+		switch parsed := value.(type) {
+		case float64:
+			return int(parsed), true
+		case int:
+			return parsed, true
+		}
+	}
+	return 0, false
+}
+
+func stringField(object map[string]any, names ...string) (string, bool) {
+	for _, name := range names {
+		value, ok := object[name]
+		if !ok {
+			continue
+		}
+		if parsed, ok := value.(string); ok {
+			return parsed, true
+		}
+	}
+	return "", false
 }
 
 func (u codexUsageResponse) windows() []UsageWindow {

--- a/internal/accounts/codex_usage_test.go
+++ b/internal/accounts/codex_usage_test.go
@@ -52,3 +52,63 @@ func TestDisplayWindowsTagsAdditionalLimitsWithFeature(t *testing.T) {
 		t.Fatal("expected the additional rate limit window tagged with its limit_name as Feature")
 	}
 }
+
+func TestCodexUsageParsesComplimentaryResetInfo(t *testing.T) {
+	raw := `{
+		"plan_type": "pro",
+		"rate_limit": {"allowed": true},
+		"complimentary_session_reset": {
+			"eligible": true,
+			"available": false,
+			"consumed": true,
+			"used_count": 1,
+			"total_count": 1
+		}
+	}`
+	var usage codexUsageResponse
+	if err := json.Unmarshal([]byte(raw), &usage); err != nil {
+		t.Fatal(err)
+	}
+
+	info := usage.ComplimentaryReset
+	if info == nil || !info.Known {
+		t.Fatalf("complimentary reset info missing: %+v", usage.ComplimentaryReset)
+	}
+	if !info.Consumed || info.Available {
+		t.Fatalf("reset state = consumed:%v available:%v, want consumed only", info.Consumed, info.Available)
+	}
+	if info.Eligible == nil || !*info.Eligible {
+		t.Fatalf("eligible = %+v, want true", info.Eligible)
+	}
+	if info.Used == nil || *info.Used != 1 || info.Total == nil || *info.Total != 1 {
+		t.Fatalf("counts = used:%v total:%v, want 1/1", info.Used, info.Total)
+	}
+	if info.Source != "complimentary_session_reset" {
+		t.Fatalf("source = %q, want complimentary_session_reset", info.Source)
+	}
+}
+
+func TestCodexUsageParsesOneTimeResetRemainingCount(t *testing.T) {
+	raw := `{
+		"plan_type": "pro",
+		"rate_limit": {"allowed": true},
+		"rewards": {
+			"one_time_reset": {
+				"remaining": 1,
+				"total": 1
+			}
+		}
+	}`
+	var usage codexUsageResponse
+	if err := json.Unmarshal([]byte(raw), &usage); err != nil {
+		t.Fatal(err)
+	}
+
+	info := usage.ComplimentaryReset
+	if info == nil || !info.Available || info.Consumed {
+		t.Fatalf("reset state = %+v, want available", info)
+	}
+	if info.Source != "rewards.one_time_reset" {
+		t.Fatalf("source = %q, want rewards.one_time_reset", info.Source)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -211,6 +211,45 @@ func (r *AccountRef) FetchUsageWindowsCached(ctx context.Context, client *http.C
 	return nil, false, err
 }
 
+// ResolvedAccount returns a refreshed, token-bearing OAuth account for the
+// given email, refreshing the stored token if it has expired. The bool is
+// false (with no error) when no stored OAuth account matches email. It is the
+// single path the rate-limit-reset handler uses to get a live credential for a
+// server-owned account without going through the usage-status sweep.
+func (r *AccountRef) ResolvedAccount(ctx context.Context, email string) (accounts.Account, bool, error) {
+	if r == nil {
+		return accounts.Account{}, false, fmt.Errorf("account store not configured")
+	}
+	storedAccounts, err := r.store.ListStored()
+	if err != nil {
+		return accounts.Account{}, false, err
+	}
+	var matched *accounts.StoredCodexAccount
+	for i := range storedAccounts {
+		if storedAccounts[i].Email == email {
+			s := storedAccounts[i]
+			matched = &s
+			break
+		}
+	}
+	if matched == nil {
+		return accounts.Account{}, false, nil
+	}
+	if matched.IsAPIKey() {
+		return accounts.Account{}, false, fmt.Errorf("account %s is an API-key account", email)
+	}
+	refreshed, _, err := r.store.RefreshStoredIfExpired(ctx, r.client, *matched)
+	if err != nil {
+		return accounts.Account{}, false, err
+	}
+	account, ok := refreshed.Account(refreshed.SourcePath(r.store))
+	if !ok {
+		return accounts.Account{}, false, fmt.Errorf("account %s has no access token", email)
+	}
+	r.replace(account)
+	return account, true, nil
+}
+
 type AccountStatus struct {
 	ID          string            `json:"id"`
 	Provider    accounts.Provider `json:"provider"`
@@ -225,10 +264,11 @@ type AccountStatus struct {
 
 type AccountUsageStatus struct {
 	AccountStatus
-	Active   bool                   `json:"active,omitempty"`
-	PlanType string                 `json:"plan_type,omitempty"`
-	Windows  []accounts.UsageWindow `json:"windows,omitempty"`
-	Credits  *accounts.CreditsInfo  `json:"credits,omitempty"`
+	Active             bool                             `json:"active,omitempty"`
+	PlanType           string                           `json:"plan_type,omitempty"`
+	Windows            []accounts.UsageWindow           `json:"windows,omitempty"`
+	Credits            *accounts.CreditsInfo            `json:"credits,omitempty"`
+	ComplimentaryReset *accounts.ComplimentaryResetInfo `json:"complimentary_reset,omitempty"`
 }
 
 func NewAccountRef(store accounts.CodexStore, initial []accounts.Account, client *http.Client) *AccountRef {
@@ -530,6 +570,7 @@ func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus
 			next.PlanType = details.PlanType
 			next.Windows = details.Windows
 			next.Credits = details.Credits
+			next.ComplimentaryReset = details.ComplimentaryReset
 			out[i] = next
 		}()
 	}
@@ -752,6 +793,7 @@ func (s Server) Handler() http.Handler {
 	mux.HandleFunc("/_subrouter/accounts", s.requireAdmin(s.handleAccounts))
 	mux.HandleFunc("/_subrouter/account-status", s.requireAdmin(s.handleAccountStatus))
 	mux.HandleFunc("/_subrouter/usage-status", s.requireAdmin(s.handleUsageStatus))
+	mux.HandleFunc("/_subrouter/rate-limit-reset", s.requireAdmin(s.handleRateLimitReset))
 	mux.HandleFunc("/_subrouter/reload-accounts", s.requireAdmin(s.handleReloadAccounts))
 	mux.HandleFunc("/_subrouter/sessions", s.requireAdmin(s.handleSessions))
 	mux.HandleFunc("/_subrouter/dashboard", s.requireAdmin(s.handleDashboard))
@@ -923,6 +965,222 @@ func (s Server) reloadAccounts(ctx context.Context) (int, int, error) {
 	}
 	s.SchedulerRef.Set(scheduler)
 	return len(loaded), scored, nil
+}
+
+// RateLimitResetResult is the per-account outcome of a rate-limit reset
+// request, whether the account was a single target or part of an --all sweep.
+type RateLimitResetResult struct {
+	Email         string                         `json:"email"`
+	Eligible      bool                           `json:"eligible"`
+	Reset         bool                           `json:"reset"`
+	DryRun        bool                           `json:"dry_run,omitempty"`
+	Credit        *accounts.RateLimitResetCredit `json:"credit,omitempty"`
+	WindowsBefore []accounts.UsageWindow         `json:"windows_before,omitempty"`
+	WindowsAfter  []accounts.UsageWindow         `json:"windows_after,omitempty"`
+	Error         string                         `json:"error,omitempty"`
+}
+
+// handleRateLimitReset redeems a ChatGPT Pro "rate-limit reset" credit for one
+// account (?email=...) or for every cooked OAuth account that still has a
+// credit available (?all=true). Pass dry_run=true to list candidates without
+// consuming a credit. The handler is admin-gated like the other _subrouter
+// endpoints because redeeming a credit is a real, externally-visible action on
+// the upstream account.
+func (s Server) handleRateLimitReset(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.AccountRef == nil {
+		http.Error(w, "account store not configured", http.StatusInternalServerError)
+		return
+	}
+	ctx := r.Context()
+	dryRun := parseBoolParam(r, "dry_run", "dry-run")
+	all := parseBoolParam(r, "all", "all_accounts")
+	email := strings.TrimSpace(r.URL.Query().Get("email"))
+	if email == "" && r.URL.Query().Has("account") {
+		email = strings.TrimSpace(r.URL.Query().Get("account"))
+	}
+
+	var results []RateLimitResetResult
+	switch {
+	case all:
+		results = s.rateLimitResetAllAccounts(ctx, dryRun)
+	case email != "":
+		results = []RateLimitResetResult{s.rateLimitResetOne(ctx, email, dryRun)}
+	default:
+		http.Error(w, "email or all=true is required", http.StatusBadRequest)
+		return
+	}
+
+	resetCount := 0
+	for i := range results {
+		if results[i].Reset {
+			resetCount++
+		}
+	}
+	// Invalidate the cached usage-status snapshot so the next status read
+	// reflects the freshly reset windows instead of the pre-reset picture.
+	s.AccountRef.InvalidateUsageStatusCache()
+	writeJSON(w, map[string]any{
+		"ok":      true,
+		"reset":   resetCount,
+		"dry_run": dryRun,
+		"results": results,
+	})
+}
+
+// rateLimitResetOne resolves a single account by email and redeems a credit if
+// it is cooked on its 7d window and has a credit available.
+func (s Server) rateLimitResetOne(ctx context.Context, email string, dryRun bool) RateLimitResetResult {
+	result := RateLimitResetResult{Email: email, DryRun: dryRun}
+	account, ok, err := s.AccountRef.ResolvedAccount(ctx, email)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	if !ok {
+		result.Error = "account not found"
+		return result
+	}
+	return s.redeemAccountIfEligible(ctx, account, dryRun)
+}
+
+// rateLimitResetAllAccounts sweeps every stored OAuth account, redeems a credit
+// for each one that is cooked on its 7d window and still has a credit available.
+// Accounts that are healthy or out of credits are skipped silently.
+func (s Server) rateLimitResetAllAccounts(ctx context.Context, dryRun bool) []RateLimitResetResult {
+	storedAccounts, err := s.AccountRef.store.ListStored()
+	if err != nil {
+		return []RateLimitResetResult{{
+			Email: "",
+			Error: err.Error(),
+		}}
+	}
+	// Cap concurrent usage fetches so a large pool does not trip the upstream
+	// usage endpoint's per-IP rate limit (the same reason FetchUsageWindowsCached
+	// exists). Eligibility is decided from usage, then redemption runs serially.
+	sem := make(chan struct{}, 4)
+	var wg sync.WaitGroup
+	type candidate struct {
+		account accounts.Account
+		before  []accounts.UsageWindow
+	}
+	candidates := make([]candidate, 0, len(storedAccounts))
+	var mu sync.Mutex
+	for i := range storedAccounts {
+		stored := storedAccounts[i]
+		if stored.IsAPIKey() {
+			continue
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			account, ok := stored.Account(stored.SourcePath(s.AccountRef.store))
+			if !ok || account.Token == "" {
+				return
+			}
+			details, err := accounts.FetchCodexUsageDetails(ctx, s.AccountRef.client, account)
+			if err != nil {
+				return
+			}
+			if !rateLimitCooked(details) {
+				return
+			}
+			if !rateLimitHasCredit(details) {
+				return
+			}
+			mu.Lock()
+			candidates = append(candidates, candidate{account: account, before: details.Windows})
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	results := make([]RateLimitResetResult, 0, len(candidates))
+	for _, c := range candidates {
+		res := s.redeemAccountIfEligible(ctx, c.account, dryRun)
+		// Preserve the before-windows captured during the sweep when the
+		// redeem path could not refetch them.
+		if len(res.WindowsBefore) == 0 {
+			res.WindowsBefore = c.before
+		}
+		results = append(results, res)
+	}
+	return results
+}
+
+// redeemAccountIfEligible fetches current usage, and if the account is cooked
+// on its 7d window with a credit available, redeems one credit. dryRun lists
+// eligibility without consuming.
+func (s Server) redeemAccountIfEligible(ctx context.Context, account accounts.Account, dryRun bool) RateLimitResetResult {
+	result := RateLimitResetResult{Email: account.Email, DryRun: dryRun}
+	before, err := accounts.FetchCodexUsageDetails(ctx, s.AccountRef.client, account)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	result.WindowsBefore = before.Windows
+	if !rateLimitCooked(before) {
+		result.Error = "account is not cooked; skipping"
+		return result
+	}
+	if !rateLimitHasCredit(before) {
+		result.Eligible = false
+		result.Error = "no rate-limit reset credits available"
+		return result
+	}
+	result.Eligible = true
+	if dryRun {
+		return result
+	}
+	credit, err := accounts.RedeemRateLimitReset(ctx, s.AccountRef.client, account)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	result.Credit = &credit
+	result.Reset = true
+	if after, err := accounts.FetchCodexUsageDetails(ctx, s.AccountRef.client, account); err == nil {
+		result.WindowsAfter = after.Windows
+	}
+	return result
+}
+
+// rateLimitCooked reports whether an account is currently blocked by its
+// account-wide 7d (secondary) rate-limit window. We treat the upstream
+// limit_reached flag as authoritative and fall back to the secondary window
+// being fully consumed.
+func rateLimitCooked(details accounts.CodexUsageDetails) bool {
+	if details.RawRateLimit.LimitReached {
+		return true
+	}
+	if sw := details.RawRateLimit.SecondaryWindow; sw != nil && sw.UsedPercent >= 100 {
+		return true
+	}
+	return false
+}
+
+// rateLimitHasCredit reports whether usage advertised at least one redeemable
+// rate-limit reset credit for the account.
+func rateLimitHasCredit(details accounts.CodexUsageDetails) bool {
+	return details.ComplimentaryReset != nil && details.ComplimentaryReset.Available
+}
+
+// parseBoolParam accepts a few truthy spellings ("1", "true", "yes", "on") for
+// a boolean query parameter, checking aliases in order.
+func parseBoolParam(r *http.Request, aliases ...string) bool {
+	q := r.URL.Query()
+	for _, alias := range aliases {
+		v := strings.ToLower(strings.TrimSpace(q.Get(alias)))
+		if v == "1" || v == "true" || v == "yes" || v == "on" {
+			return true
+		}
+	}
+	return false
 }
 
 func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account) ([]selectacct.Score, int) {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -1030,6 +1030,9 @@ func TestUsageStatusEndpointFetchesUsageWithoutForcingFreshRefresh(t *testing.T)
 					"reset_after_seconds":  int64(time.Hour / time.Second),
 				},
 			},
+			"complimentary_session_reset": map[string]any{
+				"available": true,
+			},
 		})
 		return &http.Response{
 			StatusCode: http.StatusOK,
@@ -1060,6 +1063,9 @@ func TestUsageStatusEndpointFetchesUsageWithoutForcingFreshRefresh(t *testing.T)
 	}
 	if len(statuses) != 1 || !statuses[0].AuthValid || statuses[0].Refreshed || statuses[0].PlanType != "pro" || !statuses[0].Active {
 		t.Fatalf("unexpected statuses: %+v", statuses)
+	}
+	if statuses[0].ComplimentaryReset == nil || !statuses[0].ComplimentaryReset.Available {
+		t.Fatalf("missing complimentary reset status: %+v", statuses[0].ComplimentaryReset)
 	}
 }
 

--- a/internal/proxy/rate_limit_reset_test.go
+++ b/internal/proxy/rate_limit_reset_test.go
@@ -1,0 +1,238 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+// emailFromTestJWT extracts the embedded email from a test "alg:none" JWT so a
+// fake transport can serve different accounts from the same bearer token set.
+func emailFromTestJWT(bearer string) string {
+	token := strings.TrimPrefix(bearer, "Bearer ")
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ""
+	}
+	var claims struct {
+		Profile struct {
+			Email string `json:"email"`
+		} `json:"https://api.openai.com/profile"`
+	}
+	_ = json.Unmarshal(payload, &claims)
+	return claims.Profile.Email
+}
+
+// whamResponder returns a fake RoundTrip that serves the wham usage, credits,
+// and consume endpoints based on request path. consumeCounter is incremented
+// when the consume endpoint is hit, and usage responses adapt post-consume.
+func whamResponder(t *testing.T, consumeCounter *int, cookedBeforeReset bool) proxyRoundTripFunc {
+	t.Helper()
+	return proxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		header := make(http.Header)
+		header.Set("Content-Type", "application/json")
+		var body []byte
+		switch req.URL.Path {
+		case "/backend-api/wham/usage":
+			consumed := *consumeCounter > 0
+			used := 100
+			limitReached := cookedBeforeReset
+			resetAfter := 250000
+			if consumed {
+				used = 0
+				limitReached = false
+				resetAfter = 604800
+			}
+			body, _ = json.Marshal(map[string]any{
+				"plan_type": "pro",
+				"rate_limit": map[string]any{
+					"limit_reached": limitReached,
+					"secondary_window": map[string]any{
+						"used_percent":         used,
+						"limit_window_seconds": 604800,
+						"reset_after_seconds":  resetAfter,
+					},
+				},
+				"rate_limit_reset_credits": map[string]any{"available_count": 2 - *consumeCounter},
+			})
+		case "/backend-api/wham/rate-limit-reset-credits":
+			body = []byte(`{"credits":[{"id":"RateLimitResetCredit_test","reset_type":"codex_rate_limits","status":"available"}]}`)
+		case "/backend-api/wham/rate-limit-reset-credits/consume":
+			if req.Method != http.MethodPost {
+				return &http.Response{StatusCode: http.StatusMethodNotAllowed, Header: header, Body: io.NopCloser(nil), Request: req}, nil
+			}
+			*consumeCounter++
+			body = []byte(`{"code":"reset","credit":{"id":"RateLimitResetCredit_test","status":"redeemed"}}`)
+		default:
+			return &http.Response{StatusCode: http.StatusNotFound, Header: header, Body: io.NopCloser(nil), Request: req}, nil
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: header, Body: io.NopCloser(bytes.NewReader(body)), Request: req}, nil
+	})
+}
+
+// TestRateLimitResetEndpointRedeemsCookedAccountWithCredit asserts the email
+// path fetches usage, sees a cooked account with a credit, redeems it, and
+// reports before/after windows.
+func TestRateLimitResetEndpointRedeemsCookedAccountWithCredit(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store := accounts.CodexStore{Dir: t.TempDir()}
+	stored := proxyStoredOAuthAccount("cooked@example.com", "fresh", time.Now().Add(time.Hour))
+	if err := store.SaveStored(stored); err != nil {
+		t.Fatal(err)
+	}
+
+	var consume int
+	client := &http.Client{Transport: whamResponder(t, &consume, true)}
+	handler := Server{AccountRef: NewAccountRef(store, nil, client), MaxBodyBytes: 1024}.Handler()
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/_subrouter/rate-limit-reset?email=cooked@example.com", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if consume != 1 {
+		t.Fatalf("expected exactly 1 consume call, got %d", consume)
+	}
+	var payload struct {
+		Reset   int                    `json:"reset"`
+		Results []RateLimitResetResult `json:"results"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Reset != 1 || len(payload.Results) != 1 {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	res := payload.Results[0]
+	if !res.Reset || res.Credit == nil || res.Credit.Status != "redeemed" {
+		t.Errorf("unexpected result: %+v", res)
+	}
+	if len(res.WindowsBefore) == 0 || len(res.WindowsAfter) == 0 {
+		t.Errorf("expected before+after windows: %+v", res)
+	}
+}
+
+// TestRateLimitResetEndpointRejectsMissingTarget asserts the handler requires
+// an email or all=true rather than silently no-op'ing.
+func TestRateLimitResetEndpointRejectsMissingTarget(t *testing.T) {
+	handler := Server{AccountRef: NewAccountRef(accounts.CodexStore{Dir: t.TempDir()}, nil, nil), MaxBodyBytes: 1024}.Handler()
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/_subrouter/rate-limit-reset", nil))
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", recorder.Code)
+	}
+}
+
+// TestRateLimitResetEndpointDryRunDoesNotConsume asserts dry_run lists
+// eligibility without hitting the consume endpoint.
+func TestRateLimitResetEndpointDryRunDoesNotConsume(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store := accounts.CodexStore{Dir: t.TempDir()}
+	stored := proxyStoredOAuthAccount("cooked@example.com", "fresh", time.Now().Add(time.Hour))
+	if err := store.SaveStored(stored); err != nil {
+		t.Fatal(err)
+	}
+	var consume int
+	client := &http.Client{Transport: whamResponder(t, &consume, true)}
+	handler := Server{AccountRef: NewAccountRef(store, nil, client), MaxBodyBytes: 1024}.Handler()
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/_subrouter/rate-limit-reset?email=cooked@example.com&dry_run=true", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if consume != 0 {
+		t.Fatalf("dry_run must not consume, got %d", consume)
+	}
+	var payload struct {
+		DryRun  bool                   `json:"dry_run"`
+		Reset   int                    `json:"reset"`
+		Results []RateLimitResetResult `json:"results"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if !payload.DryRun || payload.Reset != 0 || len(payload.Results) != 1 || !payload.Results[0].Eligible {
+		t.Fatalf("unexpected dry-run payload: %+v", payload)
+	}
+}
+
+// TestRateLimitResetEndpointAllSkipsHealthy asserts the all=true sweep only
+// redeems accounts that are cooked on the 7d window with a credit available.
+func TestRateLimitResetEndpointAllSkipsHealthy(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store := accounts.CodexStore{Dir: t.TempDir()}
+	if err := store.SaveStored(proxyStoredOAuthAccount("cooked@example.com", "cooked", time.Now().Add(time.Hour))); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveStored(proxyStoredOAuthAccount("healthy@example.com", "healthy", time.Now().Add(time.Hour))); err != nil {
+		t.Fatal(err)
+	}
+
+	var consume int
+	client := &http.Client{Transport: proxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		header := make(http.Header)
+		header.Set("Content-Type", "application/json")
+		// healthy token -> low usage + limit not reached; cooked token -> cooked.
+		isCooked := emailFromTestJWT(req.Header.Get("Authorization")) == "cooked@example.com"
+		switch req.URL.Path {
+		case "/backend-api/wham/usage":
+			used := 5
+			limitReached := false
+			if isCooked {
+				used = 100
+				limitReached = true
+			}
+			body, _ := json.Marshal(map[string]any{
+				"plan_type": "pro",
+				"rate_limit": map[string]any{
+					"limit_reached": limitReached,
+					"secondary_window": map[string]any{
+						"used_percent": used, "limit_window_seconds": 604800, "reset_after_seconds": 250000,
+					},
+				},
+				"rate_limit_reset_credits": map[string]any{"available_count": 2},
+			})
+			return &http.Response{StatusCode: http.StatusOK, Header: header, Body: io.NopCloser(bytes.NewReader(body)), Request: req}, nil
+		case "/backend-api/wham/rate-limit-reset-credits":
+			return &http.Response{StatusCode: http.StatusOK, Header: header, Body: io.NopCloser(bytes.NewReader([]byte(`{"credits":[{"id":"x","status":"available"}]}`))), Request: req}, nil
+		case "/backend-api/wham/rate-limit-reset-credits/consume":
+			consume++
+			return &http.Response{StatusCode: http.StatusOK, Header: header, Body: io.NopCloser(bytes.NewReader([]byte(`{"code":"reset","credit":{"id":"x","status":"redeemed"}}`))), Request: req}, nil
+		default:
+			return &http.Response{StatusCode: http.StatusNotFound, Header: header, Body: io.NopCloser(nil), Request: req}, nil
+		}
+	})}
+	handler := Server{AccountRef: NewAccountRef(store, nil, client), MaxBodyBytes: 1024}.Handler()
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/_subrouter/rate-limit-reset?all=true", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if consume != 1 {
+		t.Fatalf("--all should consume exactly 1 credit (cooked only), got %d", consume)
+	}
+	var payload struct {
+		Reset   int                    `json:"reset"`
+		Results []RateLimitResetResult `json:"results"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Reset != 1 || len(payload.Results) != 1 || payload.Results[0].Email != "cooked@example.com" {
+		t.Fatalf("--all should only reset the cooked account, got %+v", payload)
+	}
+}


### PR DESCRIPTION
Today the \"1x reset\" column in `subrouter status` only **displays** rate-limit reset availability parsed from `wham/usage` — redeeming a credit meant hitting the ChatGPT UI by hand. This adds the write-side so a cooked account can be un-cooked in one command, with no per-account browser session.

## What

- **accounts**: `ListRateLimitResetCredits` / `ConsumeRateLimitResetCredit` / `RedeemRateLimitReset` against `GET/POST /wham/rate-limit-reset-credits[/consume]`. Consumes Codex.app's exact request shape (`{credit_id, redeem_request_id}`) and headers (`OAI-Client-Id: codex`, codex UA) — the consume endpoint is on the upstream's codex-client allowlist, not the Cloudflare-gated web path. `redeem_request_id` is a stdlib `crypto/rand` v4 UUID (no new dependency).
- **proxy**: `POST /_subrouter/rate-limit-reset` (admin-gated). `?email=` redeems one account; `?all=true` sweeps every cooked OAuth account that still has a credit; `?dry_run=true` previews. Tokens stay server-side; the handler resolves+refreshes by email, reports before/after windows, and invalidates the usage-status cache.
- **cli**: `subrouter reset [email] [--all] [--dry-run]`. No args picks the single best candidate (cooked + credit available + longest 7d reset remaining — biggest downtime win). Works local or against a team server.

## Why this shape

Subrouter already parses `rate_limit_reset_credits.available_count` for the \"1x reset\" column; this is the missing redeem path. The team server holds the OAuth tokens, so redemption runs as a server endpoint (mirroring `usage-status`/`reload-accounts`) rather than client-side.

## Verification

- `go test ./...` green (new tests in `internal/accounts` + `internal/proxy`; updated `TestDirectSRCommandNames`).
- End-to-end proven earlier today by redeeming credits on 5 cooked accounts (7d 100% → 0%); this bakes that flow into the binary.

## Deploy note

The CLI's `/_subrouter/rate-limit-reset` call 404s against a server running the old binary, so the team server needs a binary swap + restart before `subrouter reset` works remotely. Local mode works immediately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784765287&installation_id=133855650&pr_number=22&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F22&signature=8458884d6d5576256e35784c5a6e9857f58428d638065106e6347fd127175e57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redeem ChatGPT Pro rate‑limit reset credits from the CLI and team server, so cooked accounts can be un‑cooked in one command without using the ChatGPT UI.

- **New Features**
  - CLI: `subrouter reset [email] [--all] [--dry-run]`. Picks the best cooked account with a credit (longest 7d reset remaining) when no email is given. Works local or against a team server.
  - Server: admin `POST /_subrouter/rate-limit-reset` with `?email=...` or `?all=true` and `?dry_run=true`. Resolves/refreshes tokens by email, calls upstream `GET/POST /wham/rate-limit-reset-credits[/consume]`, returns before/after windows, and invalidates the `usage-status` cache.
  - Accounts: `ListRateLimitResetCredits` / `ConsumeRateLimitResetCredit` / `RedeemRateLimitReset` with Codex headers and a v4 UUID idempotency key.
  - Status: table shows complimentary reset state (e.g., avail/used/not elig/unknown).

- **Migration**
  - Upgrade the team server before using `subrouter reset` remotely. Older servers 404 on `/_subrouter/rate-limit-reset`. Local mode works immediately.

<sup>Written for commit a444bff263e8402dc0e8b524806d6b4c9104cf2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `reset [email]` command to redeem rate-limit reset credits, with support for `--all` and `--dry-run` flags to target multiple accounts or preview changes without consuming credits
  * Added "Reset" column to usage grid displaying complimentary reset availability, status, and remaining credits for eligible accounts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->