### PR TITLE
Respect Claude OAuth app quota

### DIFF
--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -1167,6 +1167,11 @@ func isClaudeWeeklyWindow(window accounts.UsageWindow) bool {
 	return name == "7d" || name == "weekly"
 }
 
+func isClaudeOAuthAppsWeeklyWindow(window accounts.UsageWindow) bool {
+	name := strings.ToLower(window.Name)
+	return strings.Contains(name, "oauth-apps") || strings.Contains(name, "7d_oi")
+}
+
 func isClaudeOpusWeeklyWindow(window accounts.UsageWindow) bool {
 	return strings.Contains(strings.ToLower(window.Name), "opus")
 }
@@ -1266,11 +1271,11 @@ func claudeUsageWindows(usage *agentclaude.UsageResponse) []accounts.UsageWindow
 		return nil
 	}
 	var windows []accounts.UsageWindow
-	add := func(name string, limit *agentclaude.RateLimit) {
+	add := func(name string, windowSeconds int64, limit *agentclaude.RateLimit) {
 		if limit == nil || limit.Utilization == nil {
 			return
 		}
-		window := accounts.UsageWindow{Name: name, UsedPercent: *limit.Utilization}
+		window := accounts.UsageWindow{Name: name, UsedPercent: *limit.Utilization, LimitWindowSeconds: windowSeconds}
 		if reset, err := time.Parse(time.RFC3339, limit.ResetsAt); err == nil {
 			seconds := int64(time.Until(reset).Seconds())
 			if seconds < 0 {
@@ -1280,10 +1285,15 @@ func claudeUsageWindows(usage *agentclaude.UsageResponse) []accounts.UsageWindow
 		}
 		windows = append(windows, window)
 	}
-	add("5h", usage.FiveHour)
-	add("7d", usage.SevenDay)
-	add("opus-weekly", usage.SevenDayOpus)
-	add("sonnet-weekly", usage.SevenDaySonnet)
+	const (
+		fiveHourSeconds = int64(5 * 60 * 60)
+		sevenDaySeconds = int64(7 * 24 * 60 * 60)
+	)
+	add("5h", fiveHourSeconds, usage.FiveHour)
+	add("7d", sevenDaySeconds, usage.SevenDay)
+	add("oauth-apps-weekly", sevenDaySeconds, usage.SevenDayOAuthApps)
+	add("opus-weekly", sevenDaySeconds, usage.SevenDayOpus)
+	add("sonnet-weekly", sevenDaySeconds, usage.SevenDaySonnet)
 	if usage.ExtraUsage != nil && usage.ExtraUsage.IsEnabled && usage.ExtraUsage.Utilization != nil {
 		windows = append(windows, accounts.UsageWindow{Name: "extra", UsedPercent: *usage.ExtraUsage.Utilization})
 	}
@@ -1602,6 +1612,7 @@ func usageGridColumns(out io.Writer, numbered bool, provider accounts.Provider) 
 			usageGridColumn{Key: "Session", Title: "Session", Width: windowWidth},
 			usageGridColumn{Key: "Weekly", Title: "Weekly", Width: windowWidth},
 		)
+		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "OAuth wk", Title: "OAuth wk", Width: sparkWidth}, termWidth)
 		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Opus wk", Title: "Opus wk", Width: sparkWidth}, termWidth)
 		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Sonnet wk", Title: "Sonnet wk", Width: 9}, termWidth)
 		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Extra", Title: "Extra", Width: sparkWidth}, termWidth)
@@ -1623,6 +1634,7 @@ func usageGridColumns(out io.Writer, numbered bool, provider accounts.Provider) 
 	extra = widenUsageGridColumn(columns, "Account", extra, 36)
 	extra = widenUsageGridColumn(columns, "Pick", extra, 34)
 	extra = widenUsageGridColumn(columns, "State", extra, 14)
+	extra = widenUsageGridColumn(columns, "OAuth wk", extra, 10)
 	extra = widenUsageGridColumn(columns, "Sonnet wk", extra, 10)
 	extra = widenUsageGridColumn(columns, "Spark wk", extra, 10)
 	extra = widenUsageGridColumn(columns, "Weekly", extra, 12)
