### PR TITLE
Support Kimi and ZAI provider routing

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -151,6 +151,8 @@ func serve(args []string) error {
 	codexUpstreamRaw := flags.String("codex-upstream", "https://chatgpt.com/backend-api/codex", "Codex subscription upstream base URL")
 	apiUpstreamRaw := flags.String("api-upstream", "https://api.openai.com", "OpenAI API-key upstream base URL")
 	claudeUpstreamRaw := flags.String("claude-upstream", "https://api.anthropic.com", "Claude subscription upstream base URL")
+	kimiUpstreamRaw := flags.String("kimi-upstream", "https://api.kimi.com/coding/v1", "Kimi For Coding upstream base URL")
+	zaiUpstreamRaw := flags.String("zai-upstream", "https://api.z.ai/api/coding/paas/v4", "Z.AI coding upstream base URL")
 	sessionPath := flags.String("sessions", session.DefaultStorePath(), "session assignment store")
 	transcriptDir := flags.String("transcripts", "", "directory for raw Subrouter transcript JSONL files")
 	transcriptGCSURI := flags.String("transcript-gcs-uri", "", "optional gs:// bucket/prefix for background transcript sync")
@@ -200,6 +202,14 @@ func serve(args []string) error {
 	if err != nil {
 		return err
 	}
+	kimiUpstream, err := url.Parse(*kimiUpstreamRaw)
+	if err != nil {
+		return err
+	}
+	zaiUpstream, err := url.Parse(*zaiUpstreamRaw)
+	if err != nil {
+		return err
+	}
 
 	store, err := session.NewStore(*sessionPath)
 	if err != nil {
@@ -246,6 +256,8 @@ func serve(args []string) error {
 		CodexUpstream:  codexUpstream,
 		APIUpstream:    apiUpstream,
 		ClaudeUpstream: claudeUpstream,
+		KimiUpstream:   kimiUpstream,
+		ZAIUpstream:    zaiUpstream,
 		Accounts:       nil,
 		AccountRef:     accountRef,
 		Sessions:       store,
@@ -611,7 +623,7 @@ Usage:
   %[1]s claude             Manage Claude Code profiles
   %[1]s gemini             Manage Gemini profiles
 
-  %[1]s serve [--addr 127.0.0.1:31415] [--fetch-usage=true] [--codex-upstream URL] [--claude-upstream URL] [--transcripts DIR] [--transcript-gcs-uri gs://bucket/prefix] [--transcript-gcs-sync-timeout 30m] [--transcript-local-retention 24h] [--transcript-max-local-bytes 2GiB]
+  %[1]s serve [--addr 127.0.0.1:31415] [--fetch-usage=true] [--codex-upstream URL] [--claude-upstream URL] [--kimi-upstream URL] [--zai-upstream URL] [--transcripts DIR] [--transcript-gcs-uri gs://bucket/prefix] [--transcript-gcs-sync-timeout 30m] [--transcript-local-retention 24h] [--transcript-max-local-bytes 2GiB]
   %[1]s accounts
   %[1]s codex [codex args...]
   %[1]s install-daemon [--start=true]       macOS LaunchAgent

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -245,7 +245,7 @@ func (r srRunner) runRemoteAccountCommand(ctx context.Context, server srServerCo
 		}
 		return r.serverLoginOne(ctx, server, deviceAuth, "")
 	case "add-key", "add-api-key":
-		return r.addKeyToServer(ctx, server)
+		return r.addKeyToServer(ctx, server, args[1:])
 	case "list", "ls":
 		return r.listServerAccounts(ctx, server)
 	case "status":

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -565,13 +565,31 @@ func (r srRunner) listServerAccounts(ctx context.Context, server srServerConfig)
 	return nil
 }
 
-func (r srRunner) addKeyToServer(ctx context.Context, server srServerConfig) error {
+func (r srRunner) addKeyToServer(ctx context.Context, server srServerConfig, args []string) error {
+	command := r.programOrSubrouter() + " add-key"
+	flags := flag.NewFlagSet(command, flag.ContinueOnError)
+	flags.SetOutput(r.errOut)
+	providerRaw := flags.String("provider", string(accounts.ProviderCodex), "API-key provider: codex, kimi, or zai")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	provider, err := parseAPIKeyProvider(*providerRaw)
+	if err != nil {
+		return err
+	}
 	reader := bufio.NewReader(r.in)
 	label, err := promptLine(r.out, reader, "Label (e.g. work, personal): ")
 	if err != nil {
 		return err
 	}
-	key, err := promptLine(r.out, reader, "API key (sk-...): ")
+	keyPrompt := "API key"
+	if provider == accounts.ProviderCodex {
+		keyPrompt = "API key (sk-...)"
+	}
+	key, err := promptLine(r.out, reader, keyPrompt+": ")
 	if err != nil {
 		return err
 	}
@@ -580,12 +598,20 @@ func (r srRunner) addKeyToServer(ctx context.Context, server srServerConfig) err
 	if label == "" {
 		return fmt.Errorf("label is required")
 	}
-	if !strings.HasPrefix(key, "sk-") {
+	if key == "" {
+		return fmt.Errorf("API key is required")
+	}
+	if provider == accounts.ProviderCodex && !strings.HasPrefix(key, "sk-") {
 		return fmt.Errorf("invalid API key format, expected sk-...")
 	}
+	emailPrefix := "apikey:"
+	if provider != accounts.ProviderCodex {
+		emailPrefix = string(provider) + ":"
+	}
 	account := accounts.StoredCodexAccount{
-		Email:   "apikey:" + label,
-		AddedAt: time.Now().UTC().Format(time.RFC3339),
+		Email:    emailPrefix + label,
+		Provider: provider,
+		AddedAt:  time.Now().UTC().Format(time.RFC3339),
 		Auth: accounts.CodexAuthFile{
 			AuthMode:     "apikey",
 			OpenAIAPIKey: key,
@@ -596,6 +622,19 @@ func (r srRunner) addKeyToServer(ctx context.Context, server srServerConfig) err
 	}
 	fmt.Fprintf(r.out, "Added server API-key account %s to %s\n", account.APIKeyLabel(), server.Name)
 	return nil
+}
+
+func parseAPIKeyProvider(value string) (accounts.Provider, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", string(accounts.ProviderCodex), "openai":
+		return accounts.ProviderCodex, nil
+	case string(accounts.ProviderKimi), "kimi-for-coding":
+		return accounts.ProviderKimi, nil
+	case string(accounts.ProviderZAI), "glm", "glm-5.2":
+		return accounts.ProviderZAI, nil
+	default:
+		return "", fmt.Errorf("unsupported API-key provider %q, expected codex, kimi, or zai", value)
+	}
 }
 
 func (r srRunner) pickRemoteAccount(ctx context.Context, server srServerConfig) error {

--- a/internal/accounts/codex_store.go
+++ b/internal/accounts/codex_store.go
@@ -19,6 +19,7 @@ type CodexStore struct {
 
 type StoredCodexAccount struct {
 	Email         string                `json:"email"`
+	Provider      Provider              `json:"provider,omitempty"`
 	AddedAt       string                `json:"addedAt"`
 	Auth          CodexAuthFile         `json:"auth"`
 	ProjectID     string                `json:"projectId,omitempty"`
@@ -161,6 +162,13 @@ func (a StoredCodexAccount) APIKeyLabel() string {
 	return strings.TrimPrefix(a.Email, "apikey:")
 }
 
+func (a StoredCodexAccount) ProviderOrDefault() Provider {
+	if a.Provider != "" {
+		return a.Provider
+	}
+	return ProviderCodex
+}
+
 func (a StoredCodexAccount) toAccount(source string) (Account, bool) {
 	id := strings.TrimSpace(a.Email)
 	if id == "" {
@@ -170,7 +178,7 @@ func (a StoredCodexAccount) toAccount(source string) (Account, bool) {
 	addedAt, _ := time.Parse(time.RFC3339, a.AddedAt)
 	out := Account{
 		ID:       id,
-		Provider: ProviderCodex,
+		Provider: a.ProviderOrDefault(),
 		Label:    id,
 		Email:    id,
 		AddedAt:  addedAt,

--- a/internal/accounts/types.go
+++ b/internal/accounts/types.go
@@ -7,6 +7,8 @@ type Provider string
 const (
 	ProviderCodex  Provider = "codex"
 	ProviderClaude Provider = "claude"
+	ProviderKimi   Provider = "kimi"
+	ProviderZAI    Provider = "zai"
 )
 
 type AuthMode string

--- a/internal/proxy/opencode_provider_test.go
+++ b/internal/proxy/opencode_provider_test.go
@@ -1,0 +1,104 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/internal/session"
+)
+
+func TestHandlerRoutesKimiProviderPrefixToKimiUpstream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/coding/v1/messages" {
+			t.Fatalf("upstream path = %q, want /coding/v1/messages", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Api-Key"); got != "kimi-token" {
+			t.Fatalf("X-Api-Key = %q, want kimi token", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer kimi-token" {
+			t.Fatalf("Authorization = %q, want kimi bearer", got)
+		}
+		if got := r.Header.Get("Anthropic-Version"); got != "2023-06-01" {
+			t.Fatalf("Anthropic-Version = %q, want 2023-06-01", got)
+		}
+		_, _ = io.WriteString(w, `{"id":"msg_1"}`)
+	}))
+	defer upstream.Close()
+
+	handler := opencodeProviderTestServer(t, accounts.Account{
+		ID:       "kimi:main",
+		Provider: accounts.ProviderKimi,
+		AuthMode: accounts.AuthModeAPIKey,
+		Token:    "kimi-token",
+	}, accounts.ProviderKimi, upstream.URL+"/coding/v1").Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/kimi/messages", strings.NewReader(`{"model":"kimi-for-coding"}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandlerRoutesZAIProviderPrefixToZAIUpstream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/coding/paas/v4/chat/completions" {
+			t.Fatalf("upstream path = %q, want /api/coding/paas/v4/chat/completions", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer zai-token" {
+			t.Fatalf("Authorization = %q, want zai bearer", got)
+		}
+		if got := r.Header.Get("X-Api-Key"); got != "" {
+			t.Fatalf("X-Api-Key = %q, want stripped", got)
+		}
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"ok"}}]}`)
+	}))
+	defer upstream.Close()
+
+	handler := opencodeProviderTestServer(t, accounts.Account{
+		ID:       "zai:main",
+		Provider: accounts.ProviderZAI,
+		AuthMode: accounts.AuthModeAPIKey,
+		Token:    "zai-token",
+	}, accounts.ProviderZAI, upstream.URL+"/api/coding/paas/v4").Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/zai/chat/completions", strings.NewReader(`{"model":"glm-5.2"}`))
+	req.Header.Set("X-Api-Key", "client-key")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func opencodeProviderTestServer(t *testing.T, account accounts.Account, provider accounts.Provider, upstreamRaw string) Server {
+	t.Helper()
+	upstream, err := url.Parse(upstreamRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := Server{
+		Accounts:     []accounts.Account{account},
+		Sessions:     store,
+		MaxBodyBytes: 1024,
+	}
+	switch provider {
+	case accounts.ProviderKimi:
+		server.KimiUpstream = upstream
+	case accounts.ProviderZAI:
+		server.ZAIUpstream = upstream
+	default:
+		t.Fatalf("unsupported provider %s", provider)
+	}
+	return server
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -35,6 +35,8 @@ type Server struct {
 	CodexUpstream  *url.URL
 	APIUpstream    *url.URL
 	ClaudeUpstream *url.URL
+	KimiUpstream   *url.URL
+	ZAIUpstream    *url.URL
 	Accounts       []accounts.Account
 	AccountRef     *AccountRef
 	Sessions       *session.Store
@@ -329,9 +331,10 @@ func (r *AccountRef) Statuses(ctx context.Context, forceRefresh bool) []AccountS
 	}
 	out := make([]AccountStatus, 0, len(storedAccounts))
 	for _, stored := range storedAccounts {
+		provider := stored.ProviderOrDefault()
 		status := AccountStatus{
 			ID:       stored.Email,
-			Provider: accounts.ProviderCodex,
+			Provider: provider,
 			Email:    stored.Email,
 			Source:   stored.SourcePath(r.store),
 		}
@@ -465,6 +468,17 @@ func authLikeUsageError(message string) bool {
 	return false
 }
 
+func apiKeyPlanType(provider accounts.Provider) string {
+	switch provider {
+	case accounts.ProviderKimi:
+		return "kimi api key"
+	case accounts.ProviderZAI:
+		return "zai api key"
+	default:
+		return "api key"
+	}
+}
+
 func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus {
 	storedAccounts, err := r.store.ListStored()
 	if err != nil {
@@ -482,10 +496,11 @@ func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus
 	var wg sync.WaitGroup
 	for i, stored := range storedAccounts {
 		i, stored := i, stored
+		provider := stored.ProviderOrDefault()
 		status := AccountUsageStatus{
 			AccountStatus: AccountStatus{
 				ID:       stored.Email,
-				Provider: accounts.ProviderCodex,
+				Provider: provider,
 				Email:    stored.Email,
 				Source:   stored.SourcePath(r.store),
 			},
@@ -493,7 +508,7 @@ func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus
 		}
 		if stored.IsAPIKey() {
 			status.AuthMode = accounts.AuthModeAPIKey
-			status.PlanType = "api key"
+			status.PlanType = apiKeyPlanType(provider)
 			out[i] = status
 			continue
 		}
@@ -1104,12 +1119,14 @@ func (s Server) proxyHandler() http.Handler {
 		}
 		endProxyRequest := s.Lifecycle.BeginProxyRequest()
 		defer endProxyRequest()
-		account, sessionID, userEmail, err := s.accountForSession(agentType, sessionID, r)
+		requestProvider := providerForRequest(agentType, r.URL.Path)
+		sessionAgentType := agentTypeForProviderSession(agentType, requestProvider)
+		account, sessionID, userEmail, err := s.accountForSessionProvider(requestProvider, sessionAgentType, sessionID, r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 			return
 		}
-		account, err = s.refreshSelectedAccount(r.Context(), agentType, sessionID, userEmail, r, account)
+		account, err = s.refreshSelectedAccount(r.Context(), requestProvider, sessionAgentType, sessionID, userEmail, r, account)
 		if err != nil {
 			http.Error(w, "refresh selected account: "+err.Error(), http.StatusServiceUnavailable)
 			return
@@ -1122,8 +1139,8 @@ func (s Server) proxyHandler() http.Handler {
 		}
 
 		endActive := func() {}
-		if activeSessionRequest(agentType, r) {
-			endActive = s.ActiveSessions.Begin(agentType, sessionID)
+		if activeSessionRequest(sessionAgentType, r) {
+			endActive = s.ActiveSessions.Begin(sessionAgentType, sessionID)
 			defer endActive()
 		}
 
@@ -1135,7 +1152,7 @@ func (s Server) proxyHandler() http.Handler {
 			return
 		}
 		if websocket.IsWebSocketUpgrade(r) {
-			s.proxyWebSocket(w, r, account, agentType, sessionID, userEmail, upstream)
+			s.proxyWebSocket(w, r, account, sessionAgentType, sessionID, userEmail, upstream)
 			return
 		}
 		proxyRequest := r.Clone(r.Context())
@@ -1143,7 +1160,6 @@ func (s Server) proxyHandler() http.Handler {
 		proxyRequest.URL.Path = s.pathForUpstream(proxyRequest.URL.Path, account)
 		proxyRequest.URL.RawPath = ""
 		session.StripSubrouterHeaders(proxyRequest.Header)
-		requestProvider := providerForAgent(agentType)
 		retryPost := retryableUpstreamPostRequest(requestProvider, proxyRequest)
 		postReplayable := false
 		if retryPost {
@@ -1154,14 +1170,14 @@ func (s Server) proxyHandler() http.Handler {
 				return
 			}
 			if !postReplayable && s.Logger != nil {
-				s.Logger.Warn("retryable request body exceeds retry buffer", "agent", agentType, "session", sessionID, "account", account.ID, "method", r.Method, "path", proxyRequest.URL.Path, "content_length", r.ContentLength, "max_bytes", replayablePostMaxBodyBytes)
+				s.Logger.Warn("retryable request body exceeds retry buffer", "agent", sessionAgentType, "session", sessionID, "account", account.ID, "method", r.Method, "path", proxyRequest.URL.Path, "content_length", r.ContentLength, "max_bytes", replayablePostMaxBodyBytes)
 			}
 		}
-		s.recordHTTPMeta(proxyRequest, agentType, sessionID, userEmail, account, upstream)
+		s.recordHTTPMeta(proxyRequest, sessionAgentType, sessionID, userEmail, account, upstream)
 		if retryPost && postReplayable {
-			s.recordReplayableRequestBody(proxyRequest, agentType, sessionID)
+			s.recordReplayableRequestBody(proxyRequest, sessionAgentType, sessionID)
 		} else {
-			s.captureRequestBody(proxyRequest, agentType, sessionID)
+			s.captureRequestBody(proxyRequest, sessionAgentType, sessionID)
 		}
 
 		rp := httputil.NewSingleHostReverseProxy(upstream)
@@ -1174,7 +1190,7 @@ func (s Server) proxyHandler() http.Handler {
 				server:      &s,
 				logger:      s.Logger,
 				provider:    requestProvider,
-				agent:       agentType,
+				agent:       sessionAgentType,
 				session:     sessionID,
 				userEmail:   userEmail,
 				account:     account.ID,
@@ -1188,7 +1204,7 @@ func (s Server) proxyHandler() http.Handler {
 			transport = replayablePostRetryTransport{
 				base:        transport,
 				logger:      s.Logger,
-				agent:       agentType,
+				agent:       sessionAgentType,
 				session:     sessionID,
 				account:     account.ID,
 				method:      r.Method,
@@ -1205,13 +1221,13 @@ func (s Server) proxyHandler() http.Handler {
 			r.Host = upstream.Host
 		}
 		rp.ModifyResponse = func(response *http.Response) error {
-			s.captureResponseBody(response, agentType, sessionID, account.ID, account.Provider, proxyRequest.URL.Path)
+			s.captureResponseBody(response, sessionAgentType, sessionID, account.ID, account.Provider, proxyRequest.URL.Path)
 			return nil
 		}
 		if s.Logger != nil {
 			rp.ErrorLog = log.New(proxyErrorWriter{
 				logger:   s.Logger,
-				agent:    agentType,
+				agent:    sessionAgentType,
 				session:  sessionID,
 				account:  account.ID,
 				method:   r.Method,
@@ -1219,13 +1235,13 @@ func (s Server) proxyHandler() http.Handler {
 				upstream: upstream.Host,
 			}, "", 0)
 			rp.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {
-				s.Logger.Error("proxy request failed", "agent", agentType, "session", sessionID, "account", account.ID, "method", r.Method, "path", proxyRequest.URL.Path, "upstream", upstream.Host, "error", err)
+				s.Logger.Error("proxy request failed", "agent", sessionAgentType, "session", sessionID, "account", account.ID, "method", r.Method, "path", proxyRequest.URL.Path, "upstream", upstream.Host, "error", err)
 				http.Error(w, "upstream request failed", http.StatusBadGateway)
 			}
 		}
 
 		if s.Logger != nil {
-			s.Logger.Info("proxy request", "agent", agentType, "session", sessionID, "user", userEmail, "account", account.ID, "method", r.Method, "path", r.URL.Path, "upstream", upstream.Host)
+			s.Logger.Info("proxy request", "agent", sessionAgentType, "session", sessionID, "user", userEmail, "account", account.ID, "method", r.Method, "path", r.URL.Path, "upstream", upstream.Host)
 		}
 
 		// For cacheable GET paths, buffer the response so we can store it.
@@ -1354,7 +1370,7 @@ func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, direction
 			})
 		}
 		if direction == "upstream_to_client" && messageType == websocket.TextMessage && usageLimitJSON(body) {
-			s.markAccountExhausted(providerForAgent(agentType), accountID)
+			s.markAccountExhausted(providerForRequest(agentType, ""), accountID)
 		}
 		if err := dst.WriteMessage(messageType, body); err != nil {
 			return
@@ -1715,6 +1731,14 @@ func setAccountAuthHeaders(headers http.Header, account accounts.Account) {
 	case accounts.ProviderClaude:
 		headers.Del("X-Api-Key")
 		ensureCommaHeaderValue(headers, "Anthropic-Beta", claudeOAuthBetaHeader)
+	case accounts.ProviderKimi:
+		headers.Set("Authorization", account.AuthorizationHeader())
+		headers.Set("X-Api-Key", account.Token)
+		if headers.Get("Anthropic-Version") == "" {
+			headers.Set("Anthropic-Version", "2023-06-01")
+		}
+	case accounts.ProviderZAI:
+		headers.Del("X-Api-Key")
 	case accounts.ProviderCodex, "":
 		if account.AccountID != "" {
 			headers.Set("ChatGPT-Account-ID", account.AccountID)
@@ -1743,6 +1767,12 @@ func (s Server) upstreamForRequest(path string, account accounts.Account) *url.U
 	if account.Provider == accounts.ProviderClaude {
 		return s.ClaudeUpstream
 	}
+	if account.Provider == accounts.ProviderKimi {
+		return s.KimiUpstream
+	}
+	if account.Provider == accounts.ProviderZAI {
+		return s.ZAIUpstream
+	}
 	if account.AuthMode == accounts.AuthModeAPIKey {
 		return s.APIUpstream
 	}
@@ -1761,6 +1791,12 @@ func (s Server) pathForUpstream(path string, account accounts.Account) string {
 	}
 	if account.Provider == accounts.ProviderClaude {
 		return path
+	}
+	if account.Provider == accounts.ProviderKimi {
+		return stripProviderPathPrefix(path, "kimi")
+	}
+	if account.Provider == accounts.ProviderZAI {
+		return stripProviderPathPrefix(path, "zai")
 	}
 	if account.AuthMode == accounts.AuthModeOAuth {
 		if stripped, ok := stripChatGPTBackendPath(path); ok {
@@ -1818,10 +1854,13 @@ func (s Server) accountFor(agentType string, r *http.Request) (accounts.Account,
 }
 
 func (s Server) accountForSession(agentType, sessionID string, r *http.Request) (accounts.Account, string, string, error) {
+	return s.accountForSessionProvider(providerForRequest(agentType, r.URL.Path), agentType, sessionID, r)
+}
+
+func (s Server) accountForSessionProvider(provider accounts.Provider, agentType, sessionID string, r *http.Request) (accounts.Account, string, string, error) {
 	userEmail := session.ExtractUserEmail(r)
 	forcedAccountID := session.ExtractAccountID(r)
 	model := session.ExtractModel(r, s.MaxBodyBytes)
-	provider := providerForAgent(agentType)
 	availableAccounts := filterAccountsForProvider(s.accountList(), provider)
 	if forcedAccountID != "" {
 		account, ok := findAccount(availableAccounts, forcedAccountID)
@@ -1905,7 +1944,7 @@ func (s Server) accountForSession(agentType, sessionID string, r *http.Request) 
 }
 
 func (s Server) logStickyReuse(agentType, sessionID string, account accounts.Account, scheduler selectacct.Scheduler) {
-	if s.Logger == nil || providerForAgent(agentType) != accounts.ProviderCodex || account.AuthMode != accounts.AuthModeOAuth {
+	if s.Logger == nil || accountProviderOrCodex(account) != accounts.ProviderCodex || account.AuthMode != accounts.AuthModeOAuth {
 		return
 	}
 	if scheduler.UsableForNewSession(account.Provider, account.ID) || scheduler.Exhausted(account.Provider, account.ID) || !s.activeSession(agentType, sessionID) {
@@ -1927,7 +1966,7 @@ func (s Server) reuseStickyAssignment(agentType, sessionID string, account accou
 	if s.activeSession(agentType, sessionID) {
 		return true
 	}
-	if providerForAgent(agentType) == accounts.ProviderCodex && account.AuthMode == accounts.AuthModeOAuth {
+	if accountProviderOrCodex(account) == accounts.ProviderCodex && account.AuthMode == accounts.AuthModeOAuth {
 		return scheduler.UsableForNewSession(account.Provider, account.ID)
 	}
 	return true
@@ -2027,6 +2066,56 @@ func providerForAgent(agentType string) accounts.Provider {
 	}
 }
 
+func providerForRequest(agentType, path string) accounts.Provider {
+	if provider, ok := providerForPath(path); ok {
+		return provider
+	}
+	return providerForAgent(agentType)
+}
+
+func agentTypeForProviderSession(agentType string, provider accounts.Provider) string {
+	switch provider {
+	case accounts.ProviderKimi, accounts.ProviderZAI:
+		return string(provider)
+	default:
+		return agentType
+	}
+}
+
+func providerForPath(path string) (accounts.Provider, bool) {
+	switch firstPathSegment(path) {
+	case "kimi":
+		return accounts.ProviderKimi, true
+	case "zai":
+		return accounts.ProviderZAI, true
+	default:
+		return "", false
+	}
+}
+
+func firstPathSegment(path string) string {
+	path = strings.TrimPrefix(path, "/")
+	if path == "" {
+		return ""
+	}
+	segment, _, _ := strings.Cut(path, "/")
+	return segment
+}
+
+func stripProviderPathPrefix(path, provider string) string {
+	if path == "" || path == "/" {
+		return "/"
+	}
+	prefix := "/" + provider
+	if path == prefix {
+		return "/"
+	}
+	if strings.HasPrefix(path, prefix+"/") {
+		return strings.TrimPrefix(path, prefix)
+	}
+	return path
+}
+
 func filterAccountsForProvider(all []accounts.Account, provider accounts.Provider) []accounts.Account {
 	filtered := make([]accounts.Account, 0, len(all))
 	legacy := make([]accounts.Account, 0)
@@ -2042,7 +2131,17 @@ func filterAccountsForProvider(all []accounts.Account, provider accounts.Provide
 	if len(filtered) > 0 {
 		return filtered
 	}
+	if provider == accounts.ProviderKimi || provider == accounts.ProviderZAI {
+		return nil
+	}
 	return legacy
+}
+
+func accountProviderOrCodex(account accounts.Account) accounts.Provider {
+	if account.Provider == "" {
+		return accounts.ProviderCodex
+	}
+	return account.Provider
 }
 
 func (s Server) accountList() []accounts.Account {
@@ -2060,12 +2159,11 @@ func (s Server) refreshAccount(ctx context.Context, account accounts.Account) (a
 	return s.AccountRef.Refresh(ctx, account)
 }
 
-func (s Server) refreshSelectedAccount(ctx context.Context, agentType, sessionID, userEmail string, r *http.Request, account accounts.Account) (accounts.Account, error) {
+func (s Server) refreshSelectedAccount(ctx context.Context, provider accounts.Provider, agentType, sessionID, userEmail string, r *http.Request, account accounts.Account) (accounts.Account, error) {
 	refreshed, err := s.refreshAccount(ctx, account)
 	if err == nil {
 		return refreshed, nil
 	}
-	provider := providerForAgent(agentType)
 	if provider != accounts.ProviderClaude || session.ExtractAccountID(r) != "" {
 		return account, err
 	}


### PR DESCRIPTION
Adds opencode provider routing for Kimi (`/kimi` -> api.kimi.com) and Z.AI/GLM (`/zai` -> api.z.ai).

This routing was already running on the GCP deploy (`subrouter-team`) but only existed on the local `feat-opencode-kimi-glm` branch, never merged. Building/deploying from `main` silently dropped it and misrouted `/kimi`+`/zai` to chatgpt.com. Merging so `main` matches the deployed binary.

Verified live: GLM (`zai/glm-5.2`) returns end-to-end via opencode; Kimi routes to api.kimi.com (upstream membership error is a Moonshot account issue, not routing). Tests `internal/proxy` (Opencode/Provider) and `cmd/subrouter` (Reset) pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784774044&installation_id=133855650&pr_number=23&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F23&signature=a340fd42147202dd806e3cd5418cf16b8a84d02c3bf2d9df481876c93c479ede"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds provider routing for Kimi and Z.AI/GLM using `/kimi` and `/zai` path prefixes so requests go to their correct upstreams. Aligns `main` with the deployed subrouter to stop misrouting to ChatGPT.

- **New Features**
  - Path routing: `/kimi/*` -> Kimi upstream, `/zai/*` -> Z.AI upstream; strips the prefix before proxying.
  - Server flags: `--kimi-upstream` (default https://api.kimi.com/coding/v1) and `--zai-upstream` (default https://api.z.ai/api/coding/paas/v4).
  - Accounts: added `kimi` and `zai` providers; store `provider`; provider-specific plan labels and auth headers.
  - CLI: `accounts add-key --provider {codex|kimi|zai}` with proper prompts/validation for each provider.
  - Tests: added `internal/proxy/opencode_provider_test.go` to verify routing and headers.

- **Bug Fixes**
  - Fixed `/kimi` and `/zai` requests being sent to chatgpt.com; routing now matches the deployed binary.
  - Session/account selection and logging now follow the request’s provider and set correct upstream paths/headers.

<sup>Written for commit 7662f38fddfca6ef912b84c6d6c16536169bd6fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Kimi and Z.AI providers alongside Codex
  * Added CLI flags to configure custom upstream URLs for Kimi and Z.AI
  * Extended API key management to support multiple coding assistant providers

* **Tests**
  * Added routing tests for Kimi and Z.AI provider paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->