### PR TITLE
Probe hidden Fable quota for Claude routing

### DIFF
--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -778,13 +778,13 @@ func (r srRunner) fetchUsageRows(ctx context.Context) ([]srUsageRow, error) {
 				rows[i].score = selectacct.Score{AccountID: profile.Name, Headroom: 0, ShortHeadroom: 0}
 				return
 			}
-			usage, err := agentclaude.FetchUsage(ctx, r.client, account.Token)
+			windows, err := fetchClaudeUsageWindows(ctx, r.client, account.Token)
 			if err != nil {
 				rows[i].err = err
 				rows[i].score = selectacct.Score{AccountID: profile.Name, Headroom: 0, ShortHeadroom: 0}
 				return
 			}
-			rows[i].windows = claudeUsageWindows(usage)
+			rows[i].windows = windows
 			rows[i].score = scoreFromWindows(profile.Name, rows[i].windows)
 		}()
 	}
@@ -1094,7 +1094,14 @@ func accountFromStored(account accounts.StoredCodexAccount) accounts.Account {
 }
 
 func scoreFromWindows(accountID string, windows []accounts.UsageWindow) selectacct.Score {
-	limitWindows := make([]selectacct.LimitWindow, 0, len(windows))
+	limitWindows := make([]selectacct.LimitWindow, 0, len(windows)*2)
+	hasFableWindow := false
+	for _, window := range windows {
+		if window.Feature == agentclaude.FableModel || window.Name == agentclaude.FableWindowName {
+			hasFableWindow = true
+			break
+		}
+	}
 	for _, window := range windows {
 		limitWindows = append(limitWindows, selectacct.LimitWindow{
 			Name:               window.Name,
@@ -1103,6 +1110,15 @@ func scoreFromWindows(accountID string, windows []accounts.UsageWindow) selectac
 			ResetAfterSeconds:  window.ResetAfterSeconds,
 			Feature:            window.Feature,
 		})
+		if hasFableWindow && window.Feature == "" {
+			limitWindows = append(limitWindows, selectacct.LimitWindow{
+				Name:               window.Name,
+				UsedPercent:        window.UsedPercent,
+				LimitWindowSeconds: window.LimitWindowSeconds,
+				ResetAfterSeconds:  window.ResetAfterSeconds,
+				Feature:            agentclaude.FableModel,
+			})
+		}
 	}
 	return selectacct.ScoreFromLimitWindows(accountID, 0, limitWindows)
 }
@@ -1276,6 +1292,9 @@ func claudeUsageWindows(usage *agentclaude.UsageResponse) []accounts.UsageWindow
 			return
 		}
 		window := accounts.UsageWindow{Name: name, UsedPercent: *limit.Utilization, LimitWindowSeconds: windowSeconds}
