### PR TITLE
Log request source (remote_addr + user_agent) for attribution

### DIFF
--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -699,3 +699,26 @@ func TestClaudeRateLimitHeaderFields(t *testing.T) {
 		t.Fatal("unrelated headers must not be captured")
 	}
 }
+
+func TestClientRemoteIP(t *testing.T) {
+	mk := func(remote, xff string) *http.Request {
+		r, _ := http.NewRequest(http.MethodPost, "http://x/v1/messages", nil)
+		r.RemoteAddr = remote
+		if xff != "" {
+			r.Header.Set("X-Forwarded-For", xff)
+		}
+		return r
+	}
+	cases := []struct{ remote, xff, want string }{
+		{"100.94.126.75:41562", "", "100.94.126.75"},
+		{"[fd7a:115c:a1e0::1]:443", "", "fd7a:115c:a1e0::1"},
+		{"10.0.0.1:80", "100.1.2.3, 10.0.0.1", "100.1.2.3"},
+		{"10.0.0.1:80", "100.1.2.3", "100.1.2.3"},
+		{"noport", "", "noport"},
+	}
+	for _, tc := range cases {
+		if got := clientRemoteIP(mk(tc.remote, tc.xff)); got != tc.want {
+			t.Fatalf("clientRemoteIP(remote=%q xff=%q) = %q, want %q", tc.remote, tc.xff, got, tc.want)
+		}
+	}
+}

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -712,9 +712,9 @@ func TestClientRemoteIP(t *testing.T) {
 	cases := []struct{ remote, xff, want string }{
 		{"100.94.126.75:41562", "", "100.94.126.75"},
 		{"[fd7a:115c:a1e0::1]:443", "", "fd7a:115c:a1e0::1"},
-		{"10.0.0.1:80", "100.1.2.3, 10.0.0.1", "100.1.2.3"},
-		{"10.0.0.1:80", "100.1.2.3", "100.1.2.3"},
 		{"noport", "", "noport"},
+		// X-Forwarded-For is spoofable and must be ignored; the socket peer wins.
+		{"100.94.126.75:41562", "100.1.2.3", "100.94.126.75"},
 	}
 	for _, tc := range cases {
 		if got := clientRemoteIP(mk(tc.remote, tc.xff)); got != tc.want {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1326,6 +1326,24 @@ func isLoopbackRemote(remoteAddr string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
+// clientRemoteIP returns the best-effort source IP for request attribution: the
+// leftmost X-Forwarded-For entry when present, otherwise the RemoteAddr host with
+// the port stripped. On the tailnet this is the caller's device IP, which maps to
+// a device via `tailscale status`.
+func clientRemoteIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if i := strings.IndexByte(xff, ','); i >= 0 {
+			return strings.TrimSpace(xff[:i])
+		}
+		return strings.TrimSpace(xff)
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
 func (s Server) requireAdmin(next func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if s.authorizeAdmin(r) {
@@ -1516,7 +1534,11 @@ func (s Server) proxyHandler() http.Handler {
 		}
 
 		if s.Logger != nil {
-			s.Logger.Info("proxy request", "agent", sessionAgentType, "session", sessionID, "user", userEmail, "account", account.ID, "method", r.Method, "path", r.URL.Path, "upstream", upstream.Host)
+			// remote_addr + user_agent attribute each request to a source (tailnet
+			// device / client type). Without them a concurrency spike is an
+			// anonymous wall of user="" sessions that cannot be traced to whatever
+			// fired it (a load-test loader, an agent fleet, etc.).
+			s.Logger.Info("proxy request", "agent", sessionAgentType, "session", sessionID, "user", userEmail, "account", account.ID, "method", r.Method, "path", r.URL.Path, "upstream", upstream.Host, "remote_addr", clientRemoteIP(r), "user_agent", r.UserAgent())
 		}
 
 		// For cacheable GET paths, buffer the response so we can store it.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1326,17 +1326,13 @@ func isLoopbackRemote(remoteAddr string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-// clientRemoteIP returns the best-effort source IP for request attribution: the
-// leftmost X-Forwarded-For entry when present, otherwise the RemoteAddr host with
-// the port stripped. On the tailnet this is the caller's device IP, which maps to
-// a device via `tailscale status`.
+// clientRemoteIP returns the authoritative source IP for request attribution:
+// the socket peer (RemoteAddr) host with the port stripped. subrouter is reached
+// directly on the tailnet with no trusted proxy in front, so X-Forwarded-For is
+// deliberately ignored (a caller could spoof it to frame another device); the
+// socket peer cannot be forged. On the tailnet this maps to a device via
+// `tailscale status`.
 func clientRemoteIP(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		if i := strings.IndexByte(xff, ','); i >= 0 {
-			return strings.TrimSpace(xff[:i])
-		}
-		return strings.TrimSpace(xff)
-	}
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		return r.RemoteAddr


### PR DESCRIPTION
While tracing a burst of ~160 concurrent Claude sessions (in ~90s) that tripped Anthropic's per-IP rate limit, subrouter had **no way to attribute the traffic** — every request logs `user=""`, no source, no client fingerprint, and local transcripts are pruned. The burst was an anonymous wall of sessions.

Add `remote_addr` (the caller's IP, which maps to a tailnet device via `tailscale status`) and `user_agent` to the `proxy request` log line so concurrency spikes are attributable to a source (a load-test loader, an agent fleet, etc.) and monitorable. `clientRemoteIP` prefers the leftmost `X-Forwarded-For`, else the `RemoteAddr` host with the port stripped. Test covers IPv4/IPv6/XFF/no-port.

Observability only; no routing/behavior change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785543595&installation_id=133855650&pr_number=34&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F34&signature=7af83784ea263bdb8fe9151f0262c8acde2a5656e18e362f7ebad1c348898302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add request source attribution to proxy logs by including remote_addr and user_agent so traffic spikes can be traced to devices/clients. Uses the socket peer IP (ignores X-Forwarded-For) and does not change routing or behavior.

- **New Features**
  - Log fields added to `proxy request`: `remote_addr` (from `clientRemoteIP`) and `user_agent`.
  - `clientRemoteIP` returns the `RemoteAddr` host with port stripped and ignores `X-Forwarded-For` to prevent spoofing; supports IPv4/IPv6 and no-port fallback.
  - Tests cover IPv4/IPv6, no-port, and that `X-Forwarded-For` is ignored.

<sup>Written for commit 86b631010eb778af664ef508783746cad6f570d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

