### PR TITLE
Log when a Claude rate-limit reaches the client after failover gives up

### DIFF
--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -305,10 +305,15 @@ func TestClaudeFailoverExhaustionIsLogged(t *testing.T) {
 	}}
 	var logBuf bytes.Buffer
 	server.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	// maxAttempts=2 with the 2-account server forces the max_attempts give-up
+	// path specifically: attempt 1 (cooked) fails over to fresh, attempt 2
+	// (fresh) hits attempt==maxAttempts and returns via the max_attempts branch
+	// BEFORE oauthRetryAccount could report no_alternate_account. This is the
+	// path that previously failed silently.
 	transport := usageLimitRetryTransport{
 		base: stub, server: &server, logger: server.Logger, provider: accounts.ProviderClaude,
 		agent: "claude", session: "session-x", account: "cooked@example.com",
-		method: http.MethodPost, path: "/v1/messages", maxAttempts: 3,
+		method: http.MethodPost, path: "/v1/messages", maxAttempts: 2,
 	}
 	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader([]byte(`{"model":"claude-opus-4-8"}`)))
 	if err != nil {
@@ -326,6 +331,11 @@ func TestClaudeFailoverExhaustionIsLogged(t *testing.T) {
 	logs := logBuf.String()
 	if !strings.Contains(logs, "claude rate-limit returned to client after failover exhausted") {
 		t.Fatalf("expected the client-facing failover-exhaustion signal; logs=\n%s", logs)
+	}
+	// Assert the path is specifically max_attempts (not no_alternate_account), so
+	// removing the new max_attempts logging call would fail this test.
+	if !strings.Contains(logs, "reason=max_attempts") {
+		t.Fatalf("expected reason=max_attempts in the failover-exhaustion log; logs=\n%s", logs)
 	}
 }
 

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -287,6 +287,48 @@ func TestClaudeTransient429FailsOverWithoutPoisoningScore(t *testing.T) {
 	}
 }
 
+// TestClaudeFailoverExhaustionIsLogged guards the monitoring contract: when
+// every failover attempt is rate-limited and the client ends up with a 429, the
+// single authoritative failure signal must be logged even though no
+// "no alternate account" error occurred (the maxAttempts cap was hit first).
+func TestClaudeFailoverExhaustionIsLogged(t *testing.T) {
+	server, store := claudeFailoverServer(t)
+	if _, err := store.Put("claude", "session-x", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	// Every account the server can pick returns a rejected 429, so failover
+	// never finds a healthy account and the client gets a 429.
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		h := http.Header{}
+		h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		return &http.Response{StatusCode: http.StatusTooManyRequests, Header: h, Body: io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}`))}
+	}}
+	var logBuf bytes.Buffer
+	server.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	transport := usageLimitRetryTransport{
+		base: stub, server: &server, logger: server.Logger, provider: accounts.ProviderClaude,
+		agent: "claude", session: "session-x", account: "cooked@example.com",
+		method: http.MethodPost, path: "/v1/messages", maxAttempts: 3,
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader([]byte(`{"model":"claude-opus-4-8"}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (all accounts rate-limited)", response.StatusCode)
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, "claude rate-limit returned to client after failover exhausted") {
+		t.Fatalf("expected the client-facing failover-exhaustion signal; logs=\n%s", logs)
+	}
+}
+
 func TestClaudeRateLimitHeaderFields(t *testing.T) {
 	header := http.Header{}
 	header.Set("Retry-After", "3600")

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2739,6 +2739,11 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			t.server.markAccountExhausted(t.provider, accountID)
 		}
 		if attempt == maxAttempts || t.server == nil {
+			reason := "max_attempts"
+			if t.server == nil {
+				reason = "no_server"
+			}
+			t.logClaudeFailoverExhausted(response, accountID, reason, attempt, maxAttempts, len(tried))
 			return response, nil
 		}
 		nextAccount, pickErr := t.server.oauthRetryAccount(req.Context(), t.provider, t.agent, t.session, t.userEmail, tried)
@@ -2746,6 +2751,7 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			if t.logger != nil {
 				t.logger.Warn("usage-limit retry has no alternate account", "agent", t.agent, "session", t.session, "account", accountID, "method", t.method, "path", t.path, "upstream", t.upstream, "error", pickErr)
 			}