@@ -1645,6 +1657,7 @@ func usageGridValues(row srUsageRow, rowIndex string) map[string]usageGridCell {
 		"Credits":   usageGridCreditsCell(row),
 		"Session":   usageGridWindowCell(row.windows, isClaudeSessionWindow),
 		"Weekly":    usageGridWindowCell(row.windows, isClaudeWeeklyWindow),
+		"OAuth wk":  usageGridWindowCell(row.windows, isClaudeOAuthAppsWeeklyWindow),
 		"Opus wk":   usageGridWindowCell(row.windows, isClaudeOpusWeeklyWindow),
 		"Sonnet wk": usageGridWindowCell(row.windows, isClaudeSonnetWeeklyWindow),
 		"Extra":     usageGridWindowCell(row.windows, isClaudeExtraWindow),
@@ -2077,6 +2090,9 @@ func windowLabel(window accounts.UsageWindow) string {
 	}
 	if strings.HasSuffix(name, "/secondary") {
 		return strings.TrimSuffix(name, "/secondary") + " (weekly)"
+	}
+	if name == "oauth-apps-weekly" {
+		return "OAuth apps (weekly)"
 	}
 	return name
 }

--- a/cmd/subrouter/sr_test.go
+++ b/cmd/subrouter/sr_test.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
+	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
 	"github.com/manaflow-ai/subrouter/internal/selectacct"
 )
 
@@ -1090,6 +1091,7 @@ func TestDisplayUsageRowsGridUsesClaudeLimitLabels(t *testing.T) {
 			windows: []accounts.UsageWindow{
 				{Name: "5h", UsedPercent: 11, ResetAfterSeconds: int64((3 * time.Hour) / time.Second)},
 				{Name: "7d", UsedPercent: 54, ResetAfterSeconds: int64((5 * 24 * time.Hour) / time.Second)},
+				{Name: "oauth-apps-weekly", UsedPercent: 100, ResetAfterSeconds: int64((5 * 24 * time.Hour) / time.Second)},
 				{Name: "opus-weekly", UsedPercent: 100, ResetAfterSeconds: int64((5 * 24 * time.Hour) / time.Second)},
 				{Name: "sonnet-weekly", UsedPercent: 0, ResetAfterSeconds: int64((5 * 24 * time.Hour) / time.Second)},
 			},
@@ -1097,7 +1099,7 @@ func TestDisplayUsageRowsGridUsesClaudeLimitLabels(t *testing.T) {
 	}, false)
 
 	got := out.String()
