### PR TITLE
Scan larger JSON bodies for model routing

### DIFF
--- a/internal/session/extract.go
+++ b/internal/session/extract.go
@@ -211,7 +211,7 @@ func extractJSONModel(r *http.Request, maxBodyBytes int64) string {
 	if value != nil {
 		return findJSONModel(value)
 	}
-	return extractJSONModelPrefix(r, maxBodyBytes)
+	return extractJSONModelScan(r, maxBodyBytes)
 }
 
 func extractJSONValue(r *http.Request, maxBodyBytes int64) any {
@@ -289,14 +289,20 @@ func findJSONModel(value any) string {
 
 var jsonModelFieldPattern = regexp.MustCompile(`"model"\s*:\s*"((?:\\.|[^"\\])*)"`)
 
-func extractJSONModelPrefix(r *http.Request, maxBodyBytes int64) string {
+const modelScanMaxBodyBytes = int64(8 << 20)
+
+func extractJSONModelScan(r *http.Request, maxBodyBytes int64) string {
 	if r.Body == nil || maxBodyBytes <= 0 {
 		return ""
 	}
 	if contentType := r.Header.Get("Content-Type"); !strings.Contains(contentType, "json") {
 		return ""
 	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
+	limit := maxBodyBytes
+	if limit < modelScanMaxBodyBytes {
+		limit = modelScanMaxBodyBytes
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, limit))
 	if err != nil {
 		return ""
 	}

--- a/internal/session/extract_test.go
+++ b/internal/session/extract_test.go
@@ -95,8 +95,8 @@ func TestExtractModelFromJSONAndRestoresBody(t *testing.T) {
 	}
 }
 
-func TestExtractModelFromLargeJSONPrefixAndRestoresBody(t *testing.T) {
-	body := `{"model":"claude-fable-5","messages":[{"role":"user","content":"` + strings.Repeat("x", 2048) + `"}]}`
+func TestExtractModelFromLargeJSONScanAndRestoresBody(t *testing.T) {
+	body := `{"tools":[{"input_schema":"` + strings.Repeat("x", 2048) + `"}],"model":"claude-fable-5","messages":[{"role":"user","content":"hi"}]}`
 	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 


### PR DESCRIPTION
## Summary
- scans up to 8 MiB of JSON request body for the `model` field when full JSON parsing is skipped by the normal inspect cap
- keeps exact request-body restoration after the scan
- updates the regression so `model` appears after a large tools/schema block, matching Claude Code request layout

## Tests
- `go test ./...`

## Live finding
`claude -p` put `model` after a large tools payload, beyond the 1 MiB full-parse cap. Prefix-only extraction still missed it, so Fable routing did not always enter the Fable model pool.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785646566&installation_id=133855650&pr_number=48&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F48&signature=e5e059375d85df92d2a4af5bd8a4f3aa6ace87211be7a44e554707b7d669dec1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scan up to 8 MiB of JSON request bodies to reliably find the model field even when it appears after large tools/schema blocks. This fixes routing gaps and keeps the request body restored exactly as received.

- **Bug Fixes**
  - Replace prefix-only extraction with a bounded scan (8 MiB) when skipping full JSON parsing.
  - Preserve the original request body after scanning.
  - Update test to reflect Claude-style layout with tools first and model later.

<sup>Written for commit 11ff7368c4623b0e55e4817066bedd0706468a8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

