### PR TITLE
Install the Claude reroute self-verifier on VM provision (rebuild-durable)

### DIFF
--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -132,3 +132,26 @@ sudo systemctl restart subrouter
 
 The mirror runs inside the Subrouter daemon through the GCS JSON API.
 Upload failures are logged and retried; request proxying never waits for GCS. Local cleanup only runs after a successful GCS sync and archives each pruned file under `_archive/` first.
+
+## Claude rate-limit reroute self-verifier
+
+`subrouter-verify.{sh,service,timer}` is a durable self-check for the Claude
+rate-limit reroute (a depleted account answers 200 via overage with
+`anthropic-ratelimit-unified-status: rejected`; subrouter must reroute to a
+healthy account). The systemd timer runs every 5 minutes and, all from the VM:
+
+- asserts the passive invariant (a rate-limit reaching the client after failover
+  gave up while healthy accounts existed is an ALERT),
+- watches for contract drift (Claude HTTP 429s reappearing, or any unknown
+  `anthropic-ratelimit-unified-status` value),
+- checks service health/version, and
+- runs an hourly canary that pins one tiny request to a cooked account and
+  asserts the client is not `rejected`.
+
+`startup.sh` installs and enables it on provision, so VM rebuilds keep it.
+Verdicts go to `journalctl -u subrouter-verify` and
+`/var/lib/subrouter-verify/{status.json,alerts.log}`. Watch alerts with:
+
+```bash
+journalctl -u subrouter-verify -f | grep '\[ALERT\]'
+```

--- a/deploy/gcp/startup.sh
+++ b/deploy/gcp/startup.sh
@@ -43,3 +43,16 @@ WantedBy=multi-user.target
 UNIT
 
 systemctl enable --now subrouter-tailnet-egress-block.service
+
+# Install the Claude rate-limit reroute self-verifier so it survives VM rebuilds.
+# Best-effort: a fetch failure must never abort provisioning of the proxy itself.
+install_subrouter_verify() {
+  local base="https://raw.githubusercontent.com/manaflow-ai/subrouter/main/deploy/gcp"
+  curl -fsSL "${base}/subrouter-verify.sh" -o /usr/local/bin/subrouter-verify.sh || return 1
+  chmod 0755 /usr/local/bin/subrouter-verify.sh
+  curl -fsSL "${base}/subrouter-verify.service" -o /etc/systemd/system/subrouter-verify.service || return 1
+  curl -fsSL "${base}/subrouter-verify.timer" -o /etc/systemd/system/subrouter-verify.timer || return 1
+  systemctl daemon-reload
+  systemctl enable --now subrouter-verify.timer
+}
+install_subrouter_verify || echo "startup: subrouter-verify install failed (non-fatal)"

--- a/deploy/gcp/subrouter-verify.service
+++ b/deploy/gcp/subrouter-verify.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Subrouter Claude rate-limit reroute self-verification
+After=subrouter.service
+Wants=subrouter.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/subrouter-verify.sh
+User=root
+Nice=10