-	if !strings.Contains(got, "Session") || !strings.Contains(got, "Weekly") || !strings.Contains(got, "Opus wk") || !strings.Contains(got, "Sonnet wk") {
+	if !strings.Contains(got, "Session") || !strings.Contains(got, "Weekly") || !strings.Contains(got, "OAuth wk") || !strings.Contains(got, "Opus wk") || !strings.Contains(got, "Sonnet wk") {
 		t.Fatalf("Claude grid missing Claude-specific labels:\n%s", got)
 	}
 	if strings.Contains(got, "  5h  ") || strings.Contains(got, "  7d  ") || strings.Contains(got, "Spark") {
@@ -1107,6 +1109,39 @@ func TestDisplayUsageRowsGridUsesClaudeLimitLabels(t *testing.T) {
 		t.Fatalf("Claude pick reason should use session terminology:\n%s", got)
 	}
 }
+
+func TestClaudeUsageWindowsIncludeOAuthAppsWeekly(t *testing.T) {
+	reset := time.Now().Add(4 * 24 * time.Hour).Format(time.RFC3339)
+	windows := claudeUsageWindows(&agentclaude.UsageResponse{
+		FiveHour:          &agentclaude.RateLimit{Utilization: srFloatPtr(0), ResetsAt: time.Now().Add(time.Hour).Format(time.RFC3339)},
+		SevenDay:          &agentclaude.RateLimit{Utilization: srFloatPtr(60), ResetsAt: reset},
+		SevenDayOAuthApps: &agentclaude.RateLimit{Utilization: srFloatPtr(100), ResetsAt: reset},
+	})
+
+	var oauthApps *accounts.UsageWindow
+	for i := range windows {
+		if windows[i].Name == "oauth-apps-weekly" {
+			oauthApps = &windows[i]
+			break
+		}
+	}
+	if oauthApps == nil {
+		t.Fatalf("missing oauth-apps-weekly window: %+v", windows)
+	}
+	if oauthApps.LimitWindowSeconds != int64((7*24*time.Hour)/time.Second) {
+		t.Fatalf("oauth apps LimitWindowSeconds = %d, want 7d", oauthApps.LimitWindowSeconds)
+	}
+	score := scoreFromWindows("claude@example.com", windows)
+	if score.Headroom != 0 {
+		t.Fatalf("headroom = %.2f, want 0 from saturated oauth app weekly bucket", score.Headroom)
+	}
+	cooked, reason := cookedFromWindows(windows)
+	if !cooked || !strings.Contains(reason, "OAuth apps") {
+		t.Fatalf("cooked=%v reason=%q, want OAuth apps weekly cooked", cooked, reason)
+	}
+}
+
+func srFloatPtr(v float64) *float64 { return &v }
 
 func TestDisplayUsageRowsGridCompactsForNarrowTerminals(t *testing.T) {
 	t.Setenv("COLUMNS", "80")

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -138,6 +138,68 @@ func TestClaude429FailoverEndToEndAndCaptured(t *testing.T) {
 	}
 }
 
+func TestHTTPProxyDoesNotForwardClientIPHeaders(t *testing.T) {
+	var upstreamHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		upstreamHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_ok","type":"message"}`))
+	}))
+	defer upstream.Close()
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+		{AccountID: "claude@example.com", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+	}))
+	handler := Server{
+		ClaudeUpstream: upstreamURL,
+		Accounts: []accounts.Account{
+			{ID: "claude@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-claude"},
+		},
+		Sessions:      store,
+		SchedulerRef:  schedulerRef,
+		UsageScoreTTL: 0,
+		MaxBodyBytes:  1 << 20,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	req, err := http.NewRequest(http.MethodPost, subrouter.URL+"/v1/messages", strings.NewReader(`{"model":"claude-opus-4-8","messages":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Subrouter-Agent", "claude")
+	req.Header.Set("X-Subrouter-Session", "session-forwarded")
+	req.Header.Set("Forwarded", "for=203.0.113.7")
+	req.Header.Set("X-Forwarded-For", "203.0.113.7")
+	req.Header.Set("X-Forwarded-Host", "attacker.example")
+	req.Header.Set("X-Forwarded-Proto", "http")
+	req.Header.Set("X-Real-IP", "203.0.113.8")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("status=%d body=%s, want 200", response.StatusCode, string(body))
+	}
+	for _, header := range []string{"Forwarded", "X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto", "X-Forwarded-Ssl", "X-Real-IP"} {
+		if got := upstreamHeaders.Get(header); got != "" {
+			t.Fatalf("upstream %s = %q, want stripped; headers=%v", header, got, upstreamHeaders)
+		}
+	}
+}
+
 func TestClaude429FailoverTriesPastDefaultAttemptBudget(t *testing.T) {
 	var hits []string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -263,6 +325,36 @@ func TestClaudeUsageWindowsClassifyFiveHourAsShort(t *testing.T) {
 	}
 	if score.ExpiryPressure <= 0 {
 		t.Fatal("ExpiryPressure should be > 0 once the 5h window is classified as short")
+	}
+}
+
+func TestClaudeUsageWindowsIncludeOAuthAppsWeekly(t *testing.T) {
+	usage := &agentclaude.UsageResponse{
+		FiveHour:          &agentclaude.RateLimit{Utilization: floatPtr(0), ResetsAt: time.Now().Add(time.Hour).Format(time.RFC3339)},
+		SevenDay:          &agentclaude.RateLimit{Utilization: floatPtr(60), ResetsAt: time.Now().Add(5 * 24 * time.Hour).Format(time.RFC3339)},
+		SevenDayOAuthApps: &agentclaude.RateLimit{Utilization: floatPtr(100), ResetsAt: time.Now().Add(5 * 24 * time.Hour).Format(time.RFC3339)},
+	}
+	windows := claudeUsageWindows(usage)
+
+	var oauthApps *accounts.UsageWindow
+	for i := range windows {
+		if windows[i].Name == "oauth-apps-weekly" {
+			oauthApps = &windows[i]
+			break
+		}
+	}
+	if oauthApps == nil {
+		t.Fatalf("missing oauth-apps-weekly window: %+v", windows)
+	}
+	if oauthApps.LimitWindowSeconds != 7*24*60*60 {
+		t.Fatalf("oauth apps LimitWindowSeconds = %d, want %d", oauthApps.LimitWindowSeconds, 7*24*60*60)
+	}
+	score := scoreFromUsageWindows(accounts.ProviderClaude, "acct", windows)
+	if score.Headroom != 0 {
+		t.Fatalf("Headroom = %.3f, want 0 from saturated oauth app weekly bucket", score.Headroom)
+	}
+	if score.ShortHeadroom != 1 {
+		t.Fatalf("ShortHeadroom = %.3f, want 1 from healthy 5h bucket", score.ShortHeadroom)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -720,6 +720,7 @@ func claudeUsageWindows(usage *agentclaude.UsageResponse) []accounts.UsageWindow
 	)
 	add("5h", fiveHourSeconds, usage.FiveHour)
 	add("7d", sevenDaySeconds, usage.SevenDay)
+	add("oauth-apps-weekly", sevenDaySeconds, usage.SevenDayOAuthApps)
 	add("opus-weekly", sevenDaySeconds, usage.SevenDayOpus)
 	add("sonnet-weekly", sevenDaySeconds, usage.SevenDaySonnet)
 	if usage.ExtraUsage != nil && usage.ExtraUsage.IsEnabled && usage.ExtraUsage.Utilization != nil {
@@ -1344,6 +1345,15 @@ func clientRemoteIP(r *http.Request) string {
 	return host
 }
 
+func stripOutboundForwardingHeaders(headers http.Header) {
+	headers.Del("Forwarded")
+	headers.Del("X-Forwarded-For")
+	headers.Del("X-Forwarded-Host")
+	headers.Del("X-Forwarded-Proto")
+	headers.Del("X-Forwarded-Ssl")
+	headers.Del("X-Real-IP")
+}
+
 func (s Server) requireAdmin(next func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if s.authorizeAdmin(r) {
@@ -1453,6 +1463,7 @@ func (s Server) proxyHandler() http.Handler {
 		proxyRequest.URL.Path = s.pathForUpstream(proxyRequest.URL.Path, account)
 		proxyRequest.URL.RawPath = ""
 		session.StripSubrouterHeaders(proxyRequest.Header)
+		stripOutboundForwardingHeaders(proxyRequest.Header)
 		retryPost := retryableUpstreamPostRequest(requestProvider, proxyRequest)
 		postReplayable := false
 		if retryPost {
@@ -1473,7 +1484,12 @@ func (s Server) proxyHandler() http.Handler {
 			s.captureRequestBody(proxyRequest, sessionAgentType, sessionID)
 		}
 
-		rp := httputil.NewSingleHostReverseProxy(upstream)
+		rp := &httputil.ReverseProxy{
+			Rewrite: func(pr *httputil.ProxyRequest) {
+				pr.SetURL(upstream)
+				stripOutboundForwardingHeaders(pr.Out.Header)
+			},
+		}
 		transport := s.transport()
 		if retryPost && postReplayable &&
 			(requestProvider == accounts.ProviderCodex || requestProvider == accounts.ProviderClaude) &&
@@ -1508,11 +1524,6 @@ func (s Server) proxyHandler() http.Handler {
 			}
 		}
 		rp.Transport = transport
-		originalDirector := rp.Director
-		rp.Director = func(r *http.Request) {
-			originalDirector(r)
-			r.Host = upstream.Host
-		}
 		rp.ModifyResponse = func(response *http.Response) error {
 			s.captureResponseBody(response, sessionAgentType, sessionID, account.ID, account.Provider, proxyRequest.URL.Path)
 			return nil
@@ -1580,6 +1591,7 @@ func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account a
 	headers := r.Header.Clone()
 	stripWebSocketDialHeaders(headers)
 	session.StripSubrouterHeaders(headers)
+	stripOutboundForwardingHeaders(headers)
 	setAccountAuthHeaders(headers, account)
 	s.recordWebSocketMeta(r, upstreamURL, headers, agentType, sessionID, userEmail, account, upstream)
 


### PR DESCRIPTION
## Summary
- include Claude seven_day_oauth_apps in scheduler/status usage windows
- show the Claude OAuth app weekly bucket in sr status
- stop forwarding client IP attribution headers upstream

## Tests
- go test ./...

Live logs showed Anthropic rejecting claude requests on anthropic-ratelimit-unified-7d_oi while sr only displayed the ordinary weekly bucket.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785642427&installation_id=133855650&pr_number=40&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F40&signature=3eae686a99d0ec80ae7eea941320ab71ba9d44e99a242da6ebd81a373b856767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect Claude OAuth app weekly quota in routing and status to prevent 429s when the OAuth bucket is exhausted. Also stop forwarding client IP headers to upstream for cleaner attribution and privacy.

- **Bug Fixes**
  - Include the `SevenDayOAuthApps` window in scheduling and scoring, with a 7-day duration; route away when saturated.
  - Show the OAuth bucket in `sr` status: new "OAuth wk" column and "OAuth apps (weekly)" label.
  - Strip outbound client IP attribution headers (Forwarded, X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto, X-Forwarded-Ssl, X-Real-IP) for HTTP and WebSocket requests.
  - Add tests for OAuth apps window handling and header stripping.

<sup>Written for commit 2770090d7ff3cce90132f08b13e65dcd5e00f4c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new weekly OAuth apps usage view in Claude profiles, with an additional usage column and updated labels for clearer quota tracking.
  * Improved usage reporting so weekly OAuth app limits are included alongside existing usage windows.

* **Bug Fixes**
  * Proxy requests now remove client IP forwarding headers before reaching upstream services, improving request privacy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->