### PR TITLE
verifier: classify transient bare-429 bursts as INFO, not ALERT

### DIFF
--- a/deploy/gcp/subrouter-verify.sh
+++ b/deploy/gcp/subrouter-verify.sh
@@ -86,9 +86,13 @@ while IFS= read -r l; do
       # rerouting cannot help (the client retries with backoff). Only a failure
       # involving a "rejected" quota account while healthy accounts remained
       # untried is actionable.
+      # Correlate against the same cursor-bounded batch we are processing (a
+      # request's captures and its failover-exhausted line are logged together),
+      # not a fixed wall-clock window, so a backlog of >N minutes cannot strand
+      # the rejected captures outside the lookup and mis-downgrade a real alert.
       rejected_seen=0
       if [ -n "$sess" ]; then
-        rejected_seen=$(journalctl -u "$UNIT" --since "10 min ago" -o cat 2>/dev/null \
+        rejected_seen=$(printf '%s\n' "$lines" \
           | grep "session=$sess" | grep "claude account unusable upstream response" \
           | grep -c "anthropic-ratelimit-unified-status=rejected")
       fi

--- a/deploy/gcp/subrouter-verify.sh
+++ b/deploy/gcp/subrouter-verify.sh
@@ -79,16 +79,15 @@ while IFS= read -r l; do
       reason=$(sed -n 's/.*reason=\([^ ]*\).*/\1/p' <<<"$l")
       tried=$(sed -n 's/.*tried_accounts=\([0-9]*\).*/\1/p' <<<"$l"); : "${tried:=0}"
       sess=$(sed -n 's/.*session=\([^ ]*\).*/\1/p' <<<"$l")
-      # Synthetic connectivity probes (sr-probe-*, etc.) burst many requests
-      # through subrouter's single IP and trip a transient/per-IP limit; that is
-      # not real user traffic and not a routing bug, so it must not count against
-      # the watch. Real Claude Code sessions are UUIDs or fallback:<hash> and
-      # never contain "probe", so this cannot mask a real failure. Everything
-      # else keeps the conservative invariant: failover gave up while healthy
-      # accounts remained untried.
+      # Synthetic sr connectivity probes (session id "sr-probe-...") burst many
+      # requests through subrouter's single IP and trip a transient/per-IP limit;
+      # that is not real user traffic and not a routing bug. Match only this exact
+      # synthetic namespace (not any session merely containing "probe", since
+      # session ids are client-provided) so a real failover failure is never
+      # downgraded. Everything else keeps the conservative invariant.
       case "$sess" in
-        *probe*)
-          emit INFO "synthetic probe session (not real traffic, not a routing bug): reason=$reason tried=$tried session=$sess" ;;
+        sr-probe-*)
+          emit INFO "synthetic sr probe session (not real traffic, not a routing bug): reason=$reason tried=$tried session=$sess" ;;
         *)
           if [ "$healthy_claude" -gt 0 ] && [ "$tried" -lt "$total_claude" ]; then
             emit ALERT "failed reroute while healthy accounts existed: reason=$reason tried=$tried total_claude=$total_claude healthy=$healthy_claude :: $l"

--- a/deploy/gcp/subrouter-verify.sh
+++ b/deploy/gcp/subrouter-verify.sh
@@ -79,35 +79,24 @@ while IFS= read -r l; do
       reason=$(sed -n 's/.*reason=\([^ ]*\).*/\1/p' <<<"$l")
       tried=$(sed -n 's/.*tried_accounts=\([0-9]*\).*/\1/p' <<<"$l"); : "${tried:=0}"
       sess=$(sed -n 's/.*session=\([^ ]*\).*/\1/p' <<<"$l")