--- a/deploy/gcp/subrouter-verify.sh
+++ b/deploy/gcp/subrouter-verify.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# subrouter-verify: durable self-verification of the Claude rate-limit reroute.
+#
+# Runs from a systemd timer on subrouter-team. All checks are passive (read the
+# subrouter journal + loopback status endpoints) except an hourly canary that
+# pins one tiny request to a cooked account and asserts the client is rerouted.
+#
+# Output: ALERT/INFO/OK lines go to this unit's journal (journalctl -u
+# subrouter-verify) and append to /var/lib/subrouter-verify/alerts.log; a
+# machine-readable summary is written to /var/lib/subrouter-verify/status.json.
+set -uo pipefail
+
+UNIT="subrouter.service"
+HEALTH="http://127.0.0.1:31415/_subrouter/health"
+USAGE="http://127.0.0.1:31415/_subrouter/usage-status"
+PROXY="http://127.0.0.1:31415/v1/messages"
+STATE=/var/lib/subrouter-verify
+CURSOR="$STATE/cursor"
+CANARY_STAMP="$STATE/canary.last"
+ALERTS="$STATE/alerts.log"
+STATUS="$STATE/status.json"
+mkdir -p "$STATE"
+
+now_epoch=$(date -u +%s)
+now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+alerts=0
+
+emit() { # level msg...
+  local level="$1"; shift
+  local line="$now_iso [$level] $*"
+  echo "SUBROUTER-VERIFY $line"
+  echo "$line" >> "$ALERTS"
+  [ "$level" = "ALERT" ] && alerts=$((alerts + 1))
+  return 0
+}
+
+# --- healthy Claude account count from usage-status (for the invariant) ---
+counts=$(curl -fsS "$USAGE" 2>/dev/null | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print("0 0"); sys.exit()
+rows = d if isinstance(d, list) else d.get("accounts", [])
+cl = [x for x in rows if x.get("provider") == "claude"]
+def healthy(x):
+    ws = x.get("windows") or []
+    mx = max([w.get("UsedPercent", 0) for w in ws], default=0)
+    return bool(x.get("auth_valid")) and not x.get("error") and mx < 95
+print(sum(1 for x in cl if healthy(x)), len(cl))
+' 2>/dev/null || echo "0 0")
+healthy_claude=$(awk '{print $1}' <<<"$counts"); : "${healthy_claude:=0}"
+total_claude=$(awk '{print $2}' <<<"$counts"); : "${total_claude:=0}"
+
+# --- 1. health + version (detect a down service or silent rollback) ---
+if ! systemctl is-active --quiet "$UNIT"; then
+  emit ALERT "subrouter service is not active"
+fi
+if ! curl -fsS "$HEALTH" >/dev/null 2>&1; then
+  emit ALERT "subrouter health endpoint not responding"
+fi
+ver=$(cat /etc/subrouter-version 2>/dev/null || echo unknown)
+
+# --- read new journal entries since last run (cursor-file advances itself) ---
+if [ ! -f "$CURSOR" ]; then
+  # Seed to "now" on first run so we do not alert on historical entries.
+  journalctl -u "$UNIT" --cursor-file="$CURSOR" -n0 -o cat >/dev/null 2>&1 || true
+fi
+lines=$(journalctl -u "$UNIT" --cursor-file="$CURSOR" -o cat 2>/dev/null || true)
+
+drift_429=0
+while IFS= read -r l; do
+  [ -z "$l" ] && continue
+  # 2. Failed-reroute invariant: a rate-limit reached the client after failover
+  #    gave up. Real bug only if healthy accounts existed and not all were tried.
+  case "$l" in
+    *"claude rate-limit returned to client after failover exhausted"*)
+      reason=$(sed -n 's/.*reason=\([^ ]*\).*/\1/p' <<<"$l")
+      tried=$(sed -n 's/.*tried_accounts=\([0-9]*\).*/\1/p' <<<"$l"); : "${tried:=0}"
+      if [ "$healthy_claude" -gt 0 ] && [ "$tried" -lt "$total_claude" ]; then
+        emit ALERT "failed reroute while healthy accounts existed: reason=$reason tried=$tried total_claude=$total_claude healthy=$healthy_claude :: $l"
+      else
+        emit INFO "failover exhausted, pool genuinely constrained: reason=$reason tried=$tried healthy=$healthy_claude"
+      fi
+      ;;
+  esac
+  # 3. Contract drift: Claude HTTP 429 reappearing (we handle it, but note it).
+  case "$l" in
+    *"claude account unusable upstream response"*"status=429"*)
+      drift_429=$((drift_429 + 1)) ;;
+  esac
+  # 4. Contract drift: an anthropic-ratelimit-unified-status value we do not know.
+  case "$l" in
+    *"claude account unusable upstream response"*" anthropic-ratelimit-unified-status="*)
+      st=$(sed -n 's/.* anthropic-ratelimit-unified-status=\([a-z_]*\).*/\1/p' <<<"$l")
+      case "$st" in
+        allowed|allowed_warning|rejected|"") : ;;
+        *) emit ALERT "unknown anthropic-ratelimit-unified-status=$st (possible contract drift): $l" ;;
+      esac
+      ;;
+  esac
+done <<<"$lines"
+[ "$drift_429" -gt 0 ] && emit INFO "claude HTTP 429s observed this window (handled): $drift_429"
+
+# --- 5. Canary (hourly, only when a cooked Claude account exists) ---
+last_canary=$(cat "$CANARY_STAMP" 2>/dev/null || echo 0)
+if [ $((now_epoch - last_canary)) -ge 3600 ]; then
+  cooked=$(curl -fsS "$USAGE" 2>/dev/null | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit()
+rows = d if isinstance(d, list) else d.get("accounts", [])
+for x in rows:
+    if x.get("provider") != "claude" or x.get("error"):
+        continue
+    ws = x.get("windows") or []
+    if any(w.get("Name") == "7d" and w.get("UsedPercent", 0) >= 100 for w in ws):
+        print(x.get("id")); break
+' 2>/dev/null)
+  if [ -n "$cooked" ]; then
+    echo "$now_epoch" >"$CANARY_STAMP"
+    st=$(curl -sS -D - -o /dev/null --max-time 30 -X POST "$PROXY" \
+      -H 'X-Subrouter-Agent: claude' -H "X-Subrouter-Account-ID: $cooked" \
+      -H "X-Subrouter-Session: verify-canary-$now_epoch" \
+      -H 'anthropic-version: 2023-06-01' -H 'content-type: application/json' \
+      -d '{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}' 2>/dev/null \
+      | grep -i '^anthropic-ratelimit-unified-status:' | head -1 | tr -d '\r' | awk '{print tolower($2)}')
+    # The user is hard-blocked only on "rejected"; "allowed"/"allowed_warning"
+    # both mean requests still work, so either is a pass.
+    case "$st" in
+      allowed|allowed_warning)
+        emit OK "canary: pinned cooked $cooked -> client got $st (not blocked)" ;;
+      rejected)
+        emit ALERT "canary: pinned cooked $cooked -> client got REJECTED (reroute BROKEN)" ;;
+      *)
+        emit INFO "canary: pinned cooked $cooked -> unified-status=${st:-none} (inconclusive)" ;;
+    esac
+  fi
+fi
+
+printf '{"ts":"%s","version":"%s","healthy_claude":%s,"total_claude":%s,"alerts_this_run":%s}\n' \
+  "$now_iso" "$ver" "$healthy_claude" "$total_claude" "$alerts" >"$STATUS"
+[ "$alerts" -eq 0 ] && emit OK "checks passed (version=$ver healthy_claude=$healthy_claude/$total_claude)"
+exit 0

