### PR TITLE
Fail over Claude accounts on unified-status=rejected, even on a 200

### DIFF
--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -452,6 +452,43 @@ func TestClaudeAllowedHeaderOn200DoesNotFailOver(t *testing.T) {
 	}
 }
 
+// TestClaudeRejectedNon429StatusDoesNotLogBody locks the logging scope: a
+// rejected-header response on a status other than 429/401 (here a 500) must fail
+// over but never have its body logged, since that body is not a known rate-limit
+// envelope and may contain request/error detail.
+func TestClaudeRejectedNon429StatusDoesNotLogBody(t *testing.T) {
+	server, store := claudeFailoverServer(t)
+	if _, err := store.Put("claude", "session-5xx", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	const secret = "SENSITIVE_5XX_BODY"
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		if strings.Contains(req.Header.Get("Authorization"), "tok-cooked") {
+			h := http.Header{}
+			h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+			return &http.Response{StatusCode: http.StatusInternalServerError, Header: h, Body: io.NopCloser(strings.NewReader(secret))}
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(`{"id":"ok"}`))}
+	}}
+	var logBuf bytes.Buffer
+	server.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	transport := usageLimitRetryTransport{
+		base: stub, server: &server, logger: server.Logger, provider: accounts.ProviderClaude,
+		agent: "claude", session: "session-5xx", account: "cooked@example.com",
+		method: http.MethodPost, path: "/v1/messages", maxAttempts: 3,
+	}
+	req, _ := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader([]byte(`{"model":"claude-opus-4-8"}`)))
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if strings.Contains(logBuf.String(), secret) {
+		t.Fatalf("leaked a non-rate-limit 5xx body into logs; logs=\n%s", logBuf.String())
+	}
+}
+
 func TestClaudeRateLimitHeaderFields(t *testing.T) {
 	header := http.Header{}
 	header.Set("Retry-After", "3600")

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -339,6 +339,103 @@ func TestClaudeFailoverExhaustionIsLogged(t *testing.T) {
 	}
 }
 
