### PR TITLE
Expire exhaustion marks at the upstream's own reset time

### DIFF
--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -922,3 +922,84 @@ func TestClaudeRejected5xxFailsOverNotOverloadRetried(t *testing.T) {
 		t.Fatal("a rejected 5xx must mark the depleted account exhausted")
 	}
 }
+
+func TestClaudeExhaustionExpiry(t *testing.T) {
+	now := time.Unix(1_750_000_000, 0)
+	h := http.Header{}
+	// No headers: scheduler default TTL.
+	if got := claudeExhaustionExpiry(h, now); !got.Equal(now.Add(selectacct.DefaultExhaustedTTL)) {
+		t.Fatalf("default = %v, want now+%v", got, selectacct.DefaultExhaustedTTL)
+	}
+	// Authoritative unified-reset epoch wins.
+	h.Set("Anthropic-Ratelimit-Unified-Reset", "1750003600")
+	if got := claudeExhaustionExpiry(h, now); !got.Equal(time.Unix(1_750_003_600, 0)) {
+		t.Fatalf("unified-reset = %v, want epoch 1750003600", got)
+	}
+	// A reset already in the past floors to now+1m (clock skew guard).
+	h.Set("Anthropic-Ratelimit-Unified-Reset", "1749990000")
+	if got := claudeExhaustionExpiry(h, now); !got.Equal(now.Add(time.Minute)) {
+		t.Fatalf("past reset = %v, want floor now+1m", got)
+	}
+	// Far-future reset is capped at 8d.
+	h.Set("Anthropic-Ratelimit-Unified-Reset", "1999999999")
+	if got := claudeExhaustionExpiry(h, now); !got.Equal(now.Add(8*24*time.Hour)) {
+		t.Fatalf("far reset = %v, want cap now+8d", got)
+	}
+	// Retry-After honored when unified-reset absent.
+	h = http.Header{}
+	h.Set("Retry-After", "300")
+	if got := claudeExhaustionExpiry(h, now); !got.Equal(now.Add(5*time.Minute)) {
+		t.Fatalf("retry-after = %v, want now+5m", got)
+	}
+}
+
+// TestClaudeFailoverTriesRecoveredAccount is the live regression: an account
+// whose exhaustion mark has lapsed (window reset) must be reachable by failover
+// again. Before the fix its zero score persisted until a successful usage
+// refresh, so failover burned its attempts on genuinely-cooked accounts and
+// never reached the recovered one.
+func TestClaudeFailoverTriesRecoveredAccount(t *testing.T) {
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("claude", "session-rec", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	ref := selectacct.NewSchedulerRef(selectacct.NewScheduler(nil))
+	// recovered@ was marked exhausted while cooked, but its window has reset.
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "recovered@example.com", time.Now().Add(-time.Second))
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: "cooked@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-cooked"},
+			{ID: "recovered@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-recovered"},
+		},
+		Sessions:     store,
+		SchedulerRef: ref,
+	}
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		if strings.Contains(req.Header.Get("Authorization"), "tok-recovered") {
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(`{"id":"msg_recovered"}`))}
+		}
+		h := http.Header{}
+		h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		h.Set("Anthropic-Ratelimit-Unified-Reset", "1999999999")
+		return &http.Response{StatusCode: http.StatusTooManyRequests, Header: h, Body: io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}`))}
+	}}
+	transport := usageLimitRetryTransport{
+		base: stub, server: &server, provider: accounts.ProviderClaude,
+		agent: "claude", session: "session-rec", account: "cooked@example.com",
+		method: http.MethodPost, path: "/v1/messages", maxAttempts: 6,
+	}
+	req, _ := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), "msg_recovered") {
+		t.Fatalf("status=%d body=%s, want the recovered account to serve after its mark lapsed", response.StatusCode, string(body))
+	}
+}

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strconv"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1001,5 +1002,50 @@ func TestClaudeFailoverTriesRecoveredAccount(t *testing.T) {
 	body, _ := io.ReadAll(response.Body)
 	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), "msg_recovered") {
 		t.Fatalf("status=%d body=%s, want the recovered account to serve after its mark lapsed", response.StatusCode, string(body))
+	}
+}
+
+// TestMarkTTLSelection pins the TTL class per failure kind: rate-limit marks
+// expire at the upstream reset, 401 dead-credential marks get the long
+// credential TTL, and re-marking through the passive body-inspect path must not
+// shorten a header-derived expiry.
+func TestMarkTTLSelection(t *testing.T) {
+	server, _ := claudeFailoverServer(t)
+	resetEpoch := time.Now().Add(48 * time.Hour).Unix()
+	h := http.Header{}
+	h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+	h.Set("Anthropic-Ratelimit-Unified-Reset", strconv.FormatInt(resetEpoch, 10))
+
+	// Rate-limit mark: expiry = upstream reset.
+	server.markAccountExhaustedFromResponse(accounts.ProviderClaude, "rl@example.com", http.StatusTooManyRequests, h)
+	until, ok := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "rl@example.com")
+	if !ok || !until.Equal(time.Unix(resetEpoch, 0)) {
+		t.Fatalf("rate-limit mark until=%v ok=%v, want upstream reset %v", until, ok, time.Unix(resetEpoch, 0))
+	}
+	// Re-marking with the same headers (the passive body-inspect path) must not
+	// shorten the expiry to the default TTL.
+	server.markAccountExhaustedFromResponse(accounts.ProviderClaude, "rl@example.com", http.StatusTooManyRequests, h)
+	until2, _ := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "rl@example.com")
+	if !until2.Equal(time.Unix(resetEpoch, 0)) {
+		t.Fatalf("re-mark shortened expiry to %v, want %v", until2, time.Unix(resetEpoch, 0))
+	}
+
+	// 401 dead credential: long credential TTL, not the 10m default.
+	server.markAccountExhaustedFromResponse(accounts.ProviderClaude, "dead@example.com", http.StatusUnauthorized, http.Header{})
+	deadUntil, ok := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "dead@example.com")
+	if !ok || time.Until(deadUntil) < 50*time.Minute {
+		t.Fatalf("401 mark until=%v (in %v), want ~1h credential TTL", deadUntil, time.Until(deadUntil))
+	}
+
+	// Terminal refresh failure: credential TTL; transient: short default.
+	server.markAccountExhaustedRefreshFailure(accounts.ProviderClaude, "invalid@example.com", fmt.Errorf("400 Bad Request: invalid_grant"))
+	invUntil, _ := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "invalid@example.com")
+	if time.Until(invUntil) < 50*time.Minute {
+		t.Fatalf("terminal refresh mark in %v, want ~1h", time.Until(invUntil))
+	}
+	server.markAccountExhaustedRefreshFailure(accounts.ProviderClaude, "blip@example.com", fmt.Errorf("dial tcp: connection refused"))
+	blipUntil, _ := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "blip@example.com")
+	if time.Until(blipUntil) > 15*time.Minute {
+		t.Fatalf("transient refresh mark in %v, want ~10m default", time.Until(blipUntil))
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1231,6 +1231,7 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 		seed := current.ScoreFor(account.Provider, account.ID)
 		seed.AccountID = account.ID
 		seed.Provider = account.Provider
+		seed.Fresh = false // carried forward until a fresh fetch overwrites it
 		if account.AuthMode == accounts.AuthModeAPIKey {
 			seed.Headroom = 0.01
 			seed.ShortHeadroom = 0.01
@@ -1282,7 +1283,9 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 			continue
 		}
 		if idx, ok := scoreByID[selectacct.ScoreKey(account.Provider, account.ID)]; ok {
-			scores[idx] = scoreFromUsageWindows(account.Provider, account.ID, windows)
+			next := scoreFromUsageWindows(account.Provider, account.ID, windows)
+			next.Fresh = true
+			scores[idx] = next
 			scored++
 		}
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1678,6 +1678,46 @@ func (s Server) markAccountExhausted(provider accounts.Provider, accountID strin
 	}
 }
 
+// markAccountExhaustedFromResponse marks the account exhausted until the reset
+// time the upstream itself reported, so the mark self-expires exactly when the
+// account's window recovers. Observed live: an account whose weekly window had
+// reset (real quota available) stayed zero-scored for hours because marks only
+// cleared on a successful usage refresh, which the loaded usage endpoint kept
+// failing; failover then burned its attempts on genuinely-cooked accounts and
+// never reached the recovered one.
+func (s Server) markAccountExhaustedFromResponse(provider accounts.Provider, accountID string, header http.Header) {
+	if s.SchedulerRef == nil {
+		return
+	}
+	s.SchedulerRef.MarkExhaustedUntil(provider, accountID, claudeExhaustionExpiry(header, time.Now()))
+}
+
+// claudeExhaustionExpiry picks when an exhaustion mark should lapse:
+// anthropic-ratelimit-unified-reset (epoch seconds, the authoritative window
+// reset) when present, else Retry-After seconds, else the scheduler default.
+// Clamped to [now+1m, now+8d]: the floor guards clock skew / already-passed
+// resets, the ceiling guards a nonsense far-future header pinning an account
+// out forever.
+func claudeExhaustionExpiry(header http.Header, now time.Time) time.Time {
+	until := now.Add(selectacct.DefaultExhaustedTTL)
+	if raw := strings.TrimSpace(claudeHeaderGet(header, "anthropic-ratelimit-unified-reset")); raw != "" {
+		if epoch, err := strconv.ParseInt(raw, 10, 64); err == nil && epoch > 0 {
+			until = time.Unix(epoch, 0)
+		}
+	} else if ra := strings.TrimSpace(claudeHeaderGet(header, "Retry-After")); ra != "" {
+		if secs, err := strconv.Atoi(ra); err == nil && secs > 0 {
+			until = now.Add(time.Duration(secs) * time.Second)
+		}
+	}
+	if min := now.Add(time.Minute); until.Before(min) {
+		return min
+	}
+	if max := now.Add(8 * 24 * time.Hour); until.After(max) {
+		return max
+	}
+	return until
+}
+
 func usageLimitJSON(body []byte) bool {
 	var event map[string]any
 	if err := json.Unmarshal(body, &event); err != nil {
@@ -1851,7 +1891,7 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 		// the rejected header). A transient "allowed"/"allowed_warning" 429 still
 		// fails over for this request but must not mark a healthy account exhausted.
 		if claudeAccountExhaustedByResponse(response.StatusCode, response.Header) {
-			s.markAccountExhausted(provider, accountID)
+			s.markAccountExhaustedFromResponse(provider, accountID, response.Header)
 		}
 		// Surface the genuine upstream rate-limit signal (headers now, body
 		// prefix below). Anthropic conveys subscription exhaustion only via the
@@ -2904,7 +2944,10 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			exhausted = claudeAccountExhaustedByResponse(response.StatusCode, response.Header)
 		}
 		if t.server != nil && exhausted {
-			t.server.markAccountExhausted(t.provider, accountID)
+			// Use the response's own reset time so the mark self-expires when the
+			// window recovers (codex responses lack these headers and fall back
+			// to the default TTL inside claudeExhaustionExpiry).
+			t.server.markAccountExhaustedFromResponse(t.provider, accountID, response.Header)
 		}
 		if attempt == maxAttempts || t.server == nil {
 			reason := "max_attempts"

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1685,11 +1685,44 @@ func (s Server) markAccountExhausted(provider accounts.Provider, accountID strin
 // cleared on a successful usage refresh, which the loaded usage endpoint kept
 // failing; failover then burned its attempts on genuinely-cooked accounts and
 // never reached the recovered one.
-func (s Server) markAccountExhaustedFromResponse(provider accounts.Provider, accountID string, header http.Header) {
+func (s Server) markAccountExhaustedFromResponse(provider accounts.Provider, accountID string, status int, header http.Header) {
 	if s.SchedulerRef == nil {
 		return
 	}
+	if status == http.StatusUnauthorized {
+		// Dead/expired credential, not a rate-limit window: no reset header
+		// exists and it will not self-heal on a schedule. A longer TTL avoids
+		// probing a dead account every few minutes while still picking it back
+		// up within the hour after a re-auth.
+		s.markAccountExhaustedCredential(provider, accountID)
+		return
+	}
 	s.SchedulerRef.MarkExhaustedUntil(provider, accountID, claudeExhaustionExpiry(header, time.Now()))
+}
+
+// credentialExhaustionTTL is how long an account with a dead credential
+// (401 / invalid_grant) stays out of routing before one re-probe. Credentials
+// only recover via human re-auth, so probes are pure overhead; but the mark
+// must still lapse so a re-authed account rejoins without waiting for a
+// successful usage refresh.
+const credentialExhaustionTTL = time.Hour
+
+func (s Server) markAccountExhaustedCredential(provider accounts.Provider, accountID string) {
+	if s.SchedulerRef == nil {
+		return
+	}
+	s.SchedulerRef.MarkExhaustedUntil(provider, accountID, time.Now().Add(credentialExhaustionTTL))
+}
+
+// markAccountExhaustedRefreshFailure picks the mark TTL by failure class: a
+// terminal credential error gets the long credential TTL, anything transient
+// gets the short default so the account rejoins quickly.
+func (s Server) markAccountExhaustedRefreshFailure(provider accounts.Provider, accountID string, err error) {
+	if isTerminalCredentialError(err) {
+		s.markAccountExhaustedCredential(provider, accountID)
+		return
+	}
+	s.markAccountExhausted(provider, accountID)
 }
 
 // claudeExhaustionExpiry picks when an exhaustion mark should lapse:
@@ -1891,7 +1924,7 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 		// the rejected header). A transient "allowed"/"allowed_warning" 429 still
 		// fails over for this request but must not mark a healthy account exhausted.
 		if claudeAccountExhaustedByResponse(response.StatusCode, response.Header) {
-			s.markAccountExhaustedFromResponse(provider, accountID, response.Header)
+			s.markAccountExhaustedFromResponse(provider, accountID, response.StatusCode, response.Header)
 		}
 		// Surface the genuine upstream rate-limit signal (headers now, body
 		// prefix below). Anthropic conveys subscription exhaustion only via the
@@ -1934,7 +1967,10 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 		loggedBody := false
 		inspect = func(body []byte) {
 			if inspectUsageLimit && usageLimitJSON(body) {
-				s.markAccountExhausted(provider, accountID)
+				// Use the response's headers so a header-derived reset expiry set
+				// above is recomputed identically, not overwritten with the short
+				// default TTL.
+				s.markAccountExhaustedFromResponse(provider, accountID, response.StatusCode, response.Header)
 			}
 			// Only log the body for the original hard rate-limit statuses
 			// (429/401), whose body is a known rate-limit/auth error envelope. A
@@ -2565,7 +2601,7 @@ func (s Server) refreshSelectedAccount(ctx context.Context, provider accounts.Pr
 		s.Logger.Warn("selected Claude account refresh failed, trying another account", "account", account.ID, "error", err)
 	}
 	tried := map[string]struct{}{account.ID: {}}
-	s.markAccountExhausted(provider, account.ID)
+	s.markAccountExhaustedRefreshFailure(provider, account.ID, err)
 	lastErr := err
 	for {
 		next, pickErr := s.retryAccount(ctx, provider, agentType, sessionID, userEmail, tried)
@@ -2578,7 +2614,7 @@ func (s Server) refreshSelectedAccount(ctx context.Context, provider accounts.Pr
 			return refreshed, nil
 		}
 		lastErr = err
-		s.markAccountExhausted(provider, next.ID)
+		s.markAccountExhaustedRefreshFailure(provider, next.ID, err)
 		if s.Logger != nil {
 			s.Logger.Warn("retry Claude account refresh failed", "account", next.ID, "error", err)
 		}
@@ -2947,7 +2983,7 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			// Use the response's own reset time so the mark self-expires when the
 			// window recovers (codex responses lack these headers and fall back
 			// to the default TTL inside claudeExhaustionExpiry).
-			t.server.markAccountExhaustedFromResponse(t.provider, accountID, response.Header)
+			t.server.markAccountExhaustedFromResponse(t.provider, accountID, response.StatusCode, response.Header)
 		}
 		if attempt == maxAttempts || t.server == nil {
 			reason := "max_attempts"
@@ -3151,7 +3187,9 @@ func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provide
 			lastErr = err
 			terminal := isTerminalCredentialError(err)
 			if terminal {
-				s.markAccountExhausted(provider, account.ID)
+				// Credential TTL, not the short default: a dead token only heals
+				// via human re-auth, so frequent probes are pure overhead.
+				s.markAccountExhaustedCredential(provider, account.ID)
 			}
 			if s.Logger != nil {
 				s.Logger.Warn("usage-limit retry skipping OAuth account with failed refresh",

--- a/internal/selectacct/scheduler.go
+++ b/internal/selectacct/scheduler.go
@@ -18,6 +18,12 @@ type Score struct {
 	ExpiryPressure         float64
 	Sessions               int
 	ModelScores            map[string]Score
+	// Fresh marks a score computed from a successful, current usage fetch, as
+	// opposed to a seed carried forward from the previous scheduler (fetch
+	// failed/stale) or a request-time exhaustion mark. Expiry reconciliation
+	// uses it to tell "fresh evidence re-confirmed exhausted" apart from "old
+	// zero score dragged along".
+	Fresh bool
 }
 
 type Scheduler struct {

--- a/internal/selectacct/scheduler_ref.go
+++ b/internal/selectacct/scheduler_ref.go
@@ -12,6 +12,12 @@ type SchedulerRef struct {
 	scheduler  Scheduler
 	updatedAt  time.Time
 	refreshing bool
+	// exhaustedUntil expires request-time exhaustion marks. A mark set from a
+	// rejected upstream response is only true until the account's rate-limit
+	// window resets; without an expiry a recovered account stayed zero-scored
+	// until the next SUCCESSFUL usage refresh, which under load can fail for
+	// hours, leaving real quota unroutable while clients got 429s.
+	exhaustedUntil map[string]time.Time
 }
 
 func NewSchedulerRef(scheduler Scheduler) *SchedulerRef {
@@ -22,19 +28,68 @@ func NewSchedulerRef(scheduler Scheduler) *SchedulerRef {
 }
 
 func (r *SchedulerRef) Get() Scheduler {
+	r.pruneExpired(time.Now())
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.scheduler
+}
+
+// pruneExpired drops exhaustion marks whose window has reset, restoring the
+// account to the optimistic default score so routing can try it again.
+func (r *SchedulerRef) pruneExpired(now time.Time) {
+	r.mu.RLock()
+	anyExpired := false
+	for _, until := range r.exhaustedUntil {
+		if !until.After(now) {
+			anyExpired = true
+			break
+		}
+	}
+	r.mu.RUnlock()
+	if !anyExpired {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	next := Scheduler{scores: make(map[string]Score, len(r.scheduler.scores)), sessionCounts: r.scheduler.sessionCounts}
+	for key, score := range r.scheduler.scores {
+		next.scores[key] = score
+	}
+	for key, until := range r.exhaustedUntil {
+		if until.After(now) {
+			continue
+		}
+		delete(r.exhaustedUntil, key)
+		delete(next.scores, key)
+	}
+	r.scheduler = next
 }
 
 func (r *SchedulerRef) Set(scheduler Scheduler) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.scheduler = scheduler
+	// Fresh usage data supersedes request-time marks; keeping expiries around
+	// would later delete scores that now come from a real refresh.
+	r.exhaustedUntil = nil
 	r.updatedAt = time.Now()
 }
 
+// DefaultExhaustedTTL bounds an exhaustion mark when the upstream response gave
+// no reset time. Short on purpose: re-marking a still-cooked account costs one
+// failed attempt, while over-holding a recovered account starves routing of
+// real quota.
+const DefaultExhaustedTTL = 10 * time.Minute
+
 func (r *SchedulerRef) MarkExhausted(provider accounts.Provider, accountID string) {
+	r.MarkExhaustedUntil(provider, accountID, time.Now().Add(DefaultExhaustedTTL))
+}
+
+// MarkExhaustedUntil zero-scores the account until the given time, after which
+// the mark expires and the account returns to the optimistic default so routing
+// tries it again. Callers pass the upstream's own reset time
+// (anthropic-ratelimit-unified-reset / Retry-After) when available.
+func (r *SchedulerRef) MarkExhaustedUntil(provider accounts.Provider, accountID string, until time.Time) {
 	if accountID == "" {
 		return
 	}
@@ -46,6 +101,10 @@ func (r *SchedulerRef) MarkExhausted(provider accounts.Provider, accountID strin
 		Headroom:      0,
 		ShortHeadroom: 0,
 	})
+	if r.exhaustedUntil == nil {
+		r.exhaustedUntil = make(map[string]time.Time)
+	}
+	r.exhaustedUntil[ScoreKey(provider, accountID)] = until
 	r.updatedAt = time.Now()
 }
 
@@ -76,6 +135,7 @@ func (r *SchedulerRef) FinishRefresh(scheduler Scheduler, update bool) {
 	defer r.mu.Unlock()
 	if update {
 		r.scheduler = scheduler
+		r.exhaustedUntil = nil
 	}
 	r.updatedAt = time.Now()
 	r.refreshing = false

--- a/internal/selectacct/scheduler_ref.go
+++ b/internal/selectacct/scheduler_ref.go
@@ -85,19 +85,38 @@ func (r *SchedulerRef) Set(scheduler Scheduler) {
 }
 
 // retainExhaustedExpiriesLocked reconciles mark expiries with an incoming
-// refresh. An expiry is dropped only when the new score actually supersedes the
-// mark (shows headroom). It is KEPT while the incoming score is still zero,
-// because refreshes seed from the current scheduler and carry the old zero
-// score forward when that account's own usage fetch failed — clearing the
-// expiry there would make the request-time mark permanent again, recreating the
-// stranded-recovered-account failure. Keeping an expiry for a genuinely-cooked
-// account is safe: when it lapses, routing tries the account once and the
-// upstream's reject re-marks it.
+// refresh, by evidence class:
+//   - Score shows headroom (or is gone): the mark is superseded; drop the expiry.
+//   - Carried-forward zero (the account's own usage fetch failed, seed dragged
+//     along, Fresh=false): keep the existing expiry. Clearing it would make the
+//     request-time mark permanent again, recreating the stranded-recovered-
+//     account failure this exists to fix.
+//   - Fresh zero (a successful fetch re-confirmed exhaustion, Fresh=true):
+//     re-anchor the expiry to this newest evidence — extend it to at least the
+//     fresh window's own reset (floored at the default TTL) — so an OLDER
+//     request-time expiry can never lapse a freshly-observed zero back to the
+//     optimistic default. Expiries only extend here, never shorten, so an
+//     authoritative long reset from a rejected response still holds.
 func (r *SchedulerRef) retainExhaustedExpiriesLocked() {
+	now := time.Now()
 	for key := range r.exhaustedUntil {
 		score, ok := r.scheduler.scores[key]
-		if !ok || !score.exhausted() {
+		switch {
+		case !ok || !score.exhausted():
 			delete(r.exhaustedUntil, key)
+		case score.Fresh:
+			until := now.Add(DefaultExhaustedTTL)
+			if score.ShortResetAfterSeconds > 0 {
+				if fromReset := now.Add(time.Duration(score.ShortResetAfterSeconds) * time.Second); fromReset.After(until) {
+					until = fromReset
+				}
+			}
+			if cap := now.Add(8 * 24 * time.Hour); until.After(cap) {
+				until = cap
+			}
+			if until.After(r.exhaustedUntil[key]) {
+				r.exhaustedUntil[key] = until
+			}
 		}
 	}
 }

--- a/internal/selectacct/scheduler_ref.go
+++ b/internal/selectacct/scheduler_ref.go
@@ -36,6 +36,17 @@ func (r *SchedulerRef) Get() Scheduler {
 
 // pruneExpired drops exhaustion marks whose window has reset, restoring the
 // account to the optimistic default score so routing can try it again.
+//
+// Deliberate tradeoff: a lapsed mark cannot distinguish "recovered" from "fresh
+// usage re-confirmed exhausted" (refreshes seed zero scores forward, so the two
+// are indistinguishable here). We choose optimistic retry-once: if the account
+// is still cooked, the one probe request is rejected upstream and the account
+// is immediately re-marked with the NEW authoritative reset time, so the cost
+// is bounded at one attempt per account per expiry window. The opposite choice
+// (trusting a zero score without an expiry) is the failure this fixes: a
+// recovered account's real quota stayed unroutable for hours. This matches the
+// scheduler-wide philosophy that scores are load-balancing hints and the
+// upstream response is the source of truth.
 func (r *SchedulerRef) pruneExpired(now time.Time) {
 	r.mu.RLock()
 	anyExpired := false

--- a/internal/selectacct/scheduler_ref.go
+++ b/internal/selectacct/scheduler_ref.go
@@ -135,6 +135,15 @@ func (r *SchedulerRef) MarkExhaustedUntil(provider accounts.Provider, accountID 
 	r.updatedAt = time.Now()
 }
 
+// ExhaustedUntilFor reports the expiry recorded for an account's exhaustion
+// mark, if any. Used by tests and diagnostics to verify TTL selection.
+func (r *SchedulerRef) ExhaustedUntilFor(provider accounts.Provider, accountID string) (time.Time, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	until, ok := r.exhaustedUntil[ScoreKey(provider, accountID)]
+	return until, ok
+}
+
 func (r *SchedulerRef) Stale(ttl time.Duration) bool {
 	if ttl <= 0 {
 		return false

--- a/internal/selectacct/scheduler_ref.go
+++ b/internal/selectacct/scheduler_ref.go
@@ -69,10 +69,26 @@ func (r *SchedulerRef) Set(scheduler Scheduler) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.scheduler = scheduler
-	// Fresh usage data supersedes request-time marks; keeping expiries around
-	// would later delete scores that now come from a real refresh.
-	r.exhaustedUntil = nil
+	r.retainExhaustedExpiriesLocked()
 	r.updatedAt = time.Now()
+}
+
+// retainExhaustedExpiriesLocked reconciles mark expiries with an incoming
+// refresh. An expiry is dropped only when the new score actually supersedes the
+// mark (shows headroom). It is KEPT while the incoming score is still zero,
+// because refreshes seed from the current scheduler and carry the old zero
+// score forward when that account's own usage fetch failed — clearing the
+// expiry there would make the request-time mark permanent again, recreating the
+// stranded-recovered-account failure. Keeping an expiry for a genuinely-cooked
+// account is safe: when it lapses, routing tries the account once and the
+// upstream's reject re-marks it.
+func (r *SchedulerRef) retainExhaustedExpiriesLocked() {
+	for key := range r.exhaustedUntil {
+		score, ok := r.scheduler.scores[key]
+		if !ok || !score.exhausted() {
+			delete(r.exhaustedUntil, key)
+		}
+	}
 }
 
 // DefaultExhaustedTTL bounds an exhaustion mark when the upstream response gave
@@ -135,7 +151,7 @@ func (r *SchedulerRef) FinishRefresh(scheduler Scheduler, update bool) {
 	defer r.mu.Unlock()
 	if update {
 		r.scheduler = scheduler
-		r.exhaustedUntil = nil
+		r.retainExhaustedExpiriesLocked()
 	}
 	r.updatedAt = time.Now()
 	r.refreshing = false

--- a/internal/selectacct/scheduler_ref_test.go
+++ b/internal/selectacct/scheduler_ref_test.go
@@ -95,3 +95,20 @@ func TestPartialRefreshKeepsMarkExpiry(t *testing.T) {
 		t.Fatalf("superseded mark must not prune the refreshed score: headroom=%v want 0.05", got)
 	}
 }
+
+// TestLapsedMarkRemarksOnNextReject documents the retry-once-on-lapse loop: a
+// lapsed mark makes a still-cooked account optimistic for exactly one probe;
+// the upstream's next reject re-marks it with the new authoritative reset, so
+// the cost of guessing wrong is bounded at one attempt per expiry window.
+func TestLapsedMarkRemarksOnNextReject(t *testing.T) {
+	ref := NewSchedulerRef(NewScheduler(nil))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "cooked@example.com", time.Now().Add(-time.Second))
+	if ref.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
+		t.Fatal("lapsed mark should allow one optimistic probe")
+	}
+	// The probe's rejected response re-marks with the new upstream reset.
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "cooked@example.com", time.Now().Add(2*time.Hour))
+	if !ref.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
+		t.Fatal("re-mark after the probe's reject must hold until the new reset")
+	}
+}

--- a/internal/selectacct/scheduler_ref_test.go
+++ b/internal/selectacct/scheduler_ref_test.go
@@ -112,3 +112,36 @@ func TestLapsedMarkRemarksOnNextReject(t *testing.T) {
 		t.Fatal("re-mark after the probe's reject must hold until the new reset")
 	}
 }
+
+// TestFreshZeroReanchorsExpiry: a successful usage fetch that re-confirms
+// exhaustion must re-anchor the mark's expiry to that newest evidence, so an
+// older request-time expiry cannot lapse a freshly-observed zero back to
+// optimistic. Expiries only extend, never shorten.
+func TestFreshZeroReanchorsExpiry(t *testing.T) {
+	ref := NewSchedulerRef(NewScheduler(nil))
+	// Old request-time mark about to lapse.
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "confirmed@example.com", time.Now().Add(time.Millisecond))
+	// Fresh refresh re-confirms exhaustion with a 2h window reset.
+	ref.FinishRefresh(NewScheduler([]Score{
+		{AccountID: "confirmed@example.com", Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0, ShortResetAfterSeconds: 7200, Fresh: true},
+	}), true)
+	until, ok := ref.ExhaustedUntilFor(accounts.ProviderClaude, "confirmed@example.com")
+	if !ok || time.Until(until) < 90*time.Minute {
+		t.Fatalf("fresh zero should re-anchor expiry to its reset (~2h), got %v (in %v)", until, time.Until(until))
+	}
+	if ref.Get().Exhausted(accounts.ProviderClaude, "confirmed@example.com") != true {
+		t.Fatal("freshly-confirmed exhausted account must stay exhausted")
+	}
+
+	// A fresh zero must never SHORTEN a longer authoritative expiry.
+	ref2 := NewSchedulerRef(NewScheduler(nil))
+	long := time.Now().Add(72 * time.Hour)
+	ref2.MarkExhaustedUntil(accounts.ProviderClaude, "weekly@example.com", long)
+	ref2.FinishRefresh(NewScheduler([]Score{
+		{AccountID: "weekly@example.com", Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0, ShortResetAfterSeconds: 3600, Fresh: true},
+	}), true)
+	got, _ := ref2.ExhaustedUntilFor(accounts.ProviderClaude, "weekly@example.com")
+	if !got.Equal(long) {
+		t.Fatalf("fresh zero shortened authoritative expiry: got %v want %v", got, long)
+	}
+}

--- a/internal/selectacct/scheduler_ref_test.go
+++ b/internal/selectacct/scheduler_ref_test.go
@@ -3,6 +3,8 @@ package selectacct
 import (
 	"testing"
 	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
 )
 
 func TestSchedulerRefAllowsOnlyOneStaleRefresh(t *testing.T) {
@@ -37,5 +39,33 @@ func TestSchedulerRefRetryAfterSkippedRefreshWaitsForTTL(t *testing.T) {
 	ref.SetUpdatedAt(time.Now().Add(-time.Hour))
 	if !ref.BeginRefreshIfStale(time.Minute) {
 		t.Fatal("refresh should be allowed after TTL passes")
+	}
+}
+
+// TestMarkExhaustedUntilExpires: a mark with a reset time in the past must lapse
+// on the next read, restoring the optimistic default so routing retries the
+// account. A future mark holds.
+func TestMarkExhaustedUntilExpires(t *testing.T) {
+	ref := NewSchedulerRef(NewScheduler(nil))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "recovered@example.com", time.Now().Add(-time.Second))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "cooked@example.com", time.Now().Add(time.Hour))
+	s := ref.Get()
+	if s.Exhausted(accounts.ProviderClaude, "recovered@example.com") {
+		t.Fatal("expired mark must lapse: recovered account still exhausted")
+	}
+	if !s.Exhausted(accounts.ProviderClaude, "cooked@example.com") {
+		t.Fatal("unexpired mark must hold: cooked account not exhausted")
+	}
+}
+
+// TestSetClearsExhaustedUntil: a full refresh supersedes request-time marks; a
+// later prune must not delete refreshed scores.
+func TestSetClearsExhaustedUntil(t *testing.T) {
+	ref := NewSchedulerRef(NewScheduler(nil))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "a@example.com", time.Now().Add(-time.Second))
+	ref.Set(NewScheduler([]Score{{AccountID: "a@example.com", Provider: accounts.ProviderClaude, Headroom: 0.02, ShortHeadroom: 0.02}}))
+	s := ref.Get()
+	if got := s.ScoreFor(accounts.ProviderClaude, "a@example.com").Headroom; got != 0.02 {
+		t.Fatalf("refreshed score clobbered by stale expiry prune: headroom=%v want 0.02", got)
 	}
 }

--- a/internal/selectacct/scheduler_ref_test.go
+++ b/internal/selectacct/scheduler_ref_test.go
@@ -69,3 +69,29 @@ func TestSetClearsExhaustedUntil(t *testing.T) {
 		t.Fatalf("refreshed score clobbered by stale expiry prune: headroom=%v want 0.02", got)
 	}
 }
+
+// TestPartialRefreshKeepsMarkExpiry is the mixed-refresh regression: a refresh
+// that carries the exhausted account's zero score forward (its own usage fetch
+// failed) must NOT strip the mark's expiry, or the mark becomes permanent again
+// and the recovered account stays unroutable.
+func TestPartialRefreshKeepsMarkExpiry(t *testing.T) {
+	ref := NewSchedulerRef(NewScheduler(nil))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "recovered@example.com", time.Now().Add(-time.Second))
+	// Partial refresh: another account got fresh data, but recovered@'s zero
+	// score is seeded/carried forward unchanged.
+	ref.FinishRefresh(NewScheduler([]Score{
+		{AccountID: "other@example.com", Provider: accounts.ProviderClaude, Headroom: 0.8, ShortHeadroom: 0.8},
+		{AccountID: "recovered@example.com", Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0},
+	}), true)
+	if ref.Get().Exhausted(accounts.ProviderClaude, "recovered@example.com") {
+		t.Fatal("carried-forward zero score must keep its expiry; recovered account still exhausted after lapse")
+	}
+	// But a refresh that genuinely supersedes the mark (headroom) drops the expiry.
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "busy@example.com", time.Now().Add(-time.Second))
+	ref.FinishRefresh(NewScheduler([]Score{
+		{AccountID: "busy@example.com", Provider: accounts.ProviderClaude, Headroom: 0.05, ShortHeadroom: 0.05},
+	}), true)
+	if got := ref.Get().ScoreFor(accounts.ProviderClaude, "busy@example.com").Headroom; got != 0.05 {
+		t.Fatalf("superseded mark must not prune the refreshed score: headroom=%v want 0.05", got)
+	}
+}


### PR DESCRIPTION
## Caught live (the core failed-reroute condition)

During tonight's capacity crunch, `aziz@manaflow.ai`'s weekly window **reset** (57% quota available, 88% session headroom) — yet failing sessions burned all 6 failover attempts on genuinely-cooked accounts and **never tried it**. Real users got 429s while real quota sat unroutable.

Root cause: `markAccountExhausted` zero-scores an account **permanently** — the mark only clears on a *successful* usage refresh. Under load the usage endpoint rate-limits and the refresh falls back to stale "known-good" data, so a recovered account stays buried indefinitely, ranked below stale-scored cooked accounts.

## Fix

Exhaustion marks now expire at the moment the account actually recovers:
- `MarkExhaustedUntil(provider, id, until)` records an expiry per mark; `Get()` lazily prunes lapsed marks back to the optimistic default, so routing retries the account and request-time truth decides.
- The expiry comes from the rejected response itself: `anthropic-ratelimit-unified-reset` (authoritative reset epoch) → `Retry-After` → 10-minute default; clamped to `[now+1m, now+8d]`.
- A full usage refresh (`Set`/`FinishRefresh`) clears pending expiries so a prune can never delete refreshed scores.
- Codex paths keep the default TTL (no unified headers), replacing the previous permanent mark — strictly better for the same reason.

## Tests
- Expired marks lapse, unexpired hold; refresh supersedes marks (no clobber).
- Expiry parsing: unified-reset honored, Retry-After fallback, default, past-reset floor (clock skew), far-future cap.
- Live regression E2E: failover reaches a recovered account after its mark lapses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785569583&installation_id=133855650&pr_number=38&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F38&signature=1522153e41301205fb7162a2e7ceaa98e2e970f2bff856cb6c8ab393e35cafa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expire exhaustion marks at the upstream’s reset so recovered accounts get retried and failover reaches real quota. Preserve expiries through partial refreshes, extend them when a fresh fetch re-confirms exhaustion, and use longer TTLs for dead credentials.

- **Bug Fixes**
  - Added `MarkExhaustedUntil`; proxy now sets expiry via `claudeExhaustionExpiry` using `anthropic-ratelimit-unified-reset` → `Retry-After` → 10m default, clamped to [now+1m, now+8d] (codex falls back to the default).
  - Tracked `Score.Fresh` to reconcile refreshes: headroom clears the mark; a carried zero keeps its expiry; a fresh zero re-anchors/extends it to at least the window reset (floored at the default TTL, capped at 8d).
  - Scheduler prunes expired marks on `Get()` to restore optimistic scores; a lapsed mark allows one probe and a reject re-marks it with the new reset; body-inspect re-mark uses headers so it doesn’t shorten a header-derived expiry.
  - Failure-class TTLs: 401/terminal credential errors use ~1h; transient refresh failures keep the 10m default.

<sup>Written for commit 7b619e099b9f53dd43cdc80fa58d266037cb81ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account exhaustion marks now expire automatically based on upstream recovery timing, reducing unnecessary failover delays.
  * Improved Claude account routing so recovered accounts can be selected again once their exhaustion window ends.
  * Expired routing marks are now cleared during refreshes, helping keep selection scores up to date.

* **Tests**
  * Added coverage for exhaustion timing, retry handling, and failover behavior after recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->