### PR TITLE
Add Cloudflare Durable Object subrouter

### DIFF
--- a/.github/workflows/cloudflare-do.yml
+++ b/.github/workflows/cloudflare-do.yml
@@ -1,0 +1,115 @@
+name: Cloudflare Durable Object
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/cloudflare-do.yml"
+      - "cloudflare/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/cloudflare-do.yml"
+      - "cloudflare/**"
+  workflow_dispatch:
+    inputs:
+      deploy_environment:
+        description: "Cloudflare environment to deploy"
+        required: true
+        default: "staging"
+        type: choice
+        options:
+          - staging
+          - production
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-do-${{ github.event_name == 'workflow_dispatch' && inputs.deploy_environment || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install
+        working-directory: cloudflare
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        working-directory: cloudflare
+        run: bun run typecheck
+
+      - name: Test
+        working-directory: cloudflare
+        run: bun run test
+
+      - name: Validate Worker bundle
+        working-directory: cloudflare/packages/worker
+        run: bunx wrangler deploy --env staging --dry-run --outdir dist-dry-run
+
+  deploy-staging:
+    name: Deploy staging
+    needs: verify
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' && inputs.deploy_environment == 'staging'
+    environment:
+      name: subrouter-staging
+      url: https://subrouter-staging.cmux.dev/healthz
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install
+        working-directory: cloudflare
+        run: bun install --frozen-lockfile
+
+      - name: Deploy
+        working-directory: cloudflare/packages/worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler deploy --env staging --keep-vars
+
+      - name: Smoke health
+        run: curl -fsS https://subrouter-staging.cmux.dev/healthz
+
+  deploy-production:
+    name: Deploy production
+    needs: verify
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && inputs.deploy_environment == 'production'
+    environment:
+      name: subrouter-production
+      url: https://subrouter.cmux.dev/healthz
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install
+        working-directory: cloudflare
+        run: bun install --frozen-lockfile
+
+      - name: Deploy
+        working-directory: cloudflare/packages/worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler deploy --env production --keep-vars
+
+      - name: Smoke health
+        run: curl -fsS https://subrouter.cmux.dev/healthz

--- a/cloudflare/.gitignore
+++ b/cloudflare/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+packages/*/node_modules/
+packages/*/.wrangler/
+packages/*/dist*/

--- a/cloudflare/bun.lock
+++ b/cloudflare/bun.lock
@@ -1,0 +1,239 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "subrouter-cloudflare",
+      "devDependencies": {
+        "@types/bun": "^1.1.13",
+        "@types/node": "^22.9.0",
+        "typescript": "^5.6.3",
+      },
+    },
+    "packages/core": {
+      "name": "@subrouter/core",
+      "version": "0.0.0",
+      "dependencies": {
+        "effect": "^3.21.2",
+      },
+      "devDependencies": {
+        "typescript": "^5.6.3",
+      },
+    },
+    "packages/worker": {
+      "name": "@subrouter/cloudflare-worker",
+      "version": "0.0.0",
+      "dependencies": {
+        "@subrouter/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260530.0",
+        "typescript": "^5.6.3",
+        "wrangler": "^4.93.1",
+      },
+    },
+  },
+  "packages": {
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260701.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Zd9Y1bah6DwwBN2RW8vJohffQrIUazb8UXnqSNecOxM+jJLhUuvv5IOG8dbHcV83TyZAubea6gsQXo2yH1lDdw=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260701.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yBLsjS1qCWqFyCY37qRUrYfzHHvMGvjh8zRKJ6MvUivYDhkZTzqduppK38FoqYvayLJ5KbcxH7zo5rkxGqbsaA=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260701.1", "", { "os": "linux", "cpu": "x64" }, "sha512-vMfqSIMfoo4xmZXEuUVqLpSFS921YKjiR9q7kDXPi6Vld1PK74UHg9LZuBavT2KSyemHUCTpj9y/4JSYOEyQbQ=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260701.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-HRfwbKU2pK44V2NhoM0+iH0JJSj7nQ9Wv13ifIiGYCmTtDL8/zKtEhX7kQ3D4Vy/Cpjhttl0FkfqXj1aqLDPPg=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260701.1", "", { "os": "win32", "cpu": "x64" }, "sha512-ngxCiIN9s/fM2o1IBMD0o1/mcXrv2NJVdyznh51UH8sQuvrTrXvV2nM0Uj/qU2wMwF6prgNBcdcd7AZeZGiBQA=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260702.1", "", {}, "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@subrouter/cloudflare-worker": ["@subrouter/cloudflare-worker@workspace:packages/worker"],
+
+    "@subrouter/core": ["@subrouter/core@workspace:packages/core"],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@22.20.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g=="],
+
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
+
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "miniflare": ["miniflare@4.20260701.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260701.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-L6eAAi6IKtyb/7J6L+YsH2vb1yBrJWKRXI293JYDiMl70+6nncdAgigex58w6WBd+CwvdMsqOyNyGs95Op5gWQ=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
+
+    "workerd": ["workerd@1.20260701.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260701.1", "@cloudflare/workerd-darwin-arm64": "1.20260701.1", "@cloudflare/workerd-linux-64": "1.20260701.1", "@cloudflare/workerd-linux-arm64": "1.20260701.1", "@cloudflare/workerd-windows-64": "1.20260701.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-uF813NG09JwNRRUfJ0zBomyTslSPM810dMj9LVvkQ7RAkLrQLzAlPU8Xh/3dIqZDo2bfd7tChbf2PtqLRARRJQ=="],
+
+    "wrangler": ["wrangler@4.107.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260701.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260701.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260701.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-fw69ThymNitZ0oIEBU2yNeq3kK59UKz/jyA3udwRrQIAIsxX57q5qLOpPTN7qc5t8n9pnUeofe0uxtMuhQZW8w=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+  }
+}

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "subrouter-cloudflare",
+  "private": true,
+  "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "typecheck": "bun run --filter '*' typecheck",
+    "test": "bun test packages/core/test packages/worker/test",
+    "deploy:staging": "bun run --filter '@subrouter/cloudflare-worker' deploy:staging",
+    "deploy:production": "bun run --filter '@subrouter/cloudflare-worker' deploy:production"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.1.13",
+    "@types/node": "^22.9.0",
+    "typescript": "^5.6.3"
+  }
+}

--- a/cloudflare/packages/core/package.json
+++ b/cloudflare/packages/core/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@subrouter/core",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "effect": "^3.21.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3"
+  }
+}

--- a/cloudflare/packages/core/src/index.ts
+++ b/cloudflare/packages/core/src/index.ts
@@ -1,0 +1,163 @@
+import { Context, Effect, Layer } from "effect"
+export * from "./service.ts"
+
+/**
+ * SubrouterActor — multi-tenant rewrite of the Go subrouter, hosted on Rivet
+ * actors. v1 = functional parity with Go subrouter (sticky session → account
+ * routing). Aurora-backed account store, not local JSON.
+ *
+ * This file is the *interface and sticky-routing core*. The actual Rivet
+ * actor wrapper lives in packages/actors and forwards into here. The HTTP
+ * transport (the thing that *replaces* what Go subrouter listens for at
+ * 0.0.0.0:31415) lives in packages/proxy/src/gateway.ts since the AI
+ * integrations go through the same proxy as gh/registries/etc.
+ *
+ * Why: Go subrouter today requires a long-lived VM (Mac Mini or systemd box).
+ * Rivet actors let us host it with zero VM ops, multi-tenant from the start.
+ */
+
+export interface Account {
+  readonly id: string
+  readonly orgId: string
+  readonly kind: "codex_oauth" | "anthropic_oauth" | "openai_apikey" | "anthropic_apikey"
+  readonly label: string
+  readonly enabled: boolean
+  readonly rateLimitRemaining?: number
+  readonly modelQuotas?: AccountModelQuotas
+  readonly lastUsedAt?: number
+}
+
+export interface AccountModelQuota {
+  readonly remainingPercent: number
+  readonly resetsAt?: number
+  readonly protectedBelowPercent?: number
+}
+
+export type AccountModelQuotas = Readonly<Record<string, AccountModelQuota>>
+
+// Named model-family quota pools. A request whose model name contains one of
+// these keywords draws from that pool instead of the account-wide "default":
+// Codex Spark ("spark") and Claude Opus/Sonnet weekly limits ("opus"/"sonnet").
+// Keep this in sync with what the quota populator writes into Account.modelQuotas:
+// a model keyed to a pool no account carries is ineligible everywhere (see
+// accountHasQuotaForModel), which is also what isolates providers (a Claude
+// "opus" model only matches accounts that carry an "opus" pool). Anthropic's
+// opus/sonnet caps are sub-limits of the account-wide window, so the populator
+// must set each to min(account-wide remaining, family remaining); the Codex
+// Spark pool is independent of the account-wide window.
+const MODEL_QUOTA_POOLS = ["spark", "opus", "sonnet"] as const
+
+export const quotaKeyForModel = (model: string | undefined): string => {
+  const normalized = model?.trim().toLowerCase()
+  if (!normalized) return "default"
+  for (const pool of MODEL_QUOTA_POOLS) {
+    if (normalized.includes(pool)) return pool
+  }
+  return "default"
+}
+
+export const accountHasQuotaForModel = (
+  account: Account,
+  quotaKey: string
+): boolean => {
+  const quota = account.modelQuotas?.[quotaKey]
+  if (!quota) return quotaKey === "default"
+  return quota.remainingPercent > 0
+}
+
+export interface AccountStore {
+  readonly list: (orgId: string) => Effect.Effect<ReadonlyArray<Account>>
+  readonly pick: (input: {
+    readonly orgId: string
+    readonly sessionId: string
+    readonly preferAccountId?: string
+    readonly model?: string
+    readonly quotaKey?: string
+  }) => Effect.Effect<Account | null>
+  readonly recordUse: (accountId: string) => Effect.Effect<void>
+}
+
+export class AccountStoreTag extends Context.Tag("AccountStore")<
+  AccountStoreTag,
+  AccountStore
+>() {}
+
+/**
+ * Sticky session table. In production: a Postgres row per (orgId, sessionId).
+ * Here: in-memory Map. Stickiness ensures cached agent context stays useful
+ * (matches Go subrouter's `X-Subrouter-Session` semantics).
+ */
+export const makeInMemoryStickyStore = () => {
+  const map = new Map<string, string>() // `${orgId}:${sessionId}` -> accountId
+  return {
+    get: (orgId: string, sessionId: string, quotaKey = "default"): string | null =>
+      map.get(`${orgId}:${quotaKey}:${sessionId}`) ?? null,
+    set: (
+      orgId: string,
+      sessionId: string,
+      accountId: string,
+      quotaKey = "default"
+    ): void => {
+      map.set(`${orgId}:${quotaKey}:${sessionId}`, accountId)
+    },
+    clear: (): void => {
+      map.clear()
+    },
+  }
+}
+
+/**
+ * Reference in-memory AccountStore impl that round-robins enabled accounts and
+ * respects sticky sessions. Production swaps in a Postgres-backed implementation
+ * that reads from `accounts` and `subrouter_session_assignments`.
+ */
+export const makeInMemoryAccountStoreLayer = (initial: ReadonlyArray<Account>) => {
+  const accounts = [...initial]
+  const sticky = makeInMemoryStickyStore()
+  let cursor = 0
+
+  return Layer.succeed(AccountStoreTag, {
+    list: (orgId) =>
+      Effect.succeed(accounts.filter((a) => a.orgId === orgId && a.enabled)),
+
+    pick: ({ orgId, sessionId, preferAccountId, model, quotaKey }) => {
+      const resolvedQuotaKey = quotaKey ?? quotaKeyForModel(model)
+      const isEligible = (account: Account): boolean =>
+        account.orgId === orgId &&
+        account.enabled &&
+        accountHasQuotaForModel(account, resolvedQuotaKey)
+
+      // 1. sticky table first
+      const stickyId = sticky.get(orgId, sessionId, resolvedQuotaKey)
+      if (stickyId) {
+        const found = accounts.find((a) => a.id === stickyId && isEligible(a))
+        if (found) return Effect.succeed(found)
+      }
+      // 2. explicit pin
+      if (preferAccountId) {
+        const found = accounts.find(
+          (a) => a.id === preferAccountId && isEligible(a)
+        )
+        if (found) {
+          sticky.set(orgId, sessionId, found.id, resolvedQuotaKey)
+          return Effect.succeed(found)
+        }
+      }
+      // 3. round-robin over enabled accounts for the org
+      const eligible = accounts.filter(isEligible)
+      if (eligible.length === 0) return Effect.succeed(null)
+      const pick = eligible[cursor % eligible.length]!
+      cursor += 1
+      sticky.set(orgId, sessionId, pick.id, resolvedQuotaKey)
+      return Effect.succeed(pick)
+    },
+
+    recordUse: (accountId) =>
+      Effect.sync(() => {
+        const i = accounts.findIndex((a) => a.id === accountId)
+        if (i >= 0) {
+          accounts[i] = { ...accounts[i]!, lastUsedAt: Date.now() }
+        }
+      }),
+  } satisfies AccountStore)
+}

--- a/cloudflare/packages/core/src/service.ts
+++ b/cloudflare/packages/core/src/service.ts
@@ -1,0 +1,83 @@
+/**
+ * SubrouterService — the single entry point the AI proxy hits on every
+ * upstream request. Picks a sticky account for the (orgId, sessionId)
+ * tuple.
+ *
+ * Flow:
+ *   1. route({orgId, sessionId, preferAccountId?}) -> Account
+ *   2. recordUsage({...}) -> updates last-used for observability
+ *
+ * Budget enforcement was intentionally removed — handled higher up if at
+ * all. The subrouter just routes; it does not gate.
+ */
+import { Context, Effect, Layer } from "effect"
+import {
+  AccountStoreTag,
+  type Account,
+} from "./index.ts"
+
+export class NoEligibleAccount extends Error {
+  readonly _tag = "NoEligibleAccount"
+  constructor(public readonly orgId: string) {
+    super(`no eligible subrouter account for org ${orgId}`)
+  }
+}
+
+export interface PickedRoute {
+  readonly account: Account
+}
+
+export class SubrouterService extends Context.Tag("SubrouterService")<
+  SubrouterService,
+  {
+    readonly route: (input: {
+      readonly orgId: string
+      readonly sessionId: string
+      readonly preferAccountId?: string
+      readonly model?: string
+      readonly quotaKey?: string
+    }) => Effect.Effect<PickedRoute, NoEligibleAccount>
+
+    /** Optional observability hook; no enforcement. */
+    readonly recordUsage: (input: {
+      readonly orgId: string
+      readonly sessionId: string
+      readonly accountId: string
+    }) => Effect.Effect<void>
+  }
+>() {}
+
+export const makeSubrouterServiceLayer = () =>
+  Layer.effect(
+    SubrouterService,
+    Effect.gen(function* () {
+      const accounts = yield* AccountStoreTag
+      return {
+        route: ({ orgId, sessionId, preferAccountId, model, quotaKey }) =>
+          Effect.gen(function* () {
+            const pickArgs: Parameters<typeof accounts.pick>[0] = {
+              orgId,
+              sessionId,
+            }
+            if (preferAccountId !== undefined) {
+              ;(pickArgs as { preferAccountId?: string }).preferAccountId =
+                preferAccountId
+            }
+            if (model !== undefined) {
+              ;(pickArgs as { model?: string }).model = model
+            }
+            if (quotaKey !== undefined) {
+              ;(pickArgs as { quotaKey?: string }).quotaKey = quotaKey
+            }
+            const account = yield* accounts.pick(pickArgs)
+            if (!account) {
+              return yield* Effect.fail(new NoEligibleAccount(orgId))
+            }
+            yield* accounts.recordUse(account.id)
+            return { account }
+          }),
+
+        recordUsage: ({ accountId }) => accounts.recordUse(accountId),
+      }
+    })
+  )

--- a/cloudflare/packages/core/test/service.test.ts
+++ b/cloudflare/packages/core/test/service.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test"
+import { Cause, Effect, Exit, Layer } from "effect"
+import {
+  NoEligibleAccount,
+  SubrouterService,
+  makeInMemoryAccountStoreLayer,
+  makeSubrouterServiceLayer,
+  type Account,
+} from "../src/index.ts"
+
+const seed: ReadonlyArray<Account> = [
+  { id: "a1", orgId: "org-1", kind: "codex_oauth", label: "primary", enabled: true },
+  { id: "a2", orgId: "org-1", kind: "codex_oauth", label: "spare", enabled: true },
+]
+
+const buildLayer = () =>
+  makeSubrouterServiceLayer().pipe(
+    Layer.provideMerge(makeInMemoryAccountStoreLayer(seed))
+  )
+
+describe("SubrouterService.route", () => {
+  test("happy path: returns a sticky account from the org pool", async () => {
+    const layer = buildLayer()
+    const program = Effect.gen(function* () {
+      const sub = yield* SubrouterService
+      return yield* sub.route({ orgId: "org-1", sessionId: "sess-1" })
+    })
+    const out = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    expect(out.account.orgId).toBe("org-1")
+    expect(["a1", "a2"]).toContain(out.account.id)
+  })
+
+  test("sticky: two route calls for same session pick the same account", async () => {
+    const layer = buildLayer()
+    const program = Effect.gen(function* () {
+      const sub = yield* SubrouterService
+      const a = yield* sub.route({ orgId: "org-1", sessionId: "sess-sticky" })
+      const b = yield* sub.route({ orgId: "org-1", sessionId: "sess-sticky" })
+      return [a.account.id, b.account.id]
+    })
+    const [a, b] = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    expect(a).toBe(b)
+  })
+
+  test("preferAccountId pins to that account when eligible", async () => {
+    const layer = buildLayer()
+    const program = Effect.gen(function* () {
+      const sub = yield* SubrouterService
+      return yield* sub.route({
+        orgId: "org-1",
+        sessionId: "pinned",
+        preferAccountId: "a2",
+      })
+    })
+    const out = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    expect(out.account.id).toBe("a2")
+  })
+
+  test("no eligible account for the org -> NoEligibleAccount", async () => {
+    const layer = buildLayer()
+    const program = Effect.gen(function* () {
+      const sub = yield* SubrouterService
+      return yield* sub.route({ orgId: "unknown-org", sessionId: "sess" })
+    })
+    const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(layer)))
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (!Exit.isFailure(exit)) return
+    const failure = Cause.failureOption(exit.cause)
+    if (failure._tag !== "Some") return
+    expect(failure.value).toBeInstanceOf(NoEligibleAccount)
+  })
+
+  test("recordUsage is a no-throw observability hook", async () => {
+    const layer = buildLayer()
+    const program = Effect.gen(function* () {
+      const sub = yield* SubrouterService
+      const r = yield* sub.route({ orgId: "org-1", sessionId: "sess-rec" })
+      yield* sub.recordUsage({
+        orgId: "org-1",
+        sessionId: "sess-rec",
+        accountId: r.account.id,
+      })
+      return r.account.id
+    })
+    const id = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    expect(["a1", "a2"]).toContain(id)
+  })
+})

