### PR TITLE
Observe Anthropic 529/5xx overloads (log + verifier count)

### DIFF
--- a/deploy/gcp/subrouter-verify.sh
+++ b/deploy/gcp/subrouter-verify.sh
@@ -69,6 +69,7 @@ fi
 lines=$(journalctl -u "$UNIT" --cursor-file="$CURSOR" -o cat 2>/dev/null || true)
 
 drift_429=0
+overload_5xx=0
 while IFS= read -r l; do
   [ -z "$l" ] && continue
   # 2. Failed-reroute invariant: a rate-limit reached the client after failover
@@ -89,6 +90,12 @@ while IFS= read -r l; do
     *"claude account unusable upstream response"*"status=429"*)
       drift_429=$((drift_429 + 1)) ;;
   esac
+  # 3b. Anthropic overload (529/5xx): not a subrouter bug, but track it so we
+  #     can see capacity outages that make the client (Claude Code) force-fail.
+  case "$l" in
+    *"claude upstream server error"*)
+      overload_5xx=$((overload_5xx + 1)) ;;
+  esac
   # 4. Contract drift: an anthropic-ratelimit-unified-status value we do not know.
   case "$l" in
     *"claude account unusable upstream response"*" anthropic-ratelimit-unified-status="*)
@@ -101,6 +108,15 @@ while IFS= read -r l; do
   esac
 done <<<"$lines"
 [ "$drift_429" -gt 0 ] && emit INFO "claude HTTP 429s observed this window (handled): $drift_429"
+# Anthropic overload: INFO normally, ALERT on a sustained burst so a real
+# capacity outage (clients force-failing) pings the on-call.
+if [ "$overload_5xx" -gt 0 ]; then
+  if [ "$overload_5xx" -ge 20 ]; then
+    emit ALERT "anthropic overload: $overload_5xx upstream 5xx/529 this window (clients likely force-failing)"
+  else
+    emit INFO "anthropic overload: $overload_5xx upstream 5xx/529 this window"
+  fi
+fi
 
 # --- 5. Canary (hourly, only when a cooked Claude account exists) ---
 last_canary=$(cat "$CANARY_STAMP" 2>/dev/null || echo 0)
@@ -140,7 +156,7 @@ for x in rows:
   fi
 fi
 
-printf '{"ts":"%s","version":"%s","healthy_claude":%s,"total_claude":%s,"alerts_this_run":%s}\n' \
-  "$now_iso" "$ver" "$healthy_claude" "$total_claude" "$alerts" >"$STATUS"
+printf '{"ts":"%s","version":"%s","healthy_claude":%s,"total_claude":%s,"overload_5xx":%s,"claude_429s":%s,"alerts_this_run":%s}\n' \
+  "$now_iso" "$ver" "$healthy_claude" "$total_claude" "$overload_5xx" "$drift_429" "$alerts" >"$STATUS"
 [ "$alerts" -eq 0 ] && emit OK "checks passed (version=$ver healthy_claude=$healthy_claude/$total_claude)"
 exit 0

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -651,6 +651,28 @@ func TestIsTerminalCredentialError(t *testing.T) {
 	}
 }
 
+// TestClaudeUpstreamServerErrorLoggedNotExhausted verifies a 529 overload is
+// logged for observability but does NOT mark the account exhausted (overload is
+// Anthropic-side capacity, not account-specific; rerouting can't help).
+func TestClaudeUpstreamServerErrorLoggedNotExhausted(t *testing.T) {
+	server, _ := claudeFailoverServer(t)
+	var logBuf bytes.Buffer
+	server.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	response := &http.Response{
+		StatusCode: 529,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"overloaded_error"}}`)),
+	}
+	server.captureResponseBody(response, "claude", "session-1", "acct@example.com", accounts.ProviderClaude, "/v1/messages")
+	logs := logBuf.String()
+	if !strings.Contains(logs, "claude upstream server error") || !strings.Contains(logs, "status=529") {
+		t.Fatalf("expected a 529 upstream-server-error log; logs=\n%s", logs)
+	}
+	if server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "acct@example.com") {
+		t.Fatal("a 529 overload must NOT mark the account exhausted")
+	}
+}
+
 func TestClaudeRateLimitHeaderFields(t *testing.T) {
 	header := http.Header{}
 	header.Set("Retry-After", "3600")

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1849,6 +1849,22 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 				}, claudeRateLimitHeaderFields(response.Header)...)...)
 		}
 	}
+	// Upstream server errors (529 overloaded_error, 5xx) are an Anthropic-side
+	// capacity problem, not account-specific, so subrouter passes them through
+	// (the client retries with backoff and eventually surfaces them). They were
+	// invisible before; log them so overload periods are observable. Do NOT mark
+	// the account exhausted or fail over: rerouting cannot fix an API-wide
+	// capacity issue and just amplifies load on the overloaded endpoint.
+	if provider == accounts.ProviderClaude && response.StatusCode >= 500 && s.Logger != nil {
+		s.Logger.Warn("claude upstream server error",
+			append([]any{
+				"agent", agentType,
+				"session", sessionID,
+				"account", accountID,
+				"path", path,
+				"status", response.StatusCode,
+			}, claudeRateLimitHeaderFields(response.Header)...)...)
+	}
 	inspectUsageLimit := s.SchedulerRef != nil && accountID != "" && responseStatusCanExhaust(response.StatusCode)
 	if response.Body == nil || (s.Transcripts == nil && s.Logger == nil && !inspectUsageLimit && !claudeUnusable) {
 		return


### PR DESCRIPTION
## Why

A user hit "Repeated 529 Overloaded errors" and we had **zero visibility**: `responseStatusCanExhaust` only inspects 4xx, so Claude 5xx responses passed through completely unlogged.

A **529 (`overloaded_error`) is Anthropic-side capacity**, not account-specific. subrouter correctly passes it through; Claude Code retries with backoff and then surfaces it (the error the user saw). Rerouting cannot fix an API-wide overload and would amplify load on the overloaded endpoint, so this PR adds **observability only**, no routing change.

## What

- Log Claude 5xx responses (`claude upstream server error`, status + rate-limit headers, no body) so overload periods are visible. No exhaustion-marking, no failover.
- The VM self-verifier counts them per window (INFO, or ALERT on a sustained burst ≥20) and reports `overload_5xx` (+ `claude_429s`) in `status.json`.

Test: `TestClaudeUpstreamServerErrorLoggedNotExhausted` — a 529 is logged but does not mark the account exhausted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785035889&installation_id=133855650&pr_number=30&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F30&signature=99d26fb506fae13262eb5d4728a4ffa3fd64129d0a8dd3a32dbe2c19135998fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add observability for Anthropic capacity overloads by logging Claude 5xx/529 responses and counting them in the verifier. No routing or exhaustion logic changes; this only improves visibility and alerting.

- New Features
  - Log Claude upstream server errors (529/5xx) with status and rate-limit headers; do not log body, mark exhausted, or fail over.
  - Verifier counts overloads per window and emits INFO, or ALERT when ≥20; adds `overload_5xx` and `claude_429s` to `status.json`.
  - Test ensures 529 is logged and does not mark the account exhausted.

<sup>Written for commit ba434bb7669ee28f53cdae4cbea4cdccf537e8b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

