### PR TITLE
Keep rejected Claude accounts exhausted until reset

### DIFF
--- a/cmd/subrouter/sr_claude.go
+++ b/cmd/subrouter/sr_claude.go
@@ -445,7 +445,12 @@ func (r claudeRunner) runClaude(ctx context.Context, name string, extra []string
 	cmd.Stdin = r.in
 	cmd.Stdout = r.out
 	cmd.Stderr = r.errOut
-	cmd.Env = append(os.Environ(), "CLAUDE_CONFIG_DIR="+r.store.ClaudeConfigDir(profile.Name))
+	cmd.Env = append(
+		os.Environ(),
+		"CLAUDE_CONFIG_DIR="+r.store.ClaudeConfigDir(profile.Name),
+		"CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1",
+		"CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS=CLAUDE_CONFIG_DIR",
+	)
 	return cmd.Run()
 }
 

--- a/cmd/subrouter/sr_claude_test.go
+++ b/cmd/subrouter/sr_claude_test.go
@@ -87,7 +87,7 @@ func TestClaudeFlagsRunActiveProfile(t *testing.T) {
 	}
 	recordPath := filepath.Join(home, "claude-run.txt")
 	claudePath := filepath.Join(binDir, "claude")
-	script := "#!/bin/sh\nprintf 'config=%s\\nargs=%s\\n' \"$CLAUDE_CONFIG_DIR\" \"$*\" > " + shellQuote(recordPath) + "\n"
+	script := "#!/bin/sh\nprintf 'config=%s\\npreserve=%s\\npreserve_keys=%s\\nargs=%s\\n' \"$CLAUDE_CONFIG_DIR\" \"$CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV\" \"$CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS\" \"$*\" > " + shellQuote(recordPath) + "\n"
 	if err := os.WriteFile(claudePath, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -107,6 +107,12 @@ func TestClaudeFlagsRunActiveProfile(t *testing.T) {
 	got := string(body)
 	if !strings.Contains(got, "config="+store.ClaudeConfigDir("work")) {
 		t.Fatalf("Claude did not receive active config dir:\n%s", got)
+	}
+	if !strings.Contains(got, "preserve=1") {
+		t.Fatalf("Claude did not receive cmux preservation opt-in:\n%s", got)
+	}
+	if !strings.Contains(got, "preserve_keys=CLAUDE_CONFIG_DIR") {
+		t.Fatalf("Claude did not receive cmux preservation key list:\n%s", got)
 	}
 	if !strings.Contains(got, "args=--dangerously-skip-permissions --resume 1721c0ce-b3bd-4d73-8b33-b3d02b677074") {
 		t.Fatalf("Claude did not receive flags:\n%s", got)

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -250,6 +250,21 @@ func TestClaudeAccountExhaustedByResponse(t *testing.T) {
 	}
 }
 
+func TestClaudeResponseExhaustedUntil(t *testing.T) {
+	now := time.Unix(1000, 0)
+	header := http.Header{}
+	header.Set("Anthropic-Ratelimit-Unified-Reset", "1500")
+	if got := claudeResponseExhaustedUntil(header, now); !got.Equal(time.Unix(1500, 0)) {
+		t.Fatalf("reset header parsed as %s, want %s", got, time.Unix(1500, 0))
+	}
+
+	header = http.Header{}
+	header.Set("Retry-After", "60")
+	if got := claudeResponseExhaustedUntil(header, now); !got.Equal(now.Add(time.Minute)) {
+		t.Fatalf("retry-after parsed as %s, want %s", got, now.Add(time.Minute))
+	}
+}
+
 // TestClaudeTransient429FailsOverWithoutPoisoningScore proves a transient
 // (allowed_warning) 429 still fails the request over to another account but does
 // NOT mark the first account exhausted, so the GTO scheduler keeps routing to it.
@@ -360,6 +375,7 @@ func TestClaudeRejectedHeaderOn200FailsOver(t *testing.T) {
 			// 200 OK, but Anthropic flags the account out of quota (served via overage).
 			h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
 			h.Set("Anthropic-Ratelimit-Unified-Overage-In-Use", "true")
+			h.Set("Anthropic-Ratelimit-Unified-Reset", fmt.Sprintf("%d", time.Now().Add(time.Hour).Unix()))
 			// A rejected 200 carries a real completion; it must never be logged.
 			return &http.Response{StatusCode: http.StatusOK, Header: h, Body: io.NopCloser(strings.NewReader(`{"id":"msg_overage","text":"` + secretCompletion + `"}`))}
 		}
@@ -401,6 +417,13 @@ func TestClaudeRejectedHeaderOn200FailsOver(t *testing.T) {
 	}
 	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
 		t.Fatal("a rejected-header 200 must mark the depleted account exhausted")
+	}
+	server.SchedulerRef.FinishRefresh(selectacct.NewScheduler([]selectacct.Score{
+		{AccountID: "cooked@example.com", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+		{AccountID: "fresh@example.com", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+	}), true)
+	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
+		t.Fatal("fresh usage refresh clobbered the live rejected-header exhaustion")
 	}
 	assignment, ok := store.Get("claude", "session-rej")
 	if !ok || assignment.AccountID != "fresh@example.com" {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -19,6 +19,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -51,12 +52,12 @@ type Server struct {
 	RefreshAccountFn func(context.Context, accounts.Account) (accounts.Account, error)
 	Transport        http.RoundTripper
 	Logger           *slog.Logger
-	ActiveSessions *ActiveSessions
-	Lifecycle      *Lifecycle
-	AdminToken     string
-	MaxBodyBytes   int64
-	Transcripts    *transcript.Recorder
-	ReadCache      *readCache
+	ActiveSessions   *ActiveSessions
+	Lifecycle        *Lifecycle
+	AdminToken       string
+	MaxBodyBytes     int64
+	Transcripts      *transcript.Recorder
+	ReadCache        *readCache
 }
 
 type ActiveSessions struct {
@@ -1659,6 +1660,12 @@ func (s Server) markAccountExhausted(provider accounts.Provider, accountID strin
 	}
 }
 
+func (s Server) markAccountExhaustedUntil(provider accounts.Provider, accountID string, until time.Time) {
+	if s.SchedulerRef != nil {
+		s.SchedulerRef.MarkExhaustedUntil(provider, accountID, until)
+	}
+}
+
 func usageLimitJSON(body []byte) bool {
 	var event map[string]any
 	if err := json.Unmarshal(body, &event); err != nil {
@@ -1832,7 +1839,7 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 		// the rejected header). A transient "allowed"/"allowed_warning" 429 still
 		// fails over for this request but must not mark a healthy account exhausted.
 		if claudeAccountExhaustedByResponse(response.StatusCode, response.Header) {
-			s.markAccountExhausted(provider, accountID)
+			s.markAccountExhaustedUntil(provider, accountID, claudeResponseExhaustedUntil(response.Header, time.Now()))
 		}
 		// Surface the genuine upstream rate-limit signal (headers now, body
 		// prefix below). Anthropic conveys subscription exhaustion only via the
@@ -2702,6 +2709,16 @@ func claudeAccountExhaustedByResponse(status int, header http.Header) bool {
 	return claudeUnifiedStatus(header) == "rejected"
 }
 
+func claudeResponseExhaustedUntil(header http.Header, now time.Time) time.Time {
+	if unixSeconds, err := strconv.ParseInt(strings.TrimSpace(claudeHeaderGet(header, "anthropic-ratelimit-unified-reset")), 10, 64); err == nil && unixSeconds > 0 {
+		return time.Unix(unixSeconds, 0)
+	}
+	if retryAfter, err := strconv.ParseInt(strings.TrimSpace(claudeHeaderGet(header, "retry-after")), 10, 64); err == nil && retryAfter > 0 {
+		return now.Add(time.Duration(retryAfter) * time.Second)
+	}
+	return time.Time{}
+}
+
 // claudeUnifiedStatus returns the lowercased anthropic-ratelimit-unified-status
 // header ("allowed" | "allowed_warning" | "rejected"), or "" when absent.
 func claudeUnifiedStatus(header http.Header) string {
@@ -2787,7 +2804,11 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			exhausted = claudeAccountExhaustedByResponse(response.StatusCode, response.Header)
 		}
 		if t.server != nil && exhausted {
-			t.server.markAccountExhausted(t.provider, accountID)
+			until := time.Time{}
+			if t.provider == accounts.ProviderClaude {
+				until = claudeResponseExhaustedUntil(response.Header, time.Now())
+			}
+			t.server.markAccountExhaustedUntil(t.provider, accountID, until)
 		}
 		if attempt == maxAttempts || t.server == nil {
 			reason := "max_attempts"

--- a/internal/selectacct/scheduler.go
+++ b/internal/selectacct/scheduler.go
@@ -3,6 +3,7 @@ package selectacct
 import (
 	"errors"
 	"sort"
+	"strings"
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 )
@@ -176,6 +177,19 @@ func selectionTier(account accounts.Account, score Score) int {
 func (s Scheduler) ScoreFor(provider accounts.Provider, accountID string) Score {
 	if score, ok := s.scores[ScoreKey(provider, accountID)]; ok {
 		return score
+	}
+	return Score{AccountID: accountID, Provider: provider, Headroom: 1, ShortHeadroom: 1}
+}
+
+func (s Scheduler) ScoreForKey(key string) Score {
+	if score, ok := s.scores[key]; ok {
+		return score
+	}
+	provider := accounts.ProviderCodex
+	accountID := key
+	if before, after, ok := strings.Cut(key, "\x00"); ok {
+		provider = accounts.Provider(before)
+		accountID = after
 	}
 	return Score{AccountID: accountID, Provider: provider, Headroom: 1, ShortHeadroom: 1}
 }

--- a/internal/selectacct/scheduler_ref.go
+++ b/internal/selectacct/scheduler_ref.go
@@ -8,10 +8,11 @@ import (
 )
 
 type SchedulerRef struct {
-	mu         sync.RWMutex
-	scheduler  Scheduler
-	updatedAt  time.Time
-	refreshing bool
+	mu             sync.RWMutex
+	scheduler      Scheduler
+	updatedAt      time.Time
+	refreshing     bool
+	exhaustedUntil map[string]time.Time
 }
 
 func NewSchedulerRef(scheduler Scheduler) *SchedulerRef {
@@ -30,11 +31,15 @@ func (r *SchedulerRef) Get() Scheduler {
 func (r *SchedulerRef) Set(scheduler Scheduler) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.scheduler = scheduler
+	r.scheduler = r.withActiveExhaustionLocked(scheduler, time.Now())
 	r.updatedAt = time.Now()
 }
 
 func (r *SchedulerRef) MarkExhausted(provider accounts.Provider, accountID string) {
+	r.MarkExhaustedUntil(provider, accountID, time.Time{})
+}
+
+func (r *SchedulerRef) MarkExhaustedUntil(provider accounts.Provider, accountID string, until time.Time) {
 	if accountID == "" {
 		return
 	}
@@ -46,6 +51,12 @@ func (r *SchedulerRef) MarkExhausted(provider accounts.Provider, accountID strin
 		Headroom:      0,
 		ShortHeadroom: 0,
 	})
+	if until.After(time.Now()) {
+		if r.exhaustedUntil == nil {
+			r.exhaustedUntil = map[string]time.Time{}
+		}
+		r.exhaustedUntil[ScoreKey(provider, accountID)] = until
+	}
 	r.updatedAt = time.Now()
 }
 
@@ -75,7 +86,7 @@ func (r *SchedulerRef) FinishRefresh(scheduler Scheduler, update bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if update {
-		r.scheduler = scheduler
+		r.scheduler = r.withActiveExhaustionLocked(scheduler, time.Now())
 	}
 	r.updatedAt = time.Now()
 	r.refreshing = false
@@ -91,4 +102,21 @@ func (r *SchedulerRef) SetUpdatedAt(updatedAt time.Time) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.updatedAt = updatedAt
+}
+
+func (r *SchedulerRef) withActiveExhaustionLocked(scheduler Scheduler, now time.Time) Scheduler {
+	for key, until := range r.exhaustedUntil {
+		if !until.After(now) {
+			delete(r.exhaustedUntil, key)
+			continue
+		}
+		score := scheduler.ScoreForKey(key)
+		score.Headroom = 0
+		score.ShortHeadroom = 0
+		scheduler = scheduler.WithScore(score)
+	}
+	if len(r.exhaustedUntil) == 0 {
+		r.exhaustedUntil = nil
+	}
+	return scheduler
 }

--- a/internal/selectacct/scheduler_ref_test.go
+++ b/internal/selectacct/scheduler_ref_test.go
@@ -3,6 +3,8 @@ package selectacct
 import (
 	"testing"
 	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
 )
 
 func TestSchedulerRefAllowsOnlyOneStaleRefresh(t *testing.T) {
@@ -37,5 +39,47 @@ func TestSchedulerRefRetryAfterSkippedRefreshWaitsForTTL(t *testing.T) {
 	ref.SetUpdatedAt(time.Now().Add(-time.Hour))
 	if !ref.BeginRefreshIfStale(time.Minute) {
 		t.Fatal("refresh should be allowed after TTL passes")
+	}
+}
+
+func TestSchedulerRefPreservesExhaustedUntilAcrossRefresh(t *testing.T) {
+	ref := NewSchedulerRef(NewScheduler([]Score{{
+		AccountID:     "claude@example.com",
+		Provider:      accounts.ProviderClaude,
+		Headroom:      1,
+		ShortHeadroom: 1,
+	}}))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "claude@example.com", time.Now().Add(time.Hour))
+
+	ref.FinishRefresh(NewScheduler([]Score{{
+		AccountID:     "claude@example.com",
+		Provider:      accounts.ProviderClaude,
+		Headroom:      1,
+		ShortHeadroom: 1,
+	}}), true)
+
+	if !ref.Get().Exhausted(accounts.ProviderClaude, "claude@example.com") {
+		t.Fatal("fresh usage refresh clobbered live exhausted-until state")
+	}
+}
+
+func TestSchedulerRefExpiresExhaustedUntilOnRefresh(t *testing.T) {
+	ref := NewSchedulerRef(NewScheduler([]Score{{
+		AccountID:     "claude@example.com",
+		Provider:      accounts.ProviderClaude,
+		Headroom:      1,
+		ShortHeadroom: 1,
+	}}))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "claude@example.com", time.Now().Add(-time.Second))
+
+	ref.FinishRefresh(NewScheduler([]Score{{
+		AccountID:     "claude@example.com",
+		Provider:      accounts.ProviderClaude,
+		Headroom:      1,
+		ShortHeadroom: 1,
+	}}), true)
+
+	if ref.Get().Exhausted(accounts.ProviderClaude, "claude@example.com") {
+		t.Fatal("expired exhausted-until state should not override fresh usage")
 	}
 }


### PR DESCRIPTION
## Summary
- keep Claude accounts marked exhausted until the rejected/reset window expires, even if a later usage refresh reports stale headroom
- make sr claude mark CLAUDE_CONFIG_DIR as intentional for cmux so resume+fork keeps the selected Subrouter profile

## Test
- go test ./...