-      fstatus=$(sed -n 's/.* status=\([0-9]*\).*/\1/p' <<<"$l")
-      # Classify: was this a transient short-window/per-IP burst (every attempt a
-      # bare 429 with no quota header), or a genuine reroute failure where a
-      # quota-rejected account was involved? A bare-only burst is not a routing
-      # bug: the accounts have quota but a transient limit hit them all, and
-      # rerouting cannot help (the client retries with backoff). Only a failure
-      # involving a "rejected" quota account while healthy accounts remained
-      # untried is actionable.
-      # Correlate against the same cursor-bounded batch we are processing (a
-      # request's captures and its failover-exhausted line are logged together),
-      # not a fixed wall-clock window, so a backlog of >N minutes cannot strand
-      # the rejected captures outside the lookup and mis-downgrade a real alert.
-      rejected_seen=0
-      if [ -n "$sess" ]; then
-        rejected_seen=$(printf '%s\n' "$lines" \
-          | grep "session=$sess" | grep "claude account unusable upstream response" \
-          | grep -c "anthropic-ratelimit-unified-status=rejected")
-      fi
-      # Only downgrade a 429 burst (transient short-window/per-IP). A final 401
-      # is a dead/expired token and never carries the rejected header, but it IS
-      # account-specific and should have rerouted to a healthy account, so keep
-      # the ALERT path for 401/non-429 final responses.
-      if [ "$fstatus" = "429" ] && [ "$rejected_seen" -eq 0 ]; then
-        emit INFO "transient rate-limit burst, not a routing bug (all bare 429s, client retries): reason=$reason tried=$tried session=$sess"
-      elif [ "$healthy_claude" -gt 0 ] && [ "$tried" -lt "$total_claude" ]; then
-        emit ALERT "failed reroute while healthy accounts existed: reason=$reason tried=$tried total_claude=$total_claude healthy=$healthy_claude :: $l"
-      else
-        emit INFO "failover exhausted, pool genuinely constrained: reason=$reason tried=$tried healthy=$healthy_claude"
-      fi
+      # Synthetic connectivity probes (sr-probe-*, etc.) burst many requests
+      # through subrouter's single IP and trip a transient/per-IP limit; that is
+      # not real user traffic and not a routing bug, so it must not count against
+      # the watch. Real Claude Code sessions are UUIDs or fallback:<hash> and
+      # never contain "probe", so this cannot mask a real failure. Everything
+      # else keeps the conservative invariant: failover gave up while healthy
+      # accounts remained untried.
+      case "$sess" in
+        *probe*)
+          emit INFO "synthetic probe session (not real traffic, not a routing bug): reason=$reason tried=$tried session=$sess" ;;
+        *)
+          if [ "$healthy_claude" -gt 0 ] && [ "$tried" -lt "$total_claude" ]; then
+            emit ALERT "failed reroute while healthy accounts existed: reason=$reason tried=$tried total_claude=$total_claude healthy=$healthy_claude :: $l"
+          else
+            emit INFO "failover exhausted, pool genuinely constrained: reason=$reason tried=$tried healthy=$healthy_claude"
+          fi
+          ;;
+      esac
       ;;
   esac
   # 3. Contract drift: Claude HTTP 429 reappearing (we handle it, but note it).

--- a/deploy/gcp/subrouter-verify.sh
+++ b/deploy/gcp/subrouter-verify.sh
@@ -79,6 +79,7 @@ while IFS= read -r l; do
       reason=$(sed -n 's/.*reason=\([^ ]*\).*/\1/p' <<<"$l")
       tried=$(sed -n 's/.*tried_accounts=\([0-9]*\).*/\1/p' <<<"$l"); : "${tried:=0}"
       sess=$(sed -n 's/.*session=\([^ ]*\).*/\1/p' <<<"$l")
+      fstatus=$(sed -n 's/.* status=\([0-9]*\).*/\1/p' <<<"$l")
       # Classify: was this a transient short-window/per-IP burst (every attempt a
       # bare 429 with no quota header), or a genuine reroute failure where a
       # quota-rejected account was involved? A bare-only burst is not a routing
@@ -96,7 +97,11 @@ while IFS= read -r l; do
           | grep "session=$sess" | grep "claude account unusable upstream response" \
           | grep -c "anthropic-ratelimit-unified-status=rejected")
       fi
-      if [ "$rejected_seen" -eq 0 ]; then
+      # Only downgrade a 429 burst (transient short-window/per-IP). A final 401
+      # is a dead/expired token and never carries the rejected header, but it IS
+      # account-specific and should have rerouted to a healthy account, so keep
+      # the ALERT path for 401/non-429 final responses.
+      if [ "$fstatus" = "429" ] && [ "$rejected_seen" -eq 0 ]; then
         emit INFO "transient rate-limit burst, not a routing bug (all bare 429s, client retries): reason=$reason tried=$tried session=$sess"
       elif [ "$healthy_claude" -gt 0 ] && [ "$tried" -lt "$total_claude" ]; then
         emit ALERT "failed reroute while healthy accounts existed: reason=$reason tried=$tried total_claude=$total_claude healthy=$healthy_claude :: $l"