--- a/cloudflare/packages/core/test/sticky.test.ts
+++ b/cloudflare/packages/core/test/sticky.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import {
+  AccountStoreTag,
+  makeInMemoryAccountStoreLayer,
+  type Account,
+} from "../src/index.ts"
+
+const seed: ReadonlyArray<Account> = [
+  { id: "a1", orgId: "org-1", kind: "codex_oauth", label: "team-1", enabled: true },
+  { id: "a2", orgId: "org-1", kind: "codex_oauth", label: "team-2", enabled: true },
+  { id: "a3", orgId: "org-1", kind: "codex_oauth", label: "disabled", enabled: false },
+  { id: "b1", orgId: "org-2", kind: "openai_apikey", label: "other-org", enabled: true },
+]
+
+describe("SubrouterActor sticky routing", () => {
+  test("same session picks the same account twice in a row", async () => {
+    const layer = makeInMemoryAccountStoreLayer(seed)
+    const program = Effect.gen(function* () {
+      const store = yield* AccountStoreTag
+      const first = yield* store.pick({ orgId: "org-1", sessionId: "s1" })
+      const second = yield* store.pick({ orgId: "org-1", sessionId: "s1" })
+      return [first?.id, second?.id]
+    })
+    const [a, b] = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    expect(a).toBeTruthy()
+    expect(a).toBe(b)
+  })
+
+  test("round-robin distributes new sessions across enabled accounts", async () => {
+    const layer = makeInMemoryAccountStoreLayer(seed)
+    const program = Effect.gen(function* () {
+      const store = yield* AccountStoreTag
+      const out: Array<string | null> = []
+      for (let i = 0; i < 4; i++) {
+        const picked = yield* store.pick({
+          orgId: "org-1",
+          sessionId: `new-${i}`,
+        })
+        out.push(picked?.id ?? null)
+      }
+      return out
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    // 2 enabled accounts in org-1, so 4 sessions should hit each twice.
+    const counts = result.reduce<Record<string, number>>((acc, id) => {
+      if (!id) return acc
+      acc[id] = (acc[id] ?? 0) + 1
+      return acc
+    }, {})
+    expect(Object.keys(counts).sort()).toEqual(["a1", "a2"])
+    expect(counts["a1"]).toBe(2)
+    expect(counts["a2"]).toBe(2)
+  })
+
+  test("preferAccountId pins to a specific account and starts sticky", async () => {
+    const layer = makeInMemoryAccountStoreLayer(seed)
+    const program = Effect.gen(function* () {
+      const store = yield* AccountStoreTag
+      const first = yield* store.pick({
+        orgId: "org-1",
+        sessionId: "pinned",
+        preferAccountId: "a2",
+      })
+      const second = yield* store.pick({ orgId: "org-1", sessionId: "pinned" })
+      return [first?.id, second?.id]
+    })
+    const [a, b] = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    expect(a).toBe("a2")
+    expect(b).toBe("a2")
+  })
+
+  test("org isolation: org-1 sessions never get org-2 accounts", async () => {
+    const layer = makeInMemoryAccountStoreLayer(seed)
+    const program = Effect.gen(function* () {
+      const store = yield* AccountStoreTag
+      const out: Array<string | null> = []
+      for (let i = 0; i < 5; i++) {
+        const picked = yield* store.pick({
+          orgId: "org-1",
+          sessionId: `iso-${i}`,
+        })
+        out.push(picked?.id ?? null)
+      }
+      return out
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    for (const id of result) {
+      expect(id).not.toBe("b1")
+      expect(id).not.toBe("a3") // disabled
+    }
+  })
+
+  test("no eligible accounts -> pick returns null", async () => {
+    const layer = makeInMemoryAccountStoreLayer([])
+    const program = Effect.gen(function* () {
+      const store = yield* AccountStoreTag
+      return yield* store.pick({ orgId: "org-x", sessionId: "s" })
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    expect(result).toBeNull()
+  })
+
+  test("spark model uses spark quota even when default quota is empty", async () => {
+    const layer = makeInMemoryAccountStoreLayer([
+      {
+        id: "regular-cooked",
+        orgId: "org-spark",
+        kind: "codex_oauth",
+        label: "regular cooked",
+        enabled: true,
+        modelQuotas: {
+          default: { remainingPercent: 0 },
+          spark: { remainingPercent: 100 },
+        },
+      },
+    ])
+    const program = Effect.gen(function* () {
+      const store = yield* AccountStoreTag
+      return yield* store.pick({
+        orgId: "org-spark",
+        sessionId: "spark-session",
+        model: "GPT-5.3-Codex-Spark",
+      })
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    expect(result?.id).toBe("regular-cooked")
+  })
+})
+
+describe("dual-provider model-family quota routing", () => {
+  test("claude opus model routes to a claude account carrying an opus pool", async () => {
+    const layer = makeInMemoryAccountStoreLayer([
+      {
+        id: "codex-1",
+        orgId: "org-both",
+        kind: "codex_oauth",
+        label: "codex",
+        enabled: true,
+        modelQuotas: {
+          default: { remainingPercent: 100 },
+          spark: { remainingPercent: 100 },
+        },
+      },
+      {
+        id: "claude-1",
+        orgId: "org-both",
+        kind: "anthropic_oauth",
+        label: "claude",
+        enabled: true,
+        modelQuotas: {
+          default: { remainingPercent: 100 },
+          opus: { remainingPercent: 100 },
+          sonnet: { remainingPercent: 100 },
+        },
+      },
+    ])
+    const program = Effect.gen(function* () {
+      const store = yield* AccountStoreTag
+      return yield* store.pick({
+        orgId: "org-both",
+        sessionId: "s-opus",
+        model: "claude-opus-4-1",
+      })
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    expect(result?.id).toBe("claude-1")
+  })
+
+  test("claude sonnet model uses the sonnet pool even when opus is exhausted", async () => {
+    const layer = makeInMemoryAccountStoreLayer([
+      {
+        id: "claude-1",
+        orgId: "org-c",
+        kind: "anthropic_oauth",
+        label: "claude",
+        enabled: true,
+        modelQuotas: {
+          default: { remainingPercent: 100 },
+          opus: { remainingPercent: 0 },
+          sonnet: { remainingPercent: 100 },
+        },
+      },
+    ])
+    const program = Effect.gen(function* () {
+      const store = yield* AccountStoreTag
+      return yield* store.pick({
+        orgId: "org-c",
+        sessionId: "s-sonnet",
+        model: "claude-sonnet-4-5-20250929",
+      })
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    expect(result?.id).toBe("claude-1")
+  })
+
+  test("provider isolation: a claude opus model never selects a codex account", async () => {
+    const layer = makeInMemoryAccountStoreLayer([
+      {
+        id: "codex-only",
+        orgId: "org-codex",
+        kind: "codex_oauth",
+        label: "codex",
+        enabled: true,
+        modelQuotas: {
+          default: { remainingPercent: 100 },
+          spark: { remainingPercent: 100 },
+        },
+      },
+    ])
+    const program = Effect.gen(function* () {
+      const store = yield* AccountStoreTag
+      return yield* store.pick({
+        orgId: "org-codex",
+        sessionId: "s-x",
+        model: "claude-opus-4-1",
+      })
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    expect(result).toBeNull()
+  })
+})

--- a/cloudflare/packages/core/tsconfig.json
+++ b/cloudflare/packages/core/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/cloudflare/packages/worker/README.md
+++ b/cloudflare/packages/worker/README.md
@@ -1,0 +1,85 @@
+# @subrouter/cloudflare-worker
+
+Cloudflare **Durable Objects** subrouter: a per-org subrouter service with
+sticky session affinity, per-model-family quota pools, Go-compatible
+`/_subrouter/*` admin endpoints, and upstream proxying for Codex/OpenAI and
+Claude/Anthropic accounts.
+
+## Environments
+
+| Env        | Worker name                       | URL                                  |
+| ---------- | --------------------------------- | ------------------------------------ |
+| dev        | `regatta-subrouter-do`            | `wrangler dev` -> http://127.0.0.1:8787 |
+| staging    | `regatta-subrouter-do-staging`    | https://subrouter-staging.cmux.dev   |
+| production | `regatta-subrouter-do-production` | https://subrouter.cmux.dev           |
+
+Each env is a distinct Worker with its own Durable Object namespace (isolated
+SQLite state), its own admin/proxy tokens, and its own Durable Object alarms.
+
+## Deploy
+
+```sh
+bun run deploy:staging
+bun run deploy:production
+```
+
+## Secrets
+
+`ADMIN_TOKEN` gates the `/admin/*`, `/_subrouter/*`, and `/websocket-status`
+endpoints. `PROXY_TOKEN` gates upstream proxy requests when present; if it is
+unset, proxy requests use `ADMIN_TOKEN`. Set a separate proxy token when clients
+should not share the admin credential:
+
+```sh
+bun run secret:admin:staging
+bun run secret:admin:production
+bun run secret:proxy:staging
+bun run secret:proxy:production
+```
+
+## Local dev
+
+Create `.dev.vars` (gitignored) with `ADMIN_TOKEN=<anything>` and
+`PROXY_TOKEN=<anything>` then:
+
+```sh
+bun run dev                  # local workerd + DO SQLite on :8787
+```
+
+## OAuth refresh
+
+OAuth account credentials can include `accessToken`, `refreshToken`,
+`expiresAt`, `tokenEndpoint`, and `clientId`. The Durable Object refreshes
+expired Codex and Claude OAuth credentials on use, persists rotated refresh
+tokens atomically in SQLite, and schedules the next refresh with the Durable
+Object Alarms API. Alarms wake the object in the future; long sleeps are not
+used.
+
+## Logs
+
+```sh
+bun run tail:staging         # wrangler tail --env staging
+bun run tail:production
+```
+
+## Endpoints
+
+- `GET /healthz`
+- `GET /_subrouter/health`
+- `GET /_subrouter/ready`
+- `POST /_subrouter/drain`
+- `GET /_subrouter/drain-status`
+- `GET /_subrouter/accounts`
+- `GET|POST /_subrouter/account-status`
+- `GET /_subrouter/usage-status`
+- `POST /_subrouter/reload-accounts`
+- `GET /_subrouter/sessions`
+- `GET /_subrouter/dashboard`
+- `GET /_subrouter/transcripts`
+- `GET /_subrouter/transcripts/:agent/:session`
+- `GET /_subrouter/transcripts/:agent/:session/raw`
+- `POST /route` — `{ orgId, sessionId, model?, preferAccountId?, quotaKey? }` → selected account
+- `POST /usage` — `{ orgId, sessionId, accountId }`
+- `GET /status?orgId=` — DO route counters
+- `GET /ws?orgId=` — WebSocket; messages `{ type: "ping"|"route"|"usage"|"status", ... }`
+- `GET /admin/accounts`, `POST /admin/accounts`, `POST /admin/model-probe`, `GET /websocket-status` — require `Authorization: Bearer $ADMIN_TOKEN`

--- a/cloudflare/packages/worker/package.json
+++ b/cloudflare/packages/worker/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@subrouter/cloudflare-worker",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "deploy:staging": "wrangler deploy --env staging",
+    "deploy:production": "wrangler deploy --env production",
+    "tail:staging": "wrangler tail --env staging",
+    "tail:production": "wrangler tail --env production",
+    "secret:admin:staging": "wrangler secret put ADMIN_TOKEN --env staging",
+    "secret:admin:production": "wrangler secret put ADMIN_TOKEN --env production",
+    "secret:proxy:staging": "wrangler secret put PROXY_TOKEN --env staging",
+    "secret:proxy:production": "wrangler secret put PROXY_TOKEN --env production"
+  },
+  "dependencies": {
+    "@subrouter/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260530.0",
+    "typescript": "^5.6.3",
+    "wrangler": "^4.93.1"
+  }
+}

--- a/cloudflare/packages/worker/src/contract.ts
+++ b/cloudflare/packages/worker/src/contract.ts
@@ -1,0 +1,792 @@
+import type { Account } from "@subrouter/core"
+
+export type AccountKind = Account["kind"]
+export type AgentType = "codex" | "claude" | "gemini" | string
+
+export interface AccountCredentials {
+  readonly apiKey?: string
+  readonly accessToken?: string
+  readonly refreshToken?: string
+  readonly idToken?: string
+  readonly accountId?: string
+  readonly baseUrl?: string
+  readonly expiresAt?: number
+  readonly tokenEndpoint?: string
+  readonly clientId?: string
+  readonly lastRefreshAt?: number
+  readonly refreshFailure?: OAuthRefreshFailure
+  readonly usageUrl?: string
+  readonly [key: string]: unknown
+}
+
+export interface OAuthRefreshFailure {
+  readonly at: number
+  readonly status: number
+  readonly message: string
+  readonly providerCode?: string
+  readonly providerType?: string
+}
+
+export interface OAuthRefreshResult {
+  readonly credentials: AccountCredentials
+  readonly refreshed: boolean
+}
+
+const CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
+const CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+const CLAUDE_OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+const CLAUDE_OAUTH_CLIENT_ID = "https://claude.ai/oauth/claude-code-client-metadata"
+const CLAUDE_OAUTH_BETA = "oauth-2025-04-20"
+const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
+const CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
+const REFRESH_SKEW_MS = 60_000
+
+export interface UsageWindow {
+  readonly name: string
+  readonly used_percent: number
+  readonly limit_window_seconds?: number
+  readonly reset_after_seconds?: number
+  readonly feature?: string
+}
+
+export interface CreditsInfo {
+  readonly has_credits: boolean
+  readonly unlimited: boolean
+  readonly balance: string
+}
+
+export interface ProviderUsageStatus {
+  readonly plan_type?: string
+  readonly windows?: ReadonlyArray<UsageWindow>
+  readonly credits?: CreditsInfo
+}
+
+export interface StoredAccountContract extends Account {
+  readonly hasCredentials: boolean
+  readonly hasTotp: boolean
+  readonly credentials?: AccountCredentials
+  readonly source?: string
+}
+
+export interface ProxyRouteInput {
+  readonly orgId: string
+  readonly agentType: AgentType
+  readonly sessionId: string
+  readonly userEmail?: string
+  readonly preferAccountId?: string
+  readonly model?: string
+}
+
+const sessionHeaders = [
+  "X-Subrouter-Session",
+  "X-Codex-Window-ID",
+  "X-Codex-Turn-State",
+  "X-Codex-Parent-Thread-ID",
+  "X-Session-ID",
+  "X-Conversation-ID",
+  "X-Codex-Session-ID",
+  "X-Claude-Session-ID",
+  "X-Claude-Code-Session-Id",
+  "X-Gemini-Session-ID",
+  "X-Gemini-Conversation-ID",
+  "OpenAI-Conversation-ID",
+  "Anthropic-Conversation-ID",
+  "Google-Conversation-ID",
+  "Idempotency-Key",
+] as const
+
+const userEmailHeaders = [
+  "X-Subrouter-User-Email",
+  "X-Subrouter-User",
+  "X-User-Email",
+] as const
+
+const accountHeaders = ["X-Subrouter-Account-ID", "X-Subrouter-Account"] as const
+const modelHeaders = ["X-Subrouter-Model", "X-Model"] as const
+const orgHeaders = ["X-Subrouter-Org-ID", "X-Regatta-Org-ID"] as const
+
+const subrouterHeadersToStrip = [
+  "X-Subrouter-Session",
+  "X-Subrouter-Agent",
+  "X-Subrouter-User-Email",
+  "X-Subrouter-User",
+  "X-User-Email",
+  "X-Subrouter-Account-ID",
+  "X-Subrouter-Account",
+  "X-Subrouter-Model",
+  "X-Model",
+  "X-Subrouter-Org-ID",
+  "X-Regatta-Org-ID",
+  "X-Subrouter-Proxy-Token",
+] as const
+
+export const normalizeAgentType = (value: string | null | undefined): AgentType => {
+  const normalized = value?.trim().toLowerCase() ?? ""
+  if (!normalized || normalized.length > 64) return ""
+  return /^[a-z0-9._-]+$/.test(normalized) ? normalized : ""
+}
+
+export const normalizeAccountId = (value: string | null | undefined): string => {
+  const trimmed = value?.trim() ?? ""
+  return trimmed.length > 0 && trimmed.length <= 256 ? trimmed : ""
+}
+
+export const normalizeModel = (value: string | null | undefined): string => {
+  const trimmed = value?.trim() ?? ""
+  return trimmed.length > 0 && trimmed.length <= 256 ? trimmed : ""
+}
+
+export const normalizeUserEmail = (value: string | null | undefined): string => {
+  const trimmed = value?.trim() ?? ""
+  if (!trimmed || trimmed.length > 320) return ""
+  const match = trimmed.match(/<?([^<>\s@]+@[^<>\s@]+\.[^<>\s@]+)>?$/)
+  return match?.[1]?.toLowerCase() ?? ""
+}
+
+export const normalizeOrgId = (value: string | null | undefined): string => {
+  const trimmed = value?.trim() ?? ""
+  if (!trimmed || trimmed.length > 256) return ""
+  return /^[A-Za-z0-9._:-]+$/.test(trimmed) ? trimmed : ""
+}
+
+const firstHeader = (
+  headers: Headers,
+  candidates: ReadonlyArray<string>,
+  normalize: (value: string | null | undefined) => string
+): string => {
+  for (const header of candidates) {
+    const value = normalize(headers.get(header))
+    if (value) return value
+  }
+  return ""
+}
+
+export const inferAgentType = (headers: Headers): AgentType => {
+  const explicit = normalizeAgentType(headers.get("X-Subrouter-Agent"))
+  if (explicit) return explicit
+  const userAgent = headers.get("User-Agent")?.toLowerCase() ?? ""
+  if (userAgent.includes("claude-cli") || userAgent.includes("claude-code")) {
+    return "claude"
+  }
+  if (
+    headers.has("X-Claude-Session-ID") ||
+    headers.has("X-Claude-Code-Session-Id") ||
+    headers.has("Anthropic-Conversation-ID")
+  ) {
+    return "claude"
+  }
+  if (
+    headers.has("X-Gemini-Session-ID") ||
+    headers.has("X-Gemini-Conversation-ID") ||
+    headers.has("Google-Conversation-ID")
+  ) {
+    return "gemini"
+  }
+  return "codex"
+}
+
+export const stickySessionId = (agentType: AgentType, sessionId: string): string => {
+  if (sessionId.startsWith("fallback:")) return sessionId
+  if (normalizeAgentType(agentType) !== "codex") return sessionId
+  return sessionId.split(":", 1)[0] ?? sessionId
+}
+
+export const scopedSessionKey = (agentType: AgentType, sessionId: string): string =>
+  `${normalizeAgentType(agentType) || "codex"}:${stickySessionId(agentType, sessionId)}`
+
+export const resolveOrgId = (request: Request, fallback = "demo-org"): string => {
+  const url = new URL(request.url)
+  const fromHeader = firstHeader(request.headers, orgHeaders, normalizeOrgId)
+  if (fromHeader) return fromHeader
+  return normalizeOrgId(url.searchParams.get("orgId")) || fallback
+}
+
+export const parseProxyRouteInput = async (
+  request: Request,
+  fallbackOrgId = "demo-org"
+): Promise<ProxyRouteInput> => {
+  const url = new URL(request.url)
+  const body = await parseJsonBody(request)
+  const agentType = inferAgentType(request.headers) || "codex"
+  const orgId = resolveOrgId(request, fallbackOrgId)
+  const sessionId =
+    firstHeader(request.headers, sessionHeaders, (value) => value?.trim() ?? "") ||
+    normalizeString(url.searchParams.get("session_id")) ||
+    normalizeString(url.searchParams.get("conversation_id")) ||
+    normalizeString(url.searchParams.get("thread_id")) ||
+    findJsonString(body, ["session_id", "conversation_id", "thread_id"]) ||
+    await fallbackSessionId(request)
+  const userEmail = firstHeader(request.headers, userEmailHeaders, normalizeUserEmail)
+  const preferAccountId = firstHeader(request.headers, accountHeaders, normalizeAccountId)
+  const model =
+    firstHeader(request.headers, modelHeaders, normalizeModel) ||
+    normalizeModel(url.searchParams.get("model")) ||
+    findJsonString(body, ["model"])
+
+  return {
+    orgId,
+    agentType,
+    sessionId: stickySessionId(agentType, sessionId),
+    ...(userEmail ? { userEmail } : {}),
+    ...(preferAccountId ? { preferAccountId } : {}),
+    ...(model ? { model } : {}),
+  }
+}
+
+const parseJsonBody = async (request: Request): Promise<unknown> => {
+  if (!request.headers.get("Content-Type")?.includes("json")) return null
+  const text = await request.clone().text().catch(() => "")
+  if (!text) return null
+  try {
+    return JSON.parse(text)
+  } catch {
+    return null
+  }
+}
+
+const findJsonString = (
+  value: unknown,
+  keys: ReadonlyArray<string>
+): string => {
+  if (!value || typeof value !== "object") return ""
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const found = findJsonString(entry, keys)
+      if (found) return found
+    }
+    return ""
+  }
+  const record = value as Record<string, unknown>
+  for (const key of keys) {
+    const found = normalizeString(record[key])
+    if (found) return found
+  }
+  for (const entry of Object.values(record)) {
+    const found = findJsonString(entry, keys)
+    if (found) return found
+  }
+  return ""
+}
+
+const normalizeString = (value: unknown): string =>
+  typeof value === "string" && value.trim().length > 0 ? value.trim() : ""
+
+const fallbackSessionId = async (request: Request): Promise<string> => {
+  const url = new URL(request.url)
+  const remote =
+    request.headers.get("CF-Connecting-IP") ??
+    request.headers.get("X-Forwarded-For")?.split(",", 1)[0]?.trim() ??
+    ""
+  const userAgent = request.headers.get("User-Agent") ?? ""
+  const input = `${remote}\0${userAgent}\0${request.method}\0${url.pathname}`
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input))
+  const hex = [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+  return `fallback:${hex.slice(0, 24)}`
+}
+
+export const stripSubrouterHeaders = (headers: Headers): Headers => {
+  const out = new Headers(headers)
+  for (const header of subrouterHeadersToStrip) out.delete(header)
+  return out
+}
+
+export const providerForAccount = (kind: AccountKind): "codex" | "claude" => {
+  if (kind === "anthropic_oauth" || kind === "anthropic_apikey") return "claude"
+  return "codex"
+}
+
+export const authModeForAccount = (kind: AccountKind): "oauth" | "apikey" => {
+  return kind === "openai_apikey" || kind === "anthropic_apikey" ? "apikey" : "oauth"
+}
+
+export const isOAuthKind = (kind: AccountKind): boolean =>
+  authModeForAccount(kind) === "oauth"
+
+export const safeGoAccount = (account: StoredAccountContract) => ({
+  id: account.id,
+  provider: providerForAccount(account.kind),
+  auth_mode: authModeForAccount(account.kind),
+  ...(account.label.includes("@") ? { email: account.label } : {}),
+  source: account.source ?? "durable-object",
+})
+
+export const accountStatus = (account: StoredAccountContract) => ({
+  ...safeGoAccount(account),
+  auth_checked: account.hasCredentials,
+  auth_valid: account.hasCredentials,
+})
+
+export const usageStatus = (account: StoredAccountContract) => ({
+  ...accountStatus(account),
+  plan_type: authModeForAccount(account.kind) === "apikey" ? "api key" : providerForAccount(account.kind),
+  windows: Object.entries(account.modelQuotas ?? {}).map(([name, quota]) => ({
+    name,
+    used_percent: Math.max(0, 100 - quota.remainingPercent),
+    reset_after_seconds: quota.resetsAt
+      ? Math.max(0, Math.floor((quota.resetsAt - Date.now()) / 1000))
+      : 0,
+  })),
+})
+
+export const fetchProviderUsage = async (
+  kind: AccountKind,
+  credentials: AccountCredentials,
+  fetcher: typeof fetch = fetch
+): Promise<ProviderUsageStatus> => {
+  if (!credentials.accessToken) return {}
+  if (providerForAccount(kind) === "claude") {
+    return fetchClaudeUsage(credentials, fetcher)
+  }
+  if (authModeForAccount(kind) === "oauth") {
+    return fetchCodexUsage(credentials, fetcher)
+  }
+  return { plan_type: "api key" }
+}
+
+const fetchCodexUsage = async (
+  credentials: AccountCredentials,
+  fetcher: typeof fetch
+): Promise<ProviderUsageStatus> => {
+  const response = await fetcher(credentials.usageUrl ?? CODEX_USAGE_URL, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${credentials.accessToken}`,
+      ...(credentials.accountId ? { "ChatGPT-Account-ID": credentials.accountId } : {}),
+    },
+  })
+  if (!response.ok) {
+    throw new Error(`usage fetch failed: ${response.status} ${response.statusText}`.trim())
+  }
+  const payload = (await response.json()) as CodexUsageResponse
+  return {
+    ...(payload.plan_type ? { plan_type: payload.plan_type } : {}),
+    windows: codexDisplayWindows(payload),
+    ...(payload.credits
+      ? {
+          credits: {
+            has_credits: payload.credits.has_credits,
+            unlimited: payload.credits.unlimited,
+            balance: payload.credits.balance,
+          },
+        }
+      : {}),
+  }
+}
+
+const fetchClaudeUsage = async (
+  credentials: AccountCredentials,
+  fetcher: typeof fetch
+): Promise<ProviderUsageStatus> => {
+  const response = await fetcher(credentials.usageUrl ?? CLAUDE_USAGE_URL, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${credentials.accessToken}`,
+      "anthropic-beta": CLAUDE_OAUTH_BETA,
+      "Content-Type": "application/json",
+    },
+  })
+  if (!response.ok) {
+    throw new Error(`usage fetch failed: ${response.status} ${response.statusText}`.trim())
+  }
+  const payload = (await response.json()) as ClaudeUsageResponse
+  const windows: UsageWindow[] = []
+  appendClaudeRateLimit(windows, "5h", payload.five_hour)
+  appendClaudeRateLimit(windows, "7d", payload.seven_day)
+  appendClaudeRateLimit(windows, "opus-weekly", payload.seven_day_opus)
+  appendClaudeRateLimit(windows, "sonnet-weekly", payload.seven_day_sonnet)
+  if (payload.extra_usage?.is_enabled && typeof payload.extra_usage.utilization === "number") {
+    windows.push({ name: "extra", used_percent: payload.extra_usage.utilization })
+  }
+  return { plan_type: "claude", windows }
+}
+
+interface CodexUsageResponse {
+  readonly plan_type?: string
+  readonly rate_limit?: CodexRateLimitDetails
+  readonly credits?: {
+    readonly has_credits: boolean
+    readonly unlimited: boolean
+    readonly balance: string
+  }
+  readonly additional_rate_limits?: ReadonlyArray<{
+    readonly metered_feature?: string
+    readonly limit_name?: string
+    readonly rate_limit?: CodexRateLimitDetails
+  }>
+}
+
+interface CodexRateLimitDetails {
+  readonly limit_reached?: boolean
+  readonly primary_window?: CodexLimitWindow
+  readonly secondary_window?: CodexLimitWindow
+}
+
+interface CodexLimitWindow {
+  readonly used_percent: number
+  readonly limit_window_seconds?: number
+  readonly reset_after_seconds?: number
+  readonly reset_at?: number
+}
+
+const codexDisplayWindows = (usage: CodexUsageResponse): UsageWindow[] => {
+  const windows: UsageWindow[] = []
+  appendCodexWindows(windows, "", undefined, usage.rate_limit)
+  for (const additional of usage.additional_rate_limits ?? []) {
+    const name = additional.limit_name || additional.metered_feature || "unknown"
+    appendCodexWindows(windows, `${name}/`, name, additional.rate_limit)
+  }
+  return windows
+}
+
+const appendCodexWindows = (
+  windows: UsageWindow[],
+  prefix: string,
+  feature: string | undefined,
+  details: CodexRateLimitDetails | undefined
+): void => {
+  if (!details) return
+  appendCodexWindow(windows, `${prefix}primary`, feature, details.primary_window)
+  appendCodexWindow(windows, `${prefix}secondary`, feature, details.secondary_window)
+  if (details.limit_reached) {
+    windows.push({ name: `${prefix}reached`, used_percent: 100, ...(feature ? { feature } : {}) })
+  }
+}
+
+const appendCodexWindow = (
+  windows: UsageWindow[],
+  name: string,
+  feature: string | undefined,
+  window: CodexLimitWindow | undefined
+): void => {
+  if (!window) return
+  windows.push({
+    name,
+    used_percent: window.used_percent,
+    ...(typeof window.limit_window_seconds === "number"
+      ? { limit_window_seconds: window.limit_window_seconds }
+      : {}),
+    reset_after_seconds: resetAfterSeconds(window),
+    ...(feature ? { feature } : {}),
+  })
+}
+
+const resetAfterSeconds = (window: CodexLimitWindow): number => {
+  if (typeof window.reset_after_seconds === "number" && window.reset_after_seconds > 0) {
+    return window.reset_after_seconds
+  }
+  if (typeof window.reset_at !== "number" || window.reset_at <= 0) return 0
+  return Math.max(0, window.reset_at - Math.floor(Date.now() / 1000))
+}
+
+interface ClaudeUsageResponse {
+  readonly five_hour?: ClaudeRateLimit
+  readonly seven_day?: ClaudeRateLimit
+  readonly seven_day_opus?: ClaudeRateLimit
+  readonly seven_day_sonnet?: ClaudeRateLimit
+  readonly extra_usage?: {
+    readonly is_enabled?: boolean
+    readonly utilization?: number
+  }
+}
+
+interface ClaudeRateLimit {
+  readonly utilization?: number
+  readonly resets_at?: string
+}
+
+const appendClaudeRateLimit = (
+  windows: UsageWindow[],
+  name: string,
+  limit: ClaudeRateLimit | undefined
+): void => {
+  if (!limit || typeof limit.utilization !== "number") return
+  const resetAt = limit.resets_at ? Date.parse(limit.resets_at) : NaN
+  windows.push({
+    name,
+    used_percent: limit.utilization,
+    reset_after_seconds: Number.isFinite(resetAt)
+      ? Math.max(0, Math.floor((resetAt - Date.now()) / 1000))
+      : 0,
+  })
+}
+
+export const setUpstreamAuthHeaders = (
+  headers: Headers,
+  account: StoredAccountContract
+): Headers => {
+  const out = stripSubrouterHeaders(headers)
+  out.delete("Authorization")
+  out.delete("X-Api-Key")
+  out.delete("x-api-key")
+  out.delete("ChatGPT-Account-ID")
+  const credentials = account.credentials
+  if (!credentials) return out
+  if (account.kind === "anthropic_apikey" && credentials.apiKey) {
+    out.set("x-api-key", credentials.apiKey)
+  } else {
+    const token = credentials.accessToken ?? credentials.apiKey
+    if (token) out.set("Authorization", `Bearer ${token}`)
+  }
+  if (account.kind === "anthropic_oauth") {
+    out.set("Anthropic-Beta", appendCommaValue(out.get("Anthropic-Beta"), "oauth-2025-04-20"))
+  }
+  if (providerForAccount(account.kind) === "codex" && credentials.accountId) {
+    out.set("ChatGPT-Account-ID", credentials.accountId)
+  }
+  return out
+}
+
+export const nextRefreshAt = (
+  credentials: AccountCredentials | undefined,
+  now = Date.now()
+): number | null => {
+  if (!credentials?.refreshToken || !credentials.accessToken) return null
+  const expiresAt = credentialExpiresAt(credentials)
+  if (!expiresAt) return null
+  return Math.max(now + 2_000, expiresAt - REFRESH_SKEW_MS)
+}
+
+export const credentialExpiresAt = (
+  credentials: AccountCredentials | undefined
+): number | null => {
+  if (!credentials) return null
+  if (typeof credentials.expiresAt === "number" && credentials.expiresAt > 0) {
+    return credentials.expiresAt
+  }
+  return jwtExpiryMillis(credentials.accessToken)
+}
+
+export const credentialNeedsRefresh = (
+  credentials: AccountCredentials | undefined,
+  now = Date.now()
+): boolean => {
+  if (!credentials?.refreshToken || !credentials.accessToken) return false
+  const expiresAt = credentialExpiresAt(credentials)
+  return expiresAt !== null && now + REFRESH_SKEW_MS >= expiresAt
+}
+
+export const refreshOAuthCredentials = async (
+  kind: AccountKind,
+  credentials: AccountCredentials,
+  force = false,
+  fetcher: typeof fetch = fetch,
+  now = Date.now()
+): Promise<OAuthRefreshResult> => {
+  if (!isOAuthKind(kind) || !credentials.refreshToken) {
+    return { credentials, refreshed: false }
+  }
+  if (!force && !credentialNeedsRefresh(credentials, now)) {
+    return { credentials, refreshed: false }
+  }
+  if (credentials.refreshFailure && terminalRefreshFailure(credentials.refreshFailure)) {
+    throw new Error(credentials.refreshFailure.message)
+  }
+  if (providerForAccount(kind) === "claude") {
+    return refreshClaudeCredentials(credentials, fetcher, now)
+  }
+  return refreshCodexCredentials(credentials, fetcher, now)
+}
+
+const refreshCodexCredentials = async (
+  credentials: AccountCredentials,
+  fetcher: typeof fetch,
+  now: number
+): Promise<OAuthRefreshResult> => {
+  const response = await fetcher(credentials.tokenEndpoint ?? CODEX_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      client_id: credentials.clientId ?? CODEX_OAUTH_CLIENT_ID,
+      grant_type: "refresh_token",
+      refresh_token: credentials.refreshToken,
+    }),
+  })
+  const body = await response.text()
+  if (!response.ok) {
+    throw refreshError(response.status, body)
+  }
+  const payload = parseRefreshJSON(body)
+  if (!payload.access_token || !payload.refresh_token || !payload.id_token) {
+    throw new Error("Codex OAuth refresh response missing required fields")
+  }
+  const { refreshFailure: _refreshFailure, expiresAt: _expiresAt, ...baseCredentials } = credentials
+  const expiresAt =
+    typeof payload.expires_in === "number" && payload.expires_in > 0
+      ? now + payload.expires_in * 1000
+      : jwtExpiryMillis(payload.access_token) ?? undefined
+  return {
+    credentials: {
+      ...baseCredentials,
+      accessToken: payload.access_token,
+      refreshToken: payload.refresh_token,
+      idToken: payload.id_token,
+      ...(expiresAt !== undefined ? { expiresAt } : {}),
+      lastRefreshAt: now,
+    },
+    refreshed: true,
+  }
+}
+
+const refreshClaudeCredentials = async (
+  credentials: AccountCredentials,
+  fetcher: typeof fetch,
+  now: number
+): Promise<OAuthRefreshResult> => {
+  const form = new URLSearchParams()
+  form.set("client_id", credentials.clientId ?? CLAUDE_OAUTH_CLIENT_ID)
+  form.set("grant_type", "refresh_token")
+  form.set("refresh_token", credentials.refreshToken ?? "")
+  const response = await fetcher(credentials.tokenEndpoint ?? CLAUDE_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "anthropic-beta": CLAUDE_OAUTH_BETA,
+    },
+    body: form,
+  })
+  const body = await response.text()
+  if (!response.ok) {
+    throw refreshError(response.status, body)
+  }
+  const payload = parseRefreshJSON(body)
+  if (!payload.access_token) {
+    throw new Error("Claude OAuth refresh response missing access_token")
+  }
+  const { refreshFailure: _refreshFailure, expiresAt: _expiresAt, ...baseCredentials } = credentials
+  const expiresAt =
+    typeof payload.expires_in === "number" && payload.expires_in > 0
+      ? now + payload.expires_in * 1000
+      : credentialExpiresAt({ accessToken: payload.access_token }) ?? undefined
+  return {
+    credentials: {
+      ...baseCredentials,
+      accessToken: payload.access_token,
+      ...(payload.refresh_token || credentials.refreshToken
+        ? { refreshToken: payload.refresh_token || credentials.refreshToken }
+        : {}),
+      ...(expiresAt !== undefined ? { expiresAt } : {}),
+      lastRefreshAt: now,
+    },
+    refreshed: true,
+  }
+}
+
+const parseRefreshJSON = (body: string): Record<string, unknown> & {
+  access_token?: string
+  refresh_token?: string
+  id_token?: string
+  expires_in?: number
+} => {
+  const payload = JSON.parse(body) as Record<string, unknown>
+  return payload
+}
+
+const refreshError = (status: number, body: string): Error => {
+  let message = body.trim()
+  let providerCode: string | undefined
+  let providerType: string | undefined
+  try {
+    const payload = JSON.parse(body) as {
+      error?: { message?: string; code?: string; type?: string } | string
+    }
+    if (typeof payload.error === "string") {
+      message = payload.error
+    } else if (payload.error) {
+      message = payload.error.message ?? message
+      providerCode = payload.error.code
+      providerType = payload.error.type
+    }
+  } catch {
+    // Keep the raw provider body in the error message.
+  }
+  const error = new Error(`OAuth refresh failed (${status}): ${message}`)
+  Object.assign(error, { status, providerCode, providerType })
+  return error
+}
+
+export const refreshFailureFromError = (
+  error: unknown,
+  now = Date.now()
+): OAuthRefreshFailure => {
+  const typed = error as { status?: number; providerCode?: string; providerType?: string; message?: string }
+  return {
+    at: now,
+    status: typed.status ?? 0,
+    message: typed.message ?? String(error),
+    ...(typed.providerCode ? { providerCode: typed.providerCode } : {}),
+    ...(typed.providerType ? { providerType: typed.providerType } : {}),
+  }
+}
+
+export const terminalRefreshFailure = (failure: OAuthRefreshFailure): boolean => {
+  if (failure.status !== 400 && failure.status !== 401) return false
+  const combined = `${failure.providerCode ?? ""} ${failure.message}`.toLowerCase()
+  return combined.includes("refresh_token") || combined.includes("refresh token")
+}
+
+export const jwtExpiryMillis = (token: string | undefined): number | null => {
+  if (!token) return null
+  const parts = token.split(".")
+  if (parts.length < 2) return null
+  try {
+    const payload = JSON.parse(base64UrlDecode(parts[1]!)) as { exp?: unknown }
+    return typeof payload.exp === "number" ? payload.exp * 1000 : null
+  } catch {
+    return null
+  }
+}
+
+const base64UrlDecode = (value: string): string => {
+  const normalized = value.replaceAll("-", "+").replaceAll("_", "/")
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=")
+  return atob(padded)
+}
+
+const appendCommaValue = (existing: string | null, value: string): string => {
+  if (!existing) return value
+  if (existing.split(",").some((part) => part.trim() === value)) return existing
+  return `${existing},${value}`
+}
+
+export const upstreamURLForRequest = (
+  requestURL: string,
+  account: StoredAccountContract,
+  defaultBaseUrl: string
+): URL => {
+  const input = new URL(requestURL)
+  const base = new URL(account.credentials?.baseUrl ?? defaultBaseUrl)
+  const output = new URL(base.toString())
+  output.search = input.search
+  output.pathname = upstreamPath(input.pathname, account, base.pathname)
+  return output
+}
+
+const upstreamPath = (
+  requestPath: string,
+  account: StoredAccountContract,
+  basePath: string
+): string => {
+  const path = requestPath || "/"
+  if (providerForAccount(account.kind) === "claude") return joinPath(basePath, path)
+  if (authModeForAccount(account.kind) === "apikey") {
+    return path === "/v1" || path.startsWith("/v1/")
+      ? joinPath(basePathWithoutTrailingV1(basePath), path)
+      : joinPath(basePath, path)
+  }
+  if (path === "/v1") return joinPath(basePathWithoutTrailingV1(basePath), "/")
+  if (path.startsWith("/v1/")) {
+    return joinPath(basePathWithoutTrailingV1(basePath), path.slice("/v1".length))
+  }
+  return joinPath(basePath, path)
+}
+
+const basePathWithoutTrailingV1 = (path: string): string =>
+  path.replace(/\/v1\/?$/, "") || "/"
+
+const joinPath = (basePath: string, requestPath: string): string => {
+  if (!basePath || basePath === "/") return requestPath || "/"
+  if (!requestPath || requestPath === "/") return basePath
+  return `${basePath.replace(/\/+$/, "")}/${requestPath.replace(/^\/+/, "")}`
+}

--- a/cloudflare/packages/worker/src/index.ts
+++ b/cloudflare/packages/worker/src/index.ts
@@ -1,0 +1,3022 @@
+import { DurableObject } from "cloudflare:workers"
+import {
+  accountHasQuotaForModel,
+  quotaKeyForModel,
+  type Account,
+  type AccountModelQuotas,
+} from "@subrouter/core"
+import {
+  authModeForAccount,
+  credentialNeedsRefresh,
+  fetchProviderUsage,
+  isOAuthKind,
+  nextRefreshAt,
+  normalizeAgentType,
+  parseProxyRouteInput,
+  providerForAccount,
+  refreshFailureFromError,
+  refreshOAuthCredentials,
+  safeGoAccount,
+  setUpstreamAuthHeaders,
+  stickySessionId,
+  terminalRefreshFailure,
+  upstreamURLForRequest,
+  usageStatus,
+  type AccountCredentials,
+  type AccountKind,
+  type AgentType,
+  type StoredAccountContract,
+} from "./contract.ts"
+
+type TotpAlgorithm = "SHA-1" | "SHA-256" | "SHA-512"
+
+const demoAccounts: ReadonlyArray<Account> = [
+  {
+    id: "demo-codex-primary",
+    orgId: "demo-org",
+    kind: "codex_oauth",
+    label: "demo primary",
+    enabled: true,
+    modelQuotas: {
+      default: { remainingPercent: 100 },
+      spark: { remainingPercent: 100 },
+    },
+  },
+  {
+    id: "demo-codex-spare",
+    orgId: "demo-org",
+    kind: "codex_oauth",
+    label: "demo spare",
+    enabled: true,
+    modelQuotas: {
+      default: { remainingPercent: 100 },
+      spark: { remainingPercent: 100 },
+    },
+  },
+]
+
+const accountKinds = new Set<AccountKind>([
+  "codex_oauth",
+  "anthropic_oauth",
+  "openai_apikey",
+  "anthropic_apikey",
+])
+
+interface RouteInput {
+  readonly orgId?: string
+  readonly agentType?: AgentType
+  readonly sessionId: string
+  readonly userEmail?: string
+  readonly preferAccountId?: string
+  readonly model?: string
+  readonly quotaKey?: string
+}
+
+interface UsageInput {
+  readonly orgId?: string
+  readonly sessionId: string
+  readonly accountId: string
+}
+
+interface TotpConfig {
+  readonly seed: string
+  readonly digits?: number
+  readonly period?: number
+  readonly algorithm?: TotpAlgorithm
+}
+
+interface UpsertAccountInput {
+  readonly id: string
+  readonly orgId: string
+  readonly kind: AccountKind
+  readonly label: string
+  readonly enabled?: boolean
+  readonly rateLimitRemaining?: number
+  readonly credentials?: AccountCredentials
+  readonly totp?: TotpConfig
+  readonly modelQuotas?: AccountModelQuotas
+}
+
+interface ModelProbeInput {
+  readonly orgId?: string
+  readonly accountId: string
+  readonly model: string
+  readonly prompt?: string
+}
+
+interface StoredAccount extends Account {
+  readonly hasCredentials: boolean
+  readonly hasTotp: boolean
+  readonly totpDigits: number | null
+  readonly totpPeriod: number | null
+  readonly totpAlgorithm: TotpAlgorithm | null
+  readonly source?: string
+}
+
+interface RouteOutput {
+  readonly account: StoredAccount
+  readonly routedAt: number
+  readonly quotaKey: string
+}
+
+interface StatusOutput {
+  readonly routeCount: number
+  readonly usageCount: number
+  readonly accountCount: number
+  readonly sessionCount: number
+  readonly lastRoutedAt: number | null
+  readonly lastAccountId: string | null
+  readonly lastSessionId: string | null
+  readonly draining: boolean
+}
+
+interface StatusRow {
+  readonly [key: string]: SqlStorageValue
+  readonly route_count: number
+  readonly usage_count: number
+  readonly last_routed_at: number | null
+  readonly last_account_id: string | null
+  readonly last_session_id: string | null
+  readonly cursor: number
+}
+
+interface UsageRow {
+  readonly [key: string]: SqlStorageValue
+  readonly last_used_at: number
+}
+
+interface AccountRow {
+  readonly [key: string]: SqlStorageValue
+  readonly id: string
+  readonly org_id: string
+  readonly kind: string
+  readonly label: string
+  readonly enabled: number
+  readonly rate_limit_remaining: number | null
+  readonly credentials_json: string | null
+  readonly totp_seed_base32: string | null
+  readonly totp_digits: number | null
+  readonly totp_period: number | null
+  readonly totp_algorithm: string | null
+}
+
+interface OAuthRefreshStatus {
+  readonly id: string
+  readonly provider: "codex" | "claude"
+  readonly auth_mode: "oauth" | "apikey"
+  readonly email?: string
+  readonly source: string
+  readonly auth_checked: boolean
+  readonly auth_valid: boolean
+  readonly refreshed?: boolean
+  readonly error?: string
+}
+
+interface SessionAssignmentRow {
+  readonly [key: string]: SqlStorageValue
+  readonly org_id: string
+  readonly agent_type: string
+  readonly session_id: string
+  readonly quota_key: string
+  readonly account_id: string
+  readonly user_email: string | null
+  readonly created_at: number
+  readonly updated_at: number
+}
+
+interface CountRow {
+  readonly [key: string]: SqlStorageValue
+  readonly count: number
+}
+
+interface ModelQuotaRow {
+  readonly [key: string]: SqlStorageValue
+  readonly quota_key: string
+  readonly remaining_percent: number
+  readonly resets_at: number | null
+  readonly protected_below_percent: number | null
+}
+
+interface TranscriptEventInput {
+  readonly orgId?: string | undefined
+  readonly agentType: string
+  readonly sessionId: string
+  readonly type: string
+  readonly payload: Record<string, unknown>
+}
+
+interface TranscriptBodyInput {
+  readonly orgId?: string | undefined
+  readonly agentType: string
+  readonly sessionId: string
+  readonly eventType: "http_body" | "websocket_message"
+  readonly direction: "client_to_upstream" | "upstream_to_client"
+  readonly bodyBase64: string
+  readonly bytes: number
+  readonly sha256: string
+  readonly payload?: Record<string, unknown>
+}
+
+interface TranscriptReadInput {
+  readonly orgId?: string | undefined
+  readonly agentType: string
+  readonly sessionId: string
+  readonly raw: boolean
+}
+
+interface TranscriptEventRow {
+  readonly [key: string]: SqlStorageValue
+  readonly event_id: number
+  readonly org_id: string
+  readonly agent_type: string
+  readonly session_id: string
+  readonly timestamp: string
+  readonly type: string
+  readonly payload_json: string
+  readonly size_bytes: number
+}
+
+interface TranscriptDashboardData {
+  readonly summaries: ReadonlyArray<Record<string, unknown>>
+  readonly analytics: TranscriptAnalytics
+}
+
+interface WebSocketAttachment {
+  readonly id: string
+  readonly orgId: string
+  readonly connectedAt: number
+  readonly lastMessageAt: number | null
+  readonly messageCount: number
+}
+
+interface WebSocketStatsOutput {
+  readonly connectionCount: number
+  readonly connections: ReadonlyArray<WebSocketAttachment>
+}
+
+interface WebSocketClientMessage {
+  readonly type?: unknown
+  readonly requestId?: unknown
+  readonly orgId?: unknown
+  readonly sessionId?: unknown
+  readonly preferAccountId?: unknown
+  readonly model?: unknown
+  readonly quotaKey?: unknown
+  readonly accountId?: unknown
+}
+
+interface WebSocketServerMessage {
+  readonly type: string
+  readonly requestId?: string
+  readonly ok?: boolean
+  readonly error?: string
+  readonly connectionId?: string
+  readonly connectionCount?: number
+  readonly message?: unknown
+  readonly messages?: ReadonlyArray<WebSocketServerMessage>
+}
+
+export interface Env {
+  readonly SUBROUTER_DO: DurableObjectNamespace<SubrouterDurableObject>
+  readonly ADMIN_TOKEN?: string
+  readonly PROXY_TOKEN?: string
+  readonly CODEX_UPSTREAM?: string
+  readonly API_UPSTREAM?: string
+  readonly CLAUDE_UPSTREAM?: string
+}
+
+const json = (body: unknown, init?: ResponseInit): Response =>
+  new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+  })
+
+const errorJson = (error: unknown, status: number): Response =>
+  json({ error: String((error as Error).message ?? error) }, { status })
+
+const nonEmptyString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim().length > 0 ? value : null
+
+const parseJsonRecord = async (
+  request: Request
+): Promise<Record<string, unknown> | Response> => {
+  const body = await request.json().catch(() => null)
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return json({ error: "Missing JSON body" }, { status: 400 })
+  }
+  return body as Record<string, unknown>
+}
+
+const parseRouteInput = async (request: Request): Promise<RouteInput> => {
+  const body = await request.json().catch(() => ({}))
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { orgId: "demo-org", sessionId: "default" }
+  }
+  const record = body as Record<string, unknown>
+  const input = {
+    orgId: nonEmptyString(record["orgId"]) ?? "demo-org",
+    agentType: nonEmptyString(record["agentType"]) ?? "codex",
+    sessionId: nonEmptyString(record["sessionId"]) ?? "default",
+  }
+  const userEmail = nonEmptyString(record["userEmail"])
+  const preferAccountId = nonEmptyString(record["preferAccountId"])
+  const model = nonEmptyString(record["model"])
+  const quotaKey = nonEmptyString(record["quotaKey"])
+  const modelInput = {
+    ...input,
+    ...(userEmail ? { userEmail } : {}),
+    ...(model ? { model } : {}),
+    ...(quotaKey ? { quotaKey } : {}),
+  }
+  if (preferAccountId) {
+    return { ...modelInput, preferAccountId }
+  }
+  return modelInput
+}
+
+const parseUsageInput = async (request: Request): Promise<Response | UsageInput> => {
+  const record = await parseJsonRecord(request)
+  if (record instanceof Response) return record
+
+  const sessionId = nonEmptyString(record["sessionId"])
+  if (!sessionId) {
+    return json({ error: "Missing sessionId" }, { status: 400 })
+  }
+  const accountId = nonEmptyString(record["accountId"])
+  if (!accountId) {
+    return json({ error: "Missing accountId" }, { status: 400 })
+  }
+
+  const input = { sessionId, accountId }
+  const orgId = nonEmptyString(record["orgId"])
+  if (orgId) {
+    return { ...input, orgId }
+  }
+  return input
+}
+
+const parseUpsertAccountInput = async (
+  request: Request
+): Promise<Response | UpsertAccountInput> => {
+  const record = await parseJsonRecord(request)
+  if (record instanceof Response) return record
+
+  const id = nonEmptyString(record["id"])
+  if (!id) return json({ error: "Missing id" }, { status: 400 })
+  const orgId = nonEmptyString(record["orgId"])
+  if (!orgId) return json({ error: "Missing orgId" }, { status: 400 })
+  const kind = nonEmptyString(record["kind"])
+  if (!kind || !accountKinds.has(kind as AccountKind)) {
+    return json({ error: "Invalid kind" }, { status: 400 })
+  }
+  const label = nonEmptyString(record["label"])
+  if (!label) return json({ error: "Missing label" }, { status: 400 })
+
+  const input: UpsertAccountInput = {
+    id,
+    orgId,
+    kind: kind as AccountKind,
+    label,
+    enabled: record["enabled"] === false ? false : true,
+  }
+
+  const credentials = record["credentials"]
+  const totp = record["totp"]
+  const modelQuotas = record["modelQuotas"]
+  return {
+    ...input,
+    ...(typeof record["rateLimitRemaining"] === "number"
+      ? { rateLimitRemaining: record["rateLimitRemaining"] }
+      : {}),
+    ...(credentials && typeof credentials === "object" && !Array.isArray(credentials)
+      ? { credentials: credentials as AccountCredentials }
+      : {}),
+    ...(totp && typeof totp === "object" && !Array.isArray(totp)
+      ? { totp: parseTotpConfig(totp as Record<string, unknown>) }
+      : {}),
+    ...(modelQuotas && typeof modelQuotas === "object" && !Array.isArray(modelQuotas)
+      ? { modelQuotas: parseModelQuotas(modelQuotas as Record<string, unknown>) }
+      : {}),
+  }
+}
+
+const parseModelProbeInput = async (
+  request: Request
+): Promise<Response | ModelProbeInput> => {
+  const record = await parseJsonRecord(request)
+  if (record instanceof Response) return record
+
+  const accountId = nonEmptyString(record["accountId"])
+  if (!accountId) return json({ error: "Missing accountId" }, { status: 400 })
+  const model = nonEmptyString(record["model"])
+  if (!model) return json({ error: "Missing model" }, { status: 400 })
+
+  const input = {
+    accountId,
+    model,
+    prompt:
+      nonEmptyString(record["prompt"]) ??
+      "Reply with exactly: subrouter-model-probe-ok",
+  }
+  const orgId = nonEmptyString(record["orgId"])
+  if (orgId) return { ...input, orgId }
+  return input
+}
+
+const parseTotpConfig = (record: Record<string, unknown>): TotpConfig => {
+  const seed = nonEmptyString(record["seed"])
+  if (!seed) throw new Error("Missing totp.seed")
+
+  const digits = typeof record["digits"] === "number" ? record["digits"] : 6
+  const period = typeof record["period"] === "number" ? record["period"] : 30
+  const algorithm = nonEmptyString(record["algorithm"]) ?? "SHA-1"
+  if (!["SHA-1", "SHA-256", "SHA-512"].includes(algorithm)) {
+    throw new Error("Invalid totp.algorithm")
+  }
+  if (!Number.isInteger(digits) || digits < 6 || digits > 8) {
+    throw new Error("Invalid totp.digits")
+  }
+  if (!Number.isInteger(period) || period < 15 || period > 120) {
+    throw new Error("Invalid totp.period")
+  }
+
+  return {
+    seed,
+    digits,
+    period,
+    algorithm: algorithm as TotpAlgorithm,
+  }
+}
+
+const parseModelQuotas = (
+  record: Record<string, unknown>
+): AccountModelQuotas => {
+  const quotas: Record<string, AccountModelQuotas[string]> = {}
+  for (const [rawKey, rawValue] of Object.entries(record)) {
+    const key = rawKey.trim().toLowerCase()
+    if (!key) continue
+
+    if (typeof rawValue === "number") {
+      quotas[key] = { remainingPercent: clampPercent(rawValue) }
+      continue
+    }
+
+    if (!rawValue || typeof rawValue !== "object" || Array.isArray(rawValue)) {
+      throw new Error(`Invalid quota for ${rawKey}`)
+    }
+    const value = rawValue as Record<string, unknown>
+    const remaining = value["remainingPercent"] ?? value["remaining"]
+    if (typeof remaining !== "number") {
+      throw new Error(`Invalid quota remainingPercent for ${rawKey}`)
+    }
+    quotas[key] = {
+      remainingPercent: clampPercent(remaining),
+      ...(typeof value["resetsAt"] === "number"
+        ? { resetsAt: value["resetsAt"] }
+        : {}),
+      ...(typeof value["protectedBelowPercent"] === "number"
+        ? { protectedBelowPercent: clampPercent(value["protectedBelowPercent"]) }
+        : {}),
+    }
+  }
+  return quotas
+}
+
+const clampPercent = (value: number): number => {
+  if (!Number.isFinite(value)) throw new Error("quota percent must be finite")
+  return Math.max(0, Math.min(100, value))
+}
+
+const authorizeAdmin = (request: Request, env: Env): Response | null => {
+  if (!env.ADMIN_TOKEN) {
+    return json({ error: "ADMIN_TOKEN secret is not configured" }, { status: 500 })
+  }
+  const header = request.headers.get("authorization") ?? ""
+  const bearer = header.startsWith("Bearer ") ? header.slice("Bearer ".length) : ""
+  const token =
+    bearer ||
+    request.headers.get("x-admin-token") ||
+    request.headers.get("x-subrouter-admin-token") ||
+    ""
+  if (!constantTimeStringEqual(token, env.ADMIN_TOKEN)) {
+    return json({ error: "Unauthorized" }, { status: 401 })
+  }
+  return null
+}
+
+const authorizeProxy = (request: Request, env: Env): Response | null => {
+  const token = env.PROXY_TOKEN || env.ADMIN_TOKEN
+  if (!token) return null
+  const header = request.headers.get("authorization") ?? ""
+  const bearer = header.startsWith("Bearer ") ? header.slice("Bearer ".length) : ""
+  const got = bearer || request.headers.get("x-subrouter-proxy-token") || ""
+  if (!constantTimeStringEqual(got, token)) {
+    return json({ error: "Proxy token required" }, { status: 401 })
+  }
+  return null
+}
+
+const constantTimeStringEqual = (a: string, b: string): boolean => {
+  const encoder = new TextEncoder()
+  const aa = encoder.encode(a)
+  const bb = encoder.encode(b)
+  const length = Math.max(aa.length, bb.length)
+  let diff = aa.length ^ bb.length
+  for (let i = 0; i < length; i++) {
+    diff |= (aa[i] ?? 0) ^ (bb[i] ?? 0)
+  }
+  return diff === 0
+}
+
+const rowToAccount = (row: AccountRow): StoredAccount => ({
+  id: row.id,
+  orgId: row.org_id,
+  kind: row.kind as AccountKind,
+  label: row.label,
+  enabled: row.enabled === 1,
+  ...(row.rate_limit_remaining !== null
+    ? { rateLimitRemaining: row.rate_limit_remaining }
+    : {}),
+  hasCredentials: row.credentials_json !== null,
+  hasTotp: row.totp_seed_base32 !== null,
+  totpDigits: row.totp_digits,
+  totpPeriod: row.totp_period,
+  totpAlgorithm: row.totp_algorithm as TotpAlgorithm | null,
+  source: "durable-object",
+})
+
+const quotaRowsToRecord = (
+  rows: ReadonlyArray<ModelQuotaRow>
+): AccountModelQuotas => {
+  const quotas: Record<string, AccountModelQuotas[string]> = {}
+  for (const row of rows) {
+    quotas[row.quota_key] = {
+      remainingPercent: row.remaining_percent,
+      ...(row.resets_at !== null ? { resetsAt: row.resets_at } : {}),
+      ...(row.protected_below_percent !== null
+        ? { protectedBelowPercent: row.protected_below_percent }
+        : {}),
+    }
+  }
+  return quotas
+}
+
+interface MutableTranscriptSummary {
+  agent_type: string
+  session_id: string
+  event_count: number
+  total_bytes: number
+  usage: MutableTranscriptUsage
+  first_event_at?: string
+  last_event_at?: string
+  user?: string
+  account?: string
+  has_bodies: boolean
+  size_bytes: number
+}
+
+interface MutableTranscriptUsage {
+  requests: number
+  input_tokens: number
+  cached_input_tokens: number
+  output_tokens: number
+  reasoning_tokens: number
+  total_tokens: number
+  payload_bytes: number
+}
+
+interface TranscriptUsageRecord {
+  readonly timestamp: string
+  readonly user: string
+  readonly account: string
+  readonly model: string
+  readonly usage: MutableTranscriptUsage
+}
+
+interface TranscriptUsageGroup {
+  readonly key: string
+  readonly usage: MutableTranscriptUsage
+}
+
+interface TranscriptUsageBucket {
+  readonly start: string
+  readonly label: string
+  readonly usage: MutableTranscriptUsage
+}
+
+interface TranscriptAnalytics {
+  readonly totals: MutableTranscriptUsage
+  readonly by_user: ReadonlyArray<TranscriptUsageGroup>
+  readonly by_account: ReadonlyArray<TranscriptUsageGroup>
+  readonly by_model: ReadonlyArray<TranscriptUsageGroup>
+  readonly timeline: ReadonlyArray<TranscriptUsageBucket>
+  readonly max_timeline_tokens: number
+  readonly max_user_tokens: number
+  readonly max_account_tokens: number
+}
+
+const emptyTranscriptUsage = (): MutableTranscriptUsage => ({
+  requests: 0,
+  input_tokens: 0,
+  cached_input_tokens: 0,
+  output_tokens: 0,
+  reasoning_tokens: 0,
+  total_tokens: 0,
+  payload_bytes: 0,
+})
+
+const emptyTranscriptSummary = (
+  agentType: string,
+  sessionId: string
+): MutableTranscriptSummary => ({
+  agent_type: agentType,
+  session_id: sessionId,
+  event_count: 0,
+  total_bytes: 0,
+  usage: emptyTranscriptUsage(),
+  has_bodies: false,
+  size_bytes: 0,
+})
+
+const baseSessionId = (sessionId: string): string => {
+  const index = sessionId.indexOf(":")
+  return index === -1 ? sessionId : sessionId.slice(0, index)
+}
+
+const withTranscriptSession = (
+  agentType: string,
+  sessionId: string,
+  payload: Record<string, unknown>
+): Record<string, unknown> => {
+  const normalizedAgent = normalizeAgentType(agentType) || "codex"
+  const agentSessionId = baseSessionId(sessionId)
+  return {
+    ...payload,
+    agent_type: normalizedAgent,
+    session_id: sessionId,
+    agent_session_id: agentSessionId,
+    ...(normalizedAgent === "codex" ? { codex_session_id: agentSessionId } : {}),
+  }
+}
+
+const applyTranscriptEvent = (
+  summary: MutableTranscriptSummary,
+  row: TranscriptEventRow
+): void => {
+  summary.event_count += 1
+  summary.size_bytes += row.size_bytes
+  if (!summary.first_event_at || row.timestamp < summary.first_event_at) {
+    summary.first_event_at = row.timestamp
+  }
+  if (!summary.last_event_at || row.timestamp > summary.last_event_at) {
+    summary.last_event_at = row.timestamp
+  }
+
+  const payload = parsePayload(row.payload_json)
+  const user = stringPayload(payload["user"])
+  if (user && !summary.user) summary.user = user
+  const account = stringPayload(payload["account"])
+  if (account && !summary.account) summary.account = account
+  const bytes = numberPayload(payload["bytes"])
+  if (bytes !== null) summary.total_bytes += bytes
+  const encoded = stringPayload(payload["body_base64"])
+  if (!encoded) return
+
+  summary.has_bodies = true
+  const body = base64ToString(encoded)
+  if (body === null) return
+  for (const record of usageRecordsFromBody(body, {
+    timestamp: row.timestamp,
+    user: summary.user ?? "",
+    account: summary.account ?? "",
+  })) {
+    if (bytes !== null) record.usage.payload_bytes = bytes
+    addTranscriptUsage(summary.usage, record.usage)
+  }
+}
+
+const finalizeTranscriptSummary = (
+  summary: MutableTranscriptSummary
+): Record<string, unknown> => ({
+  agent_type: summary.agent_type,
+  session_id: summary.session_id,
+  event_count: summary.event_count,
+  total_bytes: summary.total_bytes,
+  usage: summary.usage,
+  ...(summary.first_event_at ? { first_event_at: summary.first_event_at } : {}),
+  ...(summary.last_event_at ? { last_event_at: summary.last_event_at } : {}),
+  ...(summary.user ? { user: summary.user } : {}),
+  ...(summary.account ? { account: summary.account } : {}),
+  has_bodies: summary.has_bodies,
+  size_bytes: summary.size_bytes,
+})
+
+const transcriptEventFromRow = (
+  row: TranscriptEventRow,
+  raw: boolean
+): Record<string, unknown> => {
+  const payload = parsePayload(row.payload_json)
+  if (!raw) {
+    return {
+      timestamp: row.timestamp,
+      type: row.type,
+      payload: sanitizeTranscriptPayload(payload),
+    }
+  }
+  const encoded = stringPayload(payload["body_base64"])
+  if (encoded) delete payload["body_base64"]
+  const decoded = encoded ? base64ToString(encoded) : null
+  return {
+    timestamp: row.timestamp,
+    type: row.type,
+    payload,
+    ...(decoded !== null ? { body_text: decoded } : encoded ? { body_base64: encoded } : {}),
+  }
+}
+
+const parsePayload = (payloadJSON: string): Record<string, unknown> => {
+  try {
+    const payload = JSON.parse(payloadJSON) as unknown
+    return payload && typeof payload === "object" && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>)
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+const sanitizeTranscriptPayload = (
+  payload: Record<string, unknown>
+): Record<string, unknown> => {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(payload)) {
+    if (key === "body_base64") {
+      out["body_base64_redacted"] = true
+      continue
+    }
+    out[key] = value
+  }
+  return out
+}
+
+const usageRecordsFromBody = (
+  body: string,
+  context: {
+    readonly timestamp: string
+    readonly user: string
+    readonly account: string
+  }
+): TranscriptUsageRecord[] => {
+  const payloads = jsonPayloads(body)
+  const out: TranscriptUsageRecord[] = []
+  for (const payload of payloads) {
+    const record = usageRecordFromPayload(payload, context)
+    if (record) out.push(record)
+  }
+  return out
+}
+
+const jsonPayloads = (body: string): Record<string, unknown>[] => {
+  const parsed = parseJsonRecordValue(body)
+  if (parsed) return [parsed]
+  const out: Record<string, unknown>[] = []
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.trim().replace(/^data:\s*/, "").trim()
+    if (!line || line === "[DONE]") continue
+    const item = parseJsonRecordValue(line)
+    if (item) out.push(item)
+  }
+  return out
+}
+
+const parseJsonRecordValue = (text: string): Record<string, unknown> | null => {
+  try {
+    const parsed = JSON.parse(text) as unknown
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+const usageRecordFromPayload = (
+  payload: Record<string, unknown>,
+  context: {
+    readonly timestamp: string
+    readonly user: string
+    readonly account: string
+  }
+): TranscriptUsageRecord | null => {
+  const response = recordPayload(payload["response"])
+  const container = response ?? payload
+  const usage = recordPayload(container["usage"])
+  if (!usage) return null
+  const input = numberFieldPayload(usage, ["input_tokens", "prompt_tokens"])
+  const output = numberFieldPayload(usage, ["output_tokens", "completion_tokens"])
+  let total = numberFieldPayload(usage, ["total_tokens"])
+  if (total === 0) total = input + output
+  if (total === 0 && input === 0 && output === 0) return null
+  return {
+    timestamp: context.timestamp,
+    user: context.user,
+    account: context.account,
+    model: stringPayload(container["model"]) ?? "",
+    usage: {
+    requests: 1,
+    input_tokens: input,
+    cached_input_tokens: numberFieldPayload(recordPayload(usage["input_tokens_details"]) ?? {}, ["cached_tokens"]),
+    output_tokens: output,
+    reasoning_tokens: numberFieldPayload(recordPayload(usage["output_tokens_details"]) ?? {}, ["reasoning_tokens"]),
+    total_tokens: total,
+    payload_bytes: 0,
+    },
+  }
+}
+
+const usageRecordsFromRows = (
+  rows: ReadonlyArray<TranscriptEventRow>
+): TranscriptUsageRecord[] => {
+  const records: TranscriptUsageRecord[] = []
+  const contexts = new Map<string, { user: string; account: string }>()
+  for (const row of rows) {
+    const key = `${row.agent_type}\u0000${row.session_id}`
+    const context = contexts.get(key) ?? { user: "", account: "" }
+    const payload = parsePayload(row.payload_json)
+    const user = stringPayload(payload["user"])
+    if (user) context.user = user
+    const account = stringPayload(payload["account"])
+    if (account) context.account = account
+    contexts.set(key, context)
+    const encoded = stringPayload(payload["body_base64"])
+    if (!encoded) continue
+    const body = base64ToString(encoded)
+    if (body === null) continue
+    const bytes = numberPayload(payload["bytes"])
+    for (const record of usageRecordsFromBody(body, {
+      timestamp: row.timestamp,
+      user: context.user,
+      account: context.account,
+    })) {
+      if (bytes !== null) record.usage.payload_bytes = bytes
+      records.push(record)
+    }
+  }
+  return records
+}
+
+const buildTranscriptAnalytics = (
+  records: ReadonlyArray<TranscriptUsageRecord>
+): TranscriptAnalytics => {
+  const totals = emptyTranscriptUsage()
+  const byUser = new Map<string, MutableTranscriptUsage>()
+  const byAccount = new Map<string, MutableTranscriptUsage>()
+  const byModel = new Map<string, MutableTranscriptUsage>()
+  let first = 0
+  let last = 0
+
+  for (const record of records) {
+    addTranscriptUsage(totals, record.usage)
+    addUsageToGroup(byUser, orUnknown(record.user), record.usage)
+    addUsageToGroup(byAccount, orUnknown(record.account), record.usage)
+    addUsageToGroup(byModel, orUnknown(record.model), record.usage)
+    const time = Date.parse(record.timestamp)
+    if (Number.isFinite(time)) {
+      if (first === 0 || time < first) first = time
+      if (last === 0 || time > last) last = time
+    }
+  }
+
+  const by_user = sortedUsageGroups(byUser)
+  const by_account = sortedUsageGroups(byAccount)
+  const by_model = sortedUsageGroups(byModel)
+  const timeline = buildTranscriptTimeline(records, first, last)
+
+  return {
+    totals,
+    by_user,
+    by_account,
+    by_model,
+    timeline,
+    max_timeline_tokens: maxUsageTokens(timeline.map((bucket) => bucket.usage)),
+    max_user_tokens: maxUsageTokens(by_user.map((group) => group.usage)),
+    max_account_tokens: maxUsageTokens(by_account.map((group) => group.usage)),
+  }
+}
+
+const addUsageToGroup = (
+  groups: Map<string, MutableTranscriptUsage>,
+  key: string,
+  usage: MutableTranscriptUsage
+): void => {
+  const current = groups.get(key) ?? emptyTranscriptUsage()
+  addTranscriptUsage(current, usage)
+  groups.set(key, current)
+}
+
+const sortedUsageGroups = (
+  groups: Map<string, MutableTranscriptUsage>
+): TranscriptUsageGroup[] =>
+  [...groups.entries()]
+    .map(([key, usage]) => ({ key, usage }))
+    .sort((left, right) => {
+      if (left.usage.total_tokens === right.usage.total_tokens) {
+        return left.key.localeCompare(right.key)
+      }
+      return right.usage.total_tokens - left.usage.total_tokens
+    })
+
+const buildTranscriptTimeline = (
+  records: ReadonlyArray<TranscriptUsageRecord>,
+  first: number,
+  last: number
+): TranscriptUsageBucket[] => {
+  if (first === 0 || last === 0) return []
+  const size = transcriptBucketSize(last - first)
+  const start = Math.floor(first / size) * size
+  const buckets = new Map<number, MutableTranscriptUsage>()
+  for (const record of records) {
+    const time = Date.parse(record.timestamp)
+    if (!Number.isFinite(time)) continue
+    const bucketStart = Math.floor(time / size) * size
+    const usage = buckets.get(bucketStart) ?? emptyTranscriptUsage()
+    addTranscriptUsage(usage, record.usage)
+    buckets.set(bucketStart, usage)
+  }
+  const out: TranscriptUsageBucket[] = []
+  for (let cursor = start; cursor <= last; cursor += size) {
+    out.push({
+      start: new Date(cursor).toISOString(),
+      label: transcriptBucketLabel(cursor, size),
+      usage: buckets.get(cursor) ?? emptyTranscriptUsage(),
+    })
+  }
+  return out
+}
+
+const transcriptBucketSize = (spanMs: number): number => {
+  if (spanMs <= 2 * 60 * 60 * 1000) return 60 * 1000
+  if (spanMs <= 48 * 60 * 60 * 1000) return 60 * 60 * 1000
+  return 24 * 60 * 60 * 1000
+}
+
+const transcriptBucketLabel = (time: number, size: number): string => {
+  const date = new Date(time)
+  if (size < 60 * 60 * 1000) {
+    return `${pad2(date.getUTCHours())}:${pad2(date.getUTCMinutes())}`
+  }
+  if (size < 24 * 60 * 60 * 1000) {
+    return `${date.toISOString().slice(0, 10)} ${pad2(date.getUTCHours())}:00`
+  }
+  return date.toISOString().slice(0, 10)
+}
+
+const pad2 = (value: number): string => String(value).padStart(2, "0")
+
+const maxUsageTokens = (usages: ReadonlyArray<MutableTranscriptUsage>): number =>
+  usages.reduce((max, usage) => Math.max(max, usage.total_tokens), 0)
+
+const orUnknown = (value: string): string => (value.trim() ? value : "(unknown)")
+
+const addTranscriptUsage = (
+  target: MutableTranscriptUsage,
+  usage: MutableTranscriptUsage
+): void => {
+  target.requests += usage.requests
+  target.input_tokens += usage.input_tokens
+  target.cached_input_tokens += usage.cached_input_tokens
+  target.output_tokens += usage.output_tokens
+  target.reasoning_tokens += usage.reasoning_tokens
+  target.total_tokens += usage.total_tokens
+  target.payload_bytes += usage.payload_bytes
+}
+
+const recordPayload = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+
+const stringPayload = (value: unknown): string | null =>
+  typeof value === "string" && value.length > 0 ? value : null
+
+const numberPayload = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null
+
+const numberFieldPayload = (
+  values: Record<string, unknown>,
+  names: ReadonlyArray<string>
+): number => {
+  for (const name of names) {
+    const value = numberPayload(values[name])
+    if (value !== null) return value
+  }
+  return 0
+}
+
+const base64ToString = (value: string): string | null => {
+  try {
+    return atob(value)
+  } catch {
+    return null
+  }
+}
+
+const decodeBase32 = (input: string): Uint8Array => {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+  const normalized = input.toUpperCase().replaceAll(/[\s=-]/g, "")
+  let bits = 0
+  let value = 0
+  const bytes: number[] = []
+
+  for (const char of normalized) {
+    const index = alphabet.indexOf(char)
+    if (index === -1) {
+      throw new Error("TOTP seed is not valid base32")
+    }
+    value = (value << 5) | index
+    bits += 5
+    if (bits >= 8) {
+      bytes.push((value >>> (bits - 8)) & 0xff)
+      bits -= 8
+    }
+  }
+
+  return new Uint8Array(bytes)
+}
+
+const generateTotp = async (
+  seedBase32: string,
+  nowMs: number,
+  digits: number,
+  period: number,
+  algorithm: TotpAlgorithm
+) => {
+  const secret = decodeBase32(seedBase32)
+  const keyData = new ArrayBuffer(secret.byteLength)
+  new Uint8Array(keyData).set(secret)
+  const key = await crypto.subtle.importKey(
+    "raw",
+    keyData,
+    { name: "HMAC", hash: algorithm },
+    false,
+    ["sign"]
+  )
+  const counter = Math.floor(nowMs / 1000 / period)
+  const buffer = new ArrayBuffer(8)
+  const view = new DataView(buffer)
+  view.setUint32(4, counter)
+
+  const signature = new Uint8Array(await crypto.subtle.sign("HMAC", key, buffer))
+  const offset = signature[signature.length - 1]! & 0x0f
+  const binary =
+    ((signature[offset]! & 0x7f) << 24) |
+    (signature[offset + 1]! << 16) |
+    (signature[offset + 2]! << 8) |
+    signature[offset + 3]!
+  const modulo = 10 ** digits
+  const code = String(binary % modulo).padStart(digits, "0")
+
+  return {
+    code,
+    period,
+    digits,
+    algorithm,
+    secondsRemaining: period - (Math.floor(nowMs / 1000) % period),
+  }
+}
+
+export class SubrouterDurableObject extends DurableObject<Env> {
+  private readonly refreshInFlight = new Map<string, Promise<AccountRow | null>>()
+
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env)
+    this.ctx.setWebSocketAutoResponse(
+      new WebSocketRequestResponsePair("ping", "pong")
+    )
+
+    this.ctx.storage.sql.exec(`
+      CREATE TABLE IF NOT EXISTS accounts(
+        id TEXT PRIMARY KEY,
+        org_id TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        label TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        rate_limit_remaining INTEGER,
+        credentials_json TEXT,
+        totp_seed_base32 TEXT,
+        totp_digits INTEGER,
+        totp_period INTEGER,
+        totp_algorithm TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS accounts_org_enabled_idx
+        ON accounts(org_id, enabled);
+      CREATE TABLE IF NOT EXISTS subrouter_status(
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        route_count INTEGER NOT NULL DEFAULT 0,
+        usage_count INTEGER NOT NULL DEFAULT 0,
+        last_routed_at INTEGER,
+        last_account_id TEXT,
+        last_session_id TEXT,
+        cursor INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE IF NOT EXISTS sticky_sessions(
+        org_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        account_id TEXT NOT NULL,
+        PRIMARY KEY (org_id, session_id)
+      );
+      CREATE TABLE IF NOT EXISTS sticky_session_routes(
+        org_id TEXT NOT NULL,
+        quota_key TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        account_id TEXT NOT NULL,
+        PRIMARY KEY (org_id, quota_key, session_id)
+      );
+      CREATE TABLE IF NOT EXISTS session_assignments(
+        org_id TEXT NOT NULL,
+        agent_type TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        quota_key TEXT NOT NULL,
+        account_id TEXT NOT NULL,
+        user_email TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (org_id, agent_type, quota_key, session_id)
+      );
+      CREATE TABLE IF NOT EXISTS account_usage(
+        account_id TEXT PRIMARY KEY,
+        last_used_at INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS account_model_quotas(
+        account_id TEXT NOT NULL,
+        quota_key TEXT NOT NULL,
+        remaining_percent REAL NOT NULL,
+        resets_at INTEGER,
+        protected_below_percent REAL,
+        PRIMARY KEY (account_id, quota_key)
+      );
+      CREATE TABLE IF NOT EXISTS transcript_events(
+        event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        org_id TEXT NOT NULL,
+        agent_type TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        timestamp TEXT NOT NULL,
+        type TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        size_bytes INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS transcript_events_session_idx
+        ON transcript_events(org_id, agent_type, session_id, event_id);
+      CREATE INDEX IF NOT EXISTS transcript_events_org_time_idx
+        ON transcript_events(org_id, timestamp);
+      CREATE TABLE IF NOT EXISTS lifecycle(
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        draining INTEGER NOT NULL DEFAULT 0,
+        started_at INTEGER NOT NULL
+      );
+      INSERT OR IGNORE INTO subrouter_status(id) VALUES (1);
+      INSERT OR IGNORE INTO lifecycle(id, started_at) VALUES (1, ${Date.now()});
+    `)
+
+    const now = Date.now()
+    for (const account of demoAccounts) {
+      this.ctx.storage.sql.exec(
+        `INSERT OR IGNORE INTO accounts(
+          id, org_id, kind, label, enabled, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        account.id,
+        account.orgId,
+        account.kind,
+        account.label,
+        account.enabled ? 1 : 0,
+        now,
+        now
+      )
+      this.upsertModelQuotas(account.id, account.modelQuotas)
+    }
+    this.ctx.blockConcurrencyWhile(async () => {
+      await this.scheduleNextRefreshAlarm()
+    })
+  }
+
+  override async alarm(): Promise<void> {
+    await this.refreshOAuthAccounts(false)
+    await this.scheduleNextRefreshAlarm()
+  }
+
+  override async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url)
+    if (url.pathname !== "/ws") {
+      return new Response("Not Found", { status: 404 })
+    }
+    if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+      return json({ error: "Expected WebSocket Upgrade request" }, { status: 426 })
+    }
+
+    const orgId = this.resolveOrgId(url.searchParams.get("orgId") ?? undefined)
+    const pair = new WebSocketPair()
+    const [client, server] = Object.values(pair) as [WebSocket, WebSocket]
+    server.serializeAttachment({
+      id: crypto.randomUUID(),
+      orgId,
+      connectedAt: Date.now(),
+      lastMessageAt: null,
+      messageCount: 0,
+    } satisfies WebSocketAttachment)
+    this.ctx.acceptWebSocket(server, [orgId])
+    return new Response(null, { status: 101, webSocket: client })
+  }
+
+  override async webSocketMessage(
+    webSocket: WebSocket,
+    message: string | ArrayBuffer
+  ): Promise<void> {
+    if (typeof message !== "string") {
+      webSocket.send(
+        JSON.stringify({
+          type: "error",
+          ok: false,
+          error: "Binary WebSocket messages are not supported",
+        } satisfies WebSocketServerMessage)
+      )
+      return
+    }
+
+    const attachment = this.recordWebSocketMessage(webSocket)
+    try {
+      const parsed = JSON.parse(message)
+      const messages = normalizeWebSocketMessage(parsed)
+      const replies: WebSocketServerMessage[] = []
+      for (const entry of messages) {
+        replies.push(await this.handleWebSocketMessage(attachment, entry))
+      }
+      if (replies.length === 1) {
+        webSocket.send(JSON.stringify(replies[0]))
+      } else {
+        webSocket.send(
+          JSON.stringify({
+            type: "batch",
+            ok: true,
+            connectionId: attachment.id,
+            messages: replies,
+          } satisfies WebSocketServerMessage)
+        )
+      }
+    } catch (error) {
+      webSocket.send(
+        JSON.stringify({
+          type: "error",
+          ok: false,
+          connectionId: attachment.id,
+          error: String((error as Error).message ?? error),
+        } satisfies WebSocketServerMessage)
+      )
+    }
+  }
+
+  override async webSocketClose(
+    _webSocket: WebSocket,
+    _code: number,
+    _reason: string,
+    _wasClean: boolean
+  ): Promise<void> {
+    // Durable Object hibernation resumes connections from attachments; no timer
+    // cleanup is needed because closed sockets disappear from getWebSockets().
+  }
+
+  override async webSocketError(
+    _webSocket: WebSocket,
+    error: unknown
+  ): Promise<void> {
+    console.error("subrouter websocket error", error)
+  }
+
+  async webSocketStats(): Promise<WebSocketStatsOutput> {
+    const connections = this.ctx
+      .getWebSockets()
+      .map((webSocket) => webSocketAttachment(webSocket))
+      .sort((a, b) => a.connectedAt - b.connectedAt)
+    return {
+      connectionCount: connections.length,
+      connections,
+    }
+  }
+
+  async route(input: RouteInput): Promise<RouteOutput> {
+    const orgId = this.resolveOrgId(input.orgId)
+    const agentType = this.resolveAgentType(input.agentType)
+    const sessionId = stickySessionId(
+      agentType,
+      this.requireNonEmpty(input.sessionId, "sessionId")
+    )
+    const quotaKey = this.resolveQuotaKey(input)
+    const routedAt = Date.now()
+    const sql = this.ctx.storage.sql
+
+    const sticky = sql
+      .exec<SessionAssignmentRow>(
+        `SELECT account_id FROM session_assignments
+         WHERE org_id = ? AND agent_type = ? AND quota_key = ? AND session_id = ?`,
+        orgId,
+        agentType,
+        quotaKey,
+        sessionId
+      )
+      .toArray()[0]
+    const stickyAccount = sticky
+      ? this.getEligibleAccount(sql, orgId, sticky.account_id, quotaKey, true)
+      : null
+    if (stickyAccount) {
+      this.recordRouteMetadata(sql, routedAt, stickyAccount.id, sessionId)
+      return {
+        account: this.accountWithLastUsed(sql, stickyAccount),
+        routedAt,
+        quotaKey,
+      }
+    }
+
+    const preferredAccount = input.preferAccountId
+      ? this.getEligibleAccount(sql, orgId, input.preferAccountId, quotaKey, true)
+      : null
+    if (preferredAccount) {
+      this.rememberSticky(sql, orgId, agentType, quotaKey, sessionId, preferredAccount.id, input.userEmail)
+      this.recordUse(sql, preferredAccount.id)
+      this.recordRouteMetadata(sql, routedAt, preferredAccount.id, sessionId)
+      return {
+        account: this.accountWithLastUsed(sql, preferredAccount),
+        routedAt,
+        quotaKey,
+      }
+    }
+
+    const eligible = this.listEligibleAccounts(sql, orgId, quotaKey)
+    if (eligible.length === 0) {
+      throw new Error(`no eligible ${quotaKey} subrouter account for org ${orgId}`)
+    }
+
+    const status = this.statusRow(sql)
+    const account = eligible[status.cursor % eligible.length]!
+    sql.exec("UPDATE subrouter_status SET cursor = cursor + 1 WHERE id = 1")
+    this.rememberSticky(sql, orgId, agentType, quotaKey, sessionId, account.id, input.userEmail)
+    this.recordUse(sql, account.id)
+    this.recordRouteMetadata(sql, routedAt, account.id, sessionId)
+    return { account: this.accountWithLastUsed(sql, account), routedAt, quotaKey }
+  }
+
+  async routeForProxy(
+    input: RouteInput
+  ): Promise<RouteOutput & { readonly account: StoredAccountContract }> {
+    const routed = await this.route(input)
+    const row = await this.refreshAccountIfExpired(
+      routed.account.orgId,
+      routed.account.id,
+      false
+    )
+    if (!row) throw new Error("selected account disappeared")
+    const credentials = row.credentials_json
+      ? (JSON.parse(row.credentials_json) as AccountCredentials)
+      : undefined
+    return {
+      ...routed,
+      account: {
+        ...routed.account,
+        ...(credentials ? { credentials } : {}),
+      },
+    }
+  }
+
+  async recordUsage(input: UsageInput): Promise<{ ok: true }> {
+    const orgId = this.resolveOrgId(input.orgId)
+    const sessionId = this.requireNonEmpty(input.sessionId, "sessionId")
+    const accountId = this.requireNonEmpty(input.accountId, "accountId")
+    const sql = this.ctx.storage.sql
+    if (!this.getAccountRow(sql, orgId, accountId, false)) {
+      throw new Error("account does not belong to org")
+    }
+
+    this.recordUse(sql, accountId)
+    sql.exec(
+      `UPDATE subrouter_status
+       SET usage_count = usage_count + 1,
+           last_account_id = ?,
+           last_session_id = ?
+       WHERE id = 1`,
+      accountId,
+      sessionId
+    )
+    return { ok: true }
+  }
+
+  async status(): Promise<StatusOutput> {
+    const sql = this.ctx.storage.sql
+    const row = this.statusRow(sql)
+    return {
+      routeCount: row.route_count,
+      usageCount: row.usage_count,
+      accountCount: sql.exec<CountRow>("SELECT COUNT(*) AS count FROM accounts").one()
+        .count,
+      sessionCount: sql
+        .exec<CountRow>("SELECT COUNT(*) AS count FROM session_assignments")
+        .one().count,
+      lastRoutedAt: row.last_routed_at,
+      lastAccountId: row.last_account_id,
+      lastSessionId: row.last_session_id,
+      draining: this.isDraining(),
+    }
+  }
+
+  async ready(): Promise<{ ok: boolean; draining: boolean }> {
+    const draining = this.isDraining()
+    return { ok: !draining, draining }
+  }
+
+  async drain(): Promise<{ ok: true; draining: true }> {
+    this.ctx.storage.sql.exec("UPDATE lifecycle SET draining = 1 WHERE id = 1")
+    return { ok: true, draining: true }
+  }
+
+  async listSessions(): Promise<ReadonlyArray<Record<string, unknown>>> {
+    return this.ctx.storage.sql
+      .exec<SessionAssignmentRow>(
+        `SELECT * FROM session_assignments
+         ORDER BY updated_at DESC, session_id`
+      )
+      .toArray()
+      .map((row) => ({
+        org_id: row.org_id,
+        agent_type: row.agent_type,
+        session_id: row.session_id,
+        quota_key: row.quota_key,
+        account_id: row.account_id,
+        ...(row.user_email ? { user_email: row.user_email } : {}),
+        created_at: new Date(row.created_at).toISOString(),
+        updated_at: new Date(row.updated_at).toISOString(),
+      }))
+  }
+
+  async upsertAccount(input: UpsertAccountInput): Promise<{ account: StoredAccount }> {
+    const sql = this.ctx.storage.sql
+    const now = Date.now()
+    sql.exec(
+      `INSERT INTO accounts(
+        id,
+        org_id,
+        kind,
+        label,
+        enabled,
+        rate_limit_remaining,
+        credentials_json,
+        totp_seed_base32,
+        totp_digits,
+        totp_period,
+        totp_algorithm,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        org_id = excluded.org_id,
+        kind = excluded.kind,
+        label = excluded.label,
+        enabled = excluded.enabled,
+        rate_limit_remaining = excluded.rate_limit_remaining,
+        credentials_json = COALESCE(excluded.credentials_json, accounts.credentials_json),
+        totp_seed_base32 = COALESCE(excluded.totp_seed_base32, accounts.totp_seed_base32),
+        totp_digits = COALESCE(excluded.totp_digits, accounts.totp_digits),
+        totp_period = COALESCE(excluded.totp_period, accounts.totp_period),
+        totp_algorithm = COALESCE(excluded.totp_algorithm, accounts.totp_algorithm),
+        updated_at = excluded.updated_at`,
+      input.id,
+      input.orgId,
+      input.kind,
+      input.label,
+      input.enabled === false ? 0 : 1,
+      input.rateLimitRemaining ?? null,
+      input.credentials ? JSON.stringify(input.credentials) : null,
+      input.totp?.seed ?? null,
+      input.totp?.digits ?? null,
+      input.totp?.period ?? null,
+      input.totp?.algorithm ?? null,
+      now,
+      now
+    )
+    this.upsertModelQuotas(input.id, input.modelQuotas)
+    const account = this.getAccount(sql, input.orgId, input.id, false)
+    if (!account) throw new Error("account upsert failed")
+    await this.scheduleNextRefreshAlarm()
+    return { account }
+  }
+
+  async listAccounts(orgId: string): Promise<{ accounts: ReadonlyArray<StoredAccount> }> {
+    return {
+      accounts: this.ctx.storage.sql
+        .exec<AccountRow>(
+          `SELECT * FROM accounts
+           WHERE org_id = ?
+           ORDER BY id`,
+          orgId
+        )
+        .toArray()
+        .map((row) => this.accountFromRow(row)),
+    }
+  }
+
+  async accountStatuses(orgId: string, forceRefresh: boolean): Promise<ReadonlyArray<OAuthRefreshStatus>> {
+    const rows = this.ctx.storage.sql
+      .exec<AccountRow>(
+        "SELECT * FROM accounts WHERE org_id = ? ORDER BY id",
+        this.resolveOrgId(orgId)
+      )
+      .toArray()
+    const statuses: OAuthRefreshStatus[] = []
+    for (const row of rows) {
+      statuses.push(await this.refreshStatusForRow(row, forceRefresh))
+    }
+    await this.scheduleNextRefreshAlarm()
+    return statuses
+  }
+
+  async usageStatuses(orgId: string): Promise<ReadonlyArray<Record<string, unknown>>> {
+    const resolvedOrgId = this.resolveOrgId(orgId)
+    const rows = this.ctx.storage.sql
+      .exec<AccountRow>(
+        "SELECT * FROM accounts WHERE org_id = ? ORDER BY id",
+        resolvedOrgId
+      )
+      .toArray()
+    const out: Record<string, unknown>[] = []
+    for (const row of rows) {
+      const auth = await this.refreshStatusForRow(row, false)
+      const account = this.accountFromRow(row)
+      const fallback = usageStatus(account)
+      const entry: Record<string, unknown> = { ...fallback, ...auth }
+      const refreshedRow = this.getAccountRow(this.ctx.storage.sql, resolvedOrgId, row.id, false)
+      const credentials = refreshedRow?.credentials_json
+        ? (JSON.parse(refreshedRow.credentials_json) as AccountCredentials)
+        : undefined
+      if (!auth.error && credentials && isOAuthKind(row.kind as AccountKind)) {
+        try {
+          Object.assign(
+            entry,
+            await fetchProviderUsage(row.kind as AccountKind, credentials)
+          )
+        } catch (error) {
+          entry.error = String((error as Error).message ?? error)
+        }
+      }
+      out.push(entry)
+    }
+    await this.scheduleNextRefreshAlarm()
+    return out
+  }
+
+  async refreshOAuthAccounts(forceRefresh: boolean): Promise<ReadonlyArray<OAuthRefreshStatus>> {
+    const rows = this.ctx.storage.sql
+      .exec<AccountRow>(
+        `SELECT * FROM accounts
+         WHERE kind IN ('codex_oauth', 'anthropic_oauth')
+         ORDER BY org_id, id`
+      )
+      .toArray()
+    const statuses: OAuthRefreshStatus[] = []
+    for (const row of rows) {
+      statuses.push(await this.refreshStatusForRow(row, forceRefresh))
+    }
+    return statuses
+  }
+
+  async totpCode(input: { orgId?: string; accountId: string }) {
+    const orgId = this.resolveOrgId(input.orgId)
+    const accountId = this.requireNonEmpty(input.accountId, "accountId")
+    const row = this.getAccountRow(this.ctx.storage.sql, orgId, accountId, false)
+    if (!row) throw new Error("account not found")
+    if (!row.totp_seed_base32) throw new Error("account has no totp seed")
+
+    return generateTotp(
+      row.totp_seed_base32,
+      Date.now(),
+      row.totp_digits ?? 6,
+      row.totp_period ?? 30,
+      (row.totp_algorithm as TotpAlgorithm | null) ?? "SHA-1"
+    )
+  }
+
+  async modelProbe(input: ModelProbeInput) {
+    const orgId = this.resolveOrgId(input.orgId)
+    const accountId = this.requireNonEmpty(input.accountId, "accountId")
+    const row = this.getAccountRow(this.ctx.storage.sql, orgId, accountId, false)
+    if (!row) throw new Error("account not found")
+    if (!row.credentials_json) {
+      throw new Error("account has no credentials")
+    }
+
+    const credentials = JSON.parse(row.credentials_json) as AccountCredentials
+    const apiKey = credentials.apiKey ?? credentials.accessToken
+    if (!apiKey) {
+      throw new Error("account credentials need apiKey or accessToken")
+    }
+    const baseUrl = credentials.baseUrl ?? "https://api.openai.com/v1"
+    const response = await fetch(`${baseUrl.replace(/\/$/, "")}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: input.model,
+        input: input.prompt,
+        max_output_tokens: 32,
+      }),
+    })
+    const body = await response.text()
+    return {
+      ok: response.ok,
+      status: response.status,
+      model: input.model,
+      body: parseJsonOrText(body),
+    }
+  }
+
+  async recordTranscriptMeta(input: TranscriptEventInput): Promise<{ ok: true }> {
+    const agentType = normalizeAgentType(input.agentType) || "codex"
+    const sessionId = this.requireNonEmpty(input.sessionId, "sessionId")
+    this.recordTranscriptEvent({
+      ...input,
+      agentType,
+      sessionId,
+      type: input.type || "subrouter_meta",
+      payload: withTranscriptSession(agentType, sessionId, input.payload),
+    })
+    return { ok: true }
+  }
+
+  async recordTranscriptBody(input: TranscriptBodyInput): Promise<{ ok: true }> {
+    const agentType = normalizeAgentType(input.agentType) || "codex"
+    const sessionId = this.requireNonEmpty(input.sessionId, "sessionId")
+    this.recordTranscriptEvent({
+      orgId: input.orgId,
+      agentType,
+      sessionId,
+      type: input.eventType,
+      payload: withTranscriptSession(agentType, sessionId, {
+        ...(input.payload ?? {}),
+        direction: input.direction,
+        bytes: input.bytes,
+        sha256: input.sha256,
+        body_base64: input.bodyBase64,
+      }),
+    })
+    return { ok: true }
+  }
+
+  async listTranscriptSummaries(orgId?: string): Promise<ReadonlyArray<Record<string, unknown>>> {
+    const rows = this.listTranscriptRows(orgId)
+    const summaries = new Map<string, MutableTranscriptSummary>()
+    for (const row of rows) {
+      const key = `${row.agent_type}\u0000${baseSessionId(row.session_id)}`
+      let summary = summaries.get(key)
+      if (!summary) {
+        summary = emptyTranscriptSummary(row.agent_type, baseSessionId(row.session_id))
+        summaries.set(key, summary)
+      }
+      applyTranscriptEvent(summary, row)
+    }
+    return [...summaries.values()]
+      .map((summary) => finalizeTranscriptSummary(summary))
+      .sort((left, right) => {
+        const leftLast = String(left["last_event_at"] ?? "")
+        const rightLast = String(right["last_event_at"] ?? "")
+        if (leftLast === rightLast) {
+          return String(left["session_id"] ?? "").localeCompare(String(right["session_id"] ?? ""))
+        }
+        return rightLast.localeCompare(leftLast)
+      })
+  }
+
+  async transcriptDashboardData(orgId?: string): Promise<TranscriptDashboardData> {
+    const rows = this.listTranscriptRows(orgId)
+    const summaries = new Map<string, MutableTranscriptSummary>()
+    for (const row of rows) {
+      const key = `${row.agent_type}\u0000${baseSessionId(row.session_id)}`
+      let summary = summaries.get(key)
+      if (!summary) {
+        summary = emptyTranscriptSummary(row.agent_type, baseSessionId(row.session_id))
+        summaries.set(key, summary)
+      }
+      applyTranscriptEvent(summary, row)
+    }
+    return {
+      summaries: [...summaries.values()]
+        .map((summary) => finalizeTranscriptSummary(summary))
+        .sort((left, right) => {
+          const leftLast = String(left["last_event_at"] ?? "")
+          const rightLast = String(right["last_event_at"] ?? "")
+          if (leftLast === rightLast) {
+            return String(left["session_id"] ?? "").localeCompare(String(right["session_id"] ?? ""))
+          }
+          return rightLast.localeCompare(leftLast)
+        }),
+      analytics: buildTranscriptAnalytics(usageRecordsFromRows(rows)),
+    }
+  }
+
+  async readTranscriptSession(input: TranscriptReadInput): Promise<Record<string, unknown>> {
+    const orgId = this.resolveOrgId(input.orgId)
+    const agentType = normalizeAgentType(input.agentType) || "codex"
+    const sessionId = baseSessionId(this.requireNonEmpty(input.sessionId, "sessionId"))
+    const rows = this.ctx.storage.sql
+      .exec<TranscriptEventRow>(
+        `SELECT * FROM transcript_events
+         WHERE org_id = ? AND agent_type = ? AND session_id = ?
+         ORDER BY event_id`,
+        orgId,
+        agentType,
+        sessionId
+      )
+      .toArray()
+    if (rows.length === 0) throw new Error("transcript not found")
+    return {
+      agent_type: agentType,
+      session_id: sessionId,
+      events: rows.map((row) => transcriptEventFromRow(row, input.raw)),
+    }
+  }
+
+  private resolveOrgId(inputOrgId: string | undefined): string {
+    const orgId = inputOrgId ?? "demo-org"
+    return this.requireNonEmpty(orgId, "orgId")
+  }
+
+  private resolveAgentType(inputAgentType: AgentType | undefined): string {
+    return this.requireNonEmpty(inputAgentType || "codex", "agentType")
+  }
+
+  private resolveQuotaKey(input: { model?: string; quotaKey?: string }): string {
+    const explicit = input.quotaKey?.trim().toLowerCase()
+    if (explicit) return explicit
+    return quotaKeyForModel(input.model)
+  }
+
+  private requireNonEmpty(value: string, name: string): string {
+    if (value.trim().length === 0) {
+      throw new Error(`missing ${name}`)
+    }
+    return value
+  }
+
+  private statusRow(sql: SqlStorage): StatusRow {
+    return sql.exec<StatusRow>("SELECT * FROM subrouter_status WHERE id = 1").one()
+  }
+
+  private listEligibleAccounts(
+    sql: SqlStorage,
+    orgId: string,
+    quotaKey: string
+  ): StoredAccount[] {
+    return sql
+      .exec<AccountRow>(
+        `SELECT * FROM accounts
+         WHERE org_id = ? AND enabled = 1
+         ORDER BY id`,
+        orgId
+      )
+      .toArray()
+      .map((row) => this.accountFromRow(row))
+      .filter((account) => accountHasQuotaForModel(account, quotaKey))
+  }
+
+  private getEligibleAccount(
+    sql: SqlStorage,
+    orgId: string,
+    accountId: string,
+    quotaKey: string,
+    enabledOnly: boolean
+  ): StoredAccount | null {
+    const account = this.getAccount(sql, orgId, accountId, enabledOnly)
+    if (!account) return null
+    return accountHasQuotaForModel(account, quotaKey) ? account : null
+  }
+
+  private getAccount(
+    sql: SqlStorage,
+    orgId: string,
+    accountId: string,
+    enabledOnly: boolean
+  ): StoredAccount | null {
+    const row = this.getAccountRow(sql, orgId, accountId, enabledOnly)
+    return row ? this.accountFromRow(row) : null
+  }
+
+  private getAccountRow(
+    sql: SqlStorage,
+    orgId: string,
+    accountId: string,
+    enabledOnly: boolean
+  ): AccountRow | null {
+    const where = enabledOnly
+      ? "id = ? AND org_id = ? AND enabled = 1"
+      : "id = ? AND org_id = ?"
+    return (
+      sql
+        .exec<AccountRow>(`SELECT * FROM accounts WHERE ${where}`, accountId, orgId)
+        .toArray()[0] ?? null
+    )
+  }
+
+  private async refreshAccountIfExpired(
+    orgId: string,
+    accountId: string,
+    force: boolean
+  ): Promise<AccountRow | null> {
+    const row = this.getAccountRow(this.ctx.storage.sql, orgId, accountId, true)
+    if (!row) return null
+    const key = `${orgId}:${accountId}`
+    const existing = this.refreshInFlight.get(key)
+    if (existing) return existing
+    const promise = this.refreshAccountRow(row, force).finally(() => {
+      this.refreshInFlight.delete(key)
+    })
+    this.refreshInFlight.set(key, promise)
+    return promise
+  }
+
+  private async refreshAccountRow(
+    row: AccountRow,
+    force: boolean
+  ): Promise<AccountRow> {
+    const kind = row.kind as AccountKind
+    if (!isOAuthKind(kind) || !row.credentials_json) return row
+    const credentials = JSON.parse(row.credentials_json) as AccountCredentials
+    if (!credentials.accessToken || !credentials.refreshToken) return row
+    if (!force && !credentialNeedsRefresh(credentials)) return row
+    try {
+      const refreshed = await refreshOAuthCredentials(kind, credentials, force)
+      if (!refreshed.refreshed) return row
+      this.updateAccountCredentials(row.id, refreshed.credentials)
+      return {
+        ...row,
+        credentials_json: JSON.stringify(refreshed.credentials),
+      }
+    } catch (error) {
+      const failure = refreshFailureFromError(error)
+      const nextCredentials = {
+        ...credentials,
+        refreshFailure: failure,
+      }
+      if (terminalRefreshFailure(failure)) {
+        this.updateAccountCredentials(row.id, nextCredentials)
+      }
+      throw error
+    }
+  }
+
+  private async refreshStatusForRow(
+    row: AccountRow,
+    forceRefresh: boolean
+  ): Promise<OAuthRefreshStatus> {
+    const base = safeGoAccount(this.accountFromRow(row))
+    if (!isOAuthKind(row.kind as AccountKind)) {
+      return {
+        ...base,
+        auth_checked: false,
+        auth_valid: row.credentials_json !== null,
+      }
+    }
+    if (!row.credentials_json) {
+      return {
+        ...base,
+        auth_checked: true,
+        auth_valid: false,
+        error: "account has no credentials",
+      }
+    }
+    const before = JSON.parse(row.credentials_json) as AccountCredentials
+    try {
+      const refreshedRow = await this.refreshAccountIfExpired(
+        row.org_id,
+        row.id,
+        forceRefresh
+      )
+      const after = refreshedRow?.credentials_json
+        ? (JSON.parse(refreshedRow.credentials_json) as AccountCredentials)
+        : before
+      return {
+        ...base,
+        auth_checked: true,
+        auth_valid: Boolean(after.accessToken) && !after.refreshFailure,
+        refreshed: before.accessToken !== after.accessToken,
+        ...(after.refreshFailure ? { error: after.refreshFailure.message } : {}),
+      }
+    } catch (error) {
+      return {
+        ...base,
+        auth_checked: true,
+        auth_valid: false,
+        error: String((error as Error).message ?? error),
+      }
+    }
+  }
+
+  private updateAccountCredentials(
+    accountId: string,
+    credentials: AccountCredentials
+  ): void {
+    this.ctx.storage.sql.exec(
+      `UPDATE accounts
+       SET credentials_json = ?, updated_at = ?
+       WHERE id = ?`,
+      JSON.stringify(credentials),
+      Date.now(),
+      accountId
+    )
+  }
+
+  private async scheduleNextRefreshAlarm(): Promise<void> {
+    const rows = this.ctx.storage.sql
+      .exec<AccountRow>(
+        `SELECT * FROM accounts
+         WHERE kind IN ('codex_oauth', 'anthropic_oauth')
+           AND credentials_json IS NOT NULL`
+      )
+      .toArray()
+    let next: number | null = null
+    const now = Date.now()
+    for (const row of rows) {
+      const credentials = JSON.parse(row.credentials_json ?? "{}") as AccountCredentials
+      if (credentials.refreshFailure && terminalRefreshFailure(credentials.refreshFailure)) {
+        continue
+      }
+      const candidate = nextRefreshAt(credentials, now)
+      if (candidate !== null && (next === null || candidate < next)) {
+        next = candidate
+      }
+    }
+    if (next === null) {
+      await this.ctx.storage.deleteAlarm()
+      return
+    }
+    const current = await this.ctx.storage.getAlarm()
+    if (current === null || Math.abs(current - next) > 1_000) {
+      await this.ctx.storage.setAlarm(next)
+    }
+  }
+
+  private accountFromRow(row: AccountRow): StoredAccount {
+    const quotas = this.modelQuotasForAccount(row.id)
+    return {
+      ...rowToAccount(row),
+      ...(Object.keys(quotas).length > 0 ? { modelQuotas: quotas } : {}),
+    }
+  }
+
+  private modelQuotasForAccount(accountId: string): AccountModelQuotas {
+    const rows = this.ctx.storage.sql
+      .exec<ModelQuotaRow>(
+        `SELECT quota_key, remaining_percent, resets_at, protected_below_percent
+         FROM account_model_quotas
+         WHERE account_id = ?
+         ORDER BY quota_key`,
+        accountId
+      )
+      .toArray()
+    return quotaRowsToRecord(rows)
+  }
+
+  private accountWithLastUsed(
+    sql: SqlStorage,
+    account: StoredAccount
+  ): StoredAccount {
+    const usage = sql
+      .exec<UsageRow>(
+        "SELECT last_used_at FROM account_usage WHERE account_id = ?",
+        account.id
+      )
+      .toArray()[0]
+    if (!usage) return account
+    return { ...account, lastUsedAt: usage.last_used_at }
+  }
+
+  private rememberSticky(
+    sql: SqlStorage,
+    orgId: string,
+    agentType: string,
+    quotaKey: string,
+    sessionId: string,
+    accountId: string,
+    userEmail: string | undefined
+  ): void {
+    const now = Date.now()
+    sql.exec(
+      `INSERT INTO session_assignments(
+        org_id,
+        agent_type,
+        quota_key,
+        session_id,
+        account_id,
+        user_email,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(org_id, agent_type, quota_key, session_id) DO UPDATE SET
+        account_id = excluded.account_id,
+        user_email = COALESCE(excluded.user_email, session_assignments.user_email),
+        updated_at = excluded.updated_at`,
+      orgId,
+      agentType,
+      quotaKey,
+      sessionId,
+      accountId,
+      userEmail ?? null,
+      now,
+      now
+    )
+  }
+
+  private isDraining(): boolean {
+    const row = this.ctx.storage.sql
+      .exec<{ readonly [key: string]: SqlStorageValue; readonly draining: number }>(
+        "SELECT draining FROM lifecycle WHERE id = 1"
+      )
+      .one()
+    return row.draining === 1
+  }
+
+  private upsertModelQuotas(
+    accountId: string,
+    quotas: AccountModelQuotas | undefined
+  ): void {
+    if (!quotas) return
+    const sql = this.ctx.storage.sql
+    sql.exec("DELETE FROM account_model_quotas WHERE account_id = ?", accountId)
+    for (const [quotaKey, quota] of Object.entries(quotas)) {
+      sql.exec(
+        `INSERT INTO account_model_quotas(
+          account_id,
+          quota_key,
+          remaining_percent,
+          resets_at,
+          protected_below_percent
+        ) VALUES (?, ?, ?, ?, ?)`,
+        accountId,
+        quotaKey.trim().toLowerCase(),
+        quota.remainingPercent,
+        quota.resetsAt ?? null,
+        quota.protectedBelowPercent ?? null
+      )
+    }
+  }
+
+  private recordUse(sql: SqlStorage, accountId: string): void {
+    sql.exec(
+      `INSERT OR REPLACE INTO account_usage(account_id, last_used_at)
+       VALUES (?, ?)`,
+      accountId,
+      Date.now()
+    )
+  }
+
+  private recordRouteMetadata(
+    sql: SqlStorage,
+    routedAt: number,
+    accountId: string,
+    sessionId: string
+  ): void {
+    sql.exec(
+      `UPDATE subrouter_status
+       SET route_count = route_count + 1,
+           last_routed_at = ?,
+           last_account_id = ?,
+           last_session_id = ?
+       WHERE id = 1`,
+      routedAt,
+      accountId,
+      sessionId
+    )
+  }
+
+  private recordTranscriptEvent(input: TranscriptEventInput): void {
+    const orgId = this.resolveOrgId(input.orgId)
+    const agentType = normalizeAgentType(input.agentType) || "codex"
+    const sessionId = baseSessionId(this.requireNonEmpty(input.sessionId, "sessionId"))
+    const event = {
+      timestamp: new Date().toISOString(),
+      type: input.type,
+      payload: input.payload,
+    }
+    const payloadJSON = JSON.stringify(event.payload)
+    this.ctx.storage.sql.exec(
+      `INSERT INTO transcript_events(
+        org_id,
+        agent_type,
+        session_id,
+        timestamp,
+        type,
+        payload_json,
+        size_bytes
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      orgId,
+      agentType,
+      sessionId,
+      event.timestamp,
+      event.type,
+      payloadJSON,
+      new TextEncoder().encode(JSON.stringify(event)).byteLength
+    )
+  }
+
+  private listTranscriptRows(orgId?: string): TranscriptEventRow[] {
+    return this.ctx.storage.sql
+      .exec<TranscriptEventRow>(
+        `SELECT * FROM transcript_events
+         WHERE org_id = ?
+         ORDER BY agent_type, session_id, event_id`,
+        this.resolveOrgId(orgId)
+      )
+      .toArray()
+  }
+
+  private recordWebSocketMessage(webSocket: WebSocket): WebSocketAttachment {
+    const attachment = webSocketAttachment(webSocket)
+    const next = {
+      ...attachment,
+      lastMessageAt: Date.now(),
+      messageCount: attachment.messageCount + 1,
+    }
+    webSocket.serializeAttachment(next)
+    return next
+  }
+
+  private async handleWebSocketMessage(
+    attachment: WebSocketAttachment,
+    message: WebSocketClientMessage
+  ): Promise<WebSocketServerMessage> {
+    const type = nonEmptyString(message.type)
+    const requestId = requestIdFromMessage(message)
+    if (!type) {
+      throw new Error("WebSocket message is missing type")
+    }
+
+    if (type === "ping") {
+      return {
+        type: "pong",
+        ok: true,
+        ...(requestId ? { requestId } : {}),
+        connectionId: attachment.id,
+        connectionCount: this.ctx.getWebSockets().length,
+      }
+    }
+
+    if (type === "route") {
+      const sessionId = nonEmptyString(message.sessionId)
+      if (!sessionId) throw new Error("route message is missing sessionId")
+      return {
+        type: "route",
+        ok: true,
+        ...(requestId ? { requestId } : {}),
+        message: await this.route({
+          orgId: websocketOrgId(attachment, message),
+          sessionId,
+          ...(nonEmptyString(message.preferAccountId)
+            ? { preferAccountId: nonEmptyString(message.preferAccountId)! }
+            : {}),
+          ...(nonEmptyString(message.model) ? { model: nonEmptyString(message.model)! } : {}),
+          ...(nonEmptyString(message.quotaKey)
+            ? { quotaKey: nonEmptyString(message.quotaKey)! }
+            : {}),
+        }),
+      }
+    }
+
+    if (type === "usage") {
+      const sessionId = nonEmptyString(message.sessionId)
+      if (!sessionId) throw new Error("usage message is missing sessionId")
+      const accountId = nonEmptyString(message.accountId)
+      if (!accountId) throw new Error("usage message is missing accountId")
+      return {
+        type: "usage",
+        ok: true,
+        ...(requestId ? { requestId } : {}),
+        message: await this.recordUsage({
+          orgId: websocketOrgId(attachment, message),
+          sessionId,
+          accountId,
+        }),
+      }
+    }
+
+    if (type === "status") {
+      websocketOrgId(attachment, message)
+      return {
+        type: "status",
+        ok: true,
+        ...(requestId ? { requestId } : {}),
+        message: await this.status(),
+      }
+    }
+
+    throw new Error(`Unknown WebSocket message type ${type}`)
+  }
+}
+
+const parseJsonOrText = (value: string): unknown => {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return value
+  }
+}
+
+const webSocketAttachment = (webSocket: WebSocket): WebSocketAttachment => {
+  const attachment = webSocket.deserializeAttachment() as
+    | WebSocketAttachment
+    | undefined
+  if (attachment) return attachment
+  const now = Date.now()
+  return {
+    id: crypto.randomUUID(),
+    orgId: "demo-org",
+    connectedAt: now,
+    lastMessageAt: null,
+    messageCount: 0,
+  }
+}
+
+const normalizeWebSocketMessage = (
+  message: unknown
+): ReadonlyArray<WebSocketClientMessage> => {
+  if (Array.isArray(message)) {
+    return message.map((entry) => normalizeWebSocketMessageEntry(entry))
+  }
+  if (
+    message &&
+    typeof message === "object" &&
+    !Array.isArray(message) &&
+    Array.isArray((message as Record<string, unknown>)["messages"])
+  ) {
+    return ((message as Record<string, unknown>)["messages"] as unknown[]).map(
+      (entry) => normalizeWebSocketMessageEntry(entry)
+    )
+  }
+  return [normalizeWebSocketMessageEntry(message)]
+}
+
+const normalizeWebSocketMessageEntry = (
+  message: unknown
+): WebSocketClientMessage => {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    throw new Error("WebSocket message must be a JSON object")
+  }
+  return message as WebSocketClientMessage
+}
+
+const requestIdFromMessage = (message: WebSocketClientMessage): string | undefined => {
+  const requestId = nonEmptyString(message.requestId)
+  return requestId ?? undefined
+}
+
+const websocketOrgId = (
+  attachment: WebSocketAttachment,
+  message: WebSocketClientMessage
+): string => {
+  const orgId = nonEmptyString(message.orgId) ?? attachment.orgId
+  if (orgId !== attachment.orgId) {
+    throw new Error("WebSocket message orgId must match the connection orgId")
+  }
+  return orgId
+}
+
+const adminActor = (env: Env, orgId: string) =>
+  env.SUBROUTER_DO.getByName(orgId)
+
+const defaultUpstreamForAccount = (
+  env: Env,
+  account: StoredAccountContract
+): string => {
+  if (providerForAccount(account.kind) === "claude") {
+    return env.CLAUDE_UPSTREAM ?? "https://api.anthropic.com"
+  }
+  if (authModeForAccount(account.kind) === "apikey") {
+    return env.API_UPSTREAM ?? "https://api.openai.com/v1"
+  }
+  return env.CODEX_UPSTREAM ?? "https://chatgpt.com/backend-api/codex"
+}
+
+const proxyUpstream = async (
+  request: Request,
+  env: Env,
+  routeInput: RouteInput
+): Promise<Response> => {
+  const actor = env.SUBROUTER_DO.getByName(routeInput.orgId ?? "demo-org")
+  const routed = await actor.routeForProxy(routeInput)
+  const account = routed.account
+  if (!account.credentials?.apiKey && !account.credentials?.accessToken) {
+    return json(
+      { error: "selected account has no usable credential", accountId: account.id },
+      { status: 503 }
+    )
+  }
+  const upstreamURL = upstreamURLForRequest(
+    request.url,
+    account,
+    defaultUpstreamForAccount(env, account)
+  )
+  const headers = setUpstreamAuthHeaders(request.headers, account)
+  await actor.recordTranscriptMeta({
+    orgId: routeInput.orgId,
+    agentType: routeInput.agentType ?? "codex",
+    sessionId: routeInput.sessionId,
+    type: "subrouter_meta",
+    payload: {
+      transport: "http",
+      ...(routeInput.userEmail ? { user: routeInput.userEmail } : {}),
+      account: account.id,
+      method: request.method,
+      path: new URL(request.url).pathname,
+      upstream: upstreamURL.toString(),
+      headers: redactedHeaders(request.headers),
+    },
+  })
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    redirect: "manual",
+  }
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    await recordTranscriptBodyFromArrayBuffer(actor, {
+      orgId: routeInput.orgId,
+      agentType: routeInput.agentType ?? "codex",
+      sessionId: routeInput.sessionId,
+      eventType: "http_body",
+      direction: "client_to_upstream",
+      body: await request.clone().arrayBuffer(),
+    })
+    init.body = request.body
+  }
+  const upstreamRequest = new Request(upstreamURL, init)
+  const response = await fetch(upstreamRequest)
+  await recordTranscriptBodyFromArrayBuffer(actor, {
+    orgId: routeInput.orgId,
+    agentType: routeInput.agentType ?? "codex",
+    sessionId: routeInput.sessionId,
+    eventType: "http_body",
+    direction: "upstream_to_client",
+    body: await response.clone().arrayBuffer(),
+    payload: { status: response.status },
+  })
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  })
+}
+
+const proxyUpstreamWebSocket = async (
+  request: Request,
+  env: Env,
+  routeInput: RouteInput
+): Promise<Response> => {
+  const actor = env.SUBROUTER_DO.getByName(routeInput.orgId ?? "demo-org")
+  const routed = await actor.routeForProxy(routeInput)
+  const account = routed.account
+  if (!account.credentials?.apiKey && !account.credentials?.accessToken) {
+    return json(
+      { error: "selected account has no usable credential", accountId: account.id },
+      { status: 503 }
+    )
+  }
+  const upstreamURL = upstreamURLForRequest(
+    request.url,
+    account,
+    defaultUpstreamForAccount(env, account)
+  )
+  const headers = setUpstreamAuthHeaders(request.headers, account)
+  headers.set("Upgrade", "websocket")
+  await actor.recordTranscriptMeta({
+    orgId: routeInput.orgId,
+    agentType: routeInput.agentType ?? "codex",
+    sessionId: routeInput.sessionId,
+    type: "subrouter_meta",
+    payload: {
+      transport: "websocket",
+      ...(routeInput.userEmail ? { user: routeInput.userEmail } : {}),
+      account: account.id,
+      method: request.method,
+      path: new URL(request.url).pathname,
+      upstream: defaultUpstreamForAccount(env, account),
+      upstream_url: upstreamURL.toString(),
+      headers: redactedHeaders(headers),
+    },
+  })
+  const response = await fetch(
+    new Request(upstreamURL, {
+      method: "GET",
+      headers,
+      redirect: "manual",
+    })
+  )
+  if (response.status !== 101 || !response.webSocket) {
+    return new Response(await response.text().catch(() => "websocket upgrade failed"), {
+      status: response.status === 101 ? 502 : response.status,
+      statusText: response.statusText,
+      headers: websocketErrorHeaders(response.headers),
+    })
+  }
+  const upstreamSocket = response.webSocket
+  upstreamSocket.accept()
+  const pair = new WebSocketPair()
+  const [client, server] = Object.values(pair) as [WebSocket, WebSocket]
+  server.accept()
+  bridgeWebSockets({
+    actor,
+    clientSocket: server,
+    upstreamSocket,
+    orgId: routeInput.orgId,
+    agentType: routeInput.agentType ?? "codex",
+    sessionId: routeInput.sessionId,
+  })
+  return new Response(null, {
+    status: 101,
+    webSocket: client,
+    headers: websocketResponseHeaders(response.headers),
+  })
+}
+
+const isWebSocketUpgrade = (request: Request): boolean =>
+  request.headers.get("Upgrade")?.toLowerCase() === "websocket"
+
+const websocketResponseHeaders = (headers: Headers): Headers => {
+  const out = new Headers()
+  headers.forEach((value, key) => {
+    const lower = key.toLowerCase()
+    if (
+      lower === "connection" ||
+      lower === "upgrade" ||
+      lower.startsWith("sec-websocket-")
+    ) {
+      return
+    }
+    out.set(key, value)
+  })
+  return out
+}
+
+const websocketErrorHeaders = (headers: Headers): Headers => {
+  const out = new Headers()
+  const contentType = headers.get("Content-Type")
+  if (contentType) out.set("Content-Type", contentType)
+  return out
+}
+
+const sensitiveHeaders = new Set([
+  "authorization",
+  "cookie",
+  "set-cookie",
+  "proxy-authorization",
+  "x-api-key",
+  "openai-api-key",
+])
+
+const redactedHeaders = (headers: Headers): Record<string, ReadonlyArray<string>> => {
+  const out: Record<string, ReadonlyArray<string>> = {}
+  headers.forEach((value, key) => {
+    out[key] = sensitiveHeaders.has(key.toLowerCase()) ? ["<redacted>"] : [value]
+  })
+  return out
+}
+
+const recordTranscriptBodyFromArrayBuffer = async (
+  actor: DurableObjectStub<SubrouterDurableObject>,
+  input: {
+    readonly orgId?: string | undefined
+    readonly agentType: string
+    readonly sessionId: string
+    readonly eventType: "http_body" | "websocket_message"
+    readonly direction: "client_to_upstream" | "upstream_to_client"
+    readonly body: ArrayBuffer
+    readonly payload?: Record<string, unknown>
+  }
+): Promise<void> => {
+  await actor.recordTranscriptBody({
+    orgId: input.orgId,
+    agentType: input.agentType,
+    sessionId: input.sessionId,
+    eventType: input.eventType,
+    direction: input.direction,
+    bodyBase64: arrayBufferToBase64(input.body),
+    bytes: input.body.byteLength,
+    sha256: await sha256Hex(input.body),
+    ...(input.payload ? { payload: input.payload } : {}),
+  })
+}
+
+const bridgeWebSockets = (input: {
+  readonly actor: DurableObjectStub<SubrouterDurableObject>
+  readonly clientSocket: WebSocket
+  readonly upstreamSocket: WebSocket
+  readonly orgId?: string | undefined
+  readonly agentType: string
+  readonly sessionId: string
+}): void => {
+  input.clientSocket.addEventListener("message", (event) => {
+    void relayWebSocketMessage({
+      ...input,
+      source: input.clientSocket,
+      target: input.upstreamSocket,
+      direction: "client_to_upstream",
+      data: event.data,
+    })
+  })
+  input.upstreamSocket.addEventListener("message", (event) => {
+    void relayWebSocketMessage({
+      ...input,
+      source: input.upstreamSocket,
+      target: input.clientSocket,
+      direction: "upstream_to_client",
+      data: event.data,
+    })
+  })
+  input.clientSocket.addEventListener("close", () => closeWebSocket(input.upstreamSocket))
+  input.upstreamSocket.addEventListener("close", () => closeWebSocket(input.clientSocket))
+  input.clientSocket.addEventListener("error", () => closeWebSocket(input.upstreamSocket))
+  input.upstreamSocket.addEventListener("error", () => closeWebSocket(input.clientSocket))
+}
+
+const relayWebSocketMessage = async (input: {
+  readonly actor: DurableObjectStub<SubrouterDurableObject>
+  readonly source: WebSocket
+  readonly target: WebSocket
+  readonly orgId?: string | undefined
+  readonly agentType: string
+  readonly sessionId: string
+  readonly direction: "client_to_upstream" | "upstream_to_client"
+  readonly data: unknown
+}): Promise<void> => {
+  if (input.source.readyState !== WebSocket.OPEN || input.target.readyState !== WebSocket.OPEN) {
+    return
+  }
+  const message = await webSocketMessageToSendable(input.data)
+  if (!message) return
+  await recordTranscriptBodyFromArrayBuffer(input.actor, {
+    orgId: input.orgId,
+    agentType: input.agentType,
+    sessionId: input.sessionId,
+    eventType: "websocket_message",
+    direction: input.direction,
+    body: message.body,
+    payload: { opcode: message.opcode },
+  })
+  input.target.send(message.send)
+}
+
+const webSocketMessageToSendable = async (
+  data: unknown
+): Promise<{ readonly send: string | ArrayBuffer; readonly body: ArrayBuffer; readonly opcode: string } | null> => {
+  if (typeof data === "string") {
+    return {
+      send: data,
+      body: new TextEncoder().encode(data).buffer,
+      opcode: "text",
+    }
+  }
+  if (data instanceof ArrayBuffer) {
+    return { send: data, body: data, opcode: "binary" }
+  }
+  if (ArrayBuffer.isView(data)) {
+    const body = new Uint8Array(
+      new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+    ).buffer as ArrayBuffer
+    return { send: body, body, opcode: "binary" }
+  }
+  if (data instanceof Blob) {
+    const body = await data.arrayBuffer()
+    return { send: body, body, opcode: "binary" }
+  }
+  return null
+}
+
+const closeWebSocket = (webSocket: WebSocket): void => {
+  if (webSocket.readyState === WebSocket.OPEN || webSocket.readyState === WebSocket.CONNECTING) {
+    try {
+      webSocket.close()
+    } catch {
+      // The peer may already be closing.
+    }
+  }
+}
+
+const arrayBufferToBase64 = (body: ArrayBuffer): string => {
+  const bytes = new Uint8Array(body)
+  let binary = ""
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000))
+  }
+  return btoa(binary)
+}
+
+const sha256Hex = async (body: ArrayBuffer): Promise<string> => {
+  const digest = await crypto.subtle.digest("SHA-256", body)
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+const parseTranscriptPath = (
+  path: string
+): { readonly agentType: string; readonly sessionId: string; readonly raw: boolean } | null => {
+  const prefix = "/_subrouter/transcripts/"
+  if (!path.startsWith(prefix)) return null
+  let rest = path.slice(prefix.length)
+  let raw = false
+  if (rest.endsWith("/raw")) {
+    raw = true
+    rest = rest.slice(0, -"/raw".length)
+  }
+  const slash = rest.indexOf("/")
+  if (slash <= 0 || slash === rest.length - 1) return null
+  try {
+    const agentType = decodeURIComponent(rest.slice(0, slash))
+    const sessionId = decodeURIComponent(rest.slice(slash + 1))
+    if (!agentType || !sessionId) return null
+    return { agentType, sessionId, raw }
+  } catch {
+    return null
+  }
+}
+
+const renderDashboard = (
+  data: TranscriptDashboardData,
+  orgId: string
+): string => {
+  const summaries = data.summaries
+  const analytics = data.analytics
+  const totalEvents = summaries.reduce(
+    (sum, item) => sum + Number(item["event_count"] ?? 0),
+    0
+  )
+  const modelRows = usageGroupRows(analytics.by_model, "Model", analytics.by_model.length ? analytics.by_model[0]!.usage.total_tokens : 0)
+  const userRows = usageGroupRows(analytics.by_user, "User", analytics.max_user_tokens)
+  const accountRows = usageGroupRows(analytics.by_account, "Account", analytics.max_account_tokens)
+  const timelineBars = analytics.timeline
+    .map((bucket) => {
+      const height = usageBarPercent(bucket.usage.total_tokens, analytics.max_timeline_tokens)
+      return `<div class="bar" style="height:${height}%" title="${escapeHTML(bucket.label)}: ${bucket.usage.total_tokens} tokens"></div>`
+    })
+    .join("")
+  const rows = summaries
+    .map((summary) => {
+      const agentType = String(summary["agent_type"] ?? "")
+      const sessionId = String(summary["session_id"] ?? "")
+      const usage = recordPayload(summary["usage"]) ?? {}
+      const href = `/_subrouter/transcripts/${encodeURIComponent(agentType)}/${encodeURIComponent(sessionId)}?orgId=${encodeURIComponent(orgId)}`
+      const raw = `${href.replace("?", "/raw?")}`
+      return `<tr>
+        <td>${escapeHTML(agentType)}</td>
+        <td><a href="${href}">${escapeHTML(sessionId)}</a></td>
+        <td>${escapeHTML(String(summary["user"] ?? ""))}</td>
+        <td>${escapeHTML(String(summary["account"] ?? ""))}</td>
+        <td>${Number(summary["event_count"] ?? 0)}</td>
+        <td>${Number(summary["total_bytes"] ?? 0)}</td>
+        <td>${Number(usage["total_tokens"] ?? 0)}</td>
+        <td>${escapeHTML(String(summary["last_event_at"] ?? ""))}</td>
+        <td><a href="${raw}">raw</a></td>
+      </tr>`
+    })
+    .join("")
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Subrouter Trajectories</title>
+  <style>
+    :root { color-scheme: light dark; --border: #74747455; --muted: #777; --fill: #4f7cff; --fill-soft: #4f7cff33; }
+    body { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 24px; line-height: 1.35; }
+    header { display: flex; justify-content: space-between; gap: 24px; align-items: baseline; margin-bottom: 20px; }
+    h1 { margin: 0; font-size: 24px; }
+    h2 { margin-top: 28px; font-size: 18px; }
+    h3 { margin: 0 0 10px; font-size: 14px; color: var(--muted); }
+    .metrics { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; margin-bottom: 20px; }
+    .metric { border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; min-width: 120px; }
+    .value { font-size: 22px; font-weight: 700; }
+    .label { color: var(--muted); font-size: 12px; }
+    .charts { display: grid; grid-template-columns: minmax(0, 1.5fr) minmax(320px, 1fr); gap: 16px; align-items: start; }
+    .split { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; margin-top: 16px; }
+    .panel { border: 1px solid var(--border); border-radius: 8px; padding: 12px; }
+    .timeline { display: flex; align-items: end; gap: 2px; height: 180px; border-bottom: 1px solid var(--border); padding-top: 12px; }
+    .timeline .bar { flex: 1; min-width: 3px; background: var(--fill); border-radius: 3px 3px 0 0; }
+    .hbar { display: grid; grid-template-columns: minmax(120px, 1fr) minmax(140px, 2fr) 80px; gap: 10px; align-items: center; margin: 8px 0; font-size: 13px; }
+    .track { height: 10px; background: var(--fill-soft); border-radius: 999px; overflow: hidden; }
+    .track span { display: block; height: 100%; background: var(--fill); }
+    table { border-collapse: collapse; width: 100%; font-size: 13px; }
+    th, td { border-bottom: 1px solid var(--border); padding: 8px; text-align: left; vertical-align: top; }
+    th { color: var(--muted); font-weight: 600; }
+    a { color: inherit; }
+    @media (max-width: 900px) { .metrics, .charts, .split { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Subrouter Trajectories</h1>
+    <div class="label">org ${escapeHTML(orgId)}</div>
+  </header>
+  <section class="metrics">
+    <div class="metric"><div class="value">${summaries.length}</div><div class="label">Sessions</div></div>
+    <div class="metric"><div class="value">${totalEvents}</div><div class="label">Events</div></div>
+    <div class="metric"><div class="value">${formatTokens(analytics.totals.total_tokens)}</div><div class="label">Total Tokens</div></div>
+    <div class="metric"><div class="value">${analytics.totals.requests}</div><div class="label">Model Calls</div></div>
+  </section>
+  <h2>Usage</h2>
+  <section class="charts">
+    <div class="panel">
+      <h3>Tokens Over Time</h3>
+      <div class="timeline">${timelineBars || `<span class="label">No token usage found in transcripts.</span>`}</div>
+    </div>
+    <div class="panel">
+      <h3>Models</h3>
+      ${modelRows || `<p class="label">No model usage found.</p>`}
+    </div>
+  </section>
+  <section class="split">
+    <div class="panel">
+      <h3>Users</h3>
+      ${userRows || `<p class="label">No user usage found.</p>`}
+    </div>
+    <div class="panel">
+      <h3>Accounts</h3>
+      ${accountRows || `<p class="label">No account usage found.</p>`}
+    </div>
+  </section>
+  <h2>Transcripts</h2>
+  <table>
+    <thead><tr><th>Agent</th><th>Session</th><th>User</th><th>Account</th><th>Events</th><th>Bytes</th><th>Total Tokens</th><th>Last Event</th><th></th></tr></thead>
+    <tbody>${rows || `<tr><td colspan="9" class="label">No transcripts found.</td></tr>`}</tbody>
+  </table>
+</body>
+</html>`
+}
+
+const usageGroupRows = (
+  groups: ReadonlyArray<TranscriptUsageGroup>,
+  label: string,
+  maxTokens: number
+): string =>
+  groups
+    .map((group) => {
+      const width = usageBarPercent(group.usage.total_tokens, maxTokens)
+      return `<div class="hbar">
+        <div title="${escapeHTML(label)}">${escapeHTML(group.key)}</div>
+        <div class="track"><span style="width:${width}%"></span></div>
+        <div>${formatTokens(group.usage.total_tokens)}</div>
+      </div>`
+    })
+    .join("")
+
+const usageBarPercent = (value: number, max: number): number => {
+  if (max <= 0 || value <= 0) return 0
+  return Math.max(1, Math.round((value * 100) / max))
+}
+
+const formatTokens = (value: number): string => {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`
+  return String(value)
+}
+
+const escapeHTML = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url)
+
+    if (url.pathname === "/healthz") {
+      return json({ ok: true, service: "subrouter-do" })
+    }
+
+    if (url.pathname === "/_subrouter/health") {
+      return json({ ok: true })
+    }
+
+    if (url.pathname === "/_subrouter/ready") {
+      const orgId = url.searchParams.get("orgId") ?? "demo-org"
+      const ready = await env.SUBROUTER_DO.getByName(orgId).ready()
+      return json(ready, ready.ok ? undefined : { status: 503 })
+    }
+
+    if (url.pathname === "/ws") {
+      if (request.method !== "GET") {
+        return json({ error: "WebSocket endpoint requires GET" }, { status: 405 })
+      }
+      if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+        return json(
+          { error: "Expected WebSocket Upgrade request" },
+          { status: 426 }
+        )
+      }
+      const orgId = url.searchParams.get("orgId") ?? "demo-org"
+      return env.SUBROUTER_DO.getByName(orgId).fetch(request)
+    }
+
+    if (url.pathname === "/websocket-status") {
+      const unauthorized = authorizeAdmin(request, env)
+      if (unauthorized) return unauthorized
+      const orgId = url.searchParams.get("orgId") ?? "demo-org"
+      return json(await env.SUBROUTER_DO.getByName(orgId).webSocketStats())
+    }
+
+    if (url.pathname === "/route" && request.method === "POST") {
+      try {
+        const input = await parseRouteInput(request)
+        const actor = env.SUBROUTER_DO.getByName(input.orgId ?? "demo-org")
+        return json(await actor.route(input))
+      } catch (error) {
+        return errorJson(error, 409)
+      }
+    }
+
+    if (url.pathname === "/_subrouter/drain") {
+      const unauthorized = authorizeAdmin(request, env)
+      if (unauthorized) return unauthorized
+      if (request.method !== "POST") {
+        return json({ error: "method not allowed" }, { status: 405 })
+      }
+      const orgId = url.searchParams.get("orgId") ?? "demo-org"
+      return json(await env.SUBROUTER_DO.getByName(orgId).drain())
+    }
+
+    if (url.pathname === "/_subrouter/drain-status") {
+      const unauthorized = authorizeAdmin(request, env)
+      if (unauthorized) return unauthorized
+      if (request.method !== "GET") {
+        return json({ error: "method not allowed" }, { status: 405 })
+      }
+      const orgId = url.searchParams.get("orgId") ?? "demo-org"
+      return json(await env.SUBROUTER_DO.getByName(orgId).ready())
+    }
+
+    if (url.pathname === "/usage" && request.method === "POST") {
+      const input = await parseUsageInput(request)
+      if (input instanceof Response) {
+        return input
+      }
+      const actor = env.SUBROUTER_DO.getByName(input.orgId ?? "demo-org")
+      try {
+        return json(await actor.recordUsage(input))
+      } catch (error) {
+        return errorJson(error, 400)
+      }
+    }
+
+    if (url.pathname === "/status") {
+      const orgId = url.searchParams.get("orgId") ?? "demo-org"
+      const actor = env.SUBROUTER_DO.getByName(orgId)
+      try {
+        return json(await actor.status())
+      } catch (error) {
+        return errorJson(error, 400)
+      }
+    }
+
+    if (url.pathname === "/_subrouter/sessions") {
+      const unauthorized = authorizeAdmin(request, env)
+      if (unauthorized) return unauthorized
+      const orgId = url.searchParams.get("orgId") ?? "demo-org"
+      return json(await env.SUBROUTER_DO.getByName(orgId).listSessions())
+    }
+
+    if (url.pathname === "/_subrouter/accounts") {
+      const unauthorized = authorizeAdmin(request, env)
+      if (unauthorized) return unauthorized
+      const orgId = url.searchParams.get("orgId") ?? "demo-org"
+      const { accounts } = await env.SUBROUTER_DO.getByName(orgId).listAccounts(orgId)
+      return json(accounts.map((account) => safeGoAccount(account)))
+    }
+
+    if (url.pathname === "/_subrouter/account-status") {
+      const unauthorized = authorizeAdmin(request, env)
+      if (unauthorized) return unauthorized
+      if (request.method !== "GET" && request.method !== "POST") {
+        return json({ error: "method not allowed" }, { status: 405 })
+      }
+      const orgId = url.searchParams.get("orgId") ?? "demo-org"
+      return json(await env.SUBROUTER_DO.getByName(orgId).accountStatuses(orgId, request.method === "POST"))
+    }
+
+    if (url.pathname === "/_subrouter/usage-status") {
+      const unauthorized = authorizeAdmin(request, env)
+      if (unauthorized) return unauthorized
+      if (request.method !== "GET") {
+        return json({ error: "method not allowed" }, { status: 405 })
+      }
+      const orgId = url.searchParams.get("orgId") ?? "demo-org"
+      return json(await env.SUBROUTER_DO.getByName(orgId).usageStatuses(orgId))
+    }
+
+    if (url.pathname === "/_subrouter/reload-accounts") {
+      const unauthorized = authorizeAdmin(request, env)
+      if (unauthorized) return unauthorized
+      if (request.method !== "POST") {
+        return json({ error: "method not allowed" }, { status: 405 })
+      }
+      const orgId = url.searchParams.get("orgId") ?? "demo-org"
+      const { accounts } = await env.SUBROUTER_DO.getByName(orgId).listAccounts(orgId)
+      return json({ ok: true, accounts: accounts.length, usage_refreshed: 0 })
+    }
+
+    if (url.pathname === "/_subrouter/dashboard") {
+      const unauthorized = authorizeAdmin(request, env)
+      if (unauthorized) return unauthorized
+      const orgId = url.searchParams.get("orgId") ?? "demo-org"
+      const actor = env.SUBROUTER_DO.getByName(orgId)
+      return new Response(renderDashboard(await actor.transcriptDashboardData(orgId), orgId), {
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      })
+    }
+
+    if (
+      url.pathname === "/_subrouter/transcripts" ||
+      url.pathname.startsWith("/_subrouter/transcripts/")
+    ) {
+      const unauthorized = authorizeAdmin(request, env)
+      if (unauthorized) return unauthorized
+      const orgId = url.searchParams.get("orgId") ?? "demo-org"
+      const actor = env.SUBROUTER_DO.getByName(orgId)
+      if (url.pathname === "/_subrouter/transcripts") {
+        return json(await actor.listTranscriptSummaries(orgId))
+      }
+      const parsed = parseTranscriptPath(url.pathname)
+      if (!parsed) return new Response("Not Found", { status: 404 })
+      try {
+        return json(await actor.readTranscriptSession({ orgId, ...parsed }))
+      } catch (error) {
+        return errorJson(error, 404)
+      }
+    }
+
+    if (url.pathname.startsWith("/admin/")) {
+      const unauthorized = authorizeAdmin(request, env)
+      if (unauthorized) return unauthorized
+
+      if (url.pathname === "/admin/accounts" && request.method === "GET") {
+        const orgId = url.searchParams.get("orgId") ?? "demo-org"
+        return json(await adminActor(env, orgId).listAccounts(orgId))
+      }
+
+      if (url.pathname === "/admin/accounts" && request.method === "POST") {
+        try {
+          const input = await parseUpsertAccountInput(request)
+          if (input instanceof Response) return input
+          return json(await adminActor(env, input.orgId).upsertAccount(input))
+        } catch (error) {
+          return json({ error: String((error as Error).message ?? error) }, { status: 400 })
+        }
+      }
+
+      const totpMatch = url.pathname.match(/^\/admin\/accounts\/([^/]+)\/totp$/)
+      if (totpMatch && request.method === "POST") {
+        const accountId = decodeURIComponent(totpMatch[1]!)
+        const orgId = url.searchParams.get("orgId") ?? "demo-org"
+        try {
+          return json(await adminActor(env, orgId).totpCode({ orgId, accountId }))
+        } catch (error) {
+          return errorJson(error, 400)
+        }
+      }
+
+      if (url.pathname === "/admin/model-probe" && request.method === "POST") {
+        try {
+          const input = await parseModelProbeInput(request)
+          if (input instanceof Response) return input
+          return json(await adminActor(env, input.orgId ?? "demo-org").modelProbe(input))
+        } catch (error) {
+          return errorJson(error, 400)
+        }
+      }
+    }
+
+    if (url.pathname.startsWith("/_subrouter/")) {
+      return new Response("Not Found", { status: 404 })
+    }
+
+    const unauthorized = authorizeProxy(request, env)
+    if (unauthorized) return unauthorized
+    try {
+      const routeInput = await parseProxyRouteInput(request)
+      if (isWebSocketUpgrade(request)) {
+        return await proxyUpstreamWebSocket(request, env, routeInput)
+      }
+      return await proxyUpstream(request, env, routeInput)
+    } catch (error) {
+      return errorJson(error, 503)
+    }
+  },
+} satisfies ExportedHandler<Env>

--- a/cloudflare/packages/worker/test/contract.test.ts
+++ b/cloudflare/packages/worker/test/contract.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, test } from "bun:test"
+import {
+  accountStatus,
+  credentialNeedsRefresh,
+  fetchProviderUsage,
+  refreshOAuthCredentials,
+  parseProxyRouteInput,
+  safeGoAccount,
+  scopedSessionKey,
+  setUpstreamAuthHeaders,
+  upstreamURLForRequest,
+  usageStatus,
+  type StoredAccountContract,
+} from "../src/contract.ts"
+
+const jwt = (expiresAtSeconds: number): string => {
+  const payload = btoa(JSON.stringify({ exp: expiresAtSeconds }))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "")
+  return `header.${payload}.signature`
+}
+
+const codexAccount: StoredAccountContract = {
+  id: "codex-a",
+  orgId: "org-a",
+  kind: "codex_oauth",
+  label: "alice@example.com",
+  enabled: true,
+  hasCredentials: true,
+  hasTotp: false,
+  credentials: {
+    accessToken: jwt(1_700_000_000),
+    accountId: "chatgpt-account",
+    baseUrl: "https://chatgpt.example/backend-api/codex",
+  },
+  modelQuotas: {
+    default: { remainingPercent: 75 },
+  },
+}
+
+describe("subrouter Durable Object contract", () => {
+  test("parses tenant, user, account, model, and codex base session from proxy request", async () => {
+    const request = new Request("https://subrouter.cmux.dev/v1/responses", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Subrouter-Org-ID": "org-a",
+        "X-Subrouter-Session": "session-1:turn-7",
+        "X-Subrouter-User-Email": "Alice <ALICE@example.com>",
+        "X-Subrouter-Account-ID": " codex-a ",
+      },
+      body: JSON.stringify({ model: "gpt-5.3-codex-spark" }),
+    })
+
+    await expect(parseProxyRouteInput(request)).resolves.toEqual({
+      orgId: "org-a",
+      agentType: "codex",
+      sessionId: "session-1",
+      userEmail: "alice@example.com",
+      preferAccountId: "codex-a",
+      model: "gpt-5.3-codex-spark",
+    })
+  })
+
+  test("keeps claude session ids distinct from codex base-session collapsing", async () => {
+    expect(scopedSessionKey("codex", "shared:turn-1")).toBe("codex:shared")
+    expect(scopedSessionKey("claude", "shared:turn-1")).toBe("claude:shared:turn-1")
+  })
+
+  test("fallback sessions use Go-shaped client hash rather than a broad path key", async () => {
+    const first = await parseProxyRouteInput(
+      new Request("https://subrouter.cmux.dev/v1/responses", {
+        method: "POST",
+        headers: {
+          "CF-Connecting-IP": "203.0.113.1",
+          "User-Agent": "client-a",
+        },
+      })
+    )
+    const second = await parseProxyRouteInput(
+      new Request("https://subrouter.cmux.dev/v1/responses", {
+        method: "POST",
+        headers: {
+          "CF-Connecting-IP": "203.0.113.2",
+          "User-Agent": "client-a",
+        },
+      })
+    )
+
+    expect(first.sessionId).toMatch(/^fallback:[a-f0-9]{24}$/)
+    expect(second.sessionId).toMatch(/^fallback:[a-f0-9]{24}$/)
+    expect(first.sessionId).not.toBe(second.sessionId)
+  })
+
+  test("safe account and status payloads never expose credentials", () => {
+    expect(JSON.stringify(safeGoAccount(codexAccount))).not.toContain(codexAccount.credentials?.accessToken)
+    expect(JSON.stringify(accountStatus(codexAccount))).not.toContain(codexAccount.credentials?.accessToken)
+    expect(JSON.stringify(usageStatus(codexAccount))).not.toContain(codexAccount.credentials?.accessToken)
+  })
+
+  test("upstream auth strips subrouter routing headers before forwarding", () => {
+    const headers = setUpstreamAuthHeaders(
+      new Headers({
+        "X-Subrouter-Session": "session-1",
+        "X-Subrouter-Org-ID": "org-a",
+        "X-Subrouter-Account-ID": "codex-a",
+        Authorization: "Bearer caller-token",
+      }),
+      codexAccount
+    )
+
+    expect(headers.get("X-Subrouter-Session")).toBeNull()
+    expect(headers.get("X-Subrouter-Org-ID")).toBeNull()
+    expect(headers.get("X-Subrouter-Account-ID")).toBeNull()
+    expect(headers.get("Authorization")).toBe(`Bearer ${codexAccount.credentials?.accessToken}`)
+    expect(headers.get("ChatGPT-Account-ID")).toBe("chatgpt-account")
+  })
+
+  test("openai api-key requests keep one v1 prefix", () => {
+    const account: StoredAccountContract = {
+      ...codexAccount,
+      kind: "openai_apikey",
+      credentials: {
+        apiKey: "sk-test",
+        baseUrl: "https://api.openai.com/v1",
+      },
+    }
+
+    expect(
+      upstreamURLForRequest(
+        "https://subrouter.cmux.dev/v1/responses",
+        account,
+        "https://api.openai.com/v1"
+      ).toString()
+    ).toBe("https://api.openai.com/v1/responses")
+  })
+
+  test("codex oauth refresh rotates access, refresh, and id tokens", async () => {
+    const now = 1_780_000_000_000
+    const expired = jwt(Math.floor((now - 1_000) / 1000))
+    const fresh = jwt(Math.floor((now + 600_000) / 1000))
+    expect(credentialNeedsRefresh({ accessToken: expired, refreshToken: "old-refresh" }, now)).toBe(true)
+
+    const calls: Request[] = []
+    const fetcher = async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push(new Request(input, init))
+      return new Response(
+        JSON.stringify({
+          access_token: fresh,
+          refresh_token: "new-refresh",
+          id_token: "new-id",
+        }),
+        { status: 200 }
+      )
+    }
+
+    const refreshed = await refreshOAuthCredentials(
+      "codex_oauth",
+      { accessToken: expired, refreshToken: "old-refresh" },
+      false,
+      fetcher as typeof fetch,
+      now
+    )
+
+    expect(refreshed.refreshed).toBe(true)
+    expect(refreshed.credentials.accessToken).toBe(fresh)
+    expect(refreshed.credentials.refreshToken).toBe("new-refresh")
+    expect(refreshed.credentials.idToken).toBe("new-id")
+    expect(calls[0]?.headers.get("Content-Type")).toBe("application/json")
+  })
+
+  test("claude oauth refresh sends form body and anthropic beta header", async () => {
+    const now = 1_780_000_000_000
+    const calls: Request[] = []
+    const fetcher = async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push(new Request(input, init))
+      return new Response(
+        JSON.stringify({
+          access_token: "new-claude-access",
+          refresh_token: "new-claude-refresh",
+          expires_in: 3600,
+        }),
+        { status: 200 }
+      )
+    }
+
+    const refreshed = await refreshOAuthCredentials(
+      "anthropic_oauth",
+      {
+        accessToken: "old-claude-access",
+        refreshToken: "old-claude-refresh",
+        expiresAt: now - 1,
+      },
+      false,
+      fetcher as typeof fetch,
+      now
+    )
+
+    const body = await calls[0]!.text()
+    expect(calls[0]?.headers.get("anthropic-beta")).toBe("oauth-2025-04-20")
+    expect(body).toContain("grant_type=refresh_token")
+    expect(body).toContain("refresh_token=old-claude-refresh")
+    expect(refreshed.credentials.accessToken).toBe("new-claude-access")
+    expect(refreshed.credentials.refreshToken).toBe("new-claude-refresh")
+    expect(refreshed.credentials.expiresAt).toBe(now + 3_600_000)
+  })
+
+  test("codex usage fetch parses base and model-family windows", async () => {
+    const calls: Request[] = []
+    const fetcher = async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push(new Request(input, init))
+      return new Response(
+        JSON.stringify({
+          plan_type: "plus",
+          rate_limit: {
+            primary_window: {
+              used_percent: 25,
+              limit_window_seconds: 18000,
+              reset_after_seconds: 120,
+            },
+          },
+          credits: { has_credits: true, unlimited: false, balance: "1.23" },
+          additional_rate_limits: [
+            {
+              limit_name: "GPT-5.3-Codex-Spark",
+              rate_limit: {
+                secondary_window: {
+                  used_percent: 90,
+                  limit_window_seconds: 604800,
+                  reset_after_seconds: 3600,
+                },
+              },
+            },
+          ],
+        }),
+        { status: 200 }
+      )
+    }
+
+    const usage = await fetchProviderUsage(
+      "codex_oauth",
+      { accessToken: "codex-access", accountId: "chatgpt-account", usageUrl: "https://usage.example" },
+      fetcher as typeof fetch
+    )
+
+    expect(calls[0]?.headers.get("Authorization")).toBe("Bearer codex-access")
+    expect(calls[0]?.headers.get("ChatGPT-Account-ID")).toBe("chatgpt-account")
+    expect(usage.plan_type).toBe("plus")
+    expect(usage.credits?.balance).toBe("1.23")
+    expect(usage.windows?.map((window) => window.name)).toEqual([
+      "primary",
+      "GPT-5.3-Codex-Spark/secondary",
+    ])
+    expect(usage.windows?.[1]?.feature).toBe("GPT-5.3-Codex-Spark")
+  })
+
+  test("claude usage fetch maps oauth usage windows", async () => {
+    const calls: Request[] = []
+    const fetcher = async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push(new Request(input, init))
+      return new Response(
+        JSON.stringify({
+          five_hour: { utilization: 12, resets_at: "2026-06-02T13:00:00.000Z" },
+          seven_day_opus: { utilization: 34, resets_at: "2026-06-03T13:00:00.000Z" },
+          seven_day_sonnet: { utilization: 56, resets_at: "2026-06-04T13:00:00.000Z" },
+        }),
+        { status: 200 }
+      )
+    }
+
+    const usage = await fetchProviderUsage(
+      "anthropic_oauth",
+      { accessToken: "claude-access", usageUrl: "https://usage.example" },
+      fetcher as typeof fetch
+    )
+
+    expect(calls[0]?.headers.get("Authorization")).toBe("Bearer claude-access")
+    expect(calls[0]?.headers.get("anthropic-beta")).toBe("oauth-2025-04-20")
+    expect(usage.plan_type).toBe("claude")
+    expect(usage.windows?.map((window) => window.name)).toEqual([
+      "5h",
+      "opus-weekly",
+      "sonnet-weekly",
+    ])
+  })
+})

--- a/cloudflare/packages/worker/test/worker-transcripts.test.ts
+++ b/cloudflare/packages/worker/test/worker-transcripts.test.ts
@@ -1,0 +1,505 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const adminToken = "admin-test-token"
+const proxyToken = "proxy-test-token"
+
+const processes: Bun.Subprocess[] = []
+const servers: Array<{ stop: () => void }> = []
+
+afterEach(async () => {
+  for (const proc of processes.splice(0)) {
+    proc.kill()
+    await proc.exited.catch(() => {})
+  }
+  for (const server of servers.splice(0)) server.stop()
+})
+
+describe("subrouter Durable Object Worker transcripts", () => {
+  test("refreshes near-expiry OAuth credentials from a Durable Object alarm", async () => {
+    let refreshCalls = 0
+    const authServer = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        if (new URL(request.url).pathname !== "/oauth/token") {
+          return new Response("Not Found", { status: 404 })
+        }
+        refreshCalls += 1
+        const body = await request.json() as Record<string, unknown>
+        expect(body.grant_type).toBe("refresh_token")
+        expect(body.refresh_token).toBe("old-refresh-token")
+        return Response.json({
+          access_token: "alarm-refreshed-access-token",
+          refresh_token: "alarm-refreshed-refresh-token",
+          id_token: "alarm-refreshed-id-token",
+        })
+      },
+    })
+    servers.push(authServer)
+
+    let upstreamAuth: string | null = null
+    const upstream = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        upstreamAuth = request.headers.get("Authorization")
+        return Response.json({ ok: true })
+      },
+    })
+    servers.push(upstream)
+
+    const baseURL = await startWorker(`${upstream.url.origin}/backend-api/codex`)
+    await upsertAccount(baseURL, {
+      id: "acct-refresh",
+      orgId: "org-refresh",
+      kind: "codex_oauth",
+      label: "refresh@example.com",
+      credentials: {
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        idToken: "old-id-token",
+        expiresAt: Date.now() + 2_500,
+        tokenEndpoint: `${authServer.url.origin}/oauth/token`,
+      },
+    })
+
+    await waitForCondition(() => refreshCalls >= 1, "Durable Object alarm refresh")
+    expect(refreshCalls).toBe(1)
+
+    const proxied = await fetch(`${baseURL}/v1/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${proxyToken}`,
+        "Content-Type": "application/json",
+        "X-Subrouter-Org-ID": "org-refresh",
+        "X-Subrouter-Session": "refresh-session",
+      },
+      body: "{}",
+    })
+    expect(proxied.status).toBe(200)
+    expect(upstreamAuth as string | null).toBe("Bearer alarm-refreshed-access-token")
+    expect(refreshCalls).toBe(1)
+  }, 60_000)
+
+  test("keeps admin state, routing, sessions, and lifecycle scoped per org", async () => {
+    const baseURL = await startWorker("https://codex.invalid/backend-api/codex")
+    await upsertAccount(baseURL, {
+      id: "acct-a",
+      orgId: "org-a",
+      kind: "openai_apikey",
+      label: "org-a@example.com",
+      credentials: { apiKey: "sk-org-a" },
+    })
+    await upsertAccount(baseURL, {
+      id: "acct-b",
+      orgId: "org-b",
+      kind: "openai_apikey",
+      label: "org-b@example.com",
+      credentials: { apiKey: "sk-org-b" },
+    })
+
+    const unauthorizedProxy = await fetch(`${baseURL}/v1/responses`, {
+      method: "POST",
+      body: "{}",
+    })
+    expect(unauthorizedProxy.status).toBe(401)
+
+    const orgAAccounts = await adminJSON<Array<Record<string, any>>>(
+      baseURL,
+      "/_subrouter/accounts?orgId=org-a"
+    )
+    const orgBAccounts = await adminJSON<Array<Record<string, any>>>(
+      baseURL,
+      "/_subrouter/accounts?orgId=org-b"
+    )
+    expect(orgAAccounts.map((account) => account.id)).toEqual(["acct-a"])
+    expect(orgBAccounts.map((account) => account.id)).toEqual(["acct-b"])
+    expect(JSON.stringify(orgAAccounts)).not.toContain("sk-org-a")
+
+    const orgAStatus = await adminJSON<Array<Record<string, any>>>(
+      baseURL,
+      "/_subrouter/account-status?orgId=org-a"
+    )
+    expect(orgAStatus.map((account) => account.id)).toEqual(["acct-a"])
+
+    const orgAUsage = await adminJSON<Array<Record<string, any>>>(
+      baseURL,
+      "/_subrouter/usage-status?orgId=org-a"
+    )
+    expect(orgAUsage.map((account) => account.id)).toEqual(["acct-a"])
+    expect(orgAUsage[0]?.plan_type).toBe("api key")
+
+    const routeA = await fetch(`${baseURL}/route`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ orgId: "org-a", sessionId: "shared-session", model: "gpt-5" }),
+    })
+    expect(routeA.status).toBe(200)
+    const routeABody = (await routeA.json()) as Record<string, any>
+    expect(routeABody.account.id).toBe("acct-a")
+
+    const routeB = await fetch(`${baseURL}/route`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ orgId: "org-b", sessionId: "shared-session", model: "gpt-5" }),
+    })
+    expect(routeB.status).toBe(200)
+    const routeBBody = (await routeB.json()) as Record<string, any>
+    expect(routeBBody.account.id).toBe("acct-b")
+
+    const crossOrgUsage = await fetch(`${baseURL}/usage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ orgId: "org-a", sessionId: "shared-session", accountId: "acct-b" }),
+    })
+    expect(crossOrgUsage.status).toBe(400)
+
+    const sessionsA = await adminJSON<Array<Record<string, any>>>(
+      baseURL,
+      "/_subrouter/sessions?orgId=org-a"
+    )
+    const sessionsB = await adminJSON<Array<Record<string, any>>>(
+      baseURL,
+      "/_subrouter/sessions?orgId=org-b"
+    )
+    expect(sessionsA).toHaveLength(1)
+    expect(sessionsA[0]?.account_id).toBe("acct-a")
+    expect(sessionsB).toHaveLength(1)
+    expect(sessionsB[0]?.account_id).toBe("acct-b")
+
+    expect((await fetch(`${baseURL}/_subrouter/ready?orgId=org-a`)).status).toBe(200)
+    const drainA = await fetch(`${baseURL}/_subrouter/drain?orgId=org-a`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${adminToken}` },
+    })
+    expect(drainA.status).toBe(200)
+    expect((await fetch(`${baseURL}/_subrouter/ready?orgId=org-a`)).status).toBe(503)
+    expect((await fetch(`${baseURL}/_subrouter/ready?orgId=org-b`)).status).toBe(200)
+  }, 60_000)
+
+  test("records scoped HTTP transcripts with sanitized and raw endpoints", async () => {
+    const upstreamRequests: Array<{ path: string; auth: string | null; body: string }> = []
+    const upstream = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url)
+        upstreamRequests.push({
+          path: url.pathname,
+          auth: request.headers.get("Authorization"),
+          body: await request.text(),
+        })
+        return Response.json({
+          response: {
+            model: "gpt-5.5",
+            usage: {
+              input_tokens: 100,
+              output_tokens: 7,
+              total_tokens: 107,
+            },
+          },
+        })
+      },
+    })
+    servers.push(upstream)
+
+    const baseURL = await startWorker(`${upstream.url.origin}/backend-api/codex`)
+
+    await upsertCodexAccount(baseURL, "org-a", "acct-a")
+
+    const proxied = await fetch(`${baseURL}/v1/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${proxyToken}`,
+        "Content-Type": "application/json",
+        "X-Subrouter-Org-ID": "org-a",
+        "X-Subrouter-Session": "session-1:turn-0",
+        "X-Subrouter-User-Email": "symphony@manaflow.ai",
+      },
+      body: JSON.stringify({ model: "gpt-5.5", input: "secret body" }),
+    })
+    expect(proxied.status).toBe(200)
+    expect(upstreamRequests).toHaveLength(1)
+    expect(upstreamRequests[0]?.path).toBe("/backend-api/codex/responses")
+    expect(upstreamRequests[0]?.auth).toBe("Bearer codex-access-token")
+
+    const list = await fetch(`${baseURL}/_subrouter/transcripts?orgId=org-a`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    })
+    expect(list.status).toBe(200)
+    const summaries = (await list.json()) as Array<Record<string, any>>
+    expect(summaries).toHaveLength(1)
+    expect(summaries[0]?.agent_type).toBe("codex")
+    expect(summaries[0]?.session_id).toBe("session-1")
+    expect(summaries[0]?.event_count).toBe(3)
+    expect(summaries[0]?.has_bodies).toBe(true)
+    expect(summaries[0]?.usage.total_tokens).toBe(107)
+    expect(summaries[0]?.user).toBe("symphony@manaflow.ai")
+    expect(summaries[0]?.account).toBe("acct-a")
+
+    const otherOrgList = await fetch(`${baseURL}/_subrouter/transcripts?orgId=org-b`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    })
+    expect((await otherOrgList.json()) as unknown[]).toEqual([])
+
+    const detail = await fetch(
+      `${baseURL}/_subrouter/transcripts/codex/session-1?orgId=org-a`,
+      { headers: { Authorization: `Bearer ${adminToken}` } }
+    )
+    const detailText = await detail.text()
+    expect(detail.status).toBe(200)
+    expect(detailText).not.toContain("body_base64\"")
+    expect(detailText).not.toContain(proxyToken)
+    expect(detailText).not.toContain("codex-access-token")
+    expect(detailText).toContain("body_base64_redacted")
+    expect(detailText).toContain("<redacted>")
+
+    const raw = await fetch(
+      `${baseURL}/_subrouter/transcripts/codex/session-1/raw?orgId=org-a`,
+      { headers: { Authorization: `Bearer ${adminToken}` } }
+    )
+    const rawText = await raw.text()
+    expect(raw.status).toBe(200)
+    expect(rawText).toContain("secret body")
+    expect(rawText).toContain("gpt-5.5")
+
+    const dashboard = await fetch(`${baseURL}/_subrouter/dashboard?orgId=org-a`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    })
+    const dashboardText = await dashboard.text()
+    expect(dashboard.status).toBe(200)
+    expect(dashboardText).toContain("session-1")
+    expect(dashboardText).toContain("Total Tokens")
+    expect(dashboardText).toContain("Model Calls")
+    expect(dashboardText).toContain("Tokens Over Time")
+    expect(dashboardText).toContain("Models")
+    expect(dashboardText).toContain("Users")
+    expect(dashboardText).toContain("Accounts")
+    expect(dashboardText).toContain("107")
+    expect(dashboardText).toContain("gpt-5.5")
+    expect(dashboardText).toContain("symphony@manaflow.ai")
+    expect(dashboardText).toContain("acct-a")
+  }, 60_000)
+
+  test("records proxied WebSocket messages in both directions", async () => {
+    let upstreamAuth: string | null = null
+    const upstream = Bun.serve({
+      port: 0,
+      fetch(request, server) {
+        upstreamAuth = request.headers.get("Authorization")
+        if (server.upgrade(request)) return undefined
+        return new Response("Expected WebSocket", { status: 426 })
+      },
+      websocket: {
+        message(socket, message) {
+          socket.send(
+            JSON.stringify({
+              response: {
+                model: "gpt-5.5",
+                usage: {
+                  input_tokens: 8,
+                  output_tokens: 3,
+                  total_tokens: 11,
+                },
+              },
+              echoed: String(message),
+            })
+          )
+        },
+      },
+    })
+    servers.push(upstream)
+
+    const baseURL = await startWorker(`${upstream.url.origin}/backend-api/codex`)
+    await upsertCodexAccount(baseURL, "org-ws", "acct-ws")
+
+    const wsURL = baseURL.replace("http://", "ws://") + "/v1/responses"
+    const socket = new WebSocket(wsURL, {
+      headers: {
+        Authorization: `Bearer ${proxyToken}`,
+        "X-Subrouter-Org-ID": "org-ws",
+        "X-Subrouter-Session": "ws-session:turn-0",
+        "X-Subrouter-User-Email": "symphony@manaflow.ai",
+      },
+    } as unknown as string[])
+    await waitForWebSocket(socket, "open")
+    socket.send("ws-secret")
+    const reply = await waitForWebSocket(socket, "message")
+    socket.close()
+
+    expect(String(reply.data)).toContain("ws-secret")
+    expect(upstreamAuth as string | null).toBe("Bearer codex-access-token")
+
+    const summaries = await waitForTranscriptEvents(baseURL, "org-ws", 3)
+    expect(summaries).toHaveLength(1)
+    expect(summaries[0]?.session_id).toBe("ws-session")
+    expect(summaries[0]?.event_count).toBe(3)
+    expect(summaries[0]?.usage.total_tokens).toBe(11)
+
+    const detail = await fetch(
+      `${baseURL}/_subrouter/transcripts/codex/ws-session?orgId=org-ws`,
+      { headers: { Authorization: `Bearer ${adminToken}` } }
+    )
+    const detailText = await detail.text()
+    expect(detail.status).toBe(200)
+    expect(detailText).not.toContain("body_base64\"")
+    expect(detailText).toContain("websocket_message")
+    expect(detailText).toContain("body_base64_redacted")
+
+    const raw = await fetch(
+      `${baseURL}/_subrouter/transcripts/codex/ws-session/raw?orgId=org-ws`,
+      { headers: { Authorization: `Bearer ${adminToken}` } }
+    )
+    const rawText = await raw.text()
+    expect(raw.status).toBe(200)
+    expect(rawText).toContain("ws-secret")
+    expect(rawText).toContain("gpt-5.5")
+  }, 60_000)
+})
+
+const startWorker = async (codexUpstream: string): Promise<string> => {
+  const workerPort = 18_000 + Math.floor(Math.random() * 1_000)
+  const persistDir = await mkdtemp(join(tmpdir(), "subrouter-do-worker-test-"))
+  const worker = Bun.spawn(
+    [
+      "bunx",
+      "wrangler",
+      "dev",
+      "--local",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      String(workerPort),
+      "--persist-to",
+      persistDir,
+      "--var",
+      `ADMIN_TOKEN:${adminToken}`,
+      "--var",
+      `PROXY_TOKEN:${proxyToken}`,
+      "--var",
+      `CODEX_UPSTREAM:${codexUpstream}`,
+      "--log-level",
+      "error",
+    ],
+    {
+      cwd: import.meta.dir.replace(/\/test$/, ""),
+      stdout: "pipe",
+      stderr: "pipe",
+    }
+  )
+  processes.push(worker)
+  const baseURL = `http://127.0.0.1:${workerPort}`
+  await waitForWorker(baseURL)
+  return baseURL
+}
+
+const upsertCodexAccount = async (
+  baseURL: string,
+  orgId: string,
+  accountId: string
+): Promise<void> => {
+  await upsertAccount(baseURL, {
+    id: accountId,
+    orgId,
+    kind: "codex_oauth",
+    label: "lawrence@manaflow.ai",
+    credentials: {
+      accessToken: "codex-access-token",
+    },
+  })
+}
+
+const upsertAccount = async (
+  baseURL: string,
+  input: {
+    readonly id: string
+    readonly orgId: string
+    readonly kind: string
+    readonly label: string
+    readonly credentials: Record<string, unknown>
+  }
+): Promise<void> => {
+  const upsert = await fetch(`${baseURL}/admin/accounts`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(input),
+  })
+  expect(upsert.status).toBe(200)
+}
+
+const adminJSON = async <T>(baseURL: string, path: string): Promise<T> => {
+  const response = await fetch(`${baseURL}${path}`, {
+    headers: { Authorization: `Bearer ${adminToken}` },
+  })
+  expect(response.status).toBe(200)
+  return (await response.json()) as T
+}
+
+const waitForTranscriptEvents = async (
+  baseURL: string,
+  orgId: string,
+  eventCount: number
+): Promise<Array<Record<string, any>>> => {
+  const deadline = Date.now() + 10_000
+  let summaries: Array<Record<string, any>> = []
+  while (Date.now() < deadline) {
+    const list = await fetch(`${baseURL}/_subrouter/transcripts?orgId=${orgId}`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    })
+    summaries = (await list.json()) as Array<Record<string, any>>
+    if ((summaries[0]?.event_count ?? 0) >= eventCount) return summaries
+    await Bun.sleep(100)
+  }
+  return summaries
+}
+
+const waitForWebSocket = <Type extends "open" | "message">(
+  socket: WebSocket,
+  type: Type
+): Promise<Type extends "message" ? MessageEvent : Event> =>
+  new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`websocket ${type} timed out`)), 10_000)
+    socket.addEventListener(
+      type,
+      (event) => {
+        clearTimeout(timeout)
+        resolve(event as Type extends "message" ? MessageEvent : Event)
+      },
+      { once: true }
+    )
+    socket.addEventListener("error", () => {
+      clearTimeout(timeout)
+      reject(new Error(`websocket ${type} failed`))
+    }, { once: true })
+  })
+
+const waitForCondition = async (
+  condition: () => boolean,
+  label: string
+): Promise<void> => {
+  const deadline = Date.now() + 10_000
+  while (Date.now() < deadline) {
+    if (condition()) return
+    await Bun.sleep(100)
+  }
+  throw new Error(`${label} timed out`)
+}
+
+const waitForWorker = async (baseURL: string): Promise<void> => {
+  const deadline = Date.now() + 20_000
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseURL}/healthz`)
+      if (response.ok) return
+      lastError = new Error(`healthz returned ${response.status}`)
+    } catch (error) {
+      lastError = error
+    }
+    await Bun.sleep(250)
+  }
+  throw lastError ?? new Error("worker did not start")
+}

--- a/cloudflare/packages/worker/tsconfig.json
+++ b/cloudflare/packages/worker/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": [
+      "bun",
+      "node",
+      "@cloudflare/workers-types"
+    ]
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/cloudflare/packages/worker/wrangler.json
+++ b/cloudflare/packages/worker/wrangler.json
@@ -1,0 +1,106 @@
+{
+  "name": "regatta-subrouter-do",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-05-30",
+  "compatibility_flags": [
+    "nodejs_compat"
+  ],
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": [
+        "SubrouterDurableObject"
+      ]
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "SUBROUTER_DO",
+        "class_name": "SubrouterDurableObject"
+      }
+    ]
+  },
+  "secrets": {
+    "required": [
+      "ADMIN_TOKEN"
+    ]
+  },
+  "vars": {
+    "CODEX_UPSTREAM": "https://chatgpt.com/backend-api/codex",
+    "API_UPSTREAM": "https://api.openai.com/v1",
+    "CLAUDE_UPSTREAM": "https://api.anthropic.com"
+  },
+  "env": {
+    "staging": {
+      "name": "regatta-subrouter-do-staging",
+      "routes": [
+        {
+          "pattern": "subrouter-staging.cmux.dev",
+          "custom_domain": true
+        }
+      ],
+      "secrets": {
+        "required": [
+          "ADMIN_TOKEN"
+        ]
+      },
+      "vars": {
+        "CODEX_UPSTREAM": "https://chatgpt.com/backend-api/codex",
+        "API_UPSTREAM": "https://api.openai.com/v1",
+        "CLAUDE_UPSTREAM": "https://api.anthropic.com"
+      },
+      "migrations": [
+        {
+          "tag": "v1",
+          "new_sqlite_classes": [
+            "SubrouterDurableObject"
+          ]
+        }
+      ],
+      "durable_objects": {
+        "bindings": [
+          {
+            "name": "SUBROUTER_DO",
+            "class_name": "SubrouterDurableObject"
+          }
+        ]
+      }
+    },
+    "production": {
+      "name": "regatta-subrouter-do-production",
+      "routes": [
+        {
+          "pattern": "subrouter.cmux.dev",
+          "custom_domain": true
+        }
+      ],
+      "secrets": {
+        "required": [
+          "ADMIN_TOKEN"
+        ]
+      },
+      "vars": {
+        "CODEX_UPSTREAM": "https://chatgpt.com/backend-api/codex",
+        "API_UPSTREAM": "https://api.openai.com/v1",
+        "CLAUDE_UPSTREAM": "https://api.anthropic.com"
+      },
+      "migrations": [
+        {
+          "tag": "v1",
+          "new_sqlite_classes": [
+            "SubrouterDurableObject"
+          ]
+        }
+      ],
+      "durable_objects": {
+        "bindings": [
+          {
+            "name": "SUBROUTER_DO",
+            "class_name": "SubrouterDurableObject"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/cloudflare/tsconfig.base.json
+++ b/cloudflare/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "types": [
+      "bun",
+      "node"
+    ],
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- add an isolated `cloudflare/` Bun workspace with an Effect-based subrouter core and Cloudflare Durable Object worker
- port Go-compatible routing/admin/session/transcript/proxy endpoints into the worker
- add Cloudflare CI/CD workflow with verify, staging deploy on main, and manual production deploy

## Deploy evidence
- staging deployed: `regatta-subrouter-do-staging` version `d7812871-226d-46e2-a55f-566b2fac2bdf`
- production deployed: `regatta-subrouter-do-production` version `983335bb-bfe0-4a7b-96c4-123313d82e6c`
- `https://subrouter.cmux.dev/healthz` returns `{"ok":true,"service":"subrouter-do"}`

