### PR TITLE
Update scheduler from fresh usage status

### DIFF
--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -458,6 +458,41 @@ func TestClaudeFableProbeTreatsHeaderless429AsFableExhausted(t *testing.T) {
 	}
 }
 
+func TestUsageStatusFreshFableWindowUpdatesSchedulerModelPool(t *testing.T) {
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+		{AccountID: "acct", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+	}))
+	server := Server{
+		Accounts: []accounts.Account{{
+			ID:       "acct",
+			Provider: accounts.ProviderClaude,
+			AuthMode: accounts.AuthModeOAuth,
+		}},
+		SchedulerRef: schedulerRef,
+	}
+	server.updateSchedulerFromUsageStatuses([]AccountUsageStatus{{
+		AccountStatus: AccountStatus{
+			ID:       "acct",
+			Provider: accounts.ProviderClaude,
+			AuthMode: accounts.AuthModeOAuth,
+		},
+		UsageFresh: true,
+		Windows: []accounts.UsageWindow{
+			{Name: "5h", UsedPercent: 10, LimitWindowSeconds: 5 * 60 * 60},
+			{Name: "7d", UsedPercent: 40, LimitWindowSeconds: 7 * 24 * 60 * 60},
+			{Name: agentclaude.FableWindowName, Feature: agentclaude.FableModel, UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
+		},
+	}})
+	base := schedulerRef.Get()
+	if base.Exhausted(accounts.ProviderClaude, "acct") {
+		t.Fatalf("base Claude score should remain usable when only Fable is exhausted")
+	}
+	fable := base.ForModel(agentclaude.FableModel)
+	if !fable.Exhausted(accounts.ProviderClaude, "acct") {
+		t.Fatalf("Fable model score should be exhausted after fresh status update")
+	}
+}
+
 // TestClaudeShortWindowDrivesRouting proves the routing calculation now prefers
 // the account with more 5h headroom even when both accounts have identical
 // account-wide (7d) headroom. Before the fix both scored equal short headroom.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -277,6 +277,7 @@ type AccountUsageStatus struct {
 	Windows            []accounts.UsageWindow           `json:"windows,omitempty"`
 	Credits            *accounts.CreditsInfo            `json:"credits,omitempty"`
 	ComplimentaryReset *accounts.ComplimentaryResetInfo `json:"complimentary_reset,omitempty"`
+	UsageFresh         bool                             `json:"-"`
 }
 
 func NewAccountRef(store accounts.CodexStore, initial []accounts.Account, client *http.Client) *AccountRef {
@@ -488,6 +489,7 @@ func (r *AccountRef) UsageStatuses(ctx context.Context) []AccountUsageStatus {
 		restored.Active = status.Active
 		restored.Refreshed = status.Refreshed
 		restored.Error = ""
+		restored.UsageFresh = false
 		out[i] = restored
 	}
 	r.usageStatusCache = append([]AccountUsageStatus(nil), out...)
@@ -592,6 +594,7 @@ func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus
 			next.Windows = details.Windows
 			next.Credits = details.Credits
 			next.ComplimentaryReset = details.ComplimentaryReset
+			next.UsageFresh = true
 			out[i] = next
 		}()
 	}
@@ -628,7 +631,7 @@ func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus
 			}
 			next.AuthValid = true
 			r.replace(account)
-			windows, _, err := r.FetchUsageWindowsCached(ctx, r.client, account)
+			windows, fresh, err := r.FetchUsageWindowsCached(ctx, r.client, account)
 			if err != nil {
 				next.Error = err.Error()
 				out[i] = next
@@ -636,6 +639,7 @@ func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus
 			}
 			next.PlanType = "claude"
 			next.Windows = windows
+			next.UsageFresh = fresh
 			out[i] = next
 		}()
 	}
@@ -953,7 +957,9 @@ func (s Server) handleUsageStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.AccountRef != nil {
-		writeJSON(w, s.withRequestTimeExhaustionWindows(s.AccountRef.UsageStatuses(r.Context())))
+		statuses := s.AccountRef.UsageStatuses(r.Context())
+		s.updateSchedulerFromUsageStatuses(statuses)
+		writeJSON(w, s.withRequestTimeExhaustionWindows(statuses))
 		return
 	}
 	accounts := s.accountList()
@@ -970,6 +976,47 @@ func (s Server) handleUsageStatus(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	writeJSON(w, s.withRequestTimeExhaustionWindows(out))
+}
+
+func (s Server) updateSchedulerFromUsageStatuses(statuses []AccountUsageStatus) {
+	if s.SchedulerRef == nil {
+		return
+	}
+	available := oauthAccounts(s.accountList())
+	if len(available) == 0 {
+		return
+	}
+	current := s.scheduler()
+	scores := make([]selectacct.Score, 0, len(available))
+	scoreByID := make(map[string]int, len(available))
+	for _, account := range available {
+		seed := current.ScoreFor(account.Provider, account.ID)
+		seed.AccountID = account.ID
+		seed.Provider = account.Provider
+		seed.Fresh = false
+		scoreByID[selectacct.ScoreKey(account.Provider, account.ID)] = len(scores)
+		scores = append(scores, seed)
+	}
+	scored := 0
+	for _, status := range statuses {
+		if !status.UsageFresh || status.AuthMode != accounts.AuthModeOAuth || len(status.Windows) == 0 {
+			continue
+		}
+		if idx, ok := scoreByID[selectacct.ScoreKey(status.Provider, status.ID)]; ok {
+			next := scoreFromUsageWindows(status.Provider, status.ID, status.Windows)
+			next.Fresh = true
+			scores[idx] = next
+			scored++
+		}
+	}
+	if scored == 0 {
+		return
+	}
+	scheduler := selectacct.NewScheduler(scores)
+	if s.Sessions != nil {
+		scheduler = scheduler.WithSessionCounts(s.Sessions.CountByAccount())
+	}
+	s.SchedulerRef.Set(scheduler)
 }
 
 func (s Server) withRequestTimeExhaustionWindows(statuses []AccountUsageStatus) []AccountUsageStatus {


### PR DESCRIPTION
## Summary
- marks usage-status rows as fresh only when they came from a live usage fetch, not last-good fallback
- updates the routing scheduler from fresh `/usage-status` windows so `sr` visibility and routing state converge
- adds coverage proving a fresh Fable status cooks only the `claude-fable-5` model pool while leaving base Claude routing usable

## Tests
- `go test ./...`

## Live finding
After PRs 44 and 45, `sr` correctly showed `Fable wk = 0%`, but a cold service could still learn by failover because the status sweep did not publish fresh Fable windows into `SchedulerRef`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785645929&installation_id=133855650&pr_number=46&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F46&signature=6b0e98b4fda1f9353d4a9413f206ec3f755b70beac2621b754fe41690b6c14dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the routing scheduler from fresh `/usage-status` data so status and routing stay in sync, preventing failover “learning” when Fable is exhausted. Also adds a test proving only the `claude-fable-5` model pool is cooked while base Claude stays routable.

- **Bug Fixes**
  - Mark usage rows as fresh only when fetched live; last-good fallbacks are not fresh.
  - On `/usage-status`, refresh `SchedulerRef` using only fresh OAuth statuses; seed from current scores and retain session counts.
  - Propagate freshness through `AccountUsageStatus` and `FetchUsageWindowsCached`.
  - Add test that a fresh Fable window exhausts only the `claude-fable-5` pool, leaving base Claude usable.

<sup>Written for commit e04fdb6d83a654bfe39a09eb960d6f5e1d88297e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