+		if name == agentclaude.FableWindowName {
+			window.Feature = agentclaude.FableModel
+		}
 		if reset, err := time.Parse(time.RFC3339, limit.ResetsAt); err == nil {
 			seconds := int64(time.Until(reset).Seconds())
 			if seconds < 0 {
@@ -1291,13 +1310,64 @@ func claudeUsageWindows(usage *agentclaude.UsageResponse) []accounts.UsageWindow
 	)
 	add("5h", fiveHourSeconds, usage.FiveHour)
 	add("7d", sevenDaySeconds, usage.SevenDay)
-	add("oauth-apps-weekly", sevenDaySeconds, usage.SevenDayOAuthApps)
+	add(agentclaude.FableWindowName, sevenDaySeconds, usage.SevenDayOAuthApps)
 	add("opus-weekly", sevenDaySeconds, usage.SevenDayOpus)
 	add("sonnet-weekly", sevenDaySeconds, usage.SevenDaySonnet)
 	if usage.ExtraUsage != nil && usage.ExtraUsage.IsEnabled && usage.ExtraUsage.Utilization != nil {
 		windows = append(windows, accounts.UsageWindow{Name: "extra", UsedPercent: *usage.ExtraUsage.Utilization})
 	}
 	return windows
+}
+
+func fetchClaudeUsageWindows(ctx context.Context, client *http.Client, accessToken string) ([]accounts.UsageWindow, error) {
+	usage, err := agentclaude.FetchUsage(ctx, client, accessToken)
+	windows := claudeUsageWindows(usage)
+	if !usageWindowNamed(windows, agentclaude.FableWindowName) {
+		fableWindows, probeErr := agentclaude.FetchFableUsageWindows(ctx, client, accessToken)
+		if probeErr == nil && len(fableWindows) > 0 {
+			windows = mergeUsageWindows(windows, fableWindows)
+		} else if err != nil {
+			if probeErr != nil {
+				return nil, probeErr
+			}
+			return nil, err
+		}
+	}
+	if err != nil && len(windows) == 0 {
+		return nil, err
+	}
+	return windows, nil
+}
+
+func mergeUsageWindows(base, extra []accounts.UsageWindow) []accounts.UsageWindow {
+	out := append([]accounts.UsageWindow(nil), base...)
+	index := make(map[string]int, len(out))
+	for i, window := range out {
+		index[usageWindowMergeKey(window)] = i
+	}
+	for _, window := range extra {
+		key := usageWindowMergeKey(window)
+		if i, ok := index[key]; ok {
+			out[i] = window
+			continue
+		}
+		index[key] = len(out)
+		out = append(out, window)
+	}
+	return out
+}
+
+func usageWindowNamed(windows []accounts.UsageWindow, name string) bool {
+	for _, window := range windows {
+		if window.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func usageWindowMergeKey(window accounts.UsageWindow) string {
+	return strings.ToLower(window.Name) + "\x00" + strings.ToLower(window.Feature)
 }
 
 func (r srRunner) ensureSwitchableForFreshUsage(ctx context.Context, account accounts.StoredCodexAccount) error {
@@ -1612,7 +1682,7 @@ func usageGridColumns(out io.Writer, numbered bool, provider accounts.Provider) 
 			usageGridColumn{Key: "Session", Title: "Session", Width: windowWidth},
 			usageGridColumn{Key: "Weekly", Title: "Weekly", Width: windowWidth},
 		)
-		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "OAuth wk", Title: "OAuth wk", Width: sparkWidth}, termWidth)
+		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Fable wk", Title: "Fable wk", Width: sparkWidth}, termWidth)
 		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Opus wk", Title: "Opus wk", Width: sparkWidth}, termWidth)
 		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Sonnet wk", Title: "Sonnet wk", Width: 9}, termWidth)
 		columns = appendUsageGridColumnIfFits(columns, usageGridColumn{Key: "Extra", Title: "Extra", Width: sparkWidth}, termWidth)
@@ -1634,7 +1704,7 @@ func usageGridColumns(out io.Writer, numbered bool, provider accounts.Provider) 
 	extra = widenUsageGridColumn(columns, "Account", extra, 36)
 	extra = widenUsageGridColumn(columns, "Pick", extra, 34)
 	extra = widenUsageGridColumn(columns, "State", extra, 14)
-	extra = widenUsageGridColumn(columns, "OAuth wk", extra, 10)
+	extra = widenUsageGridColumn(columns, "Fable wk", extra, 10)
 	extra = widenUsageGridColumn(columns, "Sonnet wk", extra, 10)
 	extra = widenUsageGridColumn(columns, "Spark wk", extra, 10)
 	extra = widenUsageGridColumn(columns, "Weekly", extra, 12)