## Verification
- `cd cloudflare && bun install --frozen-lockfile`
- `cd cloudflare && bun run typecheck`
- `cd cloudflare && bun run test`
- `cd cloudflare/packages/worker && bunx wrangler deploy --env staging --dry-run --outdir dist-dry-run`
- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `actionlint .github/workflows/cloudflare-do.yml`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785663034&installation_id=133855650&pr_number=50&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F50&signature=127f95768539b381998efd5f0c71c84ac13b8577896f969761571e2dbaca2ffa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Cloudflare Durable Object-based subrouter with sticky session routing and Go-compatible admin/proxy endpoints. Includes a new `cloudflare/` workspace and CI/CD for verify, staging on `main`, and manual production deploys.

- **New Features**
  - Cloudflare Durable Object subrouter with per-org state and sticky routing.
  - Go-compatible `/_subrouter/*` admin, session, transcript, and proxy endpoints; proxies Codex/OpenAI/Claude.
  - New `cloudflare/` workspace with `@subrouter/core` (Effect-based routing) and `@subrouter/cloudflare-worker`; CI/CD for verify + staged/prod deploys.

- **Migration**
  - Add Cloudflare secrets per env: `ADMIN_TOKEN` and `PROXY_TOKEN`.
  - Deploy via the workflow or `@subrouter/cloudflare-worker` scripts (`deploy:staging` / `deploy:production`).
  - Update callers to the new subrouter URLs; verify with `/healthz`.

<sup>Written for commit 324c515bd46934b7e9f44ecc9d2d18e0963c552f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

