### PR TITLE
Try every Claude OAuth account before surfacing 429

### DIFF
--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"strconv"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -135,6 +135,82 @@ func TestClaude429FailoverEndToEndAndCaptured(t *testing.T) {
 		if !strings.Contains(logs, want) {
 			t.Fatalf("expected rate-limit header %q in logs; logs=\n%s", want, logs)
 		}
+	}
+}
+
+func TestClaude429FailoverTriesPastDefaultAttemptBudget(t *testing.T) {
+	var hits []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		account := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer tok-")
+		hits = append(hits, account)
+		if account == "fresh-7@example.com" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"msg_fresh","type":"message"}`))
+			return
+		}
+		w.Header().Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		w.Header().Set("Anthropic-Ratelimit-Unified-Reset", strconv.FormatInt(time.Now().Add(24*time.Hour).Unix(), 10))
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(realisticAnthropic429Body))
+	}))
+	defer upstream.Close()
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("claude", "session-many", "cooked-0@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	accountsList := make([]accounts.Account, 0, 8)
+	scores := make([]selectacct.Score, 0, 8)
+	for i := 0; i < 8; i++ {
+		id := fmt.Sprintf("cooked-%d@example.com", i)
+		if i == 7 {
+			id = "fresh-7@example.com"
+		}
+		accountsList = append(accountsList, accounts.Account{ID: id, Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-" + id})
+		headroom := 0.90 - float64(i)*0.01
+		scores = append(scores, selectacct.Score{AccountID: id, Provider: accounts.ProviderClaude, Headroom: headroom, ShortHeadroom: headroom})
+	}
+
+	handler := Server{
+		ClaudeUpstream: upstreamURL,
+		Accounts:       accountsList,
+		Sessions:       store,
+		SchedulerRef:   selectacct.NewSchedulerRef(selectacct.NewScheduler(scores)),
+		UsageScoreTTL:  0,
+		MaxBodyBytes:   1 << 20,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	req, err := http.NewRequest(http.MethodPost, subrouter.URL+"/v1/messages", strings.NewReader(`{"model":"claude-fable-5","messages":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Subrouter-Agent", "claude")
+	req.Header.Set("X-Subrouter-Session", "session-many")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), "msg_fresh") {
+		t.Fatalf("status=%d body=%s hits=%v, want failover to reach the eighth account", response.StatusCode, string(body), hits)
+	}
+	if len(hits) != 8 {
+		t.Fatalf("hits=%v, want all 8 accounts tried before success", hits)
+	}
+	if hits[len(hits)-1] != "fresh-7@example.com" {
+		t.Fatalf("last hit=%q, want fresh-7@example.com; hits=%v", hits[len(hits)-1], hits)
 	}
 }
 
@@ -943,13 +1019,13 @@ func TestClaudeExhaustionExpiry(t *testing.T) {
 	}
 	// Far-future reset is capped at 8d.
 	h.Set("Anthropic-Ratelimit-Unified-Reset", "1999999999")
-	if got := claudeExhaustionExpiry(h, now); !got.Equal(now.Add(8*24*time.Hour)) {
+	if got := claudeExhaustionExpiry(h, now); !got.Equal(now.Add(8 * 24 * time.Hour)) {
 		t.Fatalf("far reset = %v, want cap now+8d", got)
 	}
 	// Retry-After honored when unified-reset absent.
 	h = http.Header{}
 	h.Set("Retry-After", "300")
-	if got := claudeExhaustionExpiry(h, now); !got.Equal(now.Add(5*time.Minute)) {
+	if got := claudeExhaustionExpiry(h, now); !got.Equal(now.Add(5 * time.Minute)) {
 		t.Fatalf("retry-after = %v, want now+5m", got)
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -52,12 +52,12 @@ type Server struct {
 	RefreshAccountFn func(context.Context, accounts.Account) (accounts.Account, error)
 	Transport        http.RoundTripper
 	Logger           *slog.Logger
-	ActiveSessions *ActiveSessions
-	Lifecycle      *Lifecycle
-	AdminToken     string
-	MaxBodyBytes   int64
-	Transcripts    *transcript.Recorder
-	ReadCache      *readCache
+	ActiveSessions   *ActiveSessions
+	Lifecycle        *Lifecycle
+	AdminToken       string
+	MaxBodyBytes     int64
+	Transcripts      *transcript.Recorder
+	ReadCache        *readCache
 }
 
 type ActiveSessions struct {
@@ -1490,7 +1490,7 @@ func (s Server) proxyHandler() http.Handler {
 				method:      r.Method,
 				path:        proxyRequest.URL.Path,
 				upstream:    upstream.Host,
-				maxAttempts: replayablePostMaxAttempts,
+				maxAttempts: s.usageLimitRetryMaxAttempts(requestProvider),
 			}
 		}
 		if retryPost && postReplayable {
@@ -2663,6 +2663,15 @@ func (s Server) retryAccount(ctx context.Context, provider accounts.Provider, ag
 
 const replayablePostMaxBodyBytes = 128 << 20
 const replayablePostMaxAttempts = 6
+
+func (s Server) usageLimitRetryMaxAttempts(provider accounts.Provider) int {
+	count := len(oauthAccounts(filterAccountsForProvider(s.accountList(), provider)))
+	if count > replayablePostMaxAttempts {
+		return count
+	}
+	return replayablePostMaxAttempts
+}
+
 const replayablePostMaxConcurrentUploads = 4
 
 var replayablePostUploadLimiter = make(chan struct{}, replayablePostMaxConcurrentUploads)


### PR DESCRIPTION
## Summary
- size Claude/Codex usage-limit failover to the OAuth provider pool instead of the fixed replay budget
- add a Claude regression where the eighth profile succeeds after seven rejected 429s

## Test
- go test ./internal/proxy -run 'TestClaude429FailoverTriesPastDefaultAttemptBudget|TestClaude429FailoverEndToEndAndCaptured|TestClaudeFailoverExhaustionIsLogged' -count=1\n- go test ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785627627&installation_id=133855650&pr_number=39&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F39&signature=40131030dffc0a7cf3fb326687eee62fbc7d5c6657aad710f0578cd65ecf5c98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Try all Claude OAuth accounts on a 429 before returning the error. This removes the fixed 6-attempt cap and improves reliability for orgs with larger account pools.

- **Bug Fixes**
  - Set retry limit to the number of Claude OAuth accounts via `usageLimitRetryMaxAttempts` (was a fixed `replayablePostMaxAttempts`).
  - Route through the entire provider pool on usage-limit 429s before surfacing the error.
  - Added `TestClaude429FailoverTriesPastDefaultAttemptBudget` to confirm success on the 8th account and correct hit order.

<sup>Written for commit 687af71c7f9bd9b14cfdb46b80f1193030173e0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failover for Claude rate-limit responses so requests can continue retrying across more available accounts before giving up.
  * Requests now have a retry budget that scales with the number of configured OAuth accounts, helping successful completion after temporary 429 errors.
* **Tests**
  * Added coverage for Claude 429 failover behavior to verify retries continue until a working account is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->