@@ -1657,7 +1727,7 @@ func usageGridValues(row srUsageRow, rowIndex string) map[string]usageGridCell {
 		"Credits":   usageGridCreditsCell(row),
 		"Session":   usageGridWindowCell(row.windows, isClaudeSessionWindow),
 		"Weekly":    usageGridWindowCell(row.windows, isClaudeWeeklyWindow),
-		"OAuth wk":  usageGridWindowCell(row.windows, isClaudeOAuthAppsWeeklyWindow),
+		"Fable wk":  usageGridWindowCell(row.windows, isClaudeOAuthAppsWeeklyWindow),
 		"Opus wk":   usageGridWindowCell(row.windows, isClaudeOpusWeeklyWindow),
 		"Sonnet wk": usageGridWindowCell(row.windows, isClaudeSonnetWeeklyWindow),
 		"Extra":     usageGridWindowCell(row.windows, isClaudeExtraWindow),
@@ -2091,8 +2161,8 @@ func windowLabel(window accounts.UsageWindow) string {
 	if strings.HasSuffix(name, "/secondary") {
 		return strings.TrimSuffix(name, "/secondary") + " (weekly)"
 	}
-	if name == "oauth-apps-weekly" {
-		return "OAuth apps (weekly)"
+	if name == agentclaude.FableWindowName {
+		return "Fable (weekly)"
 	}
 	return name
 }

--- a/cmd/subrouter/sr_test.go
+++ b/cmd/subrouter/sr_test.go
@@ -1099,7 +1099,7 @@ func TestDisplayUsageRowsGridUsesClaudeLimitLabels(t *testing.T) {
 	}, false)
 
 	got := out.String()
-	if !strings.Contains(got, "Session") || !strings.Contains(got, "Weekly") || !strings.Contains(got, "OAuth wk") || !strings.Contains(got, "Opus wk") || !strings.Contains(got, "Sonnet wk") {
+	if !strings.Contains(got, "Session") || !strings.Contains(got, "Weekly") || !strings.Contains(got, "Fable wk") || !strings.Contains(got, "Opus wk") || !strings.Contains(got, "Sonnet wk") {
 		t.Fatalf("Claude grid missing Claude-specific labels:\n%s", got)
 	}
 	if strings.Contains(got, "  5h  ") || strings.Contains(got, "  7d  ") || strings.Contains(got, "Spark") {
@@ -1131,13 +1131,23 @@ func TestClaudeUsageWindowsIncludeOAuthAppsWeekly(t *testing.T) {
 	if oauthApps.LimitWindowSeconds != int64((7*24*time.Hour)/time.Second) {
 		t.Fatalf("oauth apps LimitWindowSeconds = %d, want 7d", oauthApps.LimitWindowSeconds)
 	}
+	if oauthApps.Feature != agentclaude.FableModel {
+		t.Fatalf("oauth apps Feature = %q, want %q", oauthApps.Feature, agentclaude.FableModel)
+	}
 	score := scoreFromWindows("claude@example.com", windows)
-	if score.Headroom != 0 {
-		t.Fatalf("headroom = %.2f, want 0 from saturated oauth app weekly bucket", score.Headroom)
+	if score.Headroom == 0 {
+		t.Fatalf("base headroom = %.2f, hidden Fable bucket should not exhaust non-Fable Claude models", score.Headroom)
+	}
+	fableScore, ok := score.ModelScores[selectacct.ModelKey(agentclaude.FableModel)]
+	if !ok {
+		t.Fatalf("missing Fable model score: %+v", score.ModelScores)
+	}
+	if fableScore.Headroom != 0 {
+		t.Fatalf("Fable headroom = %.2f, want 0 from saturated oauth app weekly bucket", fableScore.Headroom)
 	}
 	cooked, reason := cookedFromWindows(windows)
-	if !cooked || !strings.Contains(reason, "OAuth apps") {
-		t.Fatalf("cooked=%v reason=%q, want OAuth apps weekly cooked", cooked, reason)
+	if !cooked || !strings.Contains(reason, "Fable") {
+		t.Fatalf("cooked=%v reason=%q, want Fable weekly cooked", cooked, reason)
 	}
 }
 

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,7 +27,13 @@ import (
 
 const (
 	usageURL        = "https://api.anthropic.com/api/oauth/usage"
+	messagesURL     = "https://api.anthropic.com/v1/messages"
 	oauthBetaHeader = "oauth-2025-04-20"
+)
+
+const (
+	FableModel      = "claude-fable-5"
+	FableWindowName = "oauth-apps-weekly"
 )
 
 var oauthTokenURL = "https://platform.claude.com/v1/oauth/token"
@@ -710,4 +718,84 @@ func FetchUsage(ctx context.Context, client *http.Client, accessToken string) (*
 		return nil, err
 	}
 	return &usage, nil
+}
+
+// FetchFableUsageWindows probes the Messages API because Anthropic's OAuth
+// usage endpoint often omits the hidden Fable/OAuth-app weekly bucket. The
+// response headers are the authoritative source for that bucket.
+func FetchFableUsageWindows(ctx context.Context, client *http.Client, accessToken string) ([]accounts.UsageWindow, error) {
+	if accessToken == "" {
+		return nil, nil
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	body := bytes.NewBufferString(`{"model":"` + FableModel + `","max_tokens":1,"messages":[{"role":"user","content":"."}]}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, messagesURL, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("anthropic-beta", oauthBetaHeader)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("Content-Type", "application/json")
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(res.Body, 64<<10))
+	windows := usageWindowsFromFableHeaders(res.Header, time.Now())
+	if len(windows) > 0 {
+		return windows, nil
+	}
+	if res.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("fable probe failed: %s", res.Status)
+	}
+	return nil, nil
+}
+
+func usageWindowsFromFableHeaders(header http.Header, now time.Time) []accounts.UsageWindow {
+	const (
+		fiveHourSeconds = int64(5 * 60 * 60)
+		sevenDaySeconds = int64(7 * 24 * 60 * 60)
+	)
+	var windows []accounts.UsageWindow
+	add := func(prefix, name string, windowSeconds int64, feature string) {
+		status := strings.ToLower(strings.TrimSpace(header.Get("anthropic-ratelimit-unified-" + prefix + "-status")))
+		rawUtil := strings.TrimSpace(header.Get("anthropic-ratelimit-unified-" + prefix + "-utilization"))
+		rawReset := strings.TrimSpace(header.Get("anthropic-ratelimit-unified-" + prefix + "-reset"))
+		if status == "" && rawUtil == "" && rawReset == "" {
+			return
+		}
+		used := 0.0
+		if rawUtil != "" {
+			if parsed, err := strconv.ParseFloat(rawUtil, 64); err == nil {
+				used = parsed * 100
+			}
+		}
+		if status == "rejected" && used < 100 {
+			used = 100
+		}
+		window := accounts.UsageWindow{
+			Name:               name,
+			UsedPercent:        used,
+			LimitWindowSeconds: windowSeconds,
+			Feature:            feature,
+		}
+		if rawReset != "" {
+			if epoch, err := strconv.ParseInt(rawReset, 10, 64); err == nil && epoch > 0 {
+				seconds := int64(time.Unix(epoch, 0).Sub(now).Seconds())
+				if seconds < 0 {
+					seconds = 0
+				}
+				window.ResetAfterSeconds = seconds
+			}
+		}
+		windows = append(windows, window)
+	}
+	add("5h", "5h", fiveHourSeconds, "")
+	add("7d", "7d", sevenDaySeconds, "")
+	add("7d_oi", FableWindowName, sevenDaySeconds, FableModel)
+	return windows
 }

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -349,12 +349,77 @@ func TestClaudeUsageWindowsIncludeOAuthAppsWeekly(t *testing.T) {
 	if oauthApps.LimitWindowSeconds != 7*24*60*60 {
 		t.Fatalf("oauth apps LimitWindowSeconds = %d, want %d", oauthApps.LimitWindowSeconds, 7*24*60*60)
 	}
-	score := scoreFromUsageWindows(accounts.ProviderClaude, "acct", windows)
-	if score.Headroom != 0 {
-		t.Fatalf("Headroom = %.3f, want 0 from saturated oauth app weekly bucket", score.Headroom)
+	if oauthApps.Feature != agentclaude.FableModel {
+		t.Fatalf("oauth apps Feature = %q, want %q", oauthApps.Feature, agentclaude.FableModel)
 	}
-	if score.ShortHeadroom != 1 {
-		t.Fatalf("ShortHeadroom = %.3f, want 1 from healthy 5h bucket", score.ShortHeadroom)
+	score := scoreFromUsageWindows(accounts.ProviderClaude, "acct", windows)
+	if score.Headroom == 0 {
+		t.Fatalf("base Headroom = %.3f, hidden Fable bucket should not exhaust non-Fable Claude models", score.Headroom)
+	}
+	fableScore, ok := score.ModelScores[selectacct.ModelKey(agentclaude.FableModel)]
+	if !ok {
+		t.Fatalf("missing Fable model score: %+v", score.ModelScores)
+	}
+	if fableScore.Headroom != 0 {
+		t.Fatalf("Fable Headroom = %.3f, want 0 from saturated oauth app weekly bucket", fableScore.Headroom)
+	}
+	if fableScore.ShortHeadroom != 1 {
+		t.Fatalf("Fable ShortHeadroom = %.3f, want 1 from healthy 5h bucket", fableScore.ShortHeadroom)
+	}
+}
+
+func TestClaudeFableProbeAddsHiddenOAuthAppsWindow(t *testing.T) {
+	usageBody := `{"five_hour":{"utilization":10.0,"resets_at":"2030-01-01T00:00:00+00:00"},"seven_day":{"utilization":60.0,"resets_at":"2030-01-02T00:00:00+00:00"}}`
+	probeHeader := http.Header{}
+	probeHeader.Set("Anthropic-Ratelimit-Unified-5h-Status", "allowed")
+	probeHeader.Set("Anthropic-Ratelimit-Unified-5h-Utilization", "0.1")
+	probeHeader.Set("Anthropic-Ratelimit-Unified-5h-Reset", fmt.Sprintf("%d", time.Now().Add(time.Hour).Unix()))
+	probeHeader.Set("Anthropic-Ratelimit-Unified-7d-Status", "allowed")
+	probeHeader.Set("Anthropic-Ratelimit-Unified-7d-Utilization", "0.6")
+	probeHeader.Set("Anthropic-Ratelimit-Unified-7d-Reset", fmt.Sprintf("%d", time.Now().Add(5*24*time.Hour).Unix()))
+	probeHeader.Set("Anthropic-Ratelimit-Unified-7d_Oi-Status", "rejected")
+	probeHeader.Set("Anthropic-Ratelimit-Unified-7d_Oi-Utilization", "1.0")
+	probeHeader.Set("Anthropic-Ratelimit-Unified-7d_Oi-Reset", fmt.Sprintf("%d", time.Now().Add(5*24*time.Hour).Unix()))
+	calls := 0
+	client := &http.Client{Transport: proxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		switch req.URL.Path {
+		case "/api/oauth/usage":
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(usageBody)), Header: http.Header{}}, nil
+		case "/v1/messages":
+			return &http.Response{StatusCode: http.StatusTooManyRequests, Body: io.NopCloser(strings.NewReader(`{"type":"error"}`)), Header: probeHeader}, nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})}
+	windows, err := fetchAccountUsageWindowsLive(context.Background(), client, accounts.Account{
+		ID:       "acct",
+		Provider: accounts.ProviderClaude,
+		AuthMode: accounts.AuthModeOAuth,
+		Token:    "tok",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want usage fetch plus Fable probe", calls)
+	}
+	var fable *accounts.UsageWindow
+	for i := range windows {
+		if windows[i].Name == "oauth-apps-weekly" {
+			fable = &windows[i]
+			break
+		}
+	}
+	if fable == nil {
+		t.Fatalf("missing Fable window: %+v", windows)
+	}
+	if fable.UsedPercent != 100 {
+		t.Fatalf("Fable UsedPercent = %.1f, want 100", fable.UsedPercent)
+	}
+	if fable.Feature != agentclaude.FableModel {
+		t.Fatalf("Fable Feature = %q, want %q", fable.Feature, agentclaude.FableModel)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -705,6 +705,9 @@ func claudeUsageWindows(usage *agentclaude.UsageResponse) []accounts.UsageWindow
 			UsedPercent:        *limit.Utilization,
 			LimitWindowSeconds: windowSeconds,
 		}
+		if name == agentclaude.FableWindowName {
+			window.Feature = agentclaude.FableModel
+		}
 		if reset, err := time.Parse(time.RFC3339, limit.ResetsAt); err == nil {
 			seconds := int64(time.Until(reset).Seconds())
 			if seconds < 0 {
@@ -720,7 +723,7 @@ func claudeUsageWindows(usage *agentclaude.UsageResponse) []accounts.UsageWindow
 	)
 	add("5h", fiveHourSeconds, usage.FiveHour)
 	add("7d", sevenDaySeconds, usage.SevenDay)
-	add("oauth-apps-weekly", sevenDaySeconds, usage.SevenDayOAuthApps)
+	add(agentclaude.FableWindowName, sevenDaySeconds, usage.SevenDayOAuthApps)
 	add("opus-weekly", sevenDaySeconds, usage.SevenDayOpus)
 	add("sonnet-weekly", sevenDaySeconds, usage.SevenDaySonnet)
 	if usage.ExtraUsage != nil && usage.ExtraUsage.IsEnabled && usage.ExtraUsage.Utilization != nil {
@@ -782,7 +785,14 @@ func scoreUsableForNewSession(score selectacct.Score) bool {
 }
 
 func scoreFromUsageWindows(provider accounts.Provider, accountID string, windows []accounts.UsageWindow) selectacct.Score {
-	limitWindows := make([]selectacct.LimitWindow, 0, len(windows))
+	limitWindows := make([]selectacct.LimitWindow, 0, len(windows)*2)
+	hasFableWindow := false
+	for _, window := range windows {
+		if window.Feature == agentclaude.FableModel || window.Name == agentclaude.FableWindowName {
+			hasFableWindow = true
+			break
+		}
+	}
 	for _, window := range windows {
 		limitWindows = append(limitWindows, selectacct.LimitWindow{
 			Name:               window.Name,
@@ -791,6 +801,15 @@ func scoreFromUsageWindows(provider accounts.Provider, accountID string, windows
 			ResetAfterSeconds:  window.ResetAfterSeconds,
 			Feature:            window.Feature,
 		})
+		if provider == accounts.ProviderClaude && hasFableWindow && window.Feature == "" {
+			limitWindows = append(limitWindows, selectacct.LimitWindow{
+				Name:               window.Name,
+				UsedPercent:        window.UsedPercent,
+				LimitWindowSeconds: window.LimitWindowSeconds,
+				ResetAfterSeconds:  window.ResetAfterSeconds,
+				Feature:            agentclaude.FableModel,
+			})
+		}
 	}
 	score := selectacct.ScoreFromLimitWindows(accountID, 0, limitWindows)
 	score.Provider = provider
@@ -1352,12 +1371,45 @@ func (s Server) fetchAccountUsageWindows(ctx context.Context, client *http.Clien
 func fetchAccountUsageWindowsLive(ctx context.Context, client *http.Client, account accounts.Account) ([]accounts.UsageWindow, error) {
 	if account.Provider == accounts.ProviderClaude {
 		usage, err := agentclaude.FetchUsage(ctx, client, account.Token)
-		if err != nil {
+		windows := claudeUsageWindows(usage)
+		if !usageWindowNamed(windows, agentclaude.FableWindowName) {
+			if fableWindows, probeErr := agentclaude.FetchFableUsageWindows(ctx, client, account.Token); probeErr == nil && len(fableWindows) > 0 {
+				windows = mergeUsageWindows(windows, fableWindows)
+			} else if err != nil {
+				if probeErr != nil {
+					return nil, probeErr
+				}
+				return nil, err
+			}
+		}
+		if err != nil && len(windows) == 0 {
 			return nil, err
 		}
-		return claudeUsageWindows(usage), nil
+		return windows, nil
 	}
 	return accounts.FetchCodexUsage(ctx, client, account)
+}
+
+func mergeUsageWindows(base, extra []accounts.UsageWindow) []accounts.UsageWindow {
+	out := append([]accounts.UsageWindow(nil), base...)
+	index := make(map[string]int, len(out))
+	for i, window := range out {
+		index[usageWindowMergeKey(window)] = i
+	}
+	for _, window := range extra {
+		key := usageWindowMergeKey(window)
+		if i, ok := index[key]; ok {
+			out[i] = window
+			continue
+		}
+		index[key] = len(out)
+		out = append(out, window)
+	}
+	return out
+}
+
+func usageWindowMergeKey(window accounts.UsageWindow) string {
+	return strings.ToLower(window.Name) + "\x00" + strings.ToLower(window.Feature)
 }
 
 const defaultUsageFetchTimeout = 10 * time.Second

--- a/internal/proxy/usage_windows_cache_test.go
+++ b/internal/proxy/usage_windows_cache_test.go
@@ -45,8 +45,8 @@ func TestFetchUsageWindowsCachedServesFromCacheWithinTTL(t *testing.T) {
 			t.Fatalf("call %d: within-TTL cache should report fresh", i)
 		}
 	}
-	if transport.calls != 1 {
-		t.Fatalf("upstream calls = %d, want 1 (cache should absorb repeats)", transport.calls)
+	if transport.calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2 (usage fetch plus one Fable probe; cache should absorb repeats)", transport.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- probes Claude Messages headers for the hidden Fable/OAuth-app weekly quota when the normal Claude usage endpoint omits it
- shows that bucket as `Fable wk` in `sr` status
- routes `claude-fable-5` with the hidden Fable weekly pool plus normal Claude session/weekly pools, without cooking non-Fable Claude models on the Fable-only bucket

## Tests
- `go test ./...`

## Root cause
Anthropic can reject Fable with `anthropic-ratelimit-unified-7d_oi-status: rejected` while `/api/oauth/usage` still shows ordinary Claude weekly quota. The scheduler only saw the ordinary usage endpoint, so it kept selecting accounts that were exhausted for Fable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785645276&installation_id=133855650&pr_number=44&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F44&signature=34734b3fd4bf0bd5f1a946f2ea9a8de5216ca8e382e2b6bd45ec493864bb5e4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Probe Anthropic Messages headers to detect the hidden Fable OAuth‑app weekly quota and use it for routing. Show it as “Fable wk” in `sr`, and score/route `claude-fable-5` against this bucket without affecting other Claude models.

- **New Features**
  - Add a lightweight `/v1/messages` probe to read header quotas and backfill the `oauth-apps-weekly` window when `/api/oauth/usage` omits it.
  - Display “Fable wk” in `sr` and label the window with Feature `claude-fable-5`.
  - Model-aware scoring: if a Fable window exists, compute headroom specifically for `claude-fable-5` while keeping other Claude models independent.

- **Bug Fixes**
  - Stop selecting Fable-exhausted accounts when the usage endpoint hides the OAuth-app weekly bucket; treat `7d_oi` rejected as 100% used.
  - Prevent Fable-only exhaustion from “cooking” non-Fable Claude models.

<sup>Written for commit 2dbad97eed0152b12b296cd98c2d3350587a3133. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