--- a/deploy/gcp/subrouter-verify.timer
+++ b/deploy/gcp/subrouter-verify.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run subrouter-verify every 5 minutes
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=5min
+RandomizedDelaySec=20
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
The `subrouter-verify` self-check (passive rejected→reroute invariant + contract-drift + health + hourly canary) was hand-installed on subrouter-team, so a VM rebuild would lose it. This commits the canonical files to `deploy/gcp/` and fetches + installs + enables them from `startup.sh` (best-effort, so a fetch failure never aborts proxy provisioning), so a rebuilt VM keeps the verifier.

- `deploy/gcp/subrouter-verify.{sh,service,timer}` — the verifier (5-min timer).
- `startup.sh` — installs + enables it on provision.
- `deploy/gcp/README.md` — documents it.

No binary change; infra/scripts only. The live VM already runs the verifier; this makes it survive a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785014503&installation_id=133855650&pr_number=27&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F27&signature=ec6ed3e90af1a8d8b1b27efe9049c1fde4f791d362f5283ac057a78a72d0e445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Claude rate-limit reroute self-verifier survive VM rebuilds. `startup.sh` now fetches and enables the verifier during provisioning so rebuilt proxies keep continuous checks.

- **New Features**
  - Added `deploy/gcp/subrouter-verify.{sh,service,timer}` with a 5‑minute systemd timer; documented in `deploy/gcp/README.md`.
  - `deploy/gcp/startup.sh` installs and enables the timer best‑effort; failures don’t block proxy provisioning.
  - Checks: rejected→reroute invariant, contract drift (HTTP 429 or unknown `anthropic-ratelimit-unified-status`), service health/version, plus an hourly canary pinned to a cooked account.
  - Outputs to `journalctl -u subrouter-verify` and `/var/lib/subrouter-verify/{status.json,alerts.log}`.

<sup>Written for commit b4e51da2483124bc2676a2162a7f1e31777bd367. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic self-checks for Subrouter on GCP, running after startup and every 5 minutes.
  * Added an hourly canary check to validate rate-limit rerouting behavior when capacity is available.
  * Added clearer health reporting and alert output in system logs and status files.

* **Documentation**
  * Updated the deployment guide with setup details, verification commands, and where to find alerts and status results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->