+// TestClaudeRejectedHeaderOn200FailsOver is the Aziz regression: a depleted
+// account answers 200 via overage but sets anthropic-ratelimit-unified-status:
+// rejected, which Claude Code hard-blocks on. subrouter must treat that 200 as
+// unusable, fail over to a healthy account, return the healthy (allowed)
+// response to the client, and mark the depleted account exhausted.
+func TestClaudeRejectedHeaderOn200FailsOver(t *testing.T) {
+	server, store := claudeFailoverServer(t)
+	if _, err := store.Put("claude", "session-rej", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	var cookedHits, freshHits int
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		if strings.Contains(req.Header.Get("Authorization"), "tok-cooked") {
+			cookedHits++
+			h := http.Header{}
+			// 200 OK, but Anthropic flags the account out of quota (served via overage).
+			h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+			h.Set("Anthropic-Ratelimit-Unified-Overage-In-Use", "true")
+			return &http.Response{StatusCode: http.StatusOK, Header: h, Body: io.NopCloser(strings.NewReader(`{"id":"msg_overage"}`))}
+		}
+		freshHits++
+		h := http.Header{}
+		h.Set("Anthropic-Ratelimit-Unified-Status", "allowed")
+		return &http.Response{StatusCode: http.StatusOK, Header: h, Body: io.NopCloser(strings.NewReader(`{"id":"msg_fresh"}`))}
+	}}
+	transport := usageLimitRetryTransport{
+		base: stub, server: &server, provider: accounts.ProviderClaude,
+		agent: "claude", session: "session-rej", account: "cooked@example.com",
+		method: http.MethodPost, path: "/v1/messages", maxAttempts: 3,
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader([]byte(`{"model":"claude-opus-4-8"}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", response.StatusCode)
+	}
+	// The client must receive the healthy account's response, not the rejected one.
+	if !strings.Contains(string(body), "msg_fresh") {
+		t.Fatalf("client got %q, want the healthy account's response", string(body))
+	}
+	if response.Header.Get("Anthropic-Ratelimit-Unified-Status") != "allowed" {
+		t.Fatalf("client header status = %q, want allowed", response.Header.Get("Anthropic-Ratelimit-Unified-Status"))
+	}
+	if cookedHits != 1 || freshHits != 1 {
+		t.Fatalf("hits cooked=%d fresh=%d, want 1/1 (rejected 200 then failover)", cookedHits, freshHits)
+	}
+	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
+		t.Fatal("a rejected-header 200 must mark the depleted account exhausted")
+	}
+	assignment, ok := store.Get("claude", "session-rej")
+	if !ok || assignment.AccountID != "fresh@example.com" {
+		t.Fatalf("sticky assignment = %+v, want moved to fresh@example.com", assignment)
+	}
+}
+
+// TestClaudeAllowedHeaderOn200DoesNotFailOver guards against over-rerouting: a
+// normal 200 with allowed/allowed_warning must pass straight through.
+func TestClaudeAllowedHeaderOn200DoesNotFailOver(t *testing.T) {
+	server, store := claudeFailoverServer(t)
+	if _, err := store.Put("claude", "session-ok", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	var hits int
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		hits++
+		h := http.Header{}
+		h.Set("Anthropic-Ratelimit-Unified-Status", "allowed_warning")
+		return &http.Response{StatusCode: http.StatusOK, Header: h, Body: io.NopCloser(strings.NewReader(`{"id":"msg_ok"}`))}
+	}}
+	transport := usageLimitRetryTransport{
+		base: stub, server: &server, provider: accounts.ProviderClaude,
+		agent: "claude", session: "session-ok", account: "cooked@example.com",
+		method: http.MethodPost, path: "/v1/messages", maxAttempts: 3,
+	}
+	req, _ := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader([]byte(`{"model":"claude-opus-4-8"}`)))
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if hits != 1 {
+		t.Fatalf("upstream hits = %d, want 1 (no failover on allowed_warning)", hits)
+	}
+	if server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
+		t.Fatal("allowed_warning must not mark the account exhausted")
+	}
+}
+
 func TestClaudeRateLimitHeaderFields(t *testing.T) {
 	header := http.Header{}
 	header.Set("Retry-After", "3600")

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -350,6 +350,7 @@ func TestClaudeRejectedHeaderOn200FailsOver(t *testing.T) {
 		t.Fatal(err)
 	}
 	var cookedHits, freshHits int
+	const secretCompletion = "SECRET_USER_COMPLETION_CONTENT"
 	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
 		if strings.Contains(req.Header.Get("Authorization"), "tok-cooked") {
 			cookedHits++
@@ -357,15 +358,18 @@ func TestClaudeRejectedHeaderOn200FailsOver(t *testing.T) {
 			// 200 OK, but Anthropic flags the account out of quota (served via overage).
 			h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
 			h.Set("Anthropic-Ratelimit-Unified-Overage-In-Use", "true")
-			return &http.Response{StatusCode: http.StatusOK, Header: h, Body: io.NopCloser(strings.NewReader(`{"id":"msg_overage"}`))}
+			// A rejected 200 carries a real completion; it must never be logged.
+			return &http.Response{StatusCode: http.StatusOK, Header: h, Body: io.NopCloser(strings.NewReader(`{"id":"msg_overage","text":"` + secretCompletion + `"}`))}
 		}
 		freshHits++
 		h := http.Header{}
 		h.Set("Anthropic-Ratelimit-Unified-Status", "allowed")
 		return &http.Response{StatusCode: http.StatusOK, Header: h, Body: io.NopCloser(strings.NewReader(`{"id":"msg_fresh"}`))}
 	}}
+	var logBuf bytes.Buffer
+	server.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	transport := usageLimitRetryTransport{
-		base: stub, server: &server, provider: accounts.ProviderClaude,
+		base: stub, server: &server, logger: server.Logger, provider: accounts.ProviderClaude,
 		agent: "claude", session: "session-rej", account: "cooked@example.com",
 		method: http.MethodPost, path: "/v1/messages", maxAttempts: 3,
 	}
@@ -399,6 +403,18 @@ func TestClaudeRejectedHeaderOn200FailsOver(t *testing.T) {
 	assignment, ok := store.Get("claude", "session-rej")
 	if !ok || assignment.AccountID != "fresh@example.com" {
 		t.Fatalf("sticky assignment = %+v, want moved to fresh@example.com", assignment)
+	}
+	// Privacy: the rejected 200's completion body must never be logged.
+	logs := logBuf.String()
+	if strings.Contains(logs, secretCompletion) {
+		t.Fatalf("leaked Claude completion content into logs; logs=\n%s", logs)
+	}
+	if strings.Contains(logs, "claude account unusable upstream body") {
+		t.Fatalf("must not log a body for a 2xx rejected response; logs=\n%s", logs)
+	}
+	// But the rejected signal itself (headers) should still be captured.
+	if !strings.Contains(logs, "claude account unusable upstream response") {
+		t.Fatalf("expected the rejected-header signal to be logged; logs=\n%s", logs)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1816,12 +1816,17 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 	// expired OAuth token with a plain 401, neither with a codex-style
 	// usage-limit body to inspect. Both mean this account can't serve the
 	// request, so drop it from selection and let failover pick another.
-	claudeUnusable := provider == accounts.ProviderClaude && accountID != "" && claudeAccountUnusableStatus(response.StatusCode)
+	// A 429/401 is unusable by status; a 200 carrying
+	// anthropic-ratelimit-unified-status=rejected is also unusable, because the
+	// account is depleted (served via overage) and Claude Code hard-blocks the
+	// user on that header even though the request "succeeded".
+	claudeUnusable := provider == accounts.ProviderClaude && accountID != "" &&
+		(claudeAccountUnusableStatus(response.StatusCode) || claudeResponseRejected(response.Header))
 	if claudeUnusable {
 		// Only poison the routing score when the account is genuinely out of
-		// quota (401, or a 429 the upstream marks "rejected"). A transient
-		// "allowed"/"allowed_warning" 429 still fails over for this request but
-		// must not mark a healthy account exhausted.
+		// quota (401, a 429 the upstream marks "rejected", or any response with
+		// the rejected header). A transient "allowed"/"allowed_warning" 429 still
+		// fails over for this request but must not mark a healthy account exhausted.
 		if claudeAccountExhaustedByResponse(response.StatusCode, response.Header) {
 			s.markAccountExhausted(provider, accountID)
 		}
@@ -2624,7 +2629,16 @@ type usageLimitRetryTransport struct {
 // by status alone.
 func (t usageLimitRetryTransport) responseUsageLimited(response *http.Response) (bool, error) {
 	if t.provider == accounts.ProviderClaude {
-		return response != nil && claudeAccountUnusableStatus(response.StatusCode), nil
+		if response == nil {
+			return false, nil
+		}
+		// Fail over on a hard status (429/401) OR on the authoritative
+		// out-of-quota header even when the upstream answered 200 via overage.
+		// Anthropic serves a "rejected" account through paid overage and returns
+		// 200, but Claude Code reads anthropic-ratelimit-unified-status=rejected
+		// and hard-blocks the user, so a 200 from a rejected account is unusable
+		// from the client's view and must be rerouted to a healthy account.
+		return claudeAccountUnusableStatus(response.StatusCode) || claudeResponseRejected(response.Header), nil
 	}
 	return responseUsageLimit(response)
 }
@@ -2647,20 +2661,35 @@ func claudeAccountUnusableStatus(code int) bool {
 // of quota, while "allowed"/"allowed_warning" mean a transient or
 // non-subscription throttle that must NOT poison a healthy account's score. When
 // the header is absent we fall back to the conservative legacy behavior and
-// treat the 429 as exhaustion.
+// treat the 429 as exhaustion. A "rejected" header marks the account exhausted
+// regardless of HTTP status, because Anthropic answers a depleted account with
+// 200 via overage while still reporting rejected.
 func claudeAccountExhaustedByResponse(status int, header http.Header) bool {
 	if status == http.StatusUnauthorized {
 		return true
 	}
-	if status != http.StatusTooManyRequests {
-		return false
-	}
-	switch strings.ToLower(strings.TrimSpace(claudeHeaderGet(header, "anthropic-ratelimit-unified-status"))) {
-	case "allowed", "allowed_warning":
-		return false
-	default:
+	switch claudeUnifiedStatus(header) {
+	case "rejected":
 		return true
+	case "allowed", "allowed_warning":
+		// Healthy or merely warned; a 429 here is a transient/non-subscription
+		// throttle that must not poison the account's routing score.
+		return false
 	}
+	// Header absent: conservative legacy behavior, treat a 429 as exhaustion.
+	return status == http.StatusTooManyRequests
+}
+
+// claudeUnifiedStatus returns the lowercased anthropic-ratelimit-unified-status
+// header ("allowed" | "allowed_warning" | "rejected"), or "" when absent.
+func claudeUnifiedStatus(header http.Header) string {
+	return strings.ToLower(strings.TrimSpace(claudeHeaderGet(header, "anthropic-ratelimit-unified-status")))
+}
+
+// claudeResponseRejected reports whether Anthropic flagged the account as out of
+// quota for this response, even if it answered 200 via overage.
+func claudeResponseRejected(header http.Header) bool {
+	return claudeUnifiedStatus(header) == "rejected"
 }
 
 func claudeHeaderGet(header http.Header, key string) string {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1857,10 +1857,11 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 			if inspectUsageLimit && usageLimitJSON(body) {
 				s.markAccountExhausted(provider, accountID)
 			}
-			// Only log the body for error responses. A rejected-header 200
-			// (overage) is a real Claude completion, so logging its body would
-			// leak user/model content; the headers already carry the signal.
-			if claudeUnusable && response.StatusCode >= 400 && !loggedBody && s.Logger != nil {
+			// Only log the body for the original hard rate-limit statuses
+			// (429/401), whose body is a known rate-limit/auth error envelope. A
+			// rejected-header response on any other status (a 200 overage
+			// completion, or an unrelated 4xx/5xx) must not have its body logged.
+			if claudeUnusable && claudeAccountUnusableStatus(response.StatusCode) && !loggedBody && s.Logger != nil {
 				loggedBody = true
 				s.Logger.Warn("claude account unusable upstream body",
 					"agent", agentType,
@@ -2858,11 +2859,12 @@ func (t usageLimitRetryTransport) logClaudeUnusableResponse(response *http.Respo
 			"upstream", t.upstream,
 			"status", response.StatusCode,
 		}, claudeRateLimitHeaderFields(response.Header)...)...)
-	// Never read or log a 2xx body: a rejected-header 200 (served via overage)
-	// contains a real Claude completion, so logging it would leak user/model
-	// content. Only error responses carry a rate-limit error envelope worth
-	// capturing; the headers above already convey the rejected signal.
-	if response.Body == nil || response.StatusCode < 400 {
+	// Only the original hard rate-limit statuses (429/401) carry a known
+	// rate-limit/auth error envelope worth logging. A rejected-header response on
+	// any other status (a 200 served via overage, or an unrelated 4xx/5xx that
+	// merely carries the header) may contain a real completion or request details,
+	// so log headers only; the headers above already convey the rejected signal.
+	if response.Body == nil || !claudeAccountUnusableStatus(response.StatusCode) {
 		return
 	}
 	prefix, err := io.ReadAll(io.LimitReader(response.Body, usageLimitInspectMaxBytes+1))

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1857,7 +1857,10 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 			if inspectUsageLimit && usageLimitJSON(body) {
 				s.markAccountExhausted(provider, accountID)
 			}
-			if claudeUnusable && !loggedBody && s.Logger != nil {
+			// Only log the body for error responses. A rejected-header 200
+			// (overage) is a real Claude completion, so logging its body would
+			// leak user/model content; the headers already carry the signal.
+			if claudeUnusable && response.StatusCode >= 400 && !loggedBody && s.Logger != nil {
 				loggedBody = true
 				s.Logger.Warn("claude account unusable upstream body",
 					"agent", agentType,
@@ -2855,7 +2858,11 @@ func (t usageLimitRetryTransport) logClaudeUnusableResponse(response *http.Respo
 			"upstream", t.upstream,
 			"status", response.StatusCode,
 		}, claudeRateLimitHeaderFields(response.Header)...)...)
-	if response.Body == nil {
+	// Never read or log a 2xx body: a rejected-header 200 (served via overage)
+	// contains a real Claude completion, so logging it would leak user/model
+	// content. Only error responses carry a rate-limit error envelope worth
+	// capturing; the headers above already convey the rejected signal.
+	if response.Body == nil || response.StatusCode < 400 {
 		return
 	}
 	prefix, err := io.ReadAll(io.LimitReader(response.Body, usageLimitInspectMaxBytes+1))


### PR DESCRIPTION
## The bug (real user, found live on subrouter-team)

A user routed through subrouter was getting hard rate-limit blocks in Claude Code while subrouter logged **zero 429s**. Root cause, confirmed by probing the live server:

A depleted Claude account does **not** return 429. Anthropic answers **HTTP 200 via paid overage** but sets:
```
Anthropic-Ratelimit-Unified-Status: rejected
Anthropic-Ratelimit-Unified-7d-Status: rejected   (utilization 1.0, threshold surpassed)
Anthropic-Ratelimit-Unified-Overage-In-Use: true
```
Claude Code reads `unified-status: rejected` and **hard-blocks the user**, while subrouter, keying only on HTTP 429/401, saw a 200, never rerouted, and kept the session sticky-pinned to the dead account.

## The fix

Treat a `rejected` unified-status as account-unusable **regardless of HTTP status**:
- The retry transport (`usageLimitRetryTransport`) now fails over a `rejected` 200 to a healthy account, so the client receives the **healthy account's `allowed` response** instead of the blocked one.
- Both the active retry path and the passive capture path **mark the depleted account exhausted**, so the scheduler stops routing to it.
- `allowed` / `allowed_warning` still pass straight through (no over-rerouting on soft warnings).

## Tests
- `TestClaudeRejectedHeaderOn200FailsOver` — a rejected-header 200 fails over to a healthy account, client gets the `allowed` response, source marked exhausted, session moved.
- `TestClaudeAllowedHeaderOn200DoesNotFailOver` — `allowed_warning` 200 passes through untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785007807&installation_id=133855650&pr_number=26&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F26&signature=3675710c002c7e9f563374520994a4a395a9ea8ee7d1865bcf4b2b196611f2d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail over Claude accounts when Anthropic returns `Anthropic-Ratelimit-Unified-Status: rejected`, even on HTTP 200, so users aren’t hard-blocked and sessions move to a healthy account. Also mark depleted accounts exhausted and restrict body logging to 429/401 to avoid leaking completions or error details.

- **Bug Fixes**
  - In `usageLimitRetryTransport`, treat `unified-status: rejected` as unusable regardless of status and fail over immediately.
  - Mark accounts exhausted on `rejected` (any status) or 401; `allowed`/`allowed_warning` never poison; same logic applied in passive capture so the scheduler stops routing to depleted accounts.
  - Log bodies only for 429/401; for `rejected` 200s and any other non-429/401 statuses, log headers only to protect user/model content.
  - Tests cover failover on `rejected` 200, no failover on `allowed_warning` 200, and no body leakage for `rejected` 200 and `rejected` 500.

<sup>Written for commit 97f02a9bc5f87f4a3db706afb4d5d90082afcb23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude requests now handle unified rate-limit status headers more accurately, including successful responses that indicate rejection.
  * Routing now fails over to a healthy upstream when a Claude response is marked rejected, even if the HTTP status is 200.
  * Responses marked allowed or allowed_warning no longer trigger failover or exhaustion handling.
  * Added coverage for both rejected and allowed unified-status cases to confirm the expected routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->