### PR TITLE
Skip exhausted Claude accounts during failover

### DIFF
--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -510,6 +510,47 @@ func TestClaudeFailoverExhaustionIsLogged(t *testing.T) {
 	}
 }
 
+func TestClaudeFailoverSkipsMarkedExhaustedAlternates(t *testing.T) {
+	server, store := claudeFailoverServer(t)
+	if _, err := store.Put("claude", "session-exhausted-alt", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	server.SchedulerRef.MarkExhaustedUntil(accounts.ProviderClaude, "fresh@example.com", time.Now().Add(time.Hour))
+
+	var calls int
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		calls++
+		if strings.Contains(req.Header.Get("Authorization"), "tok-fresh") {
+			t.Fatal("fresh account is marked exhausted and must not be retried")
+		}
+		h := http.Header{}
+		h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		h.Set("Anthropic-Ratelimit-Unified-Reset", strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10))
+		return &http.Response{StatusCode: http.StatusTooManyRequests, Header: h, Body: io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}`))}
+	}}
+	transport := usageLimitRetryTransport{
+		base: stub, server: &server, provider: accounts.ProviderClaude,
+		agent: "claude", session: "session-exhausted-alt", account: "cooked@example.com",
+		method: http.MethodPost, path: "/v1/messages", maxAttempts: 6,
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader([]byte(`{}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status=%d, want original 429", response.StatusCode)
+	}
+	if calls != 1 {
+		t.Fatalf("upstream calls=%d, want 1 because marked-exhausted alternates are skipped", calls)
+	}
+}
+
 // TestClaudeRejectedHeaderOn200FailsOver is the Aziz regression: a depleted
 // account answers 200 via overage but sets anthropic-ratelimit-unified-status:
 // rejected, which Claude Code hard-blocks on. subrouter must treat that 200 as

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3163,9 +3163,16 @@ func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provide
 	// though healthy accounts remained untried.
 	var lastErr error
 	for {
+		scheduler := s.scheduler()
+		if s.Sessions != nil {
+			scheduler = scheduler.WithSessionCounts(s.Sessions.CountByAccount())
+		}
 		candidates := make([]accounts.Account, 0, len(allCandidates))
 		for _, account := range allCandidates {
 			if _, ok := tried[account.ID]; ok {
+				continue
+			}
+			if scheduler.Exhausted(account.Provider, account.ID) {
 				continue
 			}
 			candidates = append(candidates, account)
@@ -3174,11 +3181,7 @@ func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provide
 			if lastErr != nil {
 				return accounts.Account{}, lastErr
 			}
-			return accounts.Account{}, fmt.Errorf("no untried OAuth %s accounts available", provider)
-		}
-		scheduler := s.scheduler()
-		if s.Sessions != nil {
-			scheduler = scheduler.WithSessionCounts(s.Sessions.CountByAccount())
+			return accounts.Account{}, fmt.Errorf("no untried non-exhausted OAuth %s accounts available", provider)
 		}
 		account, err := scheduler.Pick(candidates)
 		if err != nil {


### PR DESCRIPTION
## Summary
- do not retry Claude OAuth accounts with an active request-time exhaustion mark
- keep low-headroom but non-exhausted accounts eligible for failover
- bounds the no-quota case to the current upstream response instead of retrying every known-exhausted profile

## Tests
- go test ./...

Follow-up to https://github.com/manaflow-ai/subrouter/pull/40: live Anthropic headers prove the remaining 429s are real quota exhaustion on 7d_oi, but the retry path was still re-probing accounts already marked exhausted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785642824&installation_id=133855650&pr_number=41&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F41&signature=3f2efc84967169900680c977ebfb0b29a0140d31ef0c08269d78f0398a00dec3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip OAuth accounts marked exhausted during Claude failover. Prevents retry loops and returns the original 429 when no non‑exhausted alternates are available.

- **Bug Fixes**
  - Exclude scheduler-marked exhausted accounts from retry candidates; keep low-headroom but non-exhausted accounts eligible.
  - Return clearer error: "no untried non-exhausted OAuth <provider> accounts available".
  - Add regression test to verify exhausted alternates are skipped and only one upstream call is made.

<sup>Written for commit dfc7e4929734c72fedee19cfe459a1aba10cf21c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

