### PR TITLE
Extract model from large Claude JSON requests

### DIFF
--- a/internal/session/extract.go
+++ b/internal/session/extract.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/mail"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -207,10 +208,10 @@ func extractJSONID(r *http.Request, maxBodyBytes int64) string {
 
 func extractJSONModel(r *http.Request, maxBodyBytes int64) string {
 	value := extractJSONValue(r, maxBodyBytes)
-	if value == nil {
-		return ""
+	if value != nil {
+		return findJSONModel(value)
 	}
-	return findJSONModel(value)
+	return extractJSONModelPrefix(r, maxBodyBytes)
 }
 
 func extractJSONValue(r *http.Request, maxBodyBytes int64) any {
@@ -284,6 +285,31 @@ func findJSONModel(value any) string {
 		}
 	}
 	return ""
+}
+
+var jsonModelFieldPattern = regexp.MustCompile(`"model"\s*:\s*"((?:\\.|[^"\\])*)"`)
+
+func extractJSONModelPrefix(r *http.Request, maxBodyBytes int64) string {
+	if r.Body == nil || maxBodyBytes <= 0 {
+		return ""
+	}
+	if contentType := r.Header.Get("Content-Type"); !strings.Contains(contentType, "json") {
+		return ""
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
+	if err != nil {
+		return ""
+	}
+	r.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), r.Body))
+	match := jsonModelFieldPattern.FindSubmatch(body)
+	if len(match) != 2 {
+		return ""
+	}
+	unquoted, err := strconv.Unquote(`"` + string(match[1]) + `"`)
+	if err != nil {
+		return ""
+	}
+	return NormalizeModel(unquoted)
 }
 
 func fallbackID(r *http.Request) string {

--- a/internal/session/extract_test.go
+++ b/internal/session/extract_test.go
@@ -95,6 +95,23 @@ func TestExtractModelFromJSONAndRestoresBody(t *testing.T) {
 	}
 }
 
+func TestExtractModelFromLargeJSONPrefixAndRestoresBody(t *testing.T) {
+	body := `{"model":"claude-fable-5","messages":[{"role":"user","content":"` + strings.Repeat("x", 2048) + `"}]}`
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	if got := ExtractModel(req, 128); got != "claude-fable-5" {
+		t.Fatalf("got %q, want claude-fable-5", got)
+	}
+	restored, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(restored) != body {
+		t.Fatalf("body was not restored")
+	}
+}
+
 func TestExtractAgentTypeFromSubrouterHeader(t *testing.T) {
 	req := httptest.NewRequest("POST", "/v1/responses", nil)
 	req.Header.Set("X-Subrouter-Agent", "Claude")


### PR DESCRIPTION
## Summary
- extracts `model` from a bounded JSON prefix when the request body is larger than the full JSON parsing limit
- restores the consumed prefix in front of the unread body so proxying still sends the original request
- covers large Claude-style request bodies where `model` appears near the top

## Tests
- `go test ./...`

## Live finding
The `claude -p` smoke body was too large for full-body model extraction, so routing did not call `ForModel(claude-fable-5)` even after `sr` populated the Fable scheduler pool.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785646251&installation_id=133855650&pr_number=47&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F47&signature=a8d7d0919f8014aa0a2f840b1b243d47f6bac3ace56f2df959d783596f4e3188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes model extraction for large JSON bodies by scanning a bounded prefix when full parsing exceeds the limit. Restores the consumed prefix so the original request remains intact, enabling correct routing for large Claude-style payloads (e.g., "claude-fable-5").

- **Bug Fixes**
  - Scan a limited JSON prefix with a regex to read "model" when `maxBodyBytes` blocks full parse.
  - Restore the read prefix onto `r.Body` to preserve the original request for proxying.
  - Normalize and return the model; add a test that verifies extraction and body restoration on large inputs.

<sup>Written for commit a6f8e1c4899575fc5b10894e1bd35370ea3945f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model detection for JSON requests, even when the body is large, partially unreadable, or not fully parsed.
  * Preserves the original request body after inspection so it can still be read later in the request flow.
  * Added coverage to verify model extraction from a large JSON payload and confirm the body remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->