+			t.logClaudeFailoverExhausted(response, accountID, "no_alternate_account", attempt, maxAttempts, len(tried))
 			return response, nil
 		}
 		body, bodyErr := req.GetBody()
@@ -2753,6 +2759,7 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			if t.logger != nil {
 				t.logger.Warn("usage-limit retry could not replay request body", "agent", t.agent, "session", t.session, "account", accountID, "method", t.method, "path", t.path, "upstream", t.upstream, "error", bodyErr)
 			}
+			t.logClaudeFailoverExhausted(response, accountID, "replay_failed", attempt, maxAttempts, len(tried))
 			return response, nil
 		}
 		if response.Body != nil {
@@ -2771,6 +2778,35 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 		}
 	}
 	return base.RoundTrip(req)
+}
+
+// logClaudeFailoverExhausted emits the single authoritative signal that a Claude
+// rate-limit (or 401) is being returned to the client because failover gave up.
+// "no alternate account" and a silent maxAttempts exhaustion are both failures
+// from the client's view, but only the former was logged before, so a request
+// that burned through maxAttempts while untried accounts still had quota failed
+// invisibly. Monitoring keys on this one string; tried_accounts vs the account
+// pool tells whether quota may have remained elsewhere.
+func (t usageLimitRetryTransport) logClaudeFailoverExhausted(response *http.Response, accountID, reason string, attempt, maxAttempts, triedCount int) {
+	if t.logger == nil || t.provider != accounts.ProviderClaude {
+		return
+	}
+	status := 0
+	if response != nil {
+		status = response.StatusCode
+	}
+	t.logger.Warn("claude rate-limit returned to client after failover exhausted",
+		"agent", t.agent,
+		"session", t.session,
+		"final_account", accountID,
+		"reason", reason,
+		"status", status,
+		"attempts", attempt,
+		"max_attempts", maxAttempts,
+		"tried_accounts", triedCount,
+		"method", t.method,
+		"path", t.path,
+		"upstream", t.upstream)
 }
 
 // logClaudeUnusableResponse logs the upstream rate-limit headers and a bounded


### PR DESCRIPTION
Closes a monitoring blind spot found while standing up live rate-limit monitoring on subrouter-team (v0.1.21).

The replayable retry transport (`usageLimitRetryTransport`) can hit its `maxAttempts` cap (6) with every attempt rate-limited and return the 429 to the client. Only the `no alternate account` give-up path was logged, so a request that burned through `maxAttempts` while untried lower-scored accounts still had quota failed **invisibly**, which is exactly the "rate-limited and failed to reroute while quota exists" case we want to catch.

Now all three give-up paths emit one authoritative signal — `claude rate-limit returned to client after failover exhausted` — with `reason` (`max_attempts` / `no_alternate_account` / `replay_failed`), final account, status, attempts, and `tried_accounts` so the on-call can tell whether quota likely remained on untried accounts.

Purely additive logging; no routing/behavior change. Test: `TestClaudeFailoverExhaustionIsLogged` drives every account to a rejected 429 and asserts the signal fires when the client ends up with a 429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784945089&installation_id=133855650&pr_number=25&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F25&signature=10d16e5e144120b09819b9a15fe31401886140083e390cfb3d7c034e76a72375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single authoritative log when a Claude 429 reaches the client after failover gives up, closing a monitoring blind spot. No routing or behavior changes.

- **Bug Fixes**
  - Emit "claude rate-limit returned to client after failover exhausted" on all give-up paths: `max_attempts`, `no_alternate_account`, `replay_failed`, `no_server`.
  - Log fields: `reason`, `final_account`, `status`, `attempts`, `max_attempts`, `tried_accounts`, `method`, `path`, `upstream`, `agent`, `session`.
  - Test `TestClaudeFailoverExhaustionIsLogged` now forces the `max_attempts` path and asserts `reason=max_attempts` to prevent regressions.

<sup>Written for commit 7ecfe5dbe330b39421dbea92bcefbf1a1a3272cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude failover handling so a clear warning is logged whenever retries are exhausted, including when no alternate account is available, retry limits are hit, or the request can’t be replayed.
  * Preserved the final rate-limited response to the client while making exhaustion events easier to detect in logs.

* **Tests**
  * Added coverage to verify the failover-exhausted logging behavior when all retry attempts are rate-limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->