### PR TITLE
Support Claude API-key fallback

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -595,7 +595,7 @@ func usageText(program string) string {
 Usage:
   %[1]s                    Show Codex and Claude usage, grouped by provider
   %[1]s add                Add a new Codex account (opens OAuth login)
-  %[1]s add-key            Add a Codex API key account
+  %[1]s add-key            Add an API key account
   %[1]s import             Import current ~/.codex/auth.json account
   %[1]s list               List all Codex accounts
   %[1]s switch [email]     Switch active Codex account and sync OpenCode/pi

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -46,7 +46,7 @@ const srHelp = `sr - Manage Subrouter accounts
 Usage:
   sr                    Show Codex and Claude usage, grouped by provider
   sr add                Add a new Codex account (opens OAuth login)
-  sr add-key            Add a Codex API key account
+  sr add-key            Add an API key account
   sr import             Import current ~/.codex/auth.json account
   sr list               List all Codex accounts
   sr switch [email]     Switch active Codex account and sync OpenCode/pi

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -569,7 +569,7 @@ func (r srRunner) addKeyToServer(ctx context.Context, server srServerConfig, arg
 	command := r.programOrSubrouter() + " add-key"
 	flags := flag.NewFlagSet(command, flag.ContinueOnError)
 	flags.SetOutput(r.errOut)
-	providerRaw := flags.String("provider", string(accounts.ProviderCodex), "API-key provider: codex, kimi, or zai")
+	providerRaw := flags.String("provider", string(accounts.ProviderCodex), "API-key provider: codex, claude, kimi, or zai")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -628,12 +628,14 @@ func parseAPIKeyProvider(value string) (accounts.Provider, error) {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "", string(accounts.ProviderCodex), "openai":
 		return accounts.ProviderCodex, nil
+	case string(accounts.ProviderClaude), "anthropic":
+		return accounts.ProviderClaude, nil
 	case string(accounts.ProviderKimi), "kimi-for-coding":
 		return accounts.ProviderKimi, nil
 	case string(accounts.ProviderZAI), "glm", "glm-5.2":
 		return accounts.ProviderZAI, nil
 	default:
-		return "", fmt.Errorf("unsupported API-key provider %q, expected codex, kimi, or zai", value)
+		return "", fmt.Errorf("unsupported API-key provider %q, expected codex, claude, kimi, or zai", value)
 	}
 }
 

--- a/cmd/subrouter/sr_server_test.go
+++ b/cmd/subrouter/sr_server_test.go
@@ -1205,6 +1205,16 @@ func commandHasPrefix(command []string, parts []string) bool {
 	return true
 }
 
+func TestParseAPIKeyProviderClaude(t *testing.T) {
+	provider, err := parseAPIKeyProvider("claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if provider != accounts.ProviderClaude {
+		t.Fatalf("provider = %q, want claude", provider)
+	}
+}
+
 func jsonMarshalIndent(value any) ([]byte, error) {
 	return json.MarshalIndent(value, "", "  ")
 }

--- a/internal/proxy/claude_failover_test.go
+++ b/internal/proxy/claude_failover_test.go
@@ -196,6 +196,110 @@ func TestUsageLimitRetryTransportClaudeFailsOverOn401(t *testing.T) {
 	}
 }
 
+func TestUsageLimitRetryTransportClaudeFallsBackToAPIKey(t *testing.T) {
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: "cooked@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-cooked"},
+			{ID: "claude:team-key", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeAPIKey, Token: "api-key"},
+		},
+		Sessions:     store,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+			{AccountID: "cooked@example.com", Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0},
+		})),
+	}
+	if _, err := store.Put("claude", "session-1", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	var sawAPIKey bool
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		if req.Header.Get("X-Api-Key") == "api-key" {
+			sawAPIKey = true
+			if got := req.Header.Get("Authorization"); got != "" {
+				t.Fatalf("Authorization leaked on API-key retry: %q", got)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"id":"msg_1"}`)),
+				Header:     http.Header{},
+			}
+		}
+		h := http.Header{}
+		h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error"}}`)),
+			Header:     h,
+		}
+	}}
+	transport := usageLimitRetryTransport{
+		base:        stub,
+		server:      &server,
+		provider:    accounts.ProviderClaude,
+		agent:       "claude",
+		session:     "session-1",
+		account:     "cooked@example.com",
+		method:      http.MethodPost,
+		path:        "/v1/messages",
+		maxAttempts: 3,
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader([]byte(`{"model":"claude-opus-4-8"}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after API-key fallback", response.StatusCode)
+	}
+	if !sawAPIKey {
+		t.Fatal("Claude API-key fallback was not used")
+	}
+	assignment, ok := store.Get("claude", "session-1")
+	if !ok || assignment.AccountID != "claude:team-key" {
+		t.Fatalf("sticky assignment = %+v, want moved to claude:team-key", assignment)
+	}
+}
+
+func TestAccountForSessionProviderClaudeRefusesExhaustedOAuthWithoutFallback(t *testing.T) {
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := Server{
+		Accounts: []accounts.Account{{
+			ID:       "cooked@example.com",
+			Provider: accounts.ProviderClaude,
+			AuthMode: accounts.AuthModeOAuth,
+			Token:    "tok-cooked",
+		}},
+		Sessions: store,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+			{AccountID: "cooked@example.com", Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0},
+		})),
+		MaxBodyBytes: 1024,
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://subrouter.test/v1/messages", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Subrouter-Agent", "claude")
+	req.Header.Set("X-Subrouter-Session", "session-1")
+	if _, _, _, err := server.accountForSessionProvider(accounts.ProviderClaude, "claude", "session-1", req); err == nil {
+		t.Fatal("expected exhausted Claude OAuth selection to be refused")
+	}
+	if _, ok := store.Get("claude", "session-1"); ok {
+		t.Fatal("exhausted account should not be assigned to a fresh Claude session")
+	}
+}
+
 func TestCaptureResponseBodyClaude401MarksExhausted(t *testing.T) {
 	server, _ := claudeFailoverServer(t)
 	response := &http.Response{

--- a/internal/proxy/claude_failover_test.go
+++ b/internal/proxy/claude_failover_test.go
@@ -206,7 +206,7 @@ func TestUsageLimitRetryTransportClaudeFallsBackToAPIKey(t *testing.T) {
 			{ID: "cooked@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-cooked"},
 			{ID: "claude:team-key", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeAPIKey, Token: "api-key"},
 		},
-		Sessions:     store,
+		Sessions: store,
 		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
 			{AccountID: "cooked@example.com", Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0},
 		})),

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2217,6 +2217,12 @@ func setAccountAuthHeaders(headers http.Header, account accounts.Account) {
 	headers.Del("ChatGPT-Account-ID")
 	switch account.Provider {
 	case accounts.ProviderClaude:
+		if account.AuthMode == accounts.AuthModeAPIKey {
+			headers.Del("Authorization")
+			headers.Set("X-Api-Key", account.Token)
+			removeCommaHeaderValue(headers, "Anthropic-Beta", claudeOAuthBetaHeader)
+			return
+		}
 		headers.Del("X-Api-Key")
 		ensureCommaHeaderValue(headers, "Anthropic-Beta", claudeOAuthBetaHeader)
 	case accounts.ProviderKimi:
@@ -2232,6 +2238,27 @@ func setAccountAuthHeaders(headers http.Header, account accounts.Account) {
 			headers.Set("ChatGPT-Account-ID", account.AccountID)
 		}
 	}
+}
+
+func removeCommaHeaderValue(headers http.Header, key, value string) {
+	existing := headers.Get(key)
+	if existing == "" {
+		return
+	}
+	parts := strings.Split(existing, ",")
+	kept := parts[:0]
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" || trimmed == value {
+			continue
+		}
+		kept = append(kept, trimmed)
+	}
+	if len(kept) == 0 {
+		headers.Del(key)
+		return
+	}
+	headers.Set(key, strings.Join(kept, ","))
 }
 
 func ensureCommaHeaderValue(headers http.Header, key, value string) {
@@ -2407,6 +2434,9 @@ func (s Server) accountForSessionProvider(provider accounts.Provider, agentType,
 	account, err := scheduler.Pick(availableAccounts)
 	if err != nil {
 		return accounts.Account{}, sessionID, userEmail, err
+	}
+	if account.AuthMode == accounts.AuthModeOAuth && provider == accounts.ProviderClaude && scheduler.Exhausted(account.Provider, account.ID) {
+		return accounts.Account{}, sessionID, userEmail, fmt.Errorf("no non-exhausted %s accounts available", provider)
 	}
 	if account.AuthMode == accounts.AuthModeOAuth && !scheduler.UsableForNewSession(account.Provider, account.ID) && s.Logger != nil {
 		// Never refuse here based on the scheduler's view. Usage scores can be
@@ -2723,7 +2753,7 @@ const replayablePostMaxBodyBytes = 128 << 20
 const replayablePostMaxAttempts = 6
 
 func (s Server) usageLimitRetryMaxAttempts(provider accounts.Provider) int {
-	count := len(oauthAccounts(filterAccountsForProvider(s.accountList(), provider)))
+	count := len(filterAccountsForProvider(s.accountList(), provider))
 	if count > replayablePostMaxAttempts {
 		return count
 	}
@@ -3197,9 +3227,9 @@ func isTerminalCredentialError(err error) bool {
 }
 
 func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provider, agentType, sessionID, userEmail string, tried map[string]struct{}) (accounts.Account, error) {
-	allCandidates := oauthAccounts(filterAccountsForProvider(s.accountList(), provider))
+	allCandidates := filterAccountsForProvider(s.accountList(), provider)
 	if len(allCandidates) == 0 {
-		return accounts.Account{}, fmt.Errorf("no OAuth %s accounts available", provider)
+		return accounts.Account{}, fmt.Errorf("no %s accounts available", provider)
 	}
 	s.refreshUsageScoresIfStale(ctx)
 	// Loop so a single account with a dead OAuth token (refresh returns
@@ -3218,7 +3248,7 @@ func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provide
 			if _, ok := tried[account.ID]; ok {
 				continue
 			}
-			if scheduler.Exhausted(account.Provider, account.ID) {
+			if account.AuthMode == accounts.AuthModeOAuth && scheduler.Exhausted(account.Provider, account.ID) {
 				continue
 			}
 			candidates = append(candidates, account)
@@ -3227,11 +3257,19 @@ func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provide
 			if lastErr != nil {
 				return accounts.Account{}, lastErr
 			}
-			return accounts.Account{}, fmt.Errorf("no untried non-exhausted OAuth %s accounts available", provider)
+			return accounts.Account{}, fmt.Errorf("no untried non-exhausted %s accounts available", provider)
 		}
 		account, err := scheduler.Pick(candidates)
 		if err != nil {
 			return accounts.Account{}, err
+		}
+		if account.AuthMode == accounts.AuthModeAPIKey {
+			if s.Sessions != nil {
+				if _, err := s.Sessions.Put(agentType, sessionID, account.ID, userEmail); err != nil {
+					return accounts.Account{}, err
+				}
+			}
+			return account, nil
 		}
 		// Do not stop failover when the best untried account looks exhausted: scores
 		// can be stale, so trying it (the retry loop is bounded by maxAttempts and

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -1533,6 +1533,66 @@ func TestHandlerUsesExplicitSubrouterAccountID(t *testing.T) {
 	}
 }
 
+func TestHandlerUsesClaudeAPIKeyHeaders(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/v1/messages" {
+			t.Fatalf("path = %q, want /v1/messages", got)
+		}
+		if got := r.Header.Get("X-Api-Key"); got != "anthropic-key" {
+			t.Fatalf("X-Api-Key = %q, want API key", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Fatalf("Authorization leaked upstream: %q", got)
+		}
+		if strings.Contains(r.Header.Get("Anthropic-Beta"), "oauth-2025-04-20") {
+			t.Fatalf("OAuth beta sent for API-key Claude account: %q", r.Header.Get("Anthropic-Beta"))
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	claudeUpstream, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := Server{
+		ClaudeUpstream: claudeUpstream,
+		Accounts: []accounts.Account{{
+			ID:       "claude:team-key",
+			Provider: accounts.ProviderClaude,
+			AuthMode: accounts.AuthModeAPIKey,
+			Token:    "anthropic-key",
+		}},
+		Sessions:     store,
+		Scheduler:    selectacct.NewScheduler(nil),
+		MaxBodyBytes: 1024,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	req, err := http.NewRequest(http.MethodPost, subrouter.URL+"/v1/messages", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer subrouter-client-token")
+	req.Header.Set("X-Subrouter-Agent", "claude")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if _, err := io.Copy(io.Discard, response.Body); err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", response.StatusCode)
+	}
+}
+
 func TestHandlerPreservesRequestBodyBytesAfterJSONSessionExtraction(t *testing.T) {
 	body := []byte("{\n  \"input\": \"keep bytes: \\u2603\",\n  \"metadata\": {\"session_id\": \"json-session\"},\n  \"array\": [1, true, null]\n}")
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- support Claude API-key accounts via `sr server add-key --provider claude`
- send Anthropic API keys with `X-Api-Key` instead of OAuth bearer headers
- allow Claude failover to use API-key accounts after OAuth app quota is exhausted
- refuse fresh Claude sessions when only known-exhausted OAuth accounts remain

## Tests
- `go test ./...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785643783&installation_id=133855650&pr_number=43&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F43&signature=a9dab22aad8c4c52c432f6d4aa8cfebcabdc17b126fd351d48f836b6a188ef06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Claude API-key support and failover so requests switch to API-key accounts when OAuth quota is exhausted. Also blocks new Claude sessions when only exhausted OAuth accounts remain.

- **New Features**
  - Add Claude API-key accounts via `sr server add-key --provider claude` (also accepts `anthropic`).
  - Use `X-Api-Key` for Anthropic API keys; remove `Authorization` and OAuth-only `Anthropic-Beta` on API-key requests.
  - Fail over from exhausted Claude OAuth to API-key accounts and persist the session assignment.
  - Refuse new Claude sessions if only exhausted OAuth accounts are available (no API-key fallback).

<sup>Written for commit cc3676ca6559b9941f9ebb3f11c4461fc457401a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

