### PR TITLE
Deflake TestHandlerRecordsHTTPTranscriptBodies

### DIFF
--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -3269,8 +3269,18 @@ func readTranscriptEvents(t *testing.T, path string) []map[string]any {
 
 func readTranscriptEventsEventually(t *testing.T, path string, wantAtLeast int) []map[string]any {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	// Transcript events are written server-side as the request/response bodies
+	// stream and close, which races the client-side body close the caller does
+	// before polling. The events also arrive incrementally, so returning the
+	// instant len >= wantAtLeast could return before a still-pending event (e.g.
+	// upstream_to_client) is written, producing the flaky "missing http_body
+	// upstream_to_client transcript event". Wait until the count both reaches
+	// wantAtLeast AND stops growing for a short grace window, so all pending
+	// events are captured. 10s deadline absorbs CI load.
+	deadline := time.Now().Add(10 * time.Second)
+	const stableFor = 200 * time.Millisecond
 	var lastEvents []map[string]any
+	var stableSince time.Time
 	for {
 		body, err := os.ReadFile(path)
 		if err == nil {
@@ -3289,14 +3299,20 @@ func readTranscriptEventsEventually(t *testing.T, path string, wantAtLeast int) 
 				events = append(events, event)
 			}
 			if parseOK {
-				lastEvents = events
-				if len(events) >= wantAtLeast {
-					return events
+				if len(events) != len(lastEvents) {
+					stableSince = time.Time{} // count changed; reset the grace window
+				} else if len(events) >= wantAtLeast {
+					if stableSince.IsZero() {
+						stableSince = time.Now()
+					} else if time.Since(stableSince) >= stableFor {
+						return events
+					}
 				}
+				lastEvents = events
 			}
 		}
 		if time.Now().After(deadline) {
-			if len(lastEvents) > 0 {
+			if len(lastEvents) >= wantAtLeast {
 				return lastEvents
 			}
 			t.Fatalf("transcript %s did not reach %d events", path, wantAtLeast)


### PR DESCRIPTION
The CI "Build, vet, test" job has been intermittently failing on `TestHandlerRecordsHTTPTranscriptBodies` with `missing http_body upstream_to_client transcript event` across several unrelated PRs (it passes locally most runs).

**Root cause:** transcript events are written server-side as the request/response bodies stream and close, racing the client-side body close the test does before polling. `readTranscriptEventsEventually` returned the instant `len >= wantAtLeast`, which could be *before* a still-pending event (the `upstream_to_client` response body) was written.

**Fix:** the helper now waits until the event count both reaches `wantAtLeast` AND stops growing for a 200ms grace window (10s overall deadline), so all pending events are captured. Stress-tested locally: target test 50× and the transcript suite 10×, all green.

Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785036210&installation_id=133855650&pr_number=31&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F31&signature=7ca24e09f1d00d85fcdf8c17b9ed36d6be90e9304b2becb1ac345abc0d307791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflakes TestHandlerRecordsHTTPTranscriptBodies by waiting for transcript events to settle before asserting. Fixes intermittent CI failures where the `upstream_to_client` body event was missing.

- **Bug Fixes**
  - Wait until event count reaches the target and stays unchanged for 200ms.
  - Extend overall wait deadline to 10s to handle CI load.
  - On timeout, return only if the target count was reached; otherwise fail clearly.
  - Test-only change; no production impact.

<sup>Written for commit 6495b520e6eabf944a4a163676bf2a71973b6ac3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the reliability of websocket transcript checks by reducing flaky timing-related failures.
  * Added more robust waiting behavior so event verification is less likely to fail intermittently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->