### PR TITLE
Factor Claude rate limits into routing and capture the 429 message

### DIFF
--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -213,6 +213,80 @@ func TestClaudeShortWindowDrivesRouting(t *testing.T) {
 	}
 }
 
+// TestClaudeAccountExhaustedByResponse pins the authoritative-signal logic:
+// 401 and a "rejected" 429 mean the account is out of quota, while an
+// "allowed"/"allowed_warning" 429 is a transient throttle that must not poison
+// the routing score. A 429 with no unified-status header keeps the conservative
+// legacy behavior (treated as exhausted).
+func TestClaudeAccountExhaustedByResponse(t *testing.T) {
+	withStatus := func(v string) http.Header {
+		h := http.Header{}
+		if v != "" {
+			h.Set("Anthropic-Ratelimit-Unified-Status", v)
+		}
+		return h
+	}
+	cases := []struct {
+		name   string
+		status int
+		header http.Header
+		want   bool
+	}{
+		{"401 dead token", http.StatusUnauthorized, http.Header{}, true},
+		{"429 rejected", http.StatusTooManyRequests, withStatus("rejected"), true},
+		{"429 allowed_warning", http.StatusTooManyRequests, withStatus("allowed_warning"), false},
+		{"429 allowed", http.StatusTooManyRequests, withStatus("allowed"), false},
+		{"429 no header (legacy)", http.StatusTooManyRequests, http.Header{}, true},
+		{"200 healthy", http.StatusOK, withStatus("allowed"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := claudeAccountExhaustedByResponse(tc.status, tc.header); got != tc.want {
+				t.Fatalf("claudeAccountExhaustedByResponse(%d, %v) = %v, want %v", tc.status, tc.header, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClaudeTransient429FailsOverWithoutPoisoningScore proves a transient
+// (allowed_warning) 429 still fails the request over to another account but does
+// NOT mark the first account exhausted, so the GTO scheduler keeps routing to it.
+func TestClaudeTransient429FailsOverWithoutPoisoningScore(t *testing.T) {
+	server, store := claudeFailoverServer(t)
+	if _, err := store.Put("claude", "session-t", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		if strings.Contains(req.Header.Get("Authorization"), "tok-cooked") {
+			h := http.Header{}
+			h.Set("Anthropic-Ratelimit-Unified-Status", "allowed_warning")
+			return &http.Response{StatusCode: http.StatusTooManyRequests, Header: h, Body: io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`))}
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(`{"id":"msg_ok"}`))}
+	}}
+	transport := usageLimitRetryTransport{
+		base: stub, server: &server, provider: accounts.ProviderClaude,
+		agent: "claude", session: "session-t", account: "cooked@example.com",
+		method: http.MethodPost, path: "/v1/messages", maxAttempts: 3,
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader([]byte(`{"model":"claude-opus-4-8"}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after transient failover", response.StatusCode)
+	}
+	if server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
+		t.Fatal("a transient allowed_warning 429 must NOT mark the account exhausted")
+	}
+}
+
 func TestClaudeRateLimitHeaderFields(t *testing.T) {
 	header := http.Header{}
 	header.Set("Retry-After", "3600")

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -1,0 +1,241 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
+	"github.com/manaflow-ai/subrouter/internal/selectacct"
+	"github.com/manaflow-ai/subrouter/internal/session"
+)
+
+// realisticAnthropic429Body mirrors the body Anthropic returns when a Claude
+// subscription account hits its rolling rate limit. The exact wording is what we
+// want to surface in logs so operators can see "what the message is like".
+const realisticAnthropic429Body = `{"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your account's rate limit. Please try again later."}}`
+
+// TestClaude429FailoverEndToEndAndCaptured drives a real request through
+// Server.Handler() with a mock Anthropic upstream that rate-limits the first
+// account. It proves two things the user asked for: (1) the genuine 429 message
+// and rate-limit headers are captured in logs, and (2) traffic fails over to a
+// second Claude account and succeeds.
+func TestClaude429FailoverEndToEndAndCaptured(t *testing.T) {
+	var cookedHits, freshHits int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		auth := r.Header.Get("Authorization")
+		switch {
+		case strings.Contains(auth, "tok-cooked"):
+			cookedHits++
+			w.Header().Set("Retry-After", "3600")
+			w.Header().Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+			w.Header().Set("Anthropic-Ratelimit-Unified-Reset", "1750000000")
+			w.Header().Set("Anthropic-Ratelimit-Unified-Remaining", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(realisticAnthropic429Body))
+		case strings.Contains(auth, "tok-fresh"):
+			freshHits++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"msg_ok","type":"message"}`))
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"unexpected account"}`))
+		}
+	}))
+	defer upstream.Close()
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Pin the session to the cooked account so it is selected first; the 429
+	// then forces failover. Both accounts start healthy so the sticky
+	// assignment is honored until the upstream rejects it.
+	if _, err := store.Put("claude", "session-rl", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+		{AccountID: "cooked@example.com", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+		{AccountID: "fresh@example.com", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+	}))
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	handler := Server{
+		ClaudeUpstream: upstreamURL,
+		Accounts: []accounts.Account{
+			{ID: "cooked@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-cooked"},
+			{ID: "fresh@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-fresh"},
+		},
+		Sessions:      store,
+		SchedulerRef:  schedulerRef,
+		UsageScoreTTL: 0,
+		MaxBodyBytes:  1 << 20,
+		Logger:        logger,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	req, err := http.NewRequest(http.MethodPost, subrouter.URL+"/v1/messages", strings.NewReader(`{"model":"claude-opus-4-8","messages":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Subrouter-Agent", "claude")
+	req.Header.Set("X-Subrouter-Session", "session-rl")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after failover; body=%s", response.StatusCode, string(body))
+	}
+	if cookedHits != 1 {
+		t.Fatalf("cooked upstream hits = %d, want 1 (one 429 then failover)", cookedHits)
+	}
+	if freshHits != 1 {
+		t.Fatalf("fresh upstream hits = %d, want 1 (served after failover)", freshHits)
+	}
+	if !schedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
+		t.Fatal("cooked account should be marked exhausted by the 429")
+	}
+	assignment, ok := store.Get("claude", "session-rl")
+	if !ok || assignment.AccountID != "fresh@example.com" {
+		t.Fatalf("sticky assignment = %+v, want moved to fresh@example.com", assignment)
+	}
+
+	logs := logBuf.String()
+	// The genuine upstream message must be captured so operators can see it.
+	if !strings.Contains(logs, "This request would exceed your account") {
+		t.Fatalf("expected the 429 body to be logged; logs=\n%s", logs)
+	}
+	// The rate-limit headers must be captured too.
+	for _, want := range []string{"retry-after", "anthropic-ratelimit-unified-reset"} {
+		if !strings.Contains(logs, want) {
+			t.Fatalf("expected rate-limit header %q in logs; logs=\n%s", want, logs)
+		}
+	}
+}
+
+func floatPtr(v float64) *float64 { return &v }
+
+// TestClaudeUsageWindowsClassifyFiveHourAsShort guards the GTO routing fix:
+// the 5h window must be tagged with its window length so the scheduler treats it
+// as the short window. Without LimitWindowSeconds the scheduler could not tell
+// the 5h rate limit apart from the 7d one, so ShortHeadroom, the 5h reset, and
+// ExpiryPressure were all dead and the routing calculation ignored the 5h limit.
+func TestClaudeUsageWindowsClassifyFiveHourAsShort(t *testing.T) {
+	usage := &agentclaude.UsageResponse{
+		// 5h window is nearly drained and resets soon; 7d window is healthy.
+		FiveHour: &agentclaude.RateLimit{Utilization: floatPtr(95), ResetsAt: time.Now().Add(30 * time.Minute).Format(time.RFC3339)},
+		SevenDay: &agentclaude.RateLimit{Utilization: floatPtr(10), ResetsAt: time.Now().Add(5 * 24 * time.Hour).Format(time.RFC3339)},
+	}
+	windows := claudeUsageWindows(usage)
+
+	var fiveHour, sevenDay *accounts.UsageWindow
+	for i := range windows {
+		switch windows[i].Name {
+		case "5h":
+			fiveHour = &windows[i]
+		case "7d":
+			sevenDay = &windows[i]
+		}
+	}
+	if fiveHour == nil || sevenDay == nil {
+		t.Fatalf("missing windows: %+v", windows)
+	}
+	if fiveHour.LimitWindowSeconds != 5*60*60 {
+		t.Fatalf("5h LimitWindowSeconds = %d, want %d", fiveHour.LimitWindowSeconds, 5*60*60)
+	}
+	if sevenDay.LimitWindowSeconds != 7*24*60*60 {
+		t.Fatalf("7d LimitWindowSeconds = %d, want %d", sevenDay.LimitWindowSeconds, 7*24*60*60)
+	}
+
+	score := scoreFromUsageWindows(accounts.ProviderClaude, "acct", windows)
+	// Overall headroom is the min remaining (driven by the cooked 5h window).
+	if score.Headroom > 0.06 {
+		t.Fatalf("Headroom = %.3f, want ~0.05 (driven by 5h window)", score.Headroom)
+	}
+	// Short headroom must come from the 5h window specifically.
+	if score.ShortHeadroom > 0.06 {
+		t.Fatalf("ShortHeadroom = %.3f, want ~0.05 from the 5h window", score.ShortHeadroom)
+	}
+	// The 5h reset must be carried so the scheduler can compute expiry pressure.
+	if score.ShortResetAfterSeconds <= 0 {
+		t.Fatalf("ShortResetAfterSeconds = %d, want > 0 (5h reset)", score.ShortResetAfterSeconds)
+	}
+	if score.ExpiryPressure <= 0 {
+		t.Fatal("ExpiryPressure should be > 0 once the 5h window is classified as short")
+	}
+}
+
+// TestClaudeShortWindowDrivesRouting proves the routing calculation now prefers
+// the account with more 5h headroom even when both accounts have identical
+// account-wide (7d) headroom. Before the fix both scored equal short headroom.
+func TestClaudeShortWindowDrivesRouting(t *testing.T) {
+	drained := scoreFromUsageWindows(accounts.ProviderClaude, "drained", claudeUsageWindows(&agentclaude.UsageResponse{
+		FiveHour: &agentclaude.RateLimit{Utilization: floatPtr(90), ResetsAt: time.Now().Add(time.Hour).Format(time.RFC3339)},
+		SevenDay: &agentclaude.RateLimit{Utilization: floatPtr(10), ResetsAt: time.Now().Add(5 * 24 * time.Hour).Format(time.RFC3339)},
+	}))
+	fresh := scoreFromUsageWindows(accounts.ProviderClaude, "fresh", claudeUsageWindows(&agentclaude.UsageResponse{
+		FiveHour: &agentclaude.RateLimit{Utilization: floatPtr(10), ResetsAt: time.Now().Add(time.Hour).Format(time.RFC3339)},
+		SevenDay: &agentclaude.RateLimit{Utilization: floatPtr(10), ResetsAt: time.Now().Add(5 * 24 * time.Hour).Format(time.RFC3339)},
+	}))
+
+	scheduler := selectacct.NewScheduler([]selectacct.Score{drained, fresh})
+	picked, err := scheduler.Pick([]accounts.Account{
+		{ID: "drained", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth},
+		{ID: "fresh", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if picked.ID != "fresh" {
+		t.Fatalf("scheduler picked %q, want fresh (more 5h headroom)", picked.ID)
+	}
+}
+
+func TestClaudeRateLimitHeaderFields(t *testing.T) {
+	header := http.Header{}
+	header.Set("Retry-After", "3600")
+	header.Set("Anthropic-Ratelimit-Unified-Reset", "1750000000")
+	header.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+	header.Set("Content-Type", "application/json")
+	header.Set("X-Should-Not-Appear", "secret")
+
+	fields := claudeRateLimitHeaderFields(header)
+	got := map[string]string{}
+	for i := 0; i+1 < len(fields); i += 2 {
+		got[fields[i].(string)] = fields[i+1].(string)
+	}
+	if got["retry-after"] != "3600" {
+		t.Fatalf("retry-after = %q, want 3600", got["retry-after"])
+	}
+	if got["anthropic-ratelimit-unified-reset"] != "1750000000" {
+		t.Fatalf("reset = %q, want 1750000000", got["anthropic-ratelimit-unified-reset"])
+	}
+	if _, ok := got["content-type"]; ok {
+		t.Fatal("content-type should not be captured as a rate-limit field")
+	}
+	if _, ok := got["x-should-not-appear"]; ok {
+		t.Fatal("unrelated headers must not be captured")
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -683,13 +684,21 @@ func claudeUsageWindows(usage *agentclaude.UsageResponse) []accounts.UsageWindow
 		return nil
 	}
 	var windows []accounts.UsageWindow
-	add := func(name string, limit *agentclaude.RateLimit) {
+	// LimitWindowSeconds lets the scheduler classify a window as "short"
+	// (<= 6h) versus account-wide. Anthropic's usage endpoint reports
+	// utilization and a reset time but not the window length, so we encode the
+	// known fixed lengths here. Without this the 5h window is never recognized
+	// as short, so ShortHeadroom/ShortResetAfterSeconds/ExpiryPressure stay
+	// dead for every Claude account and the GTO routing calculation ignores the
+	// 5h rate limit (the one that actually bites mid-session).
+	add := func(name string, windowSeconds int64, limit *agentclaude.RateLimit) {
 		if limit == nil || limit.Utilization == nil {
 			return
 		}
 		window := accounts.UsageWindow{
-			Name:        name,
-			UsedPercent: *limit.Utilization,
+			Name:               name,
+			UsedPercent:        *limit.Utilization,
+			LimitWindowSeconds: windowSeconds,
 		}
 		if reset, err := time.Parse(time.RFC3339, limit.ResetsAt); err == nil {
 			seconds := int64(time.Until(reset).Seconds())
@@ -700,10 +709,14 @@ func claudeUsageWindows(usage *agentclaude.UsageResponse) []accounts.UsageWindow
 		}
 		windows = append(windows, window)
 	}
-	add("5h", usage.FiveHour)
-	add("7d", usage.SevenDay)
-	add("opus-weekly", usage.SevenDayOpus)
-	add("sonnet-weekly", usage.SevenDaySonnet)
+	const (
+		fiveHourSeconds = int64(5 * 60 * 60)
+		sevenDaySeconds = int64(7 * 24 * 60 * 60)
+	)
+	add("5h", fiveHourSeconds, usage.FiveHour)
+	add("7d", sevenDaySeconds, usage.SevenDay)
+	add("opus-weekly", sevenDaySeconds, usage.SevenDayOpus)
+	add("sonnet-weekly", sevenDaySeconds, usage.SevenDaySonnet)
 	if usage.ExtraUsage != nil && usage.ExtraUsage.IsEnabled && usage.ExtraUsage.Utilization != nil {
 		windows = append(windows, accounts.UsageWindow{Name: "extra", UsedPercent: *usage.ExtraUsage.Utilization})
 	}
@@ -1803,19 +1816,45 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 	// expired OAuth token with a plain 401, neither with a codex-style
 	// usage-limit body to inspect. Both mean this account can't serve the
 	// request, so drop it from selection and let failover pick another.
-	if provider == accounts.ProviderClaude && accountID != "" && claudeAccountUnusableStatus(response.StatusCode) {
+	claudeUnusable := provider == accounts.ProviderClaude && accountID != "" && claudeAccountUnusableStatus(response.StatusCode)
+	if claudeUnusable {
 		s.markAccountExhausted(provider, accountID)
+		// Surface the genuine upstream rate-limit signal (headers now, body
+		// prefix below). Anthropic conveys subscription exhaustion only via the
+		// status plus these headers and an opaque JSON body, none of which were
+		// logged before, so the actual 429 message was invisible in the wild.
+		if s.Logger != nil {
+			s.Logger.Warn("claude account unusable upstream response",
+				append([]any{
+					"agent", agentType,
+					"session", sessionID,
+					"account", accountID,
+					"path", path,
+					"status", response.StatusCode,
+				}, claudeRateLimitHeaderFields(response.Header)...)...)
+		}
 	}
 	inspectUsageLimit := s.SchedulerRef != nil && accountID != "" && responseStatusCanExhaust(response.StatusCode)
-	if response.Body == nil || (s.Transcripts == nil && s.Logger == nil && !inspectUsageLimit) {
+	if response.Body == nil || (s.Transcripts == nil && s.Logger == nil && !inspectUsageLimit && !claudeUnusable) {
 		return
 	}
 	payload := map[string]any{"status": response.StatusCode}
 	var inspect func([]byte)
-	if inspectUsageLimit {
+	if inspectUsageLimit || claudeUnusable {
+		loggedBody := false
 		inspect = func(body []byte) {
-			if usageLimitJSON(body) {
+			if inspectUsageLimit && usageLimitJSON(body) {
 				s.markAccountExhausted(provider, accountID)
+			}
+			if claudeUnusable && !loggedBody && s.Logger != nil {
+				loggedBody = true
+				s.Logger.Warn("claude account unusable upstream body",
+					"agent", agentType,
+					"session", sessionID,
+					"account", accountID,
+					"path", path,
+					"status", response.StatusCode,
+					"body", string(body))
 			}
 		}
 	}
@@ -2594,6 +2633,30 @@ func claudeAccountUnusableStatus(code int) bool {
 	return code == http.StatusTooManyRequests || code == http.StatusUnauthorized
 }
 
+// claudeRateLimitHeaderFields extracts the upstream rate-limit headers Anthropic
+// returns on a 429/401 (retry-after plus the anthropic-ratelimit-unified-*
+// family) as flat key/value slog fields, so the genuine reset/remaining signal
+// is captured in logs instead of being silently dropped.
+func claudeRateLimitHeaderFields(header http.Header) []any {
+	if header == nil {
+		return nil
+	}
+	type kv struct{ key, value string }
+	pairs := make([]kv, 0, len(header))
+	for key, values := range header {
+		lower := strings.ToLower(key)
+		if lower == "retry-after" || strings.HasPrefix(lower, "anthropic-ratelimit") {
+			pairs = append(pairs, kv{key: lower, value: strings.Join(values, ",")})
+		}
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].key < pairs[j].key })
+	fields := make([]any, 0, len(pairs)*2)
+	for _, pair := range pairs {
+		fields = append(fields, pair.key, pair.value)
+	}
+	return fields
+}
+
 func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	maxAttempts := t.maxAttempts
 	if maxAttempts < 1 {
@@ -2623,6 +2686,13 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 		}
 		if !usageLimited {
 			return response, nil
+		}
+		if t.provider == accounts.ProviderClaude {
+			// Surface the genuine upstream rate-limit signal. The active retry
+			// path consumes this 429 before the passive ModifyResponse capture
+			// runs, so without logging here the real message would be invisible
+			// whenever failover succeeds.
+			t.logClaudeUnusableResponse(response, accountID)
 		}
 		if t.server != nil {
 			t.server.markAccountExhausted(t.provider, accountID)
@@ -2660,6 +2730,44 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 		}
 	}
 	return base.RoundTrip(req)
+}
+
+// logClaudeUnusableResponse logs the upstream rate-limit headers and a bounded
+// body prefix for a Claude 429/401, then restores the body so a final-attempt
+// response can still be returned to the client intact.
+func (t usageLimitRetryTransport) logClaudeUnusableResponse(response *http.Response, accountID string) {
+	if t.logger == nil || response == nil {
+		return
+	}
+	t.logger.Warn("claude account unusable upstream response",
+		append([]any{
+			"agent", t.agent,
+			"session", t.session,
+			"account", accountID,
+			"method", t.method,
+			"path", t.path,
+			"upstream", t.upstream,
+			"status", response.StatusCode,
+		}, claudeRateLimitHeaderFields(response.Header)...)...)
+	if response.Body == nil {
+		return
+	}
+	prefix, err := io.ReadAll(io.LimitReader(response.Body, usageLimitInspectMaxBytes+1))
+	response.Body = prefixReadCloser{
+		Reader: io.MultiReader(bytes.NewReader(prefix), response.Body),
+		Closer: response.Body,
+	}
+	if err != nil {
+		return
+	}
+	t.logger.Warn("claude account unusable upstream body",
+		"agent", t.agent,
+		"session", t.session,
+		"account", accountID,
+		"method", t.method,
+		"path", t.path,
+		"status", response.StatusCode,
+		"body", string(prefix))
 }
 
 func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provider, agentType, sessionID, userEmail string, tried map[string]struct{}) (accounts.Account, error) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1818,7 +1818,13 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 	// request, so drop it from selection and let failover pick another.
 	claudeUnusable := provider == accounts.ProviderClaude && accountID != "" && claudeAccountUnusableStatus(response.StatusCode)
 	if claudeUnusable {
-		s.markAccountExhausted(provider, accountID)
+		// Only poison the routing score when the account is genuinely out of
+		// quota (401, or a 429 the upstream marks "rejected"). A transient
+		// "allowed"/"allowed_warning" 429 still fails over for this request but
+		// must not mark a healthy account exhausted.
+		if claudeAccountExhaustedByResponse(response.StatusCode, response.Header) {
+			s.markAccountExhausted(provider, accountID)
+		}
 		// Surface the genuine upstream rate-limit signal (headers now, body
 		// prefix below). Anthropic conveys subscription exhaustion only via the
 		// status plus these headers and an opaque JSON body, none of which were
@@ -2633,6 +2639,37 @@ func claudeAccountUnusableStatus(code int) bool {
 	return code == http.StatusTooManyRequests || code == http.StatusUnauthorized
 }
 
+// claudeAccountExhaustedByResponse reports whether an upstream response means the
+// account is genuinely out of subscription quota and should be dropped from the
+// routing scheduler (not merely failed over for this one request). A 401 is a
+// dead/expired token. For a 429, Anthropic's authoritative signal is the
+// anthropic-ratelimit-unified-status header: "rejected" means the account is out
+// of quota, while "allowed"/"allowed_warning" mean a transient or
+// non-subscription throttle that must NOT poison a healthy account's score. When
+// the header is absent we fall back to the conservative legacy behavior and
+// treat the 429 as exhaustion.
+func claudeAccountExhaustedByResponse(status int, header http.Header) bool {
+	if status == http.StatusUnauthorized {
+		return true
+	}
+	if status != http.StatusTooManyRequests {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(claudeHeaderGet(header, "anthropic-ratelimit-unified-status"))) {
+	case "allowed", "allowed_warning":
+		return false
+	default:
+		return true
+	}
+}
+
+func claudeHeaderGet(header http.Header, key string) string {
+	if header == nil {
+		return ""
+	}
+	return header.Get(key)
+}
+
 // claudeRateLimitHeaderFields extracts the upstream rate-limit headers Anthropic
 // returns on a 429/401 (retry-after plus the anthropic-ratelimit-unified-*
 // family) as flat key/value slog fields, so the genuine reset/remaining signal
@@ -2687,14 +2724,18 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 		if !usageLimited {
 			return response, nil
 		}
+		exhausted := true
 		if t.provider == accounts.ProviderClaude {
 			// Surface the genuine upstream rate-limit signal. The active retry
 			// path consumes this 429 before the passive ModifyResponse capture
 			// runs, so without logging here the real message would be invisible
 			// whenever failover succeeds.
 			t.logClaudeUnusableResponse(response, accountID)
+			// Only poison the score on genuine quota exhaustion; a transient
+			// "allowed"/"allowed_warning" 429 still fails over for this request.
+			exhausted = claudeAccountExhaustedByResponse(response.StatusCode, response.Header)
 		}
-		if t.server != nil {
+		if t.server != nil && exhausted {
 			t.server.markAccountExhausted(t.provider, accountID)
 		}
 		if attempt == maxAttempts || t.server == nil {


### PR DESCRIPTION
Two related Claude gaps, with the rate-limit reproduction the user asked for baked into the tests.

## 1. GTO routing now accounts for the 5h rate limit
`claudeUsageWindows()` never set `LimitWindowSeconds`, so `selectacct` could not classify Claude's 5h window as a short window (`isShortWindow` returns false when the length is 0). That left `ShortHeadroom`, the 5h reset, and `ExpiryPressure` dead for every Claude account, so the routing calculation effectively ignored the 5h limit (the one that bites mid-session) and only saw the min across all windows. This encodes the known window lengths (5h, 7d, weekly) so the 5h limit drives short-headroom and expiry-pressure.

## 2. The genuine rate-limit message is now captured
Anthropic signals subscription exhaustion with a plain 429 (and a dead/expired token with a 401), carrying `retry-after` / `anthropic-ratelimit-unified-*` headers and an opaque JSON body. None of it was logged. Worse, the active failover transport consumed the 429 before the passive response-capture ran, so whenever failover succeeded the message was invisible.

Now both paths log the status, the rate-limit headers, and a bounded body prefix (preserving the body so a final-attempt response still reaches the client). Validated live against `api.anthropic.com`: the capture fired on the real wire (caught the genuine `authentication_error` envelope as failover walked accounts). A real 429 travels the identical `claudeAccountUnusableStatus` path.

## Failover
Routing to another Claude account on 429/401 already existed (`usageLimitRetryTransport`). This PR adds an end-to-end regression test through `Server.Handler()` with a mock 429 upstream proving traffic moves to a second account and the message is captured.

## Tests
- `TestClaude429FailoverEndToEndAndCaptured` — full Handler path: 429 on account A, fail over to B (200), assert the body + headers are logged.
- `TestClaudeUsageWindowsClassifyFiveHourAsShort` — 5h window tagged as short, drives ShortHeadroom/reset/ExpiryPressure.
- `TestClaudeShortWindowDrivesRouting` — scheduler prefers the account with more 5h headroom at equal 7d headroom.
- `TestClaudeRateLimitHeaderFields` — only rate-limit headers are extracted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784935431&installation_id=133855650&pr_number=24&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F24&signature=06937d403a6fced9f6f7e0db673c910c43b9ffe88afac802585366bd5b715727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Claude routing honor the 5-hour window and surface real Anthropic 429/401 details, while avoiding score poisoning on transient throttles. This improves mid-session account selection and makes failovers debuggable.

- **Bug Fixes**
  - Routing: set `LimitWindowSeconds` for Claude windows (`5h`, `7d`, weekly) so `ShortHeadroom`, short reset, and expiry pressure work; scheduler now prefers more 5h headroom.
  - Observability: on 429/401, log status, `retry-after`, and `anthropic-ratelimit-unified-*` plus a bounded body prefix; done in both the retry transport and passive capture while preserving the body; only rate-limit headers are extracted.
  - Exhaustion gating: mark a Claude account exhausted only on 401 or a 429 with unified-status not `allowed`/`allowed_warning` (or if the header is missing); transient throttles still fail over but do not poison the score.
  - Failover: verified end-to-end that a 429 on account A fails over to B and the upstream headers/body are captured.

<sup>Written for commit 056737171334846ae6133f54a42211bb9fc0309d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude request routing when rate limits are hit, helping requests fail over more reliably to another available account.
  * Refined how Claude quota status is interpreted so temporary rate-limit warnings no longer incorrectly mark an account as exhausted.
  * Better distinguishes genuine quota exhaustion from recoverable responses, reducing unnecessary routing penalties.
  * Added more precise rate-limit response handling, including cleaner capture of relevant retry and quota headers for diagnosis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->