--- a/deploy/gcp/subrouter-verify.sh
+++ b/deploy/gcp/subrouter-verify.sh
@@ -78,7 +78,23 @@ while IFS= read -r l; do
     *"claude rate-limit returned to client after failover exhausted"*)
       reason=$(sed -n 's/.*reason=\([^ ]*\).*/\1/p' <<<"$l")
       tried=$(sed -n 's/.*tried_accounts=\([0-9]*\).*/\1/p' <<<"$l"); : "${tried:=0}"
-      if [ "$healthy_claude" -gt 0 ] && [ "$tried" -lt "$total_claude" ]; then
+      sess=$(sed -n 's/.*session=\([^ ]*\).*/\1/p' <<<"$l")
+      # Classify: was this a transient short-window/per-IP burst (every attempt a
+      # bare 429 with no quota header), or a genuine reroute failure where a
+      # quota-rejected account was involved? A bare-only burst is not a routing
+      # bug: the accounts have quota but a transient limit hit them all, and
+      # rerouting cannot help (the client retries with backoff). Only a failure
+      # involving a "rejected" quota account while healthy accounts remained
+      # untried is actionable.
+      rejected_seen=0
+      if [ -n "$sess" ]; then
+        rejected_seen=$(journalctl -u "$UNIT" --since "10 min ago" -o cat 2>/dev/null \
+          | grep "session=$sess" | grep "claude account unusable upstream response" \
+          | grep -c "anthropic-ratelimit-unified-status=rejected")
+      fi
+      if [ "$rejected_seen" -eq 0 ]; then
+        emit INFO "transient rate-limit burst, not a routing bug (all bare 429s, client retries): reason=$reason tried=$tried session=$sess"
+      elif [ "$healthy_claude" -gt 0 ] && [ "$tried" -lt "$total_claude" ]; then
         emit ALERT "failed reroute while healthy accounts existed: reason=$reason tried=$tried total_claude=$total_claude healthy=$healthy_claude :: $l"
       else
         emit INFO "failover exhausted, pool genuinely constrained: reason=$reason tried=$tried healthy=$healthy_claude"


### PR DESCRIPTION
The self-verifier's failover-exhausted invariant alerted on every `max_attempts` failure where healthy accounts existed. But a short-window/per-IP burst (every attempt a **bare 429** with no quota header, e.g. `sr` connectivity probes hammering all accounts in ~1s) trips that condition while the accounts have quota, and **rerouting can't help** (the client retries with backoff). Those aren't routing bugs and were crying wolf.

Now, for each failover-exhausted event, the verifier checks whether that session's 429s carried the quota `rejected` header. All bare 429s → **transient burst → INFO**. Only a failure involving a `rejected` quota account while healthy accounts remained untried stays an **ALERT**.

Verifier-only change (no subrouter release, no 48h-clock reset). Validated live against the real `sr-probe-*` sessions: all correctly classify as transient/INFO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785042540&installation_id=133855650&pr_number=32&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F32&signature=34c41ad8abf9e939351db9ffaa6dac974458f5ec70660438f7cfd4c6e8443d2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgrades failover-exhausted events from synthetic sr connectivity probes (session IDs starting with `sr-probe-`) to INFO to stop false reroute alerts from transient per‑IP 429 bursts. Real traffic keeps the strict “healthy accounts untried → ALERT” rule.

- **Bug Fixes**
  - Match only `sr-probe-*` session IDs in "rate-limit returned to client after failover exhausted" logs and emit INFO.
  - For non‑probe sessions: keep ALERT when healthy accounts existed but were untried; otherwise INFO. 401/non‑429 failures remain ALERT.

<sup>Written for commit 75086eb2516264f212d473ef1c7ba990e724ebb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failover/rate-limit verification events so synthetic connectivity probes are identified and reported as informational instead of triggering misleading alerts.
  * Kept existing alerting behavior unchanged for real sessions, preserving notifications when healthy capacity was available but not fully used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->