### PR TITLE
Sentry error reporting + Docker/Fly deploy path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+dist
+bin
+npm
+subrouter_cli
+deploy
+docs
+*.md
+docker-compose.yml
+Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # :latest is skipped for prerelease versions (anything with a hyphen,
+      # e.g. v1.2.3-rc1) so pulling latest never lands on an unstable build.
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
@@ -133,7 +135,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/manaflow-ai/subrouter:v${{ needs.build.outputs.version }}
-            ghcr.io/manaflow-ai/subrouter:latest
+            ${{ !contains(needs.build.outputs.version, '-') && 'ghcr.io/manaflow-ai/subrouter:latest' || '' }}
 
   # Manual opt-in only. These never run on a tag push; trigger this workflow via
   # the Actions "Run workflow" button with the toggle enabled to publish.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,41 @@ jobs:
               --notes "Subrouter ${TAG_NAME}"
           fi
 
+  docker-publish:
+    name: Publish Docker image to ghcr.io
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/manaflow-ai/subrouter:v${{ needs.build.outputs.version }}
+            ghcr.io/manaflow-ai/subrouter:latest
+
   # Manual opt-in only. These never run on a tag push; trigger this workflow via
   # the Actions "Run workflow" button with the toggle enabled to publish.
   npm-publish:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage: static Go binary, no CGO.
+FROM golang:1.25-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/subrouter ./cmd/subrouter
+
+# Runtime stage: small image, non-root user, state under /var/lib/subrouter.
+FROM alpine:3.22
+RUN apk add --no-cache ca-certificates \
+    && addgroup -S subrouter \
+    && adduser -S -G subrouter -h /var/lib/subrouter -u 10001 subrouter \
+    && mkdir -p /var/lib/subrouter \
+    && chown -R subrouter:subrouter /var/lib/subrouter
+COPY --from=build /out/subrouter /usr/local/bin/subrouter
+RUN ln -s /usr/local/bin/subrouter /usr/local/bin/sr \
+    && ln -s /usr/local/bin/subrouter /usr/local/bin/cx
+
+ENV HOME=/var/lib/subrouter \
+    SUBROUTER_STATE_DIR=/var/lib/subrouter
+
+USER subrouter
+WORKDIR /var/lib/subrouter
+VOLUME ["/var/lib/subrouter"]
+EXPOSE 31415
+
+ENTRYPOINT ["subrouter"]
+CMD ["serve", "--addr", "0.0.0.0:31415", "--sessions", "/var/lib/subrouter/sessions.json"]

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ When `SUBROUTER_ADMIN_TOKEN` or `--admin-token` is set, non-loopback requests to
 ## GCP deployment
 
 See [deploy/gcp/README.md](deploy/gcp/README.md) for the small GCP + Tailscale Subrouter deployment flow.
+See [docs/deploy.md](docs/deploy.md) for the Docker/compose and Fly.io deployment paths and Sentry error reporting.
 See [docs/production.md](docs/production.md) for the production checklist before running a shared server.
 
 Transcript recording is off by default. To persist raw Subrouter transcripts, pass a transcript directory:

