### PR TITLE
Skip dead-token Claude accounts during failover instead of aborting

### DIFF
--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -567,6 +567,90 @@ func TestClaudeFailoverSkipsDeadTokenAccount(t *testing.T) {
 	}
 }
 
+// TestClaudeFailoverTransientRefreshErrorNotPoisoned guards the refinement: a
+// transient refresh failure (not a dead token) must skip the account for this
+// request but must NOT mark it exhausted, so it stays eligible for future
+// routing once the transient condition clears.
+func TestClaudeFailoverTransientRefreshErrorNotPoisoned(t *testing.T) {
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("claude", "session-tr", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: "cooked@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-cooked"},
+			{ID: "blip@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-blip"},
+			{ID: "fresh@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-fresh"},
+		},
+		Sessions:     store,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler(nil)),
+		ScoreAccounts: func(ctx context.Context, available []accounts.Account) ([]selectacct.Score, int) {
+			h := map[string]float64{"cooked@example.com": 0, "blip@example.com": 1.0, "fresh@example.com": 0.9}
+			scores := make([]selectacct.Score, 0, len(available))
+			for _, a := range available {
+				scores = append(scores, selectacct.Score{AccountID: a.ID, Provider: a.Provider, Headroom: h[a.ID], ShortHeadroom: h[a.ID]})
+			}
+			return scores, len(scores)
+		},
+		// blip@ fails with a transient (non-credential) error, not a dead token.
+		RefreshAccountFn: func(ctx context.Context, a accounts.Account) (accounts.Account, error) {
+			if a.ID == "blip@example.com" {
+				return accounts.Account{}, fmt.Errorf("dial tcp: connection refused")
+			}
+			return a, nil
+		},
+	}
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		if strings.Contains(req.Header.Get("Authorization"), "tok-fresh") {
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(`{"id":"msg_fresh"}`))}
+		}
+		h := http.Header{}
+		h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		return &http.Response{StatusCode: http.StatusTooManyRequests, Header: h, Body: io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}`))}
+	}}
+	transport := usageLimitRetryTransport{
+		base: stub, server: &server, provider: accounts.ProviderClaude,
+		agent: "claude", session: "session-tr", account: "cooked@example.com",
+		method: http.MethodPost, path: "/v1/messages", maxAttempts: 6,
+	}
+	req, _ := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader([]byte(`{"model":"claude-opus-4-8"}`)))
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), "msg_fresh") {
+		t.Fatalf("status=%d body=%s, want 200 from fresh (transient blip skipped)", response.StatusCode, string(body))
+	}
+	if server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "blip@example.com") {
+		t.Fatal("a transient refresh error must NOT mark the account exhausted")
+	}
+}
+
+func TestIsTerminalCredentialError(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{fmt.Errorf(`Claude OAuth refresh failed: 400 Bad Request: {"error": "invalid_grant"}`), true},
+		{fmt.Errorf("profile has no refresh token"), true},
+		{fmt.Errorf("dial tcp: connection refused"), false},
+		{context.Canceled, false},
+		{context.DeadlineExceeded, false},
+		{nil, false},
+	}
+	for _, tc := range cases {
+		if got := isTerminalCredentialError(tc.err); got != tc.want {
+			t.Fatalf("isTerminalCredentialError(%v) = %v, want %v", tc.err, got, tc.want)
+		}
+	}
+}
+
 func TestClaudeRateLimitHeaderFields(t *testing.T) {
 	header := http.Header{}
 	header.Set("Retry-After", "3600")

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -2,6 +2,8 @@ package proxy
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -486,6 +488,82 @@ func TestClaudeRejectedNon429StatusDoesNotLogBody(t *testing.T) {
 	defer response.Body.Close()
 	if strings.Contains(logBuf.String(), secret) {
 		t.Fatalf("leaked a non-rate-limit 5xx body into logs; logs=\n%s", logBuf.String())
+	}
+}
+
+// TestClaudeFailoverSkipsDeadTokenAccount is the live regression caught by
+// monitoring: failover picked an account whose OAuth refresh returned
+// invalid_grant and aborted the whole retry ("no alternate account" -> 429 to
+// the client) even though healthy accounts remained untried. Failover must skip
+// the dead-token account and continue to a healthy one.
+func TestClaudeFailoverSkipsDeadTokenAccount(t *testing.T) {
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("claude", "session-dead", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: "cooked@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-cooked"},
+			{ID: "dead@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-dead"},
+			{ID: "fresh@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-fresh"},
+		},
+		Sessions:     store,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler(nil)),
+		// Pick order among untried candidates: dead (highest) before fresh, so
+		// failover tries the dead-token account first and must skip it.
+		ScoreAccounts: func(ctx context.Context, available []accounts.Account) ([]selectacct.Score, int) {
+			h := map[string]float64{"cooked@example.com": 0, "dead@example.com": 1.0, "fresh@example.com": 0.9}
+			scores := make([]selectacct.Score, 0, len(available))
+			for _, a := range available {
+				scores = append(scores, selectacct.Score{AccountID: a.ID, Provider: a.Provider, Headroom: h[a.ID], ShortHeadroom: h[a.ID]})
+			}
+			return scores, len(scores)
+		},
+		// dead@example.com has a dead refresh token; everything else refreshes fine.
+		RefreshAccountFn: func(ctx context.Context, a accounts.Account) (accounts.Account, error) {
+			if a.ID == "dead@example.com" {
+				return accounts.Account{}, fmt.Errorf("Claude OAuth refresh failed: 400 Bad Request: invalid_grant")
+			}
+			return a, nil
+		},
+	}
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		if strings.Contains(req.Header.Get("Authorization"), "tok-fresh") {
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(`{"id":"msg_fresh"}`))}
+		}
+		// cooked (and any other) -> 429 rejected
+		h := http.Header{}
+		h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		return &http.Response{StatusCode: http.StatusTooManyRequests, Header: h, Body: io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}`))}
+	}}
+	transport := usageLimitRetryTransport{
+		base: stub, server: &server, provider: accounts.ProviderClaude,
+		agent: "claude", session: "session-dead", account: "cooked@example.com",
+		method: http.MethodPost, path: "/v1/messages", maxAttempts: 6,
+	}
+	req, _ := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader([]byte(`{"model":"claude-opus-4-8"}`)))
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (failover should skip dead token and reach fresh); body=%s", response.StatusCode, string(body))
+	}
+	if !strings.Contains(string(body), "msg_fresh") {
+		t.Fatalf("client got %q, want the healthy account's response", string(body))
+	}
+	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "dead@example.com") {
+		t.Fatal("the dead-token account should be marked exhausted (dropped from selection)")
+	}
+	assignment, ok := store.Get("claude", "session-dead")
+	if !ok || assignment.AccountID != "fresh@example.com" {
+		t.Fatalf("sticky assignment = %+v, want fresh@example.com", assignment)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -45,8 +45,11 @@ type Server struct {
 	SchedulerRef   *selectacct.SchedulerRef
 	UsageScoreTTL  time.Duration
 	ScoreAccounts  func(context.Context, []accounts.Account) ([]selectacct.Score, int)
-	Transport      http.RoundTripper
-	Logger         *slog.Logger
+	// RefreshAccountFn, when set, replaces the default OAuth refresh path. Test
+	// seam for simulating dead/expired refresh tokens; nil in production.
+	RefreshAccountFn func(context.Context, accounts.Account) (accounts.Account, error)
+	Transport        http.RoundTripper
+	Logger           *slog.Logger
 	ActiveSessions *ActiveSessions
 	Lifecycle      *Lifecycle
 	AdminToken     string
@@ -2465,6 +2468,9 @@ func (s Server) accountList() []accounts.Account {
 }
 
 func (s Server) refreshAccount(ctx context.Context, account accounts.Account) (accounts.Account, error) {
+	if s.RefreshAccountFn != nil {
+		return s.RefreshAccountFn(ctx, account)
+	}
 	if s.AccountRef == nil {
 		return account, nil
 	}
@@ -2890,46 +2896,69 @@ func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provide
 	if len(allCandidates) == 0 {
 		return accounts.Account{}, fmt.Errorf("no OAuth %s accounts available", provider)
 	}
-	candidates := make([]accounts.Account, 0, len(allCandidates))
-	for _, account := range allCandidates {
-		if _, ok := tried[account.ID]; ok {
-			continue
-		}
-		candidates = append(candidates, account)
-	}
-	if len(candidates) == 0 {
-		return accounts.Account{}, fmt.Errorf("no untried OAuth %s accounts available", provider)
-	}
 	s.refreshUsageScoresIfStale(ctx)
-	scheduler := s.scheduler()
-	if s.Sessions != nil {
-		scheduler = scheduler.WithSessionCounts(s.Sessions.CountByAccount())
-	}
-	account, err := scheduler.Pick(candidates)
-	if err != nil {
-		return accounts.Account{}, err
-	}
-	// Do not stop failover when the best untried account looks exhausted: scores
-	// can be stale, so trying it (the retry loop is bounded by maxAttempts and
-	// the tried set) is strictly better than refusing an account that may have
-	// quota. A truly exhausted account just returns the upstream's own limit.
-	if !scheduler.UsableForNewSession(account.Provider, account.ID) && s.Logger != nil {
-		s.Logger.Warn("usage-limit retry selecting OAuth account below new-session headroom; trying anyway",
-			"provider", provider,
-			"account", account.ID,
-			"exhausted", scheduler.Exhausted(account.Provider, account.ID),
-			"threshold", selectacct.MinNewSessionHeadroom)
-	}
-	refreshed, err := s.refreshAccount(ctx, account)
-	if err != nil {
-		return accounts.Account{}, err
-	}
-	if s.Sessions != nil {
-		if _, err := s.Sessions.Put(agentType, sessionID, refreshed.ID, userEmail); err != nil {
+	// Loop so a single account with a dead OAuth token (refresh returns
+	// invalid_grant) does NOT abort failover: skip it and try the next untried
+	// candidate. Before this, one expired refresh token in the pool made the
+	// caller log "no alternate account" and return the 429 to the client even
+	// though healthy accounts remained untried.
+	var lastErr error
+	for {
+		candidates := make([]accounts.Account, 0, len(allCandidates))
+		for _, account := range allCandidates {
+			if _, ok := tried[account.ID]; ok {
+				continue
+			}
+			candidates = append(candidates, account)
+		}
+		if len(candidates) == 0 {
+			if lastErr != nil {
+				return accounts.Account{}, lastErr
+			}
+			return accounts.Account{}, fmt.Errorf("no untried OAuth %s accounts available", provider)
+		}
+		scheduler := s.scheduler()
+		if s.Sessions != nil {
+			scheduler = scheduler.WithSessionCounts(s.Sessions.CountByAccount())
+		}
+		account, err := scheduler.Pick(candidates)
+		if err != nil {
 			return accounts.Account{}, err
 		}
+		// Do not stop failover when the best untried account looks exhausted: scores
+		// can be stale, so trying it (the retry loop is bounded by maxAttempts and
+		// the tried set) is strictly better than refusing an account that may have
+		// quota. A truly exhausted account just returns the upstream's own limit.
+		if !scheduler.UsableForNewSession(account.Provider, account.ID) && s.Logger != nil {
+			s.Logger.Warn("usage-limit retry selecting OAuth account below new-session headroom; trying anyway",
+				"provider", provider,
+				"account", account.ID,
+				"exhausted", scheduler.Exhausted(account.Provider, account.ID),
+				"threshold", selectacct.MinNewSessionHeadroom)
+		}
+		refreshed, err := s.refreshAccount(ctx, account)
+		if err != nil {
+			// Dead/expired OAuth token (e.g. invalid_grant). Drop the account
+			// from selection and continue to the next untried candidate instead
+			// of failing the whole failover.
+			tried[account.ID] = struct{}{}
+			s.markAccountExhausted(provider, account.ID)
+			lastErr = err
+			if s.Logger != nil {
+				s.Logger.Warn("usage-limit retry skipping OAuth account with failed refresh",
+					"provider", provider,
+					"account", account.ID,
+					"error", err)
+			}
+			continue
+		}
+		if s.Sessions != nil {
+			if _, err := s.Sessions.Put(agentType, sessionID, refreshed.ID, userEmail); err != nil {
+				return accounts.Account{}, err
+			}
+		}
+		return refreshed, nil
 	}
-	return refreshed, nil
 }
 
 func responseUsageLimit(response *http.Response) (bool, error) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -2891,6 +2892,33 @@ func (t usageLimitRetryTransport) logClaudeUnusableResponse(response *http.Respo
 		"body", string(prefix))
 }
 
+// isTerminalCredentialError reports whether an account refresh failed because
+// its credential is dead and re-auth is required (so the account should be
+// dropped from selection), as opposed to a transient or context failure.
+func isTerminalCredentialError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, terminal := range []string{
+		"invalid_grant",
+		"refresh token not found",
+		"no refresh token",
+		"has no refresh token",
+		"no usable credential",
+		"invalid_client",
+		"unauthorized_client",
+	} {
+		if strings.Contains(msg, terminal) {
+			return true
+		}
+	}
+	return false
+}
+
 func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provider, agentType, sessionID, userEmail string, tried map[string]struct{}) (accounts.Account, error) {
 	allCandidates := oauthAccounts(filterAccountsForProvider(s.accountList(), provider))
 	if len(allCandidates) == 0 {
@@ -2938,16 +2966,27 @@ func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provide
 		}
 		refreshed, err := s.refreshAccount(ctx, account)
 		if err != nil {
-			// Dead/expired OAuth token (e.g. invalid_grant). Drop the account
-			// from selection and continue to the next untried candidate instead
-			// of failing the whole failover.
+			if ctx.Err() != nil {
+				// The request itself was cancelled or timed out; abort failover
+				// without poisoning the account's routing score.
+				return accounts.Account{}, err
+			}
+			// Skip this account for the rest of THIS failover and try the next
+			// untried candidate. Only poison the routing score for a terminal
+			// credential failure (a dead/expired refresh token, invalid_grant); a
+			// transient refresh failure (network blip, token-service hiccup,
+			// keychain error) must not mark an otherwise-healthy account exhausted.
 			tried[account.ID] = struct{}{}
-			s.markAccountExhausted(provider, account.ID)
 			lastErr = err
+			terminal := isTerminalCredentialError(err)
+			if terminal {
+				s.markAccountExhausted(provider, account.ID)
+			}
 			if s.Logger != nil {
 				s.Logger.Warn("usage-limit retry skipping OAuth account with failed refresh",
 					"provider", provider,
 					"account", account.ID,
+					"terminal", terminal,
 					"error", err)
 			}
 			continue


### PR DESCRIPTION
## Caught live by the monitor

Two sessions got a `429` returned to the client (`reason=no_alternate_account`) after trying only **3 and 5 of 13** Claude accounts, while ~10 healthy accounts remained untried:
```
WARN usage-limit retry has no alternate account ... account=austin@manaflow.com error="Claude OAuth refresh failed: 400 Bad Request: invalid_grant: Refresh token not found or invalid"
WARN claude rate-limit returned to client after failover exhausted ... reason=no_alternate_account status=429 tried_accounts=3
```

## Root cause

`oauthRetryAccount` picks the best untried account and refreshes its OAuth token. When that refresh fails (a dead/expired refresh token → `invalid_grant`), it returned the error, which the retry transport treated as "no alternate account" and gave up — even though healthy accounts were still untried. One bad refresh token in the pool aborted the whole failover.

## Fix

Loop in `oauthRetryAccount`: on a refresh failure, mark the account tried + exhausted (drop it from selection) and continue to the next untried candidate; only give up when no untried account remains. A single expired refresh token no longer aborts failover, and the dead account is dropped from future selection.

Adds a `RefreshAccountFn` test seam (nil in production, mirrors `ScoreAccounts`) and a regression test: failover skips a dead-token account and reaches a healthy one (client gets 200, dead account marked exhausted, session moved).

## Operational note
The accounts hitting `invalid_grant` (e.g. `austin@manaflow.ai`, `austin@manaflow.com`) have dead refresh tokens and need re-auth (`sr server login`) to rejoin the pool. This fix stops them from breaking failover, but they reduce capacity until re-authed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785020536&installation_id=133855650&pr_number=28&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F28&signature=3f27ceedee7c8cc9ffaf9089a4d99a62001b0137bc7f846e6d9ff5e688549e12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip Claude OAuth accounts with dead refresh tokens during failover instead of aborting, and only mark accounts exhausted on terminal credential errors. This prevents 429 "no_alternate_account" while keeping healthy accounts eligible.

- **Bug Fixes**
  - Reworked `oauthRetryAccount` to loop over untried OAuth accounts; on refresh failure, skip and continue; mark exhausted only for terminal credential errors (e.g., `invalid_grant`/no refresh token via `isTerminalCredentialError`); abort on context errors without poisoning; update sticky session on success.
  - Added `RefreshAccountFn` test seam (nil in prod) and tests: `TestClaudeFailoverSkipsDeadTokenAccount`, `TestClaudeFailoverTransientRefreshErrorNotPoisoned`, and `TestIsTerminalCredentialError`.

<sup>Written for commit b84ee8c0f1dc1e656783c171299c14ad82288c34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account failover so requests can automatically retry with a healthy account when one token can no longer be refreshed.
  * Added better handling for exhausted accounts, reducing repeated retries against the same failing session.
  * Sticky session assignment now updates more reliably after failover, helping keep retries on working accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->