### PR TITLE
Show Claude request-time exhaustion in status

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -934,7 +934,7 @@ func (s Server) handleUsageStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.AccountRef != nil {
-		writeJSON(w, s.AccountRef.UsageStatuses(r.Context()))
+		writeJSON(w, s.withRequestTimeExhaustionWindows(s.AccountRef.UsageStatuses(r.Context())))
 		return
 	}
 	accounts := s.accountList()
@@ -950,7 +950,53 @@ func (s Server) handleUsageStatus(w http.ResponseWriter, r *http.Request) {
 			},
 		})
 	}
-	writeJSON(w, out)
+	writeJSON(w, s.withRequestTimeExhaustionWindows(out))
+}
+
+func (s Server) withRequestTimeExhaustionWindows(statuses []AccountUsageStatus) []AccountUsageStatus {
+	if s.SchedulerRef == nil {
+		return statuses
+	}
+	now := time.Now()
+	out := append([]AccountUsageStatus(nil), statuses...)
+	for i := range out {
+		status := &out[i]
+		if status.AuthMode != accounts.AuthModeOAuth {
+			continue
+		}
+		until, ok := s.SchedulerRef.ExhaustedUntilFor(status.Provider, status.ID)
+		if !ok || !until.After(now) {
+			continue
+		}
+		resetAfter := int64(until.Sub(now).Seconds())
+		if resetAfter < 0 {
+			resetAfter = 0
+		}
+		name := "request-limit"
+		windowSeconds := int64(7 * 24 * 60 * 60)
+		if status.Provider == accounts.ProviderClaude {
+			name = "oauth-apps-weekly"
+		}
+		if usageWindowNamed(status.Windows, name) {
+			continue
+		}
+		status.Windows = append(append([]accounts.UsageWindow(nil), status.Windows...), accounts.UsageWindow{
+			Name:               name,
+			UsedPercent:        100,
+			LimitWindowSeconds: windowSeconds,
+			ResetAfterSeconds:  resetAfter,
+		})
+	}
+	return out
+}
+
+func usageWindowNamed(windows []accounts.UsageWindow, name string) bool {
+	for _, window := range windows {
+		if window.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func (s Server) handleReloadAccounts(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -1069,6 +1069,43 @@ func TestUsageStatusEndpointFetchesUsageWithoutForcingFreshRefresh(t *testing.T)
 	}
 }
 
+func TestUsageStatusEndpointIncludesClaudeRequestTimeExhaustion(t *testing.T) {
+	ref := selectacct.NewSchedulerRef(selectacct.NewScheduler(nil))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "claude@example.com", time.Now().Add(2*time.Hour))
+	handler := Server{
+		Accounts: []accounts.Account{{
+			ID:       "claude@example.com",
+			Provider: accounts.ProviderClaude,
+			AuthMode: accounts.AuthModeOAuth,
+			Email:    "claude@example.com",
+		}},
+		SchedulerRef: ref,
+		MaxBodyBytes: 1024,
+	}.Handler()
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/_subrouter/usage-status", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var statuses []AccountUsageStatus
+	if err := json.Unmarshal(recorder.Body.Bytes(), &statuses); err != nil {
+		t.Fatal(err)
+	}
+	if len(statuses) != 1 {
+		t.Fatalf("statuses = %+v, want one", statuses)
+	}
+	for _, window := range statuses[0].Windows {
+		if window.Name == "oauth-apps-weekly" {
+			if window.UsedPercent != 100 || window.ResetAfterSeconds <= 0 {
+				t.Fatalf("oauth-apps-weekly = %+v, want saturated with reset", window)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing oauth-apps-weekly window: %+v", statuses[0].Windows)
+}
+
 func TestReloadAccountsHotLoadsNewAccountWithoutRestart(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	accountStore := accounts.CodexStore{Dir: t.TempDir()}


### PR DESCRIPTION
## Summary
- expose active request-time exhaustion marks in /_subrouter/usage-status
- show marked Claude exhaustion as a saturated OAuth weekly window so sr status matches routing reality

## Tests
- go test ./...

This closes the gap where Anthropic rejects /v1/messages with 7d_oi but the usage endpoint omits that bucket, making sr look healthy after live traffic had already proven the accounts were exhausted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785643125&installation_id=133855650&pr_number=42&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F42&signature=d1bdcf24267aa0e203cf7acfb20ddd91f8e8fee3f9b5c3bb27a2d52a79b918d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface Claude OAuth request-time exhaustion in the usage status so the status matches routing behavior. When an account is marked exhausted, the status now shows a saturated window with a reset timer.

- **Bug Fixes**
  - Overlay request-time exhaustion from the scheduler onto `/_subrouter/usage-status` for OAuth accounts.
  - For Claude, add an `oauth-apps-weekly` window at 100% used with `reset_after`; for others, add `request-limit`.
  - Added a test to validate the Claude exhaustion window appears correctly.

<sup>Written for commit 33cabc3d784df2a2dfd9bd863b6d241414992bfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

