### PR TITLE
Show headerless Fable probe quota exhaustion

### DIFF
--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -1325,7 +1325,9 @@ func fetchClaudeUsageWindows(ctx context.Context, client *http.Client, accessTok
 	if !usageWindowNamed(windows, agentclaude.FableWindowName) {
 		fableWindows, probeErr := agentclaude.FetchFableUsageWindows(ctx, client, accessToken)
 		if probeErr == nil && len(fableWindows) > 0 {
-			windows = mergeUsageWindows(windows, fableWindows)
+			if err == nil || fableProbeHasPrimaryWindows(fableWindows) {
+				windows = mergeUsageWindows(windows, fableWindows)
+			}
 		} else if err != nil {
 			if probeErr != nil {
 				return nil, probeErr
@@ -1337,6 +1339,15 @@ func fetchClaudeUsageWindows(ctx context.Context, client *http.Client, accessTok
 		return nil, err
 	}
 	return windows, nil
+}
+
+func fableProbeHasPrimaryWindows(windows []accounts.UsageWindow) bool {
+	for _, window := range windows {
+		if window.Name == "5h" || window.Name == "7d" {
+			return true
+		}
+	}
+	return false
 }
 
 func mergeUsageWindows(base, extra []accounts.UsageWindow) []accounts.UsageWindow {

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -749,6 +749,14 @@ func FetchFableUsageWindows(ctx context.Context, client *http.Client, accessToke
 	if len(windows) > 0 {
 		return windows, nil
 	}
+	if res.StatusCode == http.StatusTooManyRequests {
+		return []accounts.UsageWindow{{
+			Name:               FableWindowName,
+			UsedPercent:        100,
+			LimitWindowSeconds: int64(7 * 24 * time.Hour / time.Second),
+			Feature:            FableModel,
+		}}, nil
+	}
 	if res.StatusCode == http.StatusUnauthorized {
 		return nil, fmt.Errorf("fable probe failed: %s", res.Status)
 	}

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -423,6 +423,41 @@ func TestClaudeFableProbeAddsHiddenOAuthAppsWindow(t *testing.T) {
 	}
 }
 
+func TestClaudeFableProbeTreatsHeaderless429AsFableExhausted(t *testing.T) {
+	usageBody := `{"five_hour":{"utilization":10.0,"resets_at":"2030-01-01T00:00:00+00:00"},"seven_day":{"utilization":60.0,"resets_at":"2030-01-02T00:00:00+00:00"}}`
+	client := &http.Client{Transport: proxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/api/oauth/usage":
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(usageBody)), Header: http.Header{}}, nil
+		case "/v1/messages":
+			return &http.Response{StatusCode: http.StatusTooManyRequests, Body: io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}`)), Header: http.Header{}}, nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})}
+	windows, err := fetchAccountUsageWindowsLive(context.Background(), client, accounts.Account{
+		ID:       "acct",
+		Provider: accounts.ProviderClaude,
+		AuthMode: accounts.AuthModeOAuth,
+		Token:    "tok",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	score := scoreFromUsageWindows(accounts.ProviderClaude, "acct", windows)
+	if score.Headroom == 0 {
+		t.Fatalf("base Headroom = %.3f, hidden Fable bucket should not exhaust non-Fable Claude models", score.Headroom)
+	}
+	fableScore, ok := score.ModelScores[selectacct.ModelKey(agentclaude.FableModel)]
+	if !ok {
+		t.Fatalf("missing Fable model score: %+v", score.ModelScores)
+	}
+	if fableScore.Headroom != 0 {
+		t.Fatalf("Fable Headroom = %.3f, want 0 from headerless Fable probe 429", fableScore.Headroom)
+	}
+}
+
 // TestClaudeShortWindowDrivesRouting proves the routing calculation now prefers
 // the account with more 5h headroom even when both accounts have identical
 // account-wide (7d) headroom. Before the fix both scored equal short headroom.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -993,8 +993,10 @@ func (s Server) withRequestTimeExhaustionWindows(statuses []AccountUsageStatus) 
 		}
 		name := "request-limit"
 		windowSeconds := int64(7 * 24 * 60 * 60)
+		feature := ""
 		if status.Provider == accounts.ProviderClaude {
-			name = "oauth-apps-weekly"
+			name = agentclaude.FableWindowName
+			feature = agentclaude.FableModel
 		}
 		if usageWindowNamed(status.Windows, name) {
 			continue
@@ -1004,6 +1006,7 @@ func (s Server) withRequestTimeExhaustionWindows(statuses []AccountUsageStatus) 
 			UsedPercent:        100,
 			LimitWindowSeconds: windowSeconds,
 			ResetAfterSeconds:  resetAfter,
+			Feature:            feature,
 		})
 	}
 	return out
@@ -1374,7 +1377,9 @@ func fetchAccountUsageWindowsLive(ctx context.Context, client *http.Client, acco
 		windows := claudeUsageWindows(usage)
 		if !usageWindowNamed(windows, agentclaude.FableWindowName) {
 			if fableWindows, probeErr := agentclaude.FetchFableUsageWindows(ctx, client, account.Token); probeErr == nil && len(fableWindows) > 0 {
-				windows = mergeUsageWindows(windows, fableWindows)
+				if err == nil || fableProbeHasPrimaryWindows(fableWindows) {
+					windows = mergeUsageWindows(windows, fableWindows)
+				}
 			} else if err != nil {
 				if probeErr != nil {
 					return nil, probeErr
@@ -1388,6 +1393,15 @@ func fetchAccountUsageWindowsLive(ctx context.Context, client *http.Client, acco
 		return windows, nil
 	}
 	return accounts.FetchCodexUsage(ctx, client, account)
+}
+
+func fableProbeHasPrimaryWindows(windows []accounts.UsageWindow) bool {
+	for _, window := range windows {
+		if window.Name == "5h" || window.Name == "7d" {
+			return true
+		}
+	}
+	return false
 }
 
 func mergeUsageWindows(base, extra []accounts.UsageWindow) []accounts.UsageWindow {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -1096,14 +1096,17 @@ func TestUsageStatusEndpointIncludesClaudeRequestTimeExhaustion(t *testing.T) {
 		t.Fatalf("statuses = %+v, want one", statuses)
 	}
 	for _, window := range statuses[0].Windows {
-		if window.Name == "oauth-apps-weekly" {
+		if window.Name == agentclaude.FableWindowName {
 			if window.UsedPercent != 100 || window.ResetAfterSeconds <= 0 {
-				t.Fatalf("oauth-apps-weekly = %+v, want saturated with reset", window)
+				t.Fatalf("Fable window = %+v, want saturated with reset", window)
+			}
+			if window.Feature != agentclaude.FableModel {
+				t.Fatalf("Fable Feature = %q, want %q", window.Feature, agentclaude.FableModel)
 			}
 			return
 		}
 	}
-	t.Fatalf("missing oauth-apps-weekly window: %+v", statuses[0].Windows)
+	t.Fatalf("missing Fable window: %+v", statuses[0].Windows)
 }
 
 func TestReloadAccountsHotLoadsNewAccountWithoutRestart(t *testing.T) {


### PR DESCRIPTION
## Summary
- treats a headerless 429 from the dedicated `claude-fable-5` probe as a Fable-only exhausted window
- preserves stale/error behavior for the normal Claude usage endpoint, so transient usage fetch 429s still fall back to last-good data
- marks request-time Claude exhaustion as the Fable feature bucket in `/usage-status`

## Tests
- `go test ./...`

## Live finding
The deployed minimal and fuller Fable probes returned HTTP 429 with no `anthropic-ratelimit-*` headers, while the ordinary Claude usage endpoint still reported weekly quota. Without this fallback, `sr` showed the new `Fable wk` column but left it blank.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785645670&installation_id=133855650&pr_number=45&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F45&signature=74f253851a2cfa58b4711075a58241ebe9c2f0cac10bc8f167cf6d64d2cc1979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat headerless 429s from the dedicated `claude-fable-5` probe as Fable-only quota exhaustion so `sr` shows the Fable week bucket and other Claude models keep their headroom. Also tag request-time exhaustion as the Fable bucket in `/usage-status`.

- **Bug Fixes**
  - On headerless 429 from the Fable probe, synthesize a saturated Fable window and set the Feature to the Fable model.
  - Preserve fallback to last-good data for the normal Claude usage API; merge Fable probe windows only when base usage succeeded or when the probe includes primary windows (`5h`/`7d`).
  - Add tests for headerless Fable 429 handling and for `/usage-status` including the Fable window.

<sup>Written for commit 439cb2be961fc9c525ce45408d3de37f107ed781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

