### PR TITLE
Don't poison healthy Claude accounts on a bare (headerless) 429

### DIFF
--- a/internal/proxy/claude_failover_test.go
+++ b/internal/proxy/claude_failover_test.go
@@ -86,10 +86,14 @@ func TestUsageLimitRetryTransportClaudeFailsOverOn429(t *testing.T) {
 	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
 		auth := req.Header.Get("Authorization")
 		if strings.Contains(auth, "tok-cooked") {
+			// Genuine quota exhaustion: Anthropic stamps the unified-status
+			// rejected header, which is what marks the account exhausted.
+			h := http.Header{}
+			h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
 			return &http.Response{
 				StatusCode: http.StatusTooManyRequests,
 				Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"You've hit your session limit"}}`)),
-				Header:     http.Header{},
+				Header:     h,
 			}
 		}
 		return &http.Response{
@@ -223,14 +227,35 @@ func TestReuseStickyAssignmentClaudeExhausted(t *testing.T) {
 
 func TestCaptureResponseBodyClaude429MarksExhausted(t *testing.T) {
 	server, _ := claudeFailoverServer(t)
+	// A quota 429 carries the authoritative rejected header; that is what marks
+	// the account exhausted (a bare 429 does not, see
+	// TestCaptureResponseBodyClaudeBare429DoesNotPoison).
+	h := http.Header{}
+	h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
 	response := &http.Response{
 		StatusCode: http.StatusTooManyRequests,
 		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error"}}`)),
-		Header:     http.Header{},
+		Header:     h,
 	}
 	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "/v1/messages")
 	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