--- a/cmd/subrouter/install_daemon.go
+++ b/cmd/subrouter/install_daemon.go
@@ -28,6 +28,7 @@ type daemonConfig struct {
 	LogDir               string
 	WorkingDirectory     string
 	SRSwitchInterval     string
+	SentryDSN            string
 	Path                 string
 	InstallSRAlias       bool
 	SRAliasPath          string
@@ -58,6 +59,7 @@ func installDaemon(args []string) error {
 	flags.StringVar(&config.WorkingDirectory, "working-directory", cwd, "daemon working directory")
 	flags.StringVar(&config.SRSwitchInterval, "sr-switch-interval", "10m", "sr auto-switch interval; 0 disables")
 	flags.StringVar(&config.SRSwitchInterval, "cx-switch-interval", "10m", "compatibility alias for --sr-switch-interval")
+	flags.StringVar(&config.SentryDSN, "sentry-dsn", strings.TrimSpace(os.Getenv("SENTRY_DSN")), "Sentry DSN for server error reporting; defaults to SENTRY_DSN in the current environment")
 	flags.StringVar(&config.Path, "path", defaultDaemonPath(defaultInstallPath), "PATH for the daemon")
 	flags.BoolVar(&config.InstallSRAlias, "install-sr-shim", true, "install sr as a symlink to the subrouter binary")
 	flags.StringVar(&config.SRAliasPath, "sr-shim-path", filepath.Join(home, "bin", "sr"), "sr symlink path")
@@ -298,6 +300,8 @@ func launchAgentPlist(config daemonConfig, home string) (string, error) {
 		TranscriptsDir   string
 		HasTranscripts   bool
 		SRSwitchInterval string
+		SentryDSN        string
+		HasSentryDSN     bool
 		LogPath          string
 		ErrorLogPath     string
 		WorkingDirectory string
@@ -310,6 +314,8 @@ func launchAgentPlist(config daemonConfig, home string) (string, error) {
 		TranscriptsDir:   escapeXMLString(config.TranscriptsDir),
 		HasTranscripts:   strings.TrimSpace(config.TranscriptsDir) != "",
 		SRSwitchInterval: escapeXMLString(config.SRSwitchInterval),
+		SentryDSN:        escapeXMLString(strings.TrimSpace(config.SentryDSN)),
+		HasSentryDSN:     strings.TrimSpace(config.SentryDSN) != "",
 		LogPath:          escapeXMLString(filepath.Join(config.LogDir, "subrouter.log")),
 		ErrorLogPath:     escapeXMLString(filepath.Join(config.LogDir, "subrouter.err.log")),
 		WorkingDirectory: escapeXMLString(config.WorkingDirectory),
@@ -338,7 +344,9 @@ var launchAgentTemplate = template.Must(template.New("launch-agent").Parse(`<?xm
 		<string>{{.Home}}</string>
 		<key>PATH</key>
 		<string>{{.Path}}</string>
-	</dict>
+		{{if .HasSentryDSN}}<key>SENTRY_DSN</key>
+		<string>{{.SentryDSN}}</string>
+		{{end}}</dict>
 	<key>KeepAlive</key>
 	<true/>
 	<key>Label</key>

--- a/cmd/subrouter/install_daemon_test.go
+++ b/cmd/subrouter/install_daemon_test.go
@@ -122,3 +122,45 @@ func TestInstallDaemonWritesPlistAndInstallsExecutableWithoutStarting(t *testing
 		t.Fatalf("cx alias target = %q, want %q", target, config.InstallPath)
 	}
 }
+
+func TestLaunchAgentPlistIncludesSentryDSNWhenConfigured(t *testing.T) {
+	config := daemonConfig{
+		Label:            defaultDaemonLabel,
+		Addr:             "127.0.0.1:31415",
+		InstallPath:      "/Users/tester/bin/subrouter",
+		SRSwitchInterval: "10m",
+		SentryDSN:        "https://public@o0.ingest.sentry.io/1",
+		LogDir:           "/Users/tester/Library/Logs",
+		WorkingDirectory: "/Users/tester",
+		Path:             "/usr/bin:/bin",
+	}
+	plist, err := launchAgentPlist(config, "/Users/tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(plist, "<key>SENTRY_DSN</key>") {
+		t.Fatalf("plist missing SENTRY_DSN key:\n%s", plist)
+	}
+	if !strings.Contains(plist, "<string>https://public@o0.ingest.sentry.io/1</string>") {
+		t.Fatalf("plist missing SENTRY_DSN value:\n%s", plist)
+	}
+}
+
+func TestLaunchAgentPlistOmitsSentryDSNByDefault(t *testing.T) {
+	config := daemonConfig{
+		Label:            defaultDaemonLabel,
+		Addr:             "127.0.0.1:31415",
+		InstallPath:      "/Users/tester/bin/subrouter",
+		SRSwitchInterval: "10m",
+		LogDir:           "/Users/tester/Library/Logs",
+		WorkingDirectory: "/Users/tester",
+		Path:             "/usr/bin:/bin",
+	}
+	plist, err := launchAgentPlist(config, "/Users/tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(plist, "SENTRY_DSN") {
+		t.Fatalf("plist must not mention SENTRY_DSN when unset:\n%s", plist)
+	}
+}

--- a/cmd/subrouter/install_systemd.go
+++ b/cmd/subrouter/install_systemd.go
@@ -29,6 +29,7 @@ type systemdConfig struct {
 	TranscriptsDir   string
 	SRSwitchInterval string
 	AdminToken       string
+	SentryDSN        string
 	ExtraArgs        string
 	Start            bool
 	DryRun           bool
@@ -50,6 +51,7 @@ func installSystemd(args []string) error {
 	flags.StringVar(&config.SRSwitchInterval, "sr-switch-interval", "10m", "sr auto-switch interval; 0 disables")
 	flags.StringVar(&config.SRSwitchInterval, "cx-switch-interval", "10m", "compatibility alias for --sr-switch-interval")
 	flags.StringVar(&config.AdminToken, "admin-token", "", "admin token required for non-loopback _subrouter endpoints; preserves existing SUBROUTER_ADMIN_TOKEN by default")
+	flags.StringVar(&config.SentryDSN, "sentry-dsn", "", "Sentry DSN for server error reporting; preserves existing SENTRY_DSN by default")
 	flags.StringVar(&config.ExtraArgs, "extra-args", "", "extra arguments appended to subrouter serve")
 	flags.BoolVar(&config.Start, "start", true, "enable and restart the systemd service")
 	flags.BoolVar(&config.DryRun, "dry-run", false, "print the systemd unit without writing files")
@@ -126,7 +128,7 @@ func installSystemdWithConfig(config systemdConfig, runner commandRunner) error 
 		}
 	}
 	defaultMode := os.FileMode(0o644)
-	if config.AdminToken != "" {
+	if config.AdminToken != "" || config.SentryDSN != "" {
 		defaultMode = 0o600
 	}
 	if err := os.WriteFile(systemdDefaultPath(config), []byte(defaults), defaultMode); err != nil {
@@ -241,6 +243,9 @@ func applyExistingSystemdDefaults(config *systemdConfig, defaultPath string) {
 	if config.AdminToken == "" {
 		config.AdminToken = readDefaultValue(defaultPath, "SUBROUTER_ADMIN_TOKEN")
 	}
+	if config.SentryDSN == "" {
+		config.SentryDSN = readDefaultValue(defaultPath, "SENTRY_DSN")
+	}
 }
 
 func readLegacySystemdExtraArgs() string {
@@ -318,8 +323,9 @@ SUBROUTER_TRANSCRIPTS=%s
 SUBROUTER_TRANSCRIPT_ARGS=%q
 SUBROUTER_SR_SWITCH_INTERVAL=%s
 SUBROUTER_ADMIN_TOKEN=%q
+SENTRY_DSN=%q
 SUBROUTER_EXTRA_ARGS=%q
-`, config.Addr, config.Home, config.SessionsPath, config.TranscriptsDir, transcriptArgs, config.SRSwitchInterval, config.AdminToken, config.ExtraArgs)
+`, config.Addr, config.Home, config.SessionsPath, config.TranscriptsDir, transcriptArgs, config.SRSwitchInterval, config.AdminToken, config.SentryDSN, config.ExtraArgs)
 }
 
 func systemdUnit(config systemdConfig) (string, error) {

--- a/cmd/subrouter/install_systemd_test.go
+++ b/cmd/subrouter/install_systemd_test.go
@@ -162,3 +162,45 @@ func TestReadDefaultValueUnquotesEnvFileValue(t *testing.T) {
 		t.Fatalf("extra args = %q, want %q", got, want)
 	}
 }
+
+func TestApplyExistingSystemdDefaultsPreservesSentryDSN(t *testing.T) {
+	// A re-install without --sentry-dsn must keep an existing SENTRY_DSN in
+	// /etc/default/<service>, matching the admin-token behavior.
+	path := filepath.Join(t.TempDir(), "subrouter")
+	existing := strings.Join([]string{
+		"SUBROUTER_ADDR=0.0.0.0:31415",
+		`SENTRY_DSN="https://public@o0.ingest.sentry.io/1"`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	config := systemdConfig{
+		Addr:             "0.0.0.0:31415",
+		Home:             "/var/lib/subrouter",
+		SessionsPath:     "/var/lib/subrouter/sessions.json",
+		SRSwitchInterval: "10m",
+	}
+	applyExistingSystemdDefaults(&config, path)
+
+	if config.SentryDSN != "https://public@o0.ingest.sentry.io/1" {
+		t.Fatalf("sentry dsn = %q, want preserved DSN", config.SentryDSN)
+	}
+	defaults := systemdDefaults(config)
+	if !strings.Contains(defaults, `SENTRY_DSN="https://public@o0.ingest.sentry.io/1"`) {
+		t.Fatalf("regenerated defaults dropped SENTRY_DSN:\n%s", defaults)
+	}
+}
+
+func TestApplyExistingSystemdDefaultsFlagOverridesSentryDSN(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "subrouter")
+	if err := os.WriteFile(path, []byte("SENTRY_DSN=\"https://old@o0.ingest.sentry.io/1\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	config := systemdConfig{SentryDSN: "https://new@o0.ingest.sentry.io/2"}
+	applyExistingSystemdDefaults(&config, path)
+	if config.SentryDSN != "https://new@o0.ingest.sentry.io/2" {
+		t.Fatalf("sentry dsn = %q, want flag value to win", config.SentryDSN)
+	}
+}

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -23,6 +23,7 @@ import (
 	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
 	"github.com/manaflow-ai/subrouter/internal/proxy"
 	"github.com/manaflow-ai/subrouter/internal/selectacct"
+	"github.com/manaflow-ai/subrouter/internal/sentryreport"
 	"github.com/manaflow-ai/subrouter/internal/session"
 	"github.com/manaflow-ai/subrouter/internal/storepath"
 	"github.com/manaflow-ai/subrouter/internal/transcript"
@@ -167,6 +168,7 @@ func serve(args []string) error {
 	usageScoreTTL := flags.Duration("usage-score-ttl", 30*time.Second, "maximum age for usage scores before account selection refreshes them; 0 disables")
 	shutdownTimeout := flags.Duration("shutdown-timeout", 10*time.Minute, "maximum time to drain in-flight proxy requests after SIGTERM/SIGINT")
 	adminToken := flags.String("admin-token", "", "admin token required for non-loopback _subrouter endpoints; defaults to SUBROUTER_ADMIN_TOKEN")
+	sentryDSN := flags.String("sentry-dsn", "", "Sentry DSN for server error reporting; defaults to SENTRY_DSN; empty disables reporting")
 	maxBodyBytes := flags.Int64("max-body-bytes", 1<<20, "max JSON request body bytes to inspect for session IDs")
 	fetchUsage := flags.Bool("fetch-usage", true, "fetch Codex usage on startup for account selection")
 	if err := flags.Parse(args); err != nil {
@@ -181,6 +183,28 @@ func serve(args []string) error {
 	}
 	if *adminToken == "" {
 		*adminToken = strings.TrimSpace(os.Getenv("SUBROUTER_ADMIN_TOKEN"))
+	}
+	if *sentryDSN == "" {
+		*sentryDSN = strings.TrimSpace(os.Getenv("SENTRY_DSN"))
+	}
+	// Sentry is initialized before any slog.Default() reference below so the
+	// bridge handler is what the proxy server and background goroutines pick
+	// up. With no DSN this is a no-op and behavior is unchanged.
+	sentryEnabled, err := sentryreport.Init(sentryreport.Options{
+		DSN:         *sentryDSN,
+		Environment: strings.TrimSpace(os.Getenv("SENTRY_ENVIRONMENT")),
+	})
+	if err != nil {
+		return fmt.Errorf("sentry init: %w", err)
+	}
+	if sentryEnabled {
+		// The bridge wraps an explicit stderr handler, not
+		// slog.Default().Handler(): the built-in default handler writes through
+		// the log package, and slog.SetDefault reroutes the log package into
+		// the new logger, so wrapping it would recurse and deadlock on the
+		// first log call.
+		slog.SetDefault(slog.New(sentryreport.NewLogHandler(slog.NewTextHandler(os.Stderr, nil))))
+		defer sentryreport.Flush(3 * time.Second)
 	}
 
 	var upstream *url.URL
@@ -295,9 +319,16 @@ func serve(args []string) error {
 		slog.Info("sr auto-switch disabled because usage fetching is disabled", "interval", srSwitchInterval.String())
 	}
 
+	handler := server.Handler()
+	if sentryEnabled {
+		// Recover middleware around the top-level handler: handler panics are
+		// reported (scrubbed) and answered with 500 instead of only killing
+		// the connection.
+		handler = sentryreport.HTTPMiddleware(handler)
+	}
 	httpServer := &http.Server{
 		Addr:              *addr,
-		Handler:           server.Handler(),
+		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
@@ -625,7 +656,7 @@ Usage:
   %[1]s claude             Manage Claude Code profiles
   %[1]s gemini             Manage Gemini profiles
 
-  %[1]s serve [--addr 127.0.0.1:31415] [--fetch-usage=true] [--codex-upstream URL] [--claude-upstream URL] [--kimi-upstream URL] [--zai-upstream URL] [--transcripts DIR] [--transcript-gcs-uri gs://bucket/prefix] [--transcript-gcs-sync-timeout 30m] [--transcript-local-retention 24h] [--transcript-max-local-bytes 2GiB]
+  %[1]s serve [--addr 127.0.0.1:31415] [--fetch-usage=true] [--codex-upstream URL] [--claude-upstream URL] [--kimi-upstream URL] [--zai-upstream URL] [--sentry-dsn DSN] [--transcripts DIR] [--transcript-gcs-uri gs://bucket/prefix] [--transcript-gcs-sync-timeout 30m] [--transcript-local-retention 24h] [--transcript-max-local-bytes 2GiB]
   %[1]s accounts
   %[1]s codex [codex args...]
   %[1]s install-daemon [--start=true]       macOS LaunchAgent

--- a/deploy/fly/fly.toml
+++ b/deploy/fly/fly.toml
@@ -1,0 +1,33 @@
+# Example Fly.io config for a hosted subrouter. See docs/deploy.md.
+# Deploy from the repo root with: fly deploy -c deploy/fly/fly.toml
+#
+# Fly terminates TLS at its edge and forwards plaintext HTTP to internal_port.
+# Run exactly one machine: session stickiness and the account store are
+# process-local state on the mounted volume.
+app = "subrouter"
+primary_region = "sjc"
+
+[build]
+  dockerfile = "../../Dockerfile"
+
+[http_service]
+  internal_port = 31415
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "10s"
+    method = "GET"
+    path = "/_subrouter/health"
+
+[[mounts]]
+  source = "subrouter_state"
+  destination = "/var/lib/subrouter"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/deploy/fly/fly.toml
+++ b/deploy/fly/fly.toml
@@ -1,14 +1,15 @@
 # Example Fly.io config for a hosted subrouter. See docs/deploy.md.
 # Deploy from the repo root with: fly deploy -c deploy/fly/fly.toml
+# There is intentionally no [build] section: flyctl then picks up the
+# Dockerfile from the working directory, which is the repo root for the
+# command above. A relative dockerfile path here is resolved differently by
+# different flyctl versions (config dir vs working dir), so it is avoided.
 #
 # Fly terminates TLS at its edge and forwards plaintext HTTP to internal_port.
 # Run exactly one machine: session stickiness and the account store are
 # process-local state on the mounted volume.
 app = "subrouter"
 primary_region = "sjc"
-
-[build]
-  dockerfile = "../../Dockerfile"
 
 [http_service]
   internal_port = 31415

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+# Example compose file for a hosted subrouter. See docs/deploy.md.
+#
+# Bootstrap:
+#   export SUBROUTER_ADMIN_TOKEN="$(openssl rand -hex 32)"
+#   docker compose up -d
+#
+# The data plane (everything except /_subrouter/health and /_subrouter/ready)
+# has no per-request auth yet. Keep the published port on a private network
+# (tailnet, VPC, or 127.0.0.1) until multi-tenant keys land.
+services:
+  subrouter:
+    image: ghcr.io/manaflow-ai/subrouter:latest
+    # Uncomment to build from this checkout instead of pulling the release image.
+    # build: .
+    restart: unless-stopped
+    ports:
+      - "31415:31415"
+    environment:
+      SUBROUTER_ADMIN_TOKEN: ${SUBROUTER_ADMIN_TOKEN:?set an admin token, e.g. $(openssl rand -hex 32)}
+      SENTRY_DSN: ${SENTRY_DSN:-}
+    volumes:
+      - subrouter-state:/var/lib/subrouter
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:31415/_subrouter/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  subrouter-state:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,77 @@
+# Deploying a hosted Subrouter
+
+Three supported paths: systemd on a Linux VM, Docker/compose, and Fly.io. All of them run `subrouter serve` on port 31415 with state under `/var/lib/subrouter`. Read [production.md](production.md) before sharing a server with a team.
+
+**Warning: the data plane has no per-request auth yet.** `SUBROUTER_ADMIN_TOKEN` protects the `/_subrouter/*` admin endpoints, but any client that can reach the listener can proxy LLM traffic through your accounts. Keep the listener on a private network (Tailscale, VPC, or loopback) until multi-tenant client keys land. This applies doubly to Fly.io, where the app URL is public TLS.
+
+## Admin token bootstrap
+
+Every non-loopback deployment needs an admin token. Generate one once and reuse it on the client side:
+
+```bash
+TOKEN="$(openssl rand -hex 32)"
+```
+
+After the server is up, register it locally without printing the token:
+
+```bash
+sr server add team --url https://<server>:31415 --admin-token "$TOKEN" --default
+sr server sync team --device-auth
+```
+
+`sr server sync` creates fresh server-owned OAuth chains. Do not copy local `~/.subrouter/codex/accounts/*.json` or `~/.codex/auth.json` to a server; Codex refresh tokens rotate and shared chains invalidate each other.
+
+## Sentry error reporting
+
+All three paths accept `SENTRY_DSN`. When set, `subrouter serve` reports handler panics and high-signal failures (upstream 502s, OAuth refresh chain deaths, account selection failures) to Sentry. Events are scrubbed before send: no request or response bodies, no Authorization or API-key headers, and token-shaped strings (`sk-`, `srt_`, `eyJ`, Bearer values) are redacted. Unset, nothing initializes and behavior is unchanged. `SENTRY_ENVIRONMENT` names the environment.
+
+## systemd (Linux VM)
+
+The existing path, documented in [production.md](production.md) and the [README](../README.md#linux-systemd-service):
+
+```bash
+curl -fsSL https://github.com/manaflow-ai/subrouter/releases/latest/download/install.sh | sudo sh
+sudo sr install-systemd --addr 0.0.0.0:31415 --admin-token "$TOKEN" --sentry-dsn "$SENTRY_DSN"
+```
+
+Re-running `install-systemd` preserves `SUBROUTER_ADMIN_TOKEN`, `SENTRY_DSN`, `SUBROUTER_TRANSCRIPTS`, and `SUBROUTER_EXTRA_ARGS` from `/etc/default/subrouter` when the flags are omitted. When a token or DSN is present the file is written mode 0600.
+
+On macOS, `subrouter install-daemon --sentry-dsn <dsn>` bakes `SENTRY_DSN` into the LaunchAgent plist. The flag defaults to `SENTRY_DSN` from the invoking shell, so re-running the installer with the variable exported keeps it.
+
+## Docker / compose
+
+The repo root has a multi-stage `Dockerfile` (static Go build, Alpine runtime, non-root user) and a `docker-compose.yml` example with a named state volume:
+
+```bash
+export SUBROUTER_ADMIN_TOKEN="$TOKEN"
+export SENTRY_DSN="https://...@sentry.io/..."   # optional
+docker compose up -d
+curl -fsS http://127.0.0.1:31415/_subrouter/health
+```
+
+Release tags publish `ghcr.io/manaflow-ai/subrouter:<version>` and `:latest` for amd64 and arm64. State (accounts, sessions) lives in the `subrouter-state` volume at `/var/lib/subrouter`; account files written there survive image upgrades. To add accounts, use `sr server add` + `sr server sync` from your workstation rather than exec-ing into the container.
+
+The compose file publishes 31415 on all interfaces. On a shared host, change the mapping to `127.0.0.1:31415:31415` or a tailnet address.
+
+## Fly.io
+
+[deploy/fly/fly.toml](../deploy/fly/fly.toml) runs a single machine with a volume and Fly edge TLS. Fly gives the app a public HTTPS URL, so this is the setup that most needs the auth warning above.
+
+```bash
+fly launch --no-deploy --copy-config -c deploy/fly/fly.toml
+fly volumes create subrouter_state --size 1
+fly secrets set SUBROUTER_ADMIN_TOKEN="$TOKEN"
+fly secrets set SENTRY_DSN="https://...@sentry.io/..."   # optional
+fly deploy -c deploy/fly/fly.toml
+fly scale count 1
+curl -fsS https://<app>.fly.dev/_subrouter/health
+```
+
+Keep it at one machine. Session-to-account stickiness, the account store, and usage scores are process-local; a second machine would split them. The volume mount at `/var/lib/subrouter` holds accounts and sessions across deploys.
+
+Clients then point at the public URL:
+
+```bash
+sr server add fly --url https://<app>.fly.dev --admin-token "$TOKEN" --default
+sr server sync fly --device-auth
+```

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -49,7 +49,7 @@ docker compose up -d
 curl -fsS http://127.0.0.1:31415/_subrouter/health
 ```
 
-Release tags publish `ghcr.io/manaflow-ai/subrouter:<version>` and `:latest` for amd64 and arm64. State (accounts, sessions) lives in the `subrouter-state` volume at `/var/lib/subrouter`; account files written there survive image upgrades. To add accounts, use `sr server add` + `sr server sync` from your workstation rather than exec-ing into the container.
+Release tags publish `ghcr.io/manaflow-ai/subrouter:<version>` for amd64 and arm64; `:latest` moves only on stable versions, never on prerelease tags (anything with a hyphen, like `v1.2.3-rc1`). State (accounts, sessions) lives in the `subrouter-state` volume at `/var/lib/subrouter`; account files written there survive image upgrades. To add accounts, use `sr server add` + `sr server sync` from your workstation rather than exec-ing into the container.
 
 The compose file publishes 31415 on all interfaces. On a shared host, change the mapping to `127.0.0.1:31415:31415` or a tailnet address.
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,10 @@
 module github.com/manaflow-ai/subrouter
 
-go 1.22
+go 1.25.0
 
-require github.com/gorilla/websocket v1.5.3 // indirect
+require (
+	github.com/getsentry/sentry-go v0.47.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
+	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/text v0.37.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
+github.com/getsentry/sentry-go v0.47.0 h1:AnSMSyrYA5qZCIN/2xpgAAwv63sVULV+vBq37ajouc8=
+github.com/getsentry/sentry-go v0.47.0/go.mod h1:h+b4VHpKnK7aUXB5wc+KDnPgp9ZtfliRD4eV85FbiSA=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -52,12 +52,12 @@ type Server struct {
 	RefreshAccountFn func(context.Context, accounts.Account) (accounts.Account, error)
 	Transport        http.RoundTripper
 	Logger           *slog.Logger
-	ActiveSessions *ActiveSessions
-	Lifecycle      *Lifecycle
-	AdminToken     string
-	MaxBodyBytes   int64
-	Transcripts    *transcript.Recorder
-	ReadCache      *readCache
+	ActiveSessions   *ActiveSessions
+	Lifecycle        *Lifecycle
+	AdminToken       string
+	MaxBodyBytes     int64
+	Transcripts      *transcript.Recorder
+	ReadCache        *readCache
 }
 
 type ActiveSessions struct {
@@ -1413,17 +1413,26 @@ func (s Server) proxyHandler() http.Handler {
 		sessionAgentType := agentTypeForProviderSession(agentType, requestProvider)
 		account, sessionID, userEmail, err := s.accountForSessionProvider(requestProvider, sessionAgentType, sessionID, r)
 		if err != nil {
+			if s.Logger != nil {
+				s.Logger.Error("account selection failed", "agent", sessionAgentType, "session", sessionID, "provider", string(requestProvider), "method", r.Method, "path", r.URL.Path, "error", err)
+			}
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 			return
 		}
 		account, err = s.refreshSelectedAccount(r.Context(), requestProvider, sessionAgentType, sessionID, userEmail, r, account)
 		if err != nil {
+			if s.Logger != nil {
+				s.Logger.Error("selected account refresh failed", "agent", sessionAgentType, "session", sessionID, "provider", string(requestProvider), "account", account.ID, "method", r.Method, "path", r.URL.Path, "error", err)
+			}
 			http.Error(w, "refresh selected account: "+err.Error(), http.StatusServiceUnavailable)
 			return
 		}
 
 		auth := account.AuthorizationHeader()
 		if auth == "" {
+			if s.Logger != nil {
+				s.Logger.Error("selected account has no usable credential", "agent", sessionAgentType, "session", sessionID, "provider", string(requestProvider), "account", account.ID, "method", r.Method, "path", r.URL.Path)
+			}
 			http.Error(w, "selected account has no usable credential", http.StatusServiceUnavailable)
 			return
 		}

--- a/internal/sentryreport/sentryreport.go
+++ b/internal/sentryreport/sentryreport.go
@@ -1,0 +1,306 @@
+// Package sentryreport wires optional Sentry error reporting into the
+// subrouter server. Everything in this package is inert unless Init is called
+// with a non-empty DSN, so a server without SENTRY_DSN behaves exactly as
+// before.
+//
+// Privacy contract: this proxy carries auth tokens and full LLM request
+// bodies. Events must never include request or response bodies,
+// Authorization/X-Api-Key headers, OAuth refresh chains, or token-like
+// strings. Enforcement is layered: the slog bridge only forwards an allowlist
+// of structured attributes, and scrubEvent runs as BeforeSend on every
+// outgoing event as defense in depth.
+package sentryreport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+// Options configures Init. An empty DSN disables reporting entirely.
+type Options struct {
+	DSN         string
+	Environment string
+}
+
+var enabled bool
+
+// Init starts the Sentry client when opts.DSN is non-empty. It reports
+// whether reporting is enabled. PII defaults stay off and every event passes
+// through scrubEvent before send.
+func Init(opts Options) (bool, error) {
+	if strings.TrimSpace(opts.DSN) == "" {
+		return false, nil
+	}
+	err := sentry.Init(sentry.ClientOptions{
+		Dsn:              strings.TrimSpace(opts.DSN),
+		Environment:      opts.Environment,
+		Release:          release(),
+		SendDefaultPII:   false,
+		AttachStacktrace: true,
+		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+			return scrubEvent(event)
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+	enabled = true
+	return true, nil
+}
+
+// Enabled reports whether Init succeeded with a DSN.
+func Enabled() bool {
+	return enabled
+}
+
+// Flush drains queued events; call it on shutdown.
+func Flush(timeout time.Duration) {
+	if enabled {
+		sentry.Flush(timeout)
+	}
+}
+
+func release() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok || info.Main.Version == "" || info.Main.Version == "(devel)" {
+		return ""
+	}
+	return "subrouter@" + info.Main.Version
+}
+
+// tokenPattern matches credential-shaped strings that must never leave the
+// process: OpenAI/Anthropic style sk- keys, subrouter srt_ tokens, JWTs
+// (eyJ...), and any Bearer credential.
+var tokenPattern = regexp.MustCompile(`(?i)\b(sk-[A-Za-z0-9._-]{4,}|srt_[A-Za-z0-9._-]{4,}|eyJ[A-Za-z0-9._/+=-]{8,}|Bearer\s+[^\s"']+)`)
+
+// redactTokens replaces token-like substrings with a placeholder.
+func redactTokens(value string) string {
+	return tokenPattern.ReplaceAllString(value, "[redacted]")
+}
+
+// sensitiveHeaders are dropped from any request context that reaches an
+// event. scrubEvent also nils the request body unconditionally.
+var sensitiveHeaders = map[string]struct{}{
+	"authorization":             {},
+	"proxy-authorization":       {},
+	"cookie":                    {},
+	"set-cookie":                {},
+	"x-api-key":                 {},
+	"x-subrouter-admin-token":   {},
+	"chatgpt-account-id":        {},
+	"x-subrouter-user-email":    {},
+	"openai-organization":       {},
+	"anthropic-organization-id": {},
+}
+
+// scrubEvent removes bodies, auth headers, and token-like strings from an
+// event. It runs as BeforeSend on every event, including panics captured by
+// HTTPMiddleware.
+func scrubEvent(event *sentry.Event) *sentry.Event {
+	if event == nil {
+		return nil
+	}
+	if event.Request != nil {
+		event.Request.Data = ""
+		event.Request.Cookies = ""
+		event.Request.Env = nil
+		headers := make(map[string]string, len(event.Request.Headers))
+		for name, value := range event.Request.Headers {
+			if _, sensitive := sensitiveHeaders[strings.ToLower(name)]; sensitive {
+				continue
+			}
+			headers[name] = redactTokens(value)
+		}
+		event.Request.Headers = headers
+		event.Request.QueryString = redactTokens(event.Request.QueryString)
+	}
+	event.Message = redactTokens(event.Message)
+	for i := range event.Exception {
+		event.Exception[i].Value = redactTokens(event.Exception[i].Value)
+	}
+	for key, value := range event.Tags {
+		event.Tags[key] = redactTokens(value)
+	}
+	for name, contextData := range event.Contexts {
+		for key, value := range contextData {
+			if text, ok := value.(string); ok {
+				event.Contexts[name][key] = redactTokens(text)
+			}
+		}
+	}
+	for i := range event.Breadcrumbs {
+		if event.Breadcrumbs[i] == nil {
+			continue
+		}
+		event.Breadcrumbs[i].Message = redactTokens(event.Breadcrumbs[i].Message)
+		for key, value := range event.Breadcrumbs[i].Data {
+			if text, ok := value.(string); ok {
+				event.Breadcrumbs[i].Data[key] = redactTokens(text)
+			}
+		}
+	}
+	return event
+}
+
+// HTTPMiddleware recovers panics from the wrapped handler, reports them to
+// Sentry with method/path tags only (never headers or body), and answers 500.
+// http.ErrAbortHandler is re-panicked so httputil.ReverseProxy stream aborts
+// keep their net/http semantics.
+func HTTPMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			recovered := recover()
+			if recovered == nil {
+				return
+			}
+			if err, ok := recovered.(error); ok && errors.Is(err, http.ErrAbortHandler) {
+				panic(recovered)
+			}
+			hub := sentry.CurrentHub().Clone()
+			hub.WithScope(func(scope *sentry.Scope) {
+				scope.SetTag("http_method", r.Method)
+				scope.SetTag("http_path", r.URL.Path)
+				hub.RecoverWithContext(r.Context(), recovered)
+			})
+			Flush(2 * time.Second)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// forwardedWarnMessages are the Warn-level records that still represent
+// operator-actionable failures (OAuth refresh chains dying). Everything else
+// at Warn stays local.
+var forwardedWarnMessages = map[string]struct{}{
+	"account refresh failed":                                         {},
+	"account reload refresh failed":                                  {},
+	"retry Claude account refresh failed":                            {},
+	"selected Claude account refresh failed, trying another account": {},
+}
+
+// attrTags maps slog attribute keys to Sentry tag names. Only these become
+// tags; grouping and search stay stable.
+var attrTags = map[string]string{
+	"agent":    "agent_type",
+	"upstream": "upstream",
+	"status":   "http_status",
+	"method":   "http_method",
+	"provider": "provider",
+}
+
+// logContextKey is the event context that carries allowlisted non-tag
+// attributes.
+const logContextKey = "log_attributes"
+
+// attrExtras are the additional attribute keys copied into the event's
+// log_attributes context. Every other attribute is dropped: attributes are
+// sensitive by default because log call sites include things like response
+// bodies.
+var attrExtras = map[string]struct{}{
+	"path":    {},
+	"account": {},
+	"session": {},
+	"error":   {},
+	"message": {},
+	"reason":  {},
+	"bytes":   {},
+	"signal":  {},
+}
+
+// LogHandler is a slog.Handler that forwards Error-level records (plus the
+// small refresh-failure Warn allowlist) to Sentry while delegating all output
+// to the wrapped handler.
+type LogHandler struct {
+	base  slog.Handler
+	attrs []slog.Attr
+}
+
+// NewLogHandler wraps base with Sentry forwarding.
+func NewLogHandler(base slog.Handler) *LogHandler {
+	return &LogHandler{base: base}
+}
+
+func (h *LogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.base.Enabled(ctx, level)
+}
+
+func (h *LogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &LogHandler{base: h.base.WithAttrs(attrs), attrs: append(append([]slog.Attr{}, h.attrs...), attrs...)}
+}
+
+func (h *LogHandler) WithGroup(name string) slog.Handler {
+	// Groups are not used by subrouter's log sites; forward grouped records
+	// to the base handler only.
+	return &LogHandler{base: h.base.WithGroup(name), attrs: h.attrs}
+}
+
+func (h *LogHandler) Handle(ctx context.Context, record slog.Record) error {
+	err := h.base.Handle(ctx, record)
+	if !enabled {
+		return err
+	}
+	if !shouldForward(record) {
+		return err
+	}
+	event := eventFromRecord(record, h.attrs)
+	sentry.CurrentHub().CaptureEvent(event)
+	return err
+}
+
+func shouldForward(record slog.Record) bool {
+	if record.Level >= slog.LevelError {
+		return true
+	}
+	if record.Level >= slog.LevelWarn {
+		_, ok := forwardedWarnMessages[record.Message]
+		return ok
+	}
+	return false
+}
+
+func eventFromRecord(record slog.Record, handlerAttrs []slog.Attr) *sentry.Event {
+	event := sentry.NewEvent()
+	event.Message = redactTokens(record.Message)
+	event.Logger = "slog"
+	if record.Level >= slog.LevelError {
+		event.Level = sentry.LevelError
+	} else {
+		event.Level = sentry.LevelWarning
+	}
+	logContext := sentry.Context{}
+	apply := func(attr slog.Attr) {
+		value := attr.Value.Resolve()
+		if tag, ok := attrTags[attr.Key]; ok {
+			event.Tags[tag] = redactTokens(fmt.Sprint(value.Any()))
+			return
+		}
+		if _, ok := attrExtras[attr.Key]; ok {
+			logContext[attr.Key] = redactTokens(fmt.Sprint(value.Any()))
+		}
+		// Any other key is intentionally dropped.
+	}
+	for _, attr := range handlerAttrs {
+		apply(attr)
+	}
+	record.Attrs(func(attr slog.Attr) bool {
+		apply(attr)
+		return true
+	})
+	if len(logContext) > 0 {
+		if event.Contexts == nil {
+			event.Contexts = map[string]sentry.Context{}
+		}
+		event.Contexts[logContextKey] = logContext
+	}
+	return event
+}

--- a/internal/sentryreport/sentryreport.go
+++ b/internal/sentryreport/sentryreport.go
@@ -13,6 +13,8 @@ package sentryreport
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -205,16 +207,25 @@ const logContextKey = "log_attributes"
 // attrExtras are the additional attribute keys copied into the event's
 // log_attributes context. Every other attribute is dropped: attributes are
 // sensitive by default because log call sites include things like response
-// bodies.
+// bodies. The "account" attribute is handled separately in eventFromRecord:
+// account IDs are usually OAuth account emails, so only a short hash goes
+// out.
 var attrExtras = map[string]struct{}{
 	"path":    {},
-	"account": {},
 	"session": {},
 	"error":   {},
 	"message": {},
 	"reason":  {},
 	"bytes":   {},
 	"signal":  {},
+}
+
+// accountHash reduces an account ID (often an email) to a stable non-PII
+// fingerprint so events still correlate per account. Match against local logs
+// with: printf %s '<account-id>' | shasum -a 256 | cut -c1-12
+func accountHash(accountID string) string {
+	sum := sha256.Sum256([]byte(accountID))
+	return hex.EncodeToString(sum[:])[:12]
 }
 
 // LogHandler is a slog.Handler that forwards Error-level records (plus the
@@ -282,6 +293,10 @@ func eventFromRecord(record slog.Record, handlerAttrs []slog.Attr) *sentry.Event
 		value := attr.Value.Resolve()
 		if tag, ok := attrTags[attr.Key]; ok {
 			event.Tags[tag] = redactTokens(fmt.Sprint(value.Any()))
+			return
+		}
+		if attr.Key == "account" {
+			logContext["account_hash"] = accountHash(fmt.Sprint(value.Any()))
 			return
 		}
 		if _, ok := attrExtras[attr.Key]; ok {

--- a/internal/sentryreport/sentryreport_test.go
+++ b/internal/sentryreport/sentryreport_test.go
@@ -1,0 +1,180 @@
+package sentryreport
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+func TestScrubEventRemovesAuthorizationHeaders(t *testing.T) {
+	event := sentry.NewEvent()
+	event.Request = &sentry.Request{
+		URL:         "https://chatgpt.com/backend-api/codex/responses",
+		QueryString: "token=eyJhbGciOiJIUzI1NiJ9.payload.sig",
+		Data:        `{"messages":[{"role":"user","content":"secret prompt"}]}`,
+		Cookies:     "session=abc",
+		Headers: map[string]string{
+			"Authorization":           "Bearer sk-proj-abcdef1234567890",
+			"authorization":           "Bearer srt_0123456789abcdef",
+			"X-Api-Key":               "sk-ant-api03-abcdef",
+			"Cookie":                  "session=abc",
+			"X-Subrouter-Admin-Token": "srt_admintoken123",
+			"User-Agent":              "codex-cli",
+		},
+		Env: map[string]string{"REMOTE_ADDR": "10.0.0.1"},
+	}
+
+	scrubbed := scrubEvent(event)
+
+	if scrubbed.Request.Data != "" {
+		t.Fatalf("request body must be dropped, got %q", scrubbed.Request.Data)
+	}
+	if scrubbed.Request.Cookies != "" {
+		t.Fatalf("cookies must be dropped, got %q", scrubbed.Request.Cookies)
+	}
+	if scrubbed.Request.Env != nil {
+		t.Fatalf("request env must be dropped, got %v", scrubbed.Request.Env)
+	}
+	for name := range scrubbed.Request.Headers {
+		switch strings.ToLower(name) {
+		case "authorization", "x-api-key", "cookie", "x-subrouter-admin-token":
+			t.Fatalf("sensitive header %q must be dropped", name)
+		}
+	}
+	if scrubbed.Request.Headers["User-Agent"] != "codex-cli" {
+		t.Fatalf("benign header must survive, got %v", scrubbed.Request.Headers)
+	}
+	if strings.Contains(scrubbed.Request.QueryString, "eyJ") {
+		t.Fatalf("JWT in query string must be redacted, got %q", scrubbed.Request.QueryString)
+	}
+}
+
+func TestScrubEventRedactsTokenLikeStrings(t *testing.T) {
+	event := sentry.NewEvent()
+	event.Message = "refresh failed for sk-proj-abcdef1234567890 using srt_refresh0987654321"
+	event.Exception = []sentry.Exception{{
+		Type:  "error",
+		Value: "invalid_grant: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIx.abc123 rejected",
+	}}
+	event.Tags = map[string]string{"account": "Bearer sk-live-abc123456"}
+	event.Contexts = map[string]sentry.Context{
+		"log_attributes": {
+			"error": "token srt_deadbeef00 expired",
+			"count": 3,
+		},
+	}
+	event.Breadcrumbs = []*sentry.Breadcrumb{{
+		Message: "retried with sk-admin-1234567890",
+		Data:    map[string]any{"auth": "Bearer eyJfoo.bar.baz"},
+	}}
+
+	scrubbed := scrubEvent(event)
+
+	flat := scrubbed.Message +
+		scrubbed.Exception[0].Value +
+		scrubbed.Tags["account"] +
+		scrubbed.Contexts["log_attributes"]["error"].(string) +
+		scrubbed.Breadcrumbs[0].Message +
+		scrubbed.Breadcrumbs[0].Data["auth"].(string)
+	for _, marker := range []string{"sk-", "srt_", "eyJ", "Bearer "} {
+		if strings.Contains(flat, marker) {
+			t.Fatalf("token marker %q leaked: %q", marker, flat)
+		}
+	}
+	if !strings.Contains(scrubbed.Message, "[redacted]") {
+		t.Fatalf("expected redaction placeholder, got %q", scrubbed.Message)
+	}
+	if scrubbed.Contexts["log_attributes"]["count"] != 3 {
+		t.Fatalf("non-string context values must be preserved, got %v", scrubbed.Contexts["log_attributes"]["count"])
+	}
+}
+
+func TestEventFromRecordUsesAllowlistedAttrsOnly(t *testing.T) {
+	record := slog.NewRecord(time.Now(), slog.LevelError, "proxy request failed", 0)
+	record.AddAttrs(
+		slog.String("agent", "codex"),
+		slog.String("upstream", "chatgpt.com"),
+		slog.Int("status", 502),
+		slog.String("error", "dial tcp: refused; auth Bearer sk-proj-abc12345"),
+		slog.String("body", `{"secret":"payload"}`),
+		slog.String("refresh_token", "srt_supersecret1234"),
+	)
+
+	event := eventFromRecord(record, nil)
+
+	if event.Tags["agent_type"] != "codex" || event.Tags["upstream"] != "chatgpt.com" || event.Tags["http_status"] != "502" {
+		t.Fatalf("expected agent_type/upstream/http_status tags, got %v", event.Tags)
+	}
+	logContext := event.Contexts["log_attributes"]
+	if _, ok := logContext["body"]; ok {
+		t.Fatal("body attribute must never be forwarded")
+	}
+	if _, ok := logContext["refresh_token"]; ok {
+		t.Fatal("non-allowlisted attributes must be dropped")
+	}
+	errExtra, _ := logContext["error"].(string)
+	if strings.Contains(errExtra, "sk-") || strings.Contains(errExtra, "Bearer ") {
+		t.Fatalf("token in error attr must be redacted, got %q", errExtra)
+	}
+	if !strings.Contains(errExtra, "dial tcp: refused") {
+		t.Fatalf("error context should survive redaction, got %q", errExtra)
+	}
+}
+
+func TestShouldForwardLevels(t *testing.T) {
+	errRecord := slog.NewRecord(time.Now(), slog.LevelError, "anything", 0)
+	if !shouldForward(errRecord) {
+		t.Fatal("error records must forward")
+	}
+	warnListed := slog.NewRecord(time.Now(), slog.LevelWarn, "account refresh failed", 0)
+	if !shouldForward(warnListed) {
+		t.Fatal("allowlisted warn records must forward")
+	}
+	warnOther := slog.NewRecord(time.Now(), slog.LevelWarn, "usage fetch failed", 0)
+	if shouldForward(warnOther) {
+		t.Fatal("other warn records must not forward")
+	}
+	info := slog.NewRecord(time.Now(), slog.LevelInfo, "proxy request", 0)
+	if shouldForward(info) {
+		t.Fatal("info records must not forward")
+	}
+}
+
+func TestLogHandlerDelegatesToBase(t *testing.T) {
+	base := slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})
+	handler := NewLogHandler(base)
+	if !handler.Enabled(context.Background(), slog.LevelInfo) {
+		t.Fatal("handler must mirror base enablement")
+	}
+	if handler.Enabled(context.Background(), slog.LevelDebug) {
+		t.Fatal("handler must mirror base enablement for disabled levels")
+	}
+	record := slog.NewRecord(time.Now(), slog.LevelError, "proxy request failed", 0)
+	if err := handler.Handle(context.Background(), record); err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+	derived := handler.WithAttrs([]slog.Attr{slog.String("agent", "claude")})
+	logHandler, ok := derived.(*LogHandler)
+	if !ok {
+		t.Fatalf("WithAttrs must return *LogHandler, got %T", derived)
+	}
+	event := eventFromRecord(record, logHandler.attrs)
+	if event.Tags["agent_type"] != "claude" {
+		t.Fatalf("handler attrs must contribute tags, got %v", event.Tags)
+	}
+}
+
+func TestInitDisabledWithoutDSN(t *testing.T) {
+	on, err := Init(Options{DSN: "   "})
+	if err != nil {
+		t.Fatalf("empty DSN must not error: %v", err)
+	}
+	if on {
+		t.Fatal("empty DSN must leave reporting disabled")
+	}
+}

--- a/internal/sentryreport/sentryreport_test.go
+++ b/internal/sentryreport/sentryreport_test.go
@@ -100,6 +100,7 @@ func TestEventFromRecordUsesAllowlistedAttrsOnly(t *testing.T) {
 		slog.String("agent", "codex"),
 		slog.String("upstream", "chatgpt.com"),
 		slog.Int("status", 502),
+		slog.String("account", "alice@example.com"),
 		slog.String("error", "dial tcp: refused; auth Bearer sk-proj-abc12345"),
 		slog.String("body", `{"secret":"payload"}`),
 		slog.String("refresh_token", "srt_supersecret1234"),
@@ -116,6 +117,15 @@ func TestEventFromRecordUsesAllowlistedAttrsOnly(t *testing.T) {
 	}
 	if _, ok := logContext["refresh_token"]; ok {
 		t.Fatal("non-allowlisted attributes must be dropped")
+	}
+	if _, ok := logContext["account"]; ok {
+		t.Fatal("raw account id must never be forwarded")
+	}
+	if logContext["account_hash"] != accountHash("alice@example.com") {
+		t.Fatalf("account must be forwarded as a hash, got %v", logContext["account_hash"])
+	}
+	if hash, _ := logContext["account_hash"].(string); strings.Contains(hash, "alice") || strings.Contains(hash, "@") {
+		t.Fatalf("account hash must not embed the email, got %q", hash)
 	}
 	errExtra, _ := logContext["error"].(string)
 	if strings.Contains(errExtra, "sk-") || strings.Contains(errExtra, "Bearer ") {


### PR DESCRIPTION
Two independent pieces toward a hosted subrouter.

## Sentry error reporting (opt-in)

`subrouter serve` initializes Sentry only when `--sentry-dsn` or `SENTRY_DSN` is set. Without a DSN nothing initializes and behavior is unchanged. Three hooks:

- Recover middleware around the top-level handler: panics are reported and answered with 500. `http.ErrAbortHandler` is re-panicked so `httputil.ReverseProxy` stream aborts keep their net/http semantics.
- A slog bridge handler (`internal/sentryreport.LogHandler`) forwards Error-level records plus a small allowlist of OAuth refresh-failure Warn messages. This picks up the existing high-signal sites (`proxy request failed` on upstream 502s, `reverse proxy error`, `proxy response stream read failed`, `account refresh failed`).
- New Error-level logs on the proxy 503 paths (account selection failed, selected account refresh failed, selected account has no usable credential), which previously returned 503 without logging.

Privacy is layered, since this proxy carries auth tokens and full LLM bodies:

- The bridge forwards only an attribute allowlist. `agent`/`upstream`/`status` become the `agent_type`/`upstream`/`http_status` tags; `body` and any unknown key are dropped.
- `SendDefaultPII` stays off.
- A `BeforeSend` scrubber drops request bodies, cookies, and Authorization/X-Api-Key/admin-token headers, and redacts token-shaped strings (`sk-`, `srt_`, `eyJ`, `Bearer ...`) from message, exceptions, tags, contexts, and breadcrumbs. Unit tests assert all of this.

No tenant tag: no tenant concept exists on this branch.

One gotcha found while verifying: wrapping `slog.Default().Handler()` and calling `slog.SetDefault` deadlocks, because the built-in handler writes through the `log` package and `SetDefault` reroutes the `log` package into the new logger. The bridge wraps an explicit stderr text handler instead (log format changes slightly only when Sentry is enabled).

`install-systemd` gains `--sentry-dsn`, writes `SENTRY_DSN` into `/etc/default/<service>`, and preserves an existing value across re-runs the same way it preserves the admin token (tested). The file is 0600 whenever a token or DSN is present. `install-daemon` gains `--sentry-dsn` (defaults to `SENTRY_DSN` from the invoking shell) and bakes it into the LaunchAgent plist.

## Deploy path

- `Dockerfile`: multi-stage static Go build on Alpine, non-root user, state volume at `/var/lib/subrouter`, port 31415, entrypoint `subrouter serve --addr 0.0.0.0:31415`. Image is ~20MB.
- `docker-compose.yml`: named state volume, `SUBROUTER_ADMIN_TOKEN` (required) and `SENTRY_DSN` (optional) passthrough, health check on `/_subrouter/health`.
- `deploy/fly/fly.toml`: single machine, volume mount, Fly edge TLS, `internal_port` 31415.
- `release.yml`: new `docker-publish` job on tag pushes publishes `ghcr.io/manaflow-ai/subrouter:<version>` and `:latest` for linux/amd64+arm64, alongside the existing binary release job.
- `docs/deploy.md`: systemd (links production.md), Docker/compose, and Fly paths, admin-token bootstrap, and a warning that the data plane has no per-request auth until multi-tenant keys land.

## Verification

- `go build ./... && go vet ./... && go test ./...` green (one pre-existing flaky transcript GCS timing test passed on rerun).
- `docker build .` verified locally; container smoke test with `SENTRY_DSN` set answers `/_subrouter/health` and `/_subrouter/ready` with 200 and logs through the bridge handler.
- Local `serve` with a syntactically valid DSN starts and lists accounts; an invalid DSN fails fast with `sentry init: DsnParseError`.

Note: dependency `github.com/getsentry/sentry-go v0.47.0` bumps the module's `go` directive to 1.25.0; CI uses `go-version-file: go.mod` so it follows automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785564126&installation_id=133855650&pr_number=37&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F37&signature=c7ef6e080c6dcf3f3dfd34e7a0e05553b0e58fb82a0549651647c2d5ac72dc08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional Sentry error reporting to `subrouter serve` and a Docker/Fly deploy path with published images for easy hosting. Behavior is unchanged unless a DSN is provided.

- New Features
  - Sentry is opt-in via `--sentry-dsn` or `SENTRY_DSN` (with `SENTRY_ENVIRONMENT` support). A panic-recover HTTP middleware reports crashes and returns 500, and a `slog` bridge forwards Error logs plus a small Warn allowlist; 503 paths now log at Error.
  - Privacy-first reporting: request bodies and sensitive headers are dropped; token-like strings (`sk-`, `srt_`, `eyJ`, `Bearer ...`) are redacted; only allowlisted attrs become tags/extras; account IDs are forwarded as short SHA-256 hashes. Unit tests cover scrubbing and forwarding.
  - Installers: `install-systemd` and `install-daemon` accept `--sentry-dsn` and persist `SENTRY_DSN` across re-runs; defaults file is 0600 when a token or DSN is present.
  - Deploy: added `Dockerfile` (static, non-root), `docker-compose.yml`, and Fly config; release workflow publishes `ghcr.io/manaflow-ai/subrouter:<version>` for linux/amd64 and arm64 and skips `:latest` on prerelease tags; Fly config omits `[build]` so `fly deploy -c deploy/fly/fly.toml` uses the repo-root `Dockerfile`. Added `docs/deploy.md`.

- Dependencies
  - Added `github.com/getsentry/sentry-go v0.47.0`.
  - Bumped `go` directive to `1.25.0`.

<sup>Written for commit 509c6af2d41c29214bb6c851513c747b7ebb7c6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

