### PR TITLE
Tighten Cloudflare deployment workflow

### DIFF
--- a/.github/workflows/cloudflare-do.yml
+++ b/.github/workflows/cloudflare-do.yml
@@ -80,13 +80,62 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: bunx wrangler deploy --env staging --keep-vars
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "::error title=Missing CLOUDFLARE_API_TOKEN::Set a long-lived Cloudflare API token in the subrouter repository or subrouter-staging environment secrets."
+            exit 1
+          fi
+          if [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "::error title=Missing CLOUDFLARE_ACCOUNT_ID::Set the Cloudflare account ID in the subrouter repository or subrouter-staging environment secrets."
+            exit 1
+          fi
+          bunx wrangler deploy --env staging --keep-vars
 
       - name: Smoke health
         run: curl -fsS https://subrouter-staging.cmux.dev/healthz
 
   deploy-production:
     name: Deploy production
+    needs:
+      - verify
+      - deploy-staging
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment:
+      name: subrouter-production
+      url: https://subrouter.cmux.dev/healthz
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install
+        working-directory: cloudflare
+        run: bun install --frozen-lockfile
+
+      - name: Deploy
+        working-directory: cloudflare/packages/worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "::error title=Missing CLOUDFLARE_API_TOKEN::Set a long-lived Cloudflare API token in the subrouter repository or subrouter-production environment secrets."
+            exit 1
+          fi
+          if [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "::error title=Missing CLOUDFLARE_ACCOUNT_ID::Set the Cloudflare account ID in the subrouter repository or subrouter-production environment secrets."
+            exit 1
+          fi
+          bunx wrangler deploy --env production --keep-vars
+
+      - name: Smoke health
+        run: curl -fsS https://subrouter.cmux.dev/healthz
+
+  deploy-production-manual:
+    name: Deploy production manual
     needs: verify
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && inputs.deploy_environment == 'production'
@@ -109,7 +158,16 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: bunx wrangler deploy --env production --keep-vars
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "::error title=Missing CLOUDFLARE_API_TOKEN::Set a long-lived Cloudflare API token in the subrouter repository or subrouter-production environment secrets."
+            exit 1
+          fi
+          if [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "::error title=Missing CLOUDFLARE_ACCOUNT_ID::Set the Cloudflare account ID in the subrouter repository or subrouter-production environment secrets."
+            exit 1
+          fi
+          bunx wrangler deploy --env production --keep-vars
 
       - name: Smoke health
         run: curl -fsS https://subrouter.cmux.dev/healthz

--- a/cloudflare/packages/worker/README.md
+++ b/cloudflare/packages/worker/README.md
@@ -23,6 +23,19 @@ bun run deploy:staging
 bun run deploy:production
 ```
 
+GitHub Actions runs `Cloudflare Durable Object` for changes under
+`cloudflare/**`. Pull requests run install, typecheck, tests, and a Wrangler
+dry-run bundle validation. Pushes to `main` deploy staging first, smoke
+`https://subrouter-staging.cmux.dev/healthz`, then deploy production and smoke
+`https://subrouter.cmux.dev/healthz`.
+
+Required Actions secrets:
+
+- `CLOUDFLARE_ACCOUNT_ID` - Cloudflare account ID for Wrangler.
+- `CLOUDFLARE_API_TOKEN` - long-lived Cloudflare API token with Workers deploy
+  permissions for both `regatta-subrouter-do-staging` and
+  `regatta-subrouter-do-production`.
+
 ## Secrets
 
 `ADMIN_TOKEN` gates the `/admin/*`, `/_subrouter/*`, and `/websocket-status`


### PR DESCRIPTION
Summary
- deploy production automatically after staging succeeds on main pushes
- keep manual production deployment available
- add explicit credential preflight errors and document required Actions secrets

Testing
- actionlint .github/workflows/cloudflare-do.yml
- cd cloudflare && bun install --frozen-lockfile && bun run typecheck && bun run test

Deployment note
- staging and production are already manually deployed from main commit 52452c3e28e957ea379637fa137c73486f3702b3
- CI deploy still requires adding CLOUDFLARE_API_TOKEN to manaflow-ai/subrouter

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785667115&installation_id=133855650&pr_number=51&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F51&signature=0b818714a59f067f6288ec2e9bc8a40b9127b292e44465d189b5b1254c327f8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates production deploys after staging succeeds on main, adds smoke checks, and surfaces clear preflight errors for missing Cloudflare credentials. Keeps the manual production deploy option and documents required GitHub Actions secrets.

- **New Features**
  - Auto-deploys production on main after verify + staging pass; both stages run health checks.
  - Adds preflight errors for missing `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` (staging and production).
  - Keeps manual production deploy via `workflow_dispatch`; README explains CI flow and required secrets.

- **Migration**
  - Add `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` to repo or environment secrets for staging and production. The token must have Workers deploy perms for both environments.

<sup>Written for commit ac1e53af7d7fd39087de61b3cf6d7b615b863524. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