-		t.Fatal("claude 429 should mark the account exhausted via passive inspection")
+		t.Fatal("claude rejected-header 429 should mark the account exhausted via passive inspection")
+	}
+}
+
+// TestCaptureResponseBodyClaudeBare429DoesNotPoison is the production
+// regression: healthy accounts return a headerless rate_limit_error 429 under a
+// short-window burst; that must NOT mark them exhausted (poisoning the scheduler).
+func TestCaptureResponseBodyClaudeBare429DoesNotPoison(t *testing.T) {
+	server, _ := claudeFailoverServer(t)
+	response := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}`)),
+		Header:     http.Header{},
+	}
+	server.captureResponseBody(response, "claude", "session-1", "healthy@example.com", accounts.ProviderClaude, "/v1/messages")
+	if server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "healthy@example.com") {
+		t.Fatal("a bare (headerless) 429 must NOT mark a healthy account exhausted")
 	}
 }
 

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -238,7 +238,7 @@ func TestClaudeAccountExhaustedByResponse(t *testing.T) {
 		{"429 rejected", http.StatusTooManyRequests, withStatus("rejected"), true},
 		{"429 allowed_warning", http.StatusTooManyRequests, withStatus("allowed_warning"), false},
 		{"429 allowed", http.StatusTooManyRequests, withStatus("allowed"), false},
-		{"429 no header (legacy)", http.StatusTooManyRequests, http.Header{}, true},
+		{"429 no header (transient burst, not quota)", http.StatusTooManyRequests, http.Header{}, false},
 		{"200 healthy", http.StatusOK, withStatus("allowed"), false},
 	}
 	for _, tc := range cases {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2666,29 +2666,24 @@ func claudeAccountUnusableStatus(code int) bool {
 
 // claudeAccountExhaustedByResponse reports whether an upstream response means the
 // account is genuinely out of subscription quota and should be dropped from the
-// routing scheduler (not merely failed over for this one request). A 401 is a
-// dead/expired token. For a 429, Anthropic's authoritative signal is the
-// anthropic-ratelimit-unified-status header: "rejected" means the account is out
-// of quota, while "allowed"/"allowed_warning" mean a transient or
-// non-subscription throttle that must NOT poison a healthy account's score. When
-// the header is absent we fall back to the conservative legacy behavior and
-// treat the 429 as exhaustion. A "rejected" header marks the account exhausted
-// regardless of HTTP status, because Anthropic answers a depleted account with
-// 200 via overage while still reporting rejected.
+// routing scheduler (not merely failed over for this one request). The
+// authoritative quota signal is the anthropic-ratelimit-unified-status header:
+// "rejected" marks the account exhausted regardless of HTTP status, because
+// Anthropic answers a depleted account with 200 via paid overage while still
+// reporting rejected.
+//
+// A bare 429 with no unified-status header is NOT treated as exhaustion.
+// Observed in production: healthy accounts (80-100% quota) return a headerless
+// rate_limit_error 429 under short-window request bursts, and poisoning their
+// routing score on that is wrong. Such a 429 still fails over
+// (claudeAccountUnusableStatus is status-based), but genuine quota exhaustion is
+// detected by the rejected header and the periodic usage-score refresh, not by a
+// bare 429. A 401 is always a dead/expired token.
 func claudeAccountExhaustedByResponse(status int, header http.Header) bool {
 	if status == http.StatusUnauthorized {
 		return true
 	}
-	switch claudeUnifiedStatus(header) {
-	case "rejected":
-		return true
-	case "allowed", "allowed_warning":
-		// Healthy or merely warned; a 429 here is a transient/non-subscription
-		// throttle that must not poison the account's routing score.
-		return false
-	}
-	// Header absent: conservative legacy behavior, treat a 429 as exhaustion.
-	return status == http.StatusTooManyRequests
+	return claudeUnifiedStatus(header) == "rejected"
 }
 
 // claudeUnifiedStatus returns the lowercased anthropic-ratelimit-unified-status


### PR DESCRIPTION
## Caught live by the monitor

A single session's request burst made **six healthy accounts (80-100% quota)** each return a `429` within two seconds; failover hit its attempt cap and the client got a 429. Decompressing the (gzip-encoded) 429 bodies:
```json
{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}
```
with **no** `anthropic-ratelimit-unified-*` headers. Genuine quota exhaustion instead shows as `200 + unified-status: rejected` (overage). So a bare headerless 429 is a **transient short-window/burst limit, not exhaustion**.

## Problem

The conservative default treated *any* 429 as exhaustion, so these bursts **poisoned healthy accounts' routing scores** (`markAccountExhausted`), distorting the scheduler (it self-heals on the next usage refresh, but it's wrong and can cascade).

## Fix

Only the authoritative `rejected` header (or a `401` dead token) marks an account exhausted. A bare 429 still **fails over** (status-based, unchanged) but leaves the routing score intact; genuine exhaustion is caught by the `rejected` header + the periodic usage-score refresh.

Updates the three tests that encoded the old bare-429→exhausted assumption to use the `rejected` header for quota cases, and adds `TestCaptureResponseBodyClaudeBare429DoesNotPoison`.

## Note
This does not change that the client got a 429 for that specific burst (transient limits aren't fixable by rerouting; Claude Code retries with backoff). It stops the collateral scheduler poisoning. The `maxAttempts` cap (6 < 13 accounts) is left as-is to avoid amplifying load under bursts; will revisit if bursts recur and untried accounts would have served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785028340&installation_id=133855650&pr_number=29&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F29&signature=40c70e2a9b5b6d34ef228e53d28012d8e7f2316535de5d12e8840ff1b5e094b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop marking Claude accounts as exhausted on bare (headerless) 429s to avoid poisoning routing scores during short burst limits. Only the unified-status header `rejected` (or a 401) now marks an account exhausted; 429s still fail over but no longer degrade healthy accounts.

- **Bug Fixes**
  - Update exhaustion logic: rely on `Anthropic-Ratelimit-Unified-Status: rejected`; 401 still exhausts; remove legacy “any 429 = exhausted”.
  - Add regression test `TestCaptureResponseBodyClaudeBare429DoesNotPoison`; update existing tests to use `rejected` for quota cases.
  - Preserve 429 failover behavior while preventing scheduler poisoning; genuine exhaustion still detected via `rejected` header and usage refresh.

<sup>Written for commit 7c0d500b7dd15ae4570c156f4d4bfab23cbabe14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

