### PR TITLE
Multi-tenant Cloudflare subrouter with tenant registry and account upload API

### DIFF
--- a/cloudflare/packages/worker/README.md
+++ b/cloudflare/packages/worker/README.md
@@ -147,8 +147,11 @@ curl -sS "https://subrouter.cmux.dev/_subrouter/transcripts?tenant=acme" \
   -H "Authorization: Bearer $ADMIN_TOKEN"
 ```
 
-`GET /_subrouter/health` and `GET /_subrouter/ready` are unauthenticated and do
-not return tenant data.
+`GET /_subrouter/health` and bare `GET /_subrouter/ready` are
+unauthenticated and do not return tenant data. `GET /_subrouter/ready?tenant=<id>`
+is also unauthenticated and returns only `{ ok, draining }` for load-balancer
+and rollout probes; malformed tenant ids return `400`, while well-formed unknown
+ids return ready because no tenant state exists yet.
 
 ## cmux CLI Call Sequence
 
@@ -199,7 +202,8 @@ bun run dev
 
 - `GET /healthz`
 - `GET /_subrouter/health`
-- `GET /_subrouter/ready`
+- `GET /_subrouter/ready` - service-level readiness, no tenant data.
+- `GET /_subrouter/ready?tenant=` - tenant drain readiness, returns 503 when draining; malformed tenant ids return 400.
 - `POST /admin/tenants`, `GET /admin/tenants`
 - `POST /admin/tenants/:id/rotate`, `POST /admin/tenants/:id/revoke`
 - `POST /tenant/accounts`, `GET /tenant/accounts`, `DELETE /tenant/accounts/:id`

--- a/cloudflare/packages/worker/README.md
+++ b/cloudflare/packages/worker/README.md
@@ -1,9 +1,9 @@
 # @subrouter/cloudflare-worker
 
-Cloudflare **Durable Objects** subrouter: a per-org subrouter service with
-sticky session affinity, per-model-family quota pools, Go-compatible
-`/_subrouter/*` admin endpoints, and upstream proxying for Codex/OpenAI and
-Claude/Anthropic accounts.
+Cloudflare **Durable Objects** subrouter: a multi-tenant routing service with
+hashed tenant keys, per-tenant Durable Object state, sticky session affinity,
+OAuth refresh alarms, Go-compatible `/_subrouter/*` admin endpoints, and
+upstream proxying for Codex/OpenAI and Claude/Anthropic accounts.
 
 ## Environments
 
@@ -13,8 +13,152 @@ Claude/Anthropic accounts.
 | staging    | `regatta-subrouter-do-staging`    | https://subrouter-staging.cmux.dev   |
 | production | `regatta-subrouter-do-production` | https://subrouter.cmux.dev           |
 
-Each env is a distinct Worker with its own Durable Object namespace (isolated
-SQLite state), its own admin/proxy tokens, and its own Durable Object alarms.
+Each env is a distinct Worker with its own Durable Object namespaces and
+SQLite state. Registry tenants store tenant-scoped accounts, sticky sessions,
+usage, transcripts, quotas, lifecycle, and alarms under
+`SUBROUTER_DO.getByName("tenant:" + <tenant id>)`; historical bare names such
+as `legacy` and `demo-org` remain reserved for compatibility state.
+`TENANT_REGISTRY_DO.getByName("registry")` stores only tenant metadata and
+SHA-256 hashes of tenant keys.
+
+## Auth Model
+
+`ADMIN_TOKEN` gates `/admin/*`, `/_subrouter/*`, and `/websocket-status`.
+
+Data-plane requests require a tenant key in either:
+
+```sh
+Authorization: Bearer srt_<32 lowercase hex chars>
+X-Subrouter-Tenant-Key: srt_<32 lowercase hex chars>
+```
+
+Tenant keys are returned only when created or rotated. The registry stores
+`sha256(key)` hex, never the plaintext key. Revoked keys return `403`; missing,
+malformed, unknown, and rotated-away keys return `401`.
+
+Legacy shared-token access is disabled by default. To temporarily allow the old
+`PROXY_TOKEN` path, set `ALLOW_LEGACY_PROXY_TOKEN=1` and `PROXY_TOKEN`; those
+requests route only to tenant id `legacy`.
+
+## Tenant Lifecycle
+
+Create a tenant:
+
+```sh
+curl -sS https://subrouter.cmux.dev/admin/tenants \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Acme"}'
+```
+
+Response:
+
+```json
+{"id":"acme","name":"Acme","key":"srt_0123456789abcdef0123456789abcdef","created_at":1783123200000,"revoked_at":null}
+```
+
+List tenants, without keys or hashes:
+
+```sh
+curl -sS https://subrouter.cmux.dev/admin/tenants \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+Rotate a tenant key:
+
+```sh
+curl -sS -X POST https://subrouter.cmux.dev/admin/tenants/acme/rotate \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+Revoke a tenant:
+
+```sh
+curl -sS -X POST https://subrouter.cmux.dev/admin/tenants/acme/revoke \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+## Account Upload API
+
+Upload Claude OAuth credentials:
+
+```sh
+curl -sS https://subrouter.cmux.dev/tenant/accounts \
+  -H "Authorization: Bearer $TENANT_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"provider":"claude","label":"alice@example.com","claudeAiOauth":{"accessToken":"...","refreshToken":"...","expiresAt":1735689600000,"subscriptionType":"max","rateLimitTier":"..."}}'
+```
+
+Upload an Anthropic API key:
+
+```sh
+curl -sS https://subrouter.cmux.dev/tenant/accounts \
+  -H "Authorization: Bearer $TENANT_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"provider":"anthropic-apikey","label":"anthropic prod","apiKey":"sk-ant-..."}'
+```
+
+Upload Codex OAuth tokens:
+
+```sh
+curl -sS https://subrouter.cmux.dev/tenant/accounts \
+  -H "Authorization: Bearer $TENANT_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"provider":"codex","label":"codex@example.com","tokens":{"accessToken":"...","refreshToken":"...","idToken":"...","accountID":"..."}}'
+```
+
+Upload an OpenAI API key:
+
+```sh
+curl -sS https://subrouter.cmux.dev/tenant/accounts \
+  -H "Authorization: Bearer $TENANT_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"provider":"openai-apikey","label":"openai prod","apiKey":"sk-..."}'
+```
+
+Responses are sanitized:
+
+```json
+{"id":"claude-...","provider":"claude","label":"alice@example.com","auth_mode":"oauth","created_at":"2026-07-03T00:00:00.000Z","email":"alice@example.com"}
+```
+
+List and delete accounts:
+
+```sh
+curl -sS https://subrouter.cmux.dev/tenant/accounts \
+  -H "Authorization: Bearer $TENANT_KEY"
+
+curl -sS -X DELETE https://subrouter.cmux.dev/tenant/accounts/$ACCOUNT_ID \
+  -H "Authorization: Bearer $TENANT_KEY"
+```
+
+OAuth uploads schedule the existing Durable Object alarm refresh path. Rotated
+refresh tokens are persisted in the tenant DO.
+
+## Admin Tenant Data
+
+Tenant-scoped admin reads require an explicit `?tenant=<id>`:
+
+```sh
+curl -sS "https://subrouter.cmux.dev/_subrouter/accounts?tenant=acme" \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+
+curl -sS "https://subrouter.cmux.dev/_subrouter/transcripts?tenant=acme" \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+`GET /_subrouter/health` and `GET /_subrouter/ready` are unauthenticated and do
+not return tenant data.
+
+## cmux CLI Call Sequence
+
+The follow-up cmux integration should call:
+
+1. Admin side: `POST /admin/tenants` to create the tenant and show the key once.
+2. Tenant side: `POST /tenant/accounts` to upload Claude/Codex OAuth or API-key credentials.
+3. Tenant side: `GET /tenant/accounts` to show sanitized configured accounts.
+4. Tenant side: `DELETE /tenant/accounts/:id` to remove an account.
+5. Data plane: proxy requests with `Authorization: Bearer $TENANT_KEY`.
 
 ## Deploy
 
@@ -23,12 +167,6 @@ bun run deploy:staging
 bun run deploy:production
 ```
 
-GitHub Actions runs `Cloudflare Durable Object` for changes under
-`cloudflare/**`. Pull requests run install, typecheck, tests, and a Wrangler
-dry-run bundle validation. Pushes to `main` deploy staging first, smoke
-`https://subrouter-staging.cmux.dev/healthz`, then deploy production and smoke
-`https://subrouter.cmux.dev/healthz`.
-
 Required Actions secrets:
 
 - `CLOUDFLARE_ACCOUNT_ID` - Cloudflare account ID for Wrangler.
@@ -36,43 +174,25 @@ Required Actions secrets:
   permissions for both `regatta-subrouter-do-staging` and
   `regatta-subrouter-do-production`.
 
-## Secrets
+## Local Dev
 
-`ADMIN_TOKEN` gates the `/admin/*`, `/_subrouter/*`, and `/websocket-status`
-endpoints. `PROXY_TOKEN` gates upstream proxy requests when present; if it is
-unset, proxy requests use `ADMIN_TOKEN`. Set a separate proxy token when clients
-should not share the admin credential:
+Create `.dev.vars` (gitignored) with at least:
 
 ```sh
-bun run secret:admin:staging
-bun run secret:admin:production
-bun run secret:proxy:staging
-bun run secret:proxy:production
+ADMIN_TOKEN=<anything>
 ```
 
-## Local dev
-
-Create `.dev.vars` (gitignored) with `ADMIN_TOKEN=<anything>` and
-`PROXY_TOKEN=<anything>` then:
+Optional legacy compatibility:
 
 ```sh
-bun run dev                  # local workerd + DO SQLite on :8787
+PROXY_TOKEN=<anything>
+ALLOW_LEGACY_PROXY_TOKEN=1
 ```
 
-## OAuth refresh
-
-OAuth account credentials can include `accessToken`, `refreshToken`,
-`expiresAt`, `tokenEndpoint`, and `clientId`. The Durable Object refreshes
-expired Codex and Claude OAuth credentials on use, persists rotated refresh
-tokens atomically in SQLite, and schedules the next refresh with the Durable
-Object Alarms API. Alarms wake the object in the future; long sleeps are not
-used.
-
-## Logs
+Then run:
 
 ```sh
-bun run tail:staging         # wrangler tail --env staging
-bun run tail:production
+bun run dev
 ```
 
 ## Endpoints
@@ -80,19 +200,22 @@ bun run tail:production
 - `GET /healthz`
 - `GET /_subrouter/health`
 - `GET /_subrouter/ready`
-- `POST /_subrouter/drain`
-- `GET /_subrouter/drain-status`
-- `GET /_subrouter/accounts`
-- `GET|POST /_subrouter/account-status`
-- `GET /_subrouter/usage-status`
-- `POST /_subrouter/reload-accounts`
-- `GET /_subrouter/sessions`
-- `GET /_subrouter/dashboard`
-- `GET /_subrouter/transcripts`
-- `GET /_subrouter/transcripts/:agent/:session`
-- `GET /_subrouter/transcripts/:agent/:session/raw`
-- `POST /route` — `{ orgId, sessionId, model?, preferAccountId?, quotaKey? }` → selected account
-- `POST /usage` — `{ orgId, sessionId, accountId }`
-- `GET /status?orgId=` — DO route counters
-- `GET /ws?orgId=` — WebSocket; messages `{ type: "ping"|"route"|"usage"|"status", ... }`
-- `GET /admin/accounts`, `POST /admin/accounts`, `POST /admin/model-probe`, `GET /websocket-status` — require `Authorization: Bearer $ADMIN_TOKEN`
+- `POST /admin/tenants`, `GET /admin/tenants`
+- `POST /admin/tenants/:id/rotate`, `POST /admin/tenants/:id/revoke`
+- `POST /tenant/accounts`, `GET /tenant/accounts`, `DELETE /tenant/accounts/:id`
+- `POST /_subrouter/drain?tenant=`
+- `GET /_subrouter/drain-status?tenant=`
+- `GET /_subrouter/accounts?tenant=`
+- `GET|POST /_subrouter/account-status?tenant=`
+- `GET /_subrouter/usage-status?tenant=`
+- `POST /_subrouter/reload-accounts?tenant=`
+- `GET /_subrouter/sessions?tenant=`
+- `GET /_subrouter/dashboard?tenant=`
+- `GET /_subrouter/transcripts?tenant=`
+- `GET /_subrouter/transcripts/:agent/:session?tenant=`
+- `GET /_subrouter/transcripts/:agent/:session/raw?tenant=`
+- `POST /route` - tenant-key authed route selection.
+- `POST /usage` - tenant-key authed usage recording.
+- `GET /status` - tenant-key authed DO route counters.
+- `GET /ws` - tenant-key authed WebSocket; messages `{ type: "ping"|"route"|"usage"|"status", ... }`.
+- `GET /websocket-status?tenant=`, `GET /admin/accounts?tenant=`, `POST /admin/accounts`, `POST /admin/model-probe` - require `Authorization: Bearer $ADMIN_TOKEN`.

--- a/cloudflare/packages/worker/src/contract.ts
+++ b/cloudflare/packages/worker/src/contract.ts
@@ -117,6 +117,7 @@ const subrouterHeadersToStrip = [
   "X-Model",
   "X-Subrouter-Org-ID",
   "X-Regatta-Org-ID",
+  "X-Subrouter-Tenant-Key",
   "X-Subrouter-Proxy-Token",
 ] as const
 

--- a/cloudflare/packages/worker/src/index.ts
+++ b/cloudflare/packages/worker/src/index.ts
@@ -18,6 +18,7 @@ import {
   refreshOAuthCredentials,
   safeGoAccount,
   setUpstreamAuthHeaders,
+  stripSubrouterHeaders,
   stickySessionId,
   terminalRefreshFailure,
   upstreamURLForRequest,
@@ -27,33 +28,17 @@ import {
   type AgentType,
   type StoredAccountContract,
 } from "./contract.ts"
+import {
+  isReservedTenantId,
+  isTenantKey,
+  tenantKeySha256Hex,
+  TenantRegistryDurableObject,
+  type TenantResolution,
+} from "./tenants.ts"
+
+export { TenantRegistryDurableObject }
 
 type TotpAlgorithm = "SHA-1" | "SHA-256" | "SHA-512"
-
-const demoAccounts: ReadonlyArray<Account> = [
-  {
-    id: "demo-codex-primary",
-    orgId: "demo-org",
-    kind: "codex_oauth",
-    label: "demo primary",
-    enabled: true,
-    modelQuotas: {
-      default: { remainingPercent: 100 },
-      spark: { remainingPercent: 100 },
-    },
-  },
-  {
-    id: "demo-codex-spare",
-    orgId: "demo-org",
-    kind: "codex_oauth",
-    label: "demo spare",
-    enabled: true,
-    modelQuotas: {
-      default: { remainingPercent: 100 },
-      spark: { remainingPercent: 100 },
-    },
-  },
-]
 
 const accountKinds = new Set<AccountKind>([
   "codex_oauth",
@@ -97,6 +82,21 @@ interface UpsertAccountInput {
   readonly modelQuotas?: AccountModelQuotas
 }
 
+interface TenantAccountUploadInput {
+  readonly validate: boolean
+  readonly account: UpsertAccountInput
+}
+
+interface TenantAccountOutput {
+  readonly id: string
+  readonly provider: "codex" | "claude"
+  readonly label: string
+  readonly auth_mode: "oauth" | "apikey"
+  readonly created_at: string
+  readonly email?: string
+  readonly validation?: "ok" | "failed"
+}
+
 interface ModelProbeInput {
   readonly orgId?: string
   readonly accountId: string
@@ -110,6 +110,8 @@ interface StoredAccount extends Account {
   readonly totpDigits: number | null
   readonly totpPeriod: number | null
   readonly totpAlgorithm: TotpAlgorithm | null
+  readonly createdAt: number
+  readonly updatedAt: number
   readonly source?: string
 }
 
@@ -158,6 +160,8 @@ interface AccountRow {
   readonly totp_digits: number | null
   readonly totp_period: number | null
   readonly totp_algorithm: string | null
+  readonly created_at: number
+  readonly updated_at: number
 }
 
 interface OAuthRefreshStatus {
@@ -278,8 +282,10 @@ interface WebSocketServerMessage {
 
 export interface Env {
   readonly SUBROUTER_DO: DurableObjectNamespace<SubrouterDurableObject>
+  readonly TENANT_REGISTRY_DO: DurableObjectNamespace<TenantRegistryDurableObject>
   readonly ADMIN_TOKEN?: string
   readonly PROXY_TOKEN?: string
+  readonly ALLOW_LEGACY_PROXY_TOKEN?: string
   readonly CODEX_UPSTREAM?: string
   readonly API_UPSTREAM?: string
   readonly CLAUDE_UPSTREAM?: string
@@ -403,6 +409,161 @@ const parseUpsertAccountInput = async (
   }
 }
 
+const parseTenantAccountUploadInput = async (
+  request: Request,
+  tenantId: string
+): Promise<Response | TenantAccountUploadInput> => {
+  const record = await parseJsonRecord(request)
+  if (record instanceof Response) return record
+
+  const provider = nonEmptyString(record["provider"])
+  if (!provider) return json({ error: "Missing provider" }, { status: 400 })
+  const label = nonEmptyString(record["label"]) ?? defaultTenantAccountLabel(provider)
+  if (!label) return json({ error: "Invalid provider" }, { status: 400 })
+
+  try {
+    const input = accountInputForTenantUpload(provider, label, tenantId, record)
+    const validate = new URL(request.url).searchParams.get("validate") === "1"
+    return { validate, account: input }
+  } catch (error) {
+    return json({ error: String((error as Error).message ?? error) }, { status: 400 })
+  }
+}
+
+const accountInputForTenantUpload = (
+  provider: string,
+  label: string,
+  tenantId: string,
+  record: Record<string, unknown>
+): UpsertAccountInput => {
+  if (provider === "claude") {
+    const claudeAiOauth = requireRecord(record["claudeAiOauth"], "claudeAiOauth")
+    const accessToken = requireSecretString(claudeAiOauth["accessToken"], "claudeAiOauth.accessToken")
+    const refreshToken = requireSecretString(claudeAiOauth["refreshToken"], "claudeAiOauth.refreshToken")
+    const expiresAt = claudeAiOauth["expiresAt"]
+    if (typeof expiresAt !== "number" || !Number.isFinite(expiresAt) || expiresAt <= 0) {
+      throw new Error("Invalid claudeAiOauth.expiresAt")
+    }
+    return {
+      id: randomAccountId("claude"),
+      orgId: tenantId,
+      kind: "anthropic_oauth",
+      label,
+      credentials: {
+        accessToken,
+        refreshToken,
+        expiresAt,
+        ...optionalCredentialString(claudeAiOauth, "subscriptionType"),
+        ...optionalCredentialString(claudeAiOauth, "rateLimitTier"),
+        ...optionalCredentialString(claudeAiOauth, "tokenEndpoint"),
+        ...optionalCredentialString(claudeAiOauth, "clientId"),
+        ...optionalCredentialString(claudeAiOauth, "usageUrl"),
+      },
+    }
+  }
+
+  if (provider === "anthropic-apikey") {
+    const apiKey = requireSecretString(record["apiKey"], "apiKey")
+    if (!apiKey.startsWith("sk-ant-")) throw new Error("Invalid Anthropic API key")
+    return {
+      id: randomAccountId("anthropic"),
+      orgId: tenantId,
+      kind: "anthropic_apikey",
+      label,
+      credentials: { apiKey },
+    }
+  }
+
+  if (provider === "codex") {
+    const tokens = requireRecord(record["tokens"], "tokens")
+    const accessToken = requireSecretString(tokens["accessToken"], "tokens.accessToken")
+    const refreshToken = requireSecretString(tokens["refreshToken"], "tokens.refreshToken")
+    const idToken = requireSecretString(tokens["idToken"], "tokens.idToken")
+    const accountId = requireSecretString(tokens["accountID"], "tokens.accountID")
+    return {
+      id: randomAccountId("codex"),
+      orgId: tenantId,
+      kind: "codex_oauth",
+      label,
+      credentials: {
+        accessToken,
+        refreshToken,
+        idToken,
+        accountId,
+        ...optionalCredentialString(tokens, "tokenEndpoint"),
+        ...optionalCredentialString(tokens, "clientId"),
+        ...optionalCredentialString(tokens, "usageUrl"),
+      },
+    }
+  }
+
+  if (provider === "openai-apikey") {
+    const apiKey = requireSecretString(record["apiKey"], "apiKey")
+    if (!apiKey.startsWith("sk-")) throw new Error("Invalid OpenAI API key")
+    return {
+      id: randomAccountId("openai"),
+      orgId: tenantId,
+      kind: "openai_apikey",
+      label,
+      credentials: { apiKey },
+    }
+  }
+
+  throw new Error("Invalid provider")
+}
+
+const defaultTenantAccountLabel = (provider: string): string | null => {
+  if (provider === "claude") return "Claude OAuth"
+  if (provider === "anthropic-apikey") return "Anthropic API key"
+  if (provider === "codex") return "Codex OAuth"
+  if (provider === "openai-apikey") return "OpenAI API key"
+  return null
+}
+
+const requireRecord = (value: unknown, name: string): Record<string, unknown> => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Missing ${name}`)
+  }
+  return value as Record<string, unknown>
+}
+
+const requireSecretString = (value: unknown, name: string): string => {
+  const parsed = nonEmptyString(value)
+  if (!parsed) throw new Error(`Missing ${name}`)
+  return parsed
+}
+
+const optionalCredentialString = (
+  record: Record<string, unknown>,
+  name: string
+): Record<string, string> => {
+  const value = nonEmptyString(record[name])
+  return value ? { [name]: value } : {}
+}
+
+const randomAccountId = (prefix: string): string => {
+  const bytes = new Uint8Array(8)
+  crypto.getRandomValues(bytes)
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")
+  return `${prefix}-${hex}`
+}
+
+const safeTenantAccount = (
+  account: StoredAccount,
+  validation?: "ok" | "failed"
+): TenantAccountOutput => {
+  const safe = safeGoAccount(account)
+  return {
+    id: account.id,
+    provider: safe.provider,
+    label: account.label,
+    auth_mode: safe.auth_mode,
+    created_at: new Date(account.createdAt).toISOString(),
+    ...(safe.email ? { email: safe.email } : {}),
+    ...(validation ? { validation } : {}),
+  }
+}
+
 const parseModelProbeInput = async (
   request: Request
 ): Promise<Response | ModelProbeInput> => {
@@ -507,16 +668,61 @@ const authorizeAdmin = (request: Request, env: Env): Response | null => {
   return null
 }
 
-const authorizeProxy = (request: Request, env: Env): Response | null => {
-  const token = env.PROXY_TOKEN || env.ADMIN_TOKEN
-  if (!token) return null
+interface TenantAuth {
+  readonly tenantId: string
+  readonly legacy: boolean
+}
+
+const registryActor = (env: Env): DurableObjectStub<TenantRegistryDurableObject> =>
+  env.TENANT_REGISTRY_DO.getByName("registry")
+
+const registryTenantDOName = (tenantId: string): string => `tenant:${tenantId}`
+
+const adminTenantDOName = (tenantId: string): string =>
+  isReservedTenantId(tenantId) ? tenantId : registryTenantDOName(tenantId)
+
+const tenantActor = (
+  env: Env,
+  tenant: TenantAuth
+): DurableObjectStub<SubrouterDurableObject> =>
+  env.SUBROUTER_DO.getByName(
+    tenant.legacy ? tenant.tenantId : registryTenantDOName(tenant.tenantId)
+  )
+
+const authorizeTenant = async (
+  request: Request,
+  env: Env
+): Promise<Response | TenantAuth> => {
   const header = request.headers.get("authorization") ?? ""
   const bearer = header.startsWith("Bearer ") ? header.slice("Bearer ".length) : ""
-  const got = bearer || request.headers.get("x-subrouter-proxy-token") || ""
-  if (!constantTimeStringEqual(got, token)) {
-    return json({ error: "Proxy token required" }, { status: 401 })
+  const tenantKey = request.headers.get("x-subrouter-tenant-key") || bearer
+  if (tenantKey.startsWith("srt_") || request.headers.has("x-subrouter-tenant-key")) {
+    if (!isTenantKey(tenantKey)) {
+      return json({ error: "Invalid tenant key" }, { status: 401 })
+    }
+    const resolved = await registryActor(env).resolveTenantKeySha256(
+      await tenantKeySha256Hex(tenantKey)
+    )
+    if (!resolved) {
+      return json({ error: "Invalid tenant key" }, { status: 401 })
+    }
+    if (resolved.revoked_at !== null) {
+      return json({ error: "Tenant key revoked" }, { status: 403 })
+    }
+    return { tenantId: resolved.id, legacy: false }
   }
-  return null
+
+  const legacyToken =
+    bearer || request.headers.get("x-subrouter-proxy-token") || ""
+  if (
+    env.ALLOW_LEGACY_PROXY_TOKEN === "1" &&
+    env.PROXY_TOKEN &&
+    constantTimeStringEqual(legacyToken, env.PROXY_TOKEN)
+  ) {
+    return { tenantId: "legacy", legacy: true }
+  }
+
+  return json({ error: "Tenant key required" }, { status: 401 })
 }
 
 const constantTimeStringEqual = (a: string, b: string): boolean => {
@@ -545,6 +751,8 @@ const rowToAccount = (row: AccountRow): StoredAccount => ({
   totpDigits: row.totp_digits,
   totpPeriod: row.totp_period,
   totpAlgorithm: row.totp_algorithm as TotpAlgorithm | null,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
   source: "durable-object",
 })
 
@@ -1183,22 +1391,6 @@ export class SubrouterDurableObject extends DurableObject<Env> {
       INSERT OR IGNORE INTO lifecycle(id, started_at) VALUES (1, ${Date.now()});
     `)
 
-    const now = Date.now()
-    for (const account of demoAccounts) {
-      this.ctx.storage.sql.exec(
-        `INSERT OR IGNORE INTO accounts(
-          id, org_id, kind, label, enabled, created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-        account.id,
-        account.orgId,
-        account.kind,
-        account.label,
-        account.enabled ? 1 : 0,
-        now,
-        now
-      )
-      this.upsertModelQuotas(account.id, account.modelQuotas)
-    }
     this.ctx.blockConcurrencyWhile(async () => {
       await this.scheduleNextRefreshAlarm()
     })
@@ -1523,6 +1715,34 @@ export class SubrouterDurableObject extends DurableObject<Env> {
         .toArray()
         .map((row) => this.accountFromRow(row)),
     }
+  }
+
+  async deleteAccount(input: { readonly orgId?: string; readonly accountId: string }): Promise<{ ok: true }> {
+    const orgId = this.resolveOrgId(input.orgId)
+    const accountId = this.requireNonEmpty(input.accountId, "accountId")
+    const row = this.getAccountRow(this.ctx.storage.sql, orgId, accountId, false)
+    if (!row) throw new Error("account not found")
+    const sql = this.ctx.storage.sql
+    sql.exec("DELETE FROM accounts WHERE id = ? AND org_id = ?", accountId, orgId)
+    sql.exec("DELETE FROM account_model_quotas WHERE account_id = ?", accountId)
+    sql.exec("DELETE FROM account_usage WHERE account_id = ?", accountId)
+    sql.exec(
+      "DELETE FROM session_assignments WHERE org_id = ? AND account_id = ?",
+      orgId,
+      accountId
+    )
+    sql.exec(
+      "DELETE FROM sticky_sessions WHERE org_id = ? AND account_id = ?",
+      orgId,
+      accountId
+    )
+    sql.exec(
+      "DELETE FROM sticky_session_routes WHERE org_id = ? AND account_id = ?",
+      orgId,
+      accountId
+    )
+    await this.scheduleNextRefreshAlarm()
+    return { ok: true }
   }
 
   async accountStatuses(orgId: string, forceRefresh: boolean): Promise<ReadonlyArray<OAuthRefreshStatus>> {
@@ -2289,8 +2509,46 @@ const websocketOrgId = (
   return orgId
 }
 
-const adminActor = (env: Env, orgId: string) =>
-  env.SUBROUTER_DO.getByName(orgId)
+const adminActor = (env: Env, tenantId: string) =>
+  env.SUBROUTER_DO.getByName(adminTenantDOName(tenantId))
+
+const tenantScopedAdminActor = (
+  env: Env,
+  url: URL
+): Response | { readonly tenantId: string; readonly actor: DurableObjectStub<SubrouterDurableObject> } => {
+  const tenantId = nonEmptyString(url.searchParams.get("tenant"))
+  if (!tenantId) {
+    return json({ error: "Missing tenant" }, { status: 400 })
+  }
+  return { tenantId, actor: adminActor(env, tenantId) }
+}
+
+const routeInputForTenant = <T extends { readonly orgId?: string }>(
+  input: T,
+  tenantId: string
+): T & { readonly orgId: string } => ({
+  ...input,
+  orgId: tenantId,
+})
+
+const requestWithTenantOrg = (request: Request, tenantId: string): Request => {
+  const url = new URL(request.url)
+  url.searchParams.set("orgId", tenantId)
+  return new Request(url, request)
+}
+
+const validateTenantAccountUpload = async (
+  input: UpsertAccountInput
+): Promise<"ok" | "failed"> => {
+  if (!input.credentials) return "ok"
+  if (!isOAuthKind(input.kind)) return "ok"
+  try {
+    await fetchProviderUsage(input.kind, input.credentials)
+    return "ok"
+  } catch {
+    return "failed"
+  }
+}
 
 const defaultUpstreamForAccount = (
   env: Env,
@@ -2308,9 +2566,12 @@ const defaultUpstreamForAccount = (
 const proxyUpstream = async (
   request: Request,
   env: Env,
+  actor: DurableObjectStub<SubrouterDurableObject>,
   routeInput: RouteInput
 ): Promise<Response> => {
-  const actor = env.SUBROUTER_DO.getByName(routeInput.orgId ?? "demo-org")
+  if (!routeInput.orgId) {
+    return json({ error: "tenant id required" }, { status: 401 })
+  }
   const routed = await actor.routeForProxy(routeInput)
   const account = routed.account
   if (!account.credentials?.apiKey && !account.credentials?.accessToken) {
@@ -2337,7 +2598,7 @@ const proxyUpstream = async (
       method: request.method,
       path: new URL(request.url).pathname,
       upstream: upstreamURL.toString(),
-      headers: redactedHeaders(request.headers),
+      headers: redactedHeaders(stripSubrouterHeaders(request.headers)),
     },
   })
   const init: RequestInit = {
@@ -2377,9 +2638,12 @@ const proxyUpstream = async (
 const proxyUpstreamWebSocket = async (
   request: Request,
   env: Env,
+  actor: DurableObjectStub<SubrouterDurableObject>,
   routeInput: RouteInput
 ): Promise<Response> => {
-  const actor = env.SUBROUTER_DO.getByName(routeInput.orgId ?? "demo-org")
+  if (!routeInput.orgId) {
+    return json({ error: "tenant id required" }, { status: 401 })
+  }
   const routed = await actor.routeForProxy(routeInput)
   const account = routed.account
   if (!account.credentials?.apiKey && !account.credentials?.accessToken) {
@@ -2478,6 +2742,8 @@ const sensitiveHeaders = new Set([
   "proxy-authorization",
   "x-api-key",
   "openai-api-key",
+  "x-subrouter-proxy-token",
+  "x-subrouter-tenant-key",
 ])
 
 const redactedHeaders = (headers: Headers): Record<string, ReadonlyArray<string>> => {
@@ -2671,7 +2937,7 @@ const renderDashboard = (
       const agentType = String(summary["agent_type"] ?? "")
       const sessionId = String(summary["session_id"] ?? "")
       const usage = recordPayload(summary["usage"]) ?? {}
-      const href = `/_subrouter/transcripts/${encodeURIComponent(agentType)}/${encodeURIComponent(sessionId)}?orgId=${encodeURIComponent(orgId)}`
+      const href = `/_subrouter/transcripts/${encodeURIComponent(agentType)}/${encodeURIComponent(sessionId)}?tenant=${encodeURIComponent(orgId)}`
       const raw = `${href.replace("?", "/raw?")}`
       return `<tr>
         <td>${escapeHTML(agentType)}</td>
@@ -2807,9 +3073,7 @@ export default {
     }
 
     if (url.pathname === "/_subrouter/ready") {
-      const orgId = url.searchParams.get("orgId") ?? "demo-org"
-      const ready = await env.SUBROUTER_DO.getByName(orgId).ready()
-      return json(ready, ready.ok ? undefined : { status: 503 })
+      return json({ ok: true })
     }
 
     if (url.pathname === "/ws") {
@@ -2822,22 +3086,26 @@ export default {
           { status: 426 }
         )
       }
-      const orgId = url.searchParams.get("orgId") ?? "demo-org"
-      return env.SUBROUTER_DO.getByName(orgId).fetch(request)
+      const tenant = await authorizeTenant(request, env)
+      if (tenant instanceof Response) return tenant
+      return tenantActor(env, tenant).fetch(requestWithTenantOrg(request, tenant.tenantId))
     }
 
     if (url.pathname === "/websocket-status") {
       const unauthorized = authorizeAdmin(request, env)
       if (unauthorized) return unauthorized
-      const orgId = url.searchParams.get("orgId") ?? "demo-org"
-      return json(await env.SUBROUTER_DO.getByName(orgId).webSocketStats())
+      const scoped = tenantScopedAdminActor(env, url)
+      if (scoped instanceof Response) return scoped
+      return json(await scoped.actor.webSocketStats())
     }
 
     if (url.pathname === "/route" && request.method === "POST") {
+      const tenant = await authorizeTenant(request, env)
+      if (tenant instanceof Response) return tenant
       try {
         const input = await parseRouteInput(request)
-        const actor = env.SUBROUTER_DO.getByName(input.orgId ?? "demo-org")
-        return json(await actor.route(input))
+        const actor = tenantActor(env, tenant)
+        return json(await actor.route(routeInputForTenant(input, tenant.tenantId)))
       } catch (error) {
         return errorJson(error, 409)
       }
@@ -2849,8 +3117,9 @@ export default {
       if (request.method !== "POST") {
         return json({ error: "method not allowed" }, { status: 405 })
       }
-      const orgId = url.searchParams.get("orgId") ?? "demo-org"
-      return json(await env.SUBROUTER_DO.getByName(orgId).drain())
+      const scoped = tenantScopedAdminActor(env, url)
+      if (scoped instanceof Response) return scoped
+      return json(await scoped.actor.drain())
     }
 
     if (url.pathname === "/_subrouter/drain-status") {
@@ -2859,26 +3128,30 @@ export default {
       if (request.method !== "GET") {
         return json({ error: "method not allowed" }, { status: 405 })
       }
-      const orgId = url.searchParams.get("orgId") ?? "demo-org"
-      return json(await env.SUBROUTER_DO.getByName(orgId).ready())
+      const scoped = tenantScopedAdminActor(env, url)
+      if (scoped instanceof Response) return scoped
+      return json(await scoped.actor.ready())
     }
 
     if (url.pathname === "/usage" && request.method === "POST") {
+      const tenant = await authorizeTenant(request, env)
+      if (tenant instanceof Response) return tenant
       const input = await parseUsageInput(request)
       if (input instanceof Response) {
         return input
       }
-      const actor = env.SUBROUTER_DO.getByName(input.orgId ?? "demo-org")
+      const actor = tenantActor(env, tenant)
       try {
-        return json(await actor.recordUsage(input))
+        return json(await actor.recordUsage(routeInputForTenant(input, tenant.tenantId)))
       } catch (error) {
         return errorJson(error, 400)
       }
     }
 
     if (url.pathname === "/status") {
-      const orgId = url.searchParams.get("orgId") ?? "demo-org"
-      const actor = env.SUBROUTER_DO.getByName(orgId)
+      const tenant = await authorizeTenant(request, env)
+      if (tenant instanceof Response) return tenant
+      const actor = tenantActor(env, tenant)
       try {
         return json(await actor.status())
       } catch (error) {
@@ -2889,15 +3162,17 @@ export default {
     if (url.pathname === "/_subrouter/sessions") {
       const unauthorized = authorizeAdmin(request, env)
       if (unauthorized) return unauthorized
-      const orgId = url.searchParams.get("orgId") ?? "demo-org"
-      return json(await env.SUBROUTER_DO.getByName(orgId).listSessions())
+      const scoped = tenantScopedAdminActor(env, url)
+      if (scoped instanceof Response) return scoped
+      return json(await scoped.actor.listSessions())
     }
 
     if (url.pathname === "/_subrouter/accounts") {
       const unauthorized = authorizeAdmin(request, env)
       if (unauthorized) return unauthorized
-      const orgId = url.searchParams.get("orgId") ?? "demo-org"
-      const { accounts } = await env.SUBROUTER_DO.getByName(orgId).listAccounts(orgId)
+      const scoped = tenantScopedAdminActor(env, url)
+      if (scoped instanceof Response) return scoped
+      const { accounts } = await scoped.actor.listAccounts(scoped.tenantId)
       return json(accounts.map((account) => safeGoAccount(account)))
     }
 
@@ -2907,8 +3182,9 @@ export default {
       if (request.method !== "GET" && request.method !== "POST") {
         return json({ error: "method not allowed" }, { status: 405 })
       }
-      const orgId = url.searchParams.get("orgId") ?? "demo-org"
-      return json(await env.SUBROUTER_DO.getByName(orgId).accountStatuses(orgId, request.method === "POST"))
+      const scoped = tenantScopedAdminActor(env, url)
+      if (scoped instanceof Response) return scoped
+      return json(await scoped.actor.accountStatuses(scoped.tenantId, request.method === "POST"))
     }
 
     if (url.pathname === "/_subrouter/usage-status") {
@@ -2917,8 +3193,9 @@ export default {
       if (request.method !== "GET") {
         return json({ error: "method not allowed" }, { status: 405 })
       }
-      const orgId = url.searchParams.get("orgId") ?? "demo-org"
-      return json(await env.SUBROUTER_DO.getByName(orgId).usageStatuses(orgId))
+      const scoped = tenantScopedAdminActor(env, url)
+      if (scoped instanceof Response) return scoped
+      return json(await scoped.actor.usageStatuses(scoped.tenantId))
     }
 
     if (url.pathname === "/_subrouter/reload-accounts") {
@@ -2927,17 +3204,18 @@ export default {
       if (request.method !== "POST") {
         return json({ error: "method not allowed" }, { status: 405 })
       }
-      const orgId = url.searchParams.get("orgId") ?? "demo-org"
-      const { accounts } = await env.SUBROUTER_DO.getByName(orgId).listAccounts(orgId)
+      const scoped = tenantScopedAdminActor(env, url)
+      if (scoped instanceof Response) return scoped
+      const { accounts } = await scoped.actor.listAccounts(scoped.tenantId)
       return json({ ok: true, accounts: accounts.length, usage_refreshed: 0 })
     }
 
     if (url.pathname === "/_subrouter/dashboard") {
       const unauthorized = authorizeAdmin(request, env)
       if (unauthorized) return unauthorized
-      const orgId = url.searchParams.get("orgId") ?? "demo-org"
-      const actor = env.SUBROUTER_DO.getByName(orgId)
-      return new Response(renderDashboard(await actor.transcriptDashboardData(orgId), orgId), {
+      const scoped = tenantScopedAdminActor(env, url)
+      if (scoped instanceof Response) return scoped
+      return new Response(renderDashboard(await scoped.actor.transcriptDashboardData(scoped.tenantId), scoped.tenantId), {
         headers: { "Content-Type": "text/html; charset=utf-8" },
       })
     }
@@ -2948,15 +3226,68 @@ export default {
     ) {
       const unauthorized = authorizeAdmin(request, env)
       if (unauthorized) return unauthorized
-      const orgId = url.searchParams.get("orgId") ?? "demo-org"
-      const actor = env.SUBROUTER_DO.getByName(orgId)
+      const scoped = tenantScopedAdminActor(env, url)
+      if (scoped instanceof Response) return scoped
       if (url.pathname === "/_subrouter/transcripts") {
-        return json(await actor.listTranscriptSummaries(orgId))
+        return json(await scoped.actor.listTranscriptSummaries(scoped.tenantId))
       }
       const parsed = parseTranscriptPath(url.pathname)
       if (!parsed) return new Response("Not Found", { status: 404 })
       try {
-        return json(await actor.readTranscriptSession({ orgId, ...parsed }))
+        return json(await scoped.actor.readTranscriptSession({ orgId: scoped.tenantId, ...parsed }))
+      } catch (error) {
+        return errorJson(error, 404)
+      }
+    }
+
+    if (url.pathname === "/tenant/accounts" && request.method === "POST") {
+      const tenant = await authorizeTenant(request, env)
+      if (tenant instanceof Response) return tenant
+      if (tenant.legacy) {
+        return json({ error: "Tenant key required" }, { status: 401 })
+      }
+      const input = await parseTenantAccountUploadInput(request, tenant.tenantId)
+      if (input instanceof Response) return input
+      const validation = input.validate
+        ? await validateTenantAccountUpload(input.account)
+        : undefined
+      if (validation === "failed") {
+        return json({ error: "Account validation failed", validation }, { status: 400 })
+      }
+      const actor = tenantActor(env, tenant)
+      try {
+        const { account } = await actor.upsertAccount(input.account)
+        return json(safeTenantAccount(account, validation))
+      } catch (error) {
+        return errorJson(error, 400)
+      }
+    }
+
+    if (url.pathname === "/tenant/accounts" && request.method === "GET") {
+      const tenant = await authorizeTenant(request, env)
+      if (tenant instanceof Response) return tenant
+      if (tenant.legacy) {
+        return json({ error: "Tenant key required" }, { status: 401 })
+      }
+      const { accounts } = await tenantActor(env, tenant).listAccounts(tenant.tenantId)
+      return json({ accounts: accounts.map((account) => safeTenantAccount(account)) })
+    }
+
+    const tenantAccountDeleteMatch = url.pathname.match(/^\/tenant\/accounts\/([^/]+)$/)
+    if (tenantAccountDeleteMatch && request.method === "DELETE") {
+      const tenant = await authorizeTenant(request, env)
+      if (tenant instanceof Response) return tenant
+      if (tenant.legacy) {
+        return json({ error: "Tenant key required" }, { status: 401 })
+      }
+      const accountId = decodeURIComponent(tenantAccountDeleteMatch[1]!)
+      try {
+        return json(
+          await tenantActor(env, tenant).deleteAccount({
+            orgId: tenant.tenantId,
+            accountId,
+          })
+        )
       } catch (error) {
         return errorJson(error, 404)
       }
@@ -2966,9 +3297,44 @@ export default {
       const unauthorized = authorizeAdmin(request, env)
       if (unauthorized) return unauthorized
 
+      if (url.pathname === "/admin/tenants" && request.method === "POST") {
+        const record = await parseJsonRecord(request)
+        if (record instanceof Response) return record
+        try {
+          return json(await registryActor(env).createTenant({ name: record["name"] }))
+        } catch (error) {
+          return errorJson(error, 400)
+        }
+      }
+
+      if (url.pathname === "/admin/tenants" && request.method === "GET") {
+        return json(await registryActor(env).listTenants())
+      }
+
+      const tenantRevokeMatch = url.pathname.match(/^\/admin\/tenants\/([^/]+)\/revoke$/)
+      if (tenantRevokeMatch && request.method === "POST") {
+        const tenantId = decodeURIComponent(tenantRevokeMatch[1]!)
+        try {
+          return json(await registryActor(env).revokeTenant(tenantId))
+        } catch (error) {
+          return errorJson(error, 404)
+        }
+      }
+
+      const tenantRotateMatch = url.pathname.match(/^\/admin\/tenants\/([^/]+)\/rotate$/)
+      if (tenantRotateMatch && request.method === "POST") {
+        const tenantId = decodeURIComponent(tenantRotateMatch[1]!)
+        try {
+          return json(await registryActor(env).rotateTenant(tenantId))
+        } catch (error) {
+          return errorJson(error, 400)
+        }
+      }
+
       if (url.pathname === "/admin/accounts" && request.method === "GET") {
-        const orgId = url.searchParams.get("orgId") ?? "demo-org"
-        return json(await adminActor(env, orgId).listAccounts(orgId))
+        const scoped = tenantScopedAdminActor(env, url)
+        if (scoped instanceof Response) return scoped
+        return json(await scoped.actor.listAccounts(scoped.tenantId))
       }
 
       if (url.pathname === "/admin/accounts" && request.method === "POST") {
@@ -2984,9 +3350,10 @@ export default {
       const totpMatch = url.pathname.match(/^\/admin\/accounts\/([^/]+)\/totp$/)
       if (totpMatch && request.method === "POST") {
         const accountId = decodeURIComponent(totpMatch[1]!)
-        const orgId = url.searchParams.get("orgId") ?? "demo-org"
+        const scoped = tenantScopedAdminActor(env, url)
+        if (scoped instanceof Response) return scoped
         try {
-          return json(await adminActor(env, orgId).totpCode({ orgId, accountId }))
+          return json(await scoped.actor.totpCode({ orgId: scoped.tenantId, accountId }))
         } catch (error) {
           return errorJson(error, 400)
         }
@@ -2996,25 +3363,33 @@ export default {
         try {
           const input = await parseModelProbeInput(request)
           if (input instanceof Response) return input
-          return json(await adminActor(env, input.orgId ?? "demo-org").modelProbe(input))
+          const tenantId = input.orgId ?? nonEmptyString(url.searchParams.get("tenant"))
+          if (!tenantId) return json({ error: "Missing tenant" }, { status: 400 })
+          return json(await adminActor(env, tenantId).modelProbe(routeInputForTenant(input, tenantId)))
         } catch (error) {
           return errorJson(error, 400)
         }
       }
     }
 
+    if (url.pathname.startsWith("/tenant/")) {
+      return new Response("Not Found", { status: 404 })
+    }
+
     if (url.pathname.startsWith("/_subrouter/")) {
       return new Response("Not Found", { status: 404 })
     }
 
-    const unauthorized = authorizeProxy(request, env)
-    if (unauthorized) return unauthorized
+    const tenant = await authorizeTenant(request, env)
+    if (tenant instanceof Response) return tenant
     try {
       const routeInput = await parseProxyRouteInput(request)
+      const tenantRouteInput = routeInputForTenant(routeInput, tenant.tenantId)
+      const actor = tenantActor(env, tenant)
       if (isWebSocketUpgrade(request)) {
-        return await proxyUpstreamWebSocket(request, env, routeInput)
+        return await proxyUpstreamWebSocket(request, env, actor, tenantRouteInput)
       }
-      return await proxyUpstream(request, env, routeInput)
+      return await proxyUpstream(request, env, actor, tenantRouteInput)
     } catch (error) {
       return errorJson(error, 503)
     }

--- a/cloudflare/packages/worker/src/index.ts
+++ b/cloudflare/packages/worker/src/index.ts
@@ -50,6 +50,7 @@ const accountKinds = new Set<AccountKind>([
 interface RouteInput {
   readonly orgId?: string
   readonly agentType?: AgentType
+  readonly upstreamProvider?: UpstreamProvider
   readonly sessionId: string
   readonly userEmail?: string
   readonly preferAccountId?: string
@@ -95,6 +96,17 @@ interface TenantAccountOutput {
   readonly created_at: string
   readonly email?: string
   readonly validation?: "ok" | "failed"
+}
+
+type UpstreamProvider = "claude" | "codex"
+
+const anthropicBootstrapModelQuotas: AccountModelQuotas = {
+  opus: { remainingPercent: 100 },
+  sonnet: { remainingPercent: 100 },
+}
+
+const codexBootstrapModelQuotas: AccountModelQuotas = {
+  spark: { remainingPercent: 100 },
 }
 
 interface ModelProbeInput {
@@ -262,6 +274,7 @@ interface WebSocketClientMessage {
   readonly type?: unknown
   readonly requestId?: unknown
   readonly orgId?: unknown
+  readonly agentType?: unknown
   readonly sessionId?: unknown
   readonly preferAccountId?: unknown
   readonly model?: unknown
@@ -289,6 +302,7 @@ export interface Env {
   readonly CODEX_UPSTREAM?: string
   readonly API_UPSTREAM?: string
   readonly CLAUDE_UPSTREAM?: string
+  readonly VALIDATION_TIMEOUT_MS?: string
 }
 
 const json = (body: unknown, init?: ResponseInit): Response =>
@@ -449,6 +463,7 @@ const accountInputForTenantUpload = (
       orgId: tenantId,
       kind: "anthropic_oauth",
       label,
+      modelQuotas: anthropicBootstrapModelQuotas,
       credentials: {
         accessToken,
         refreshToken,
@@ -470,6 +485,7 @@ const accountInputForTenantUpload = (
       orgId: tenantId,
       kind: "anthropic_apikey",
       label,
+      modelQuotas: anthropicBootstrapModelQuotas,
       credentials: { apiKey },
     }
   }
@@ -485,6 +501,7 @@ const accountInputForTenantUpload = (
       orgId: tenantId,
       kind: "codex_oauth",
       label,
+      modelQuotas: codexBootstrapModelQuotas,
       credentials: {
         accessToken,
         refreshToken,
@@ -562,6 +579,14 @@ const safeTenantAccount = (
     ...(safe.email ? { email: safe.email } : {}),
     ...(validation ? { validation } : {}),
   }
+}
+
+const accountMatchesUpstreamProvider = (
+  account: StoredAccountContract,
+  upstreamProvider: UpstreamProvider | undefined
+): boolean => {
+  if (!upstreamProvider) return true
+  return providerForAccount(account.kind) === upstreamProvider
 }
 
 const parseModelProbeInput = async (
@@ -1507,6 +1532,7 @@ export class SubrouterDurableObject extends DurableObject<Env> {
       this.requireNonEmpty(input.sessionId, "sessionId")
     )
     const quotaKey = this.resolveQuotaKey(input)
+    const upstreamProvider = this.resolveUpstreamProvider(input)
     const routedAt = Date.now()
     const sql = this.ctx.storage.sql
 
@@ -1521,7 +1547,7 @@ export class SubrouterDurableObject extends DurableObject<Env> {
       )
       .toArray()[0]
     const stickyAccount = sticky
-      ? this.getEligibleAccount(sql, orgId, sticky.account_id, quotaKey, true)
+      ? this.getEligibleAccount(sql, orgId, sticky.account_id, quotaKey, true, upstreamProvider)
       : null
     if (stickyAccount) {
       this.recordRouteMetadata(sql, routedAt, stickyAccount.id, sessionId)
@@ -1533,7 +1559,7 @@ export class SubrouterDurableObject extends DurableObject<Env> {
     }
 
     const preferredAccount = input.preferAccountId
-      ? this.getEligibleAccount(sql, orgId, input.preferAccountId, quotaKey, true)
+      ? this.getEligibleAccount(sql, orgId, input.preferAccountId, quotaKey, true, upstreamProvider)
       : null
     if (preferredAccount) {
       this.rememberSticky(sql, orgId, agentType, quotaKey, sessionId, preferredAccount.id, input.userEmail)
@@ -1546,9 +1572,10 @@ export class SubrouterDurableObject extends DurableObject<Env> {
       }
     }
 
-    const eligible = this.listEligibleAccounts(sql, orgId, quotaKey)
+    const eligible = this.listEligibleAccounts(sql, orgId, quotaKey, upstreamProvider)
     if (eligible.length === 0) {
-      throw new Error(`no eligible ${quotaKey} subrouter account for org ${orgId}`)
+      const providerLabel = upstreamProvider ? `${upstreamProvider} ` : ""
+      throw new Error(`no eligible ${providerLabel}${quotaKey} subrouter account for org ${orgId}`)
     }
 
     const status = this.statusRow(sql)
@@ -1981,6 +2008,16 @@ export class SubrouterDurableObject extends DurableObject<Env> {
     return quotaKeyForModel(input.model)
   }
 
+  private resolveUpstreamProvider(input: { upstreamProvider?: UpstreamProvider; agentType?: AgentType }): UpstreamProvider | undefined {
+    if (input.upstreamProvider === "claude" || input.upstreamProvider === "codex") {
+      return input.upstreamProvider
+    }
+    const agentType = normalizeAgentType(input.agentType)
+    if (agentType === "claude") return "claude"
+    if (agentType === "codex") return "codex"
+    return undefined
+  }
+
   private requireNonEmpty(value: string, name: string): string {
     if (value.trim().length === 0) {
       throw new Error(`missing ${name}`)
@@ -1995,7 +2032,8 @@ export class SubrouterDurableObject extends DurableObject<Env> {
   private listEligibleAccounts(
     sql: SqlStorage,
     orgId: string,
-    quotaKey: string
+    quotaKey: string,
+    upstreamProvider: UpstreamProvider | undefined
   ): StoredAccount[] {
     return sql
       .exec<AccountRow>(
@@ -2006,7 +2044,10 @@ export class SubrouterDurableObject extends DurableObject<Env> {
       )
       .toArray()
       .map((row) => this.accountFromRow(row))
-      .filter((account) => accountHasQuotaForModel(account, quotaKey))
+      .filter((account) =>
+        accountMatchesUpstreamProvider(account, upstreamProvider) &&
+        accountHasQuotaForModel(account, quotaKey)
+      )
   }
 
   private getEligibleAccount(
@@ -2014,11 +2055,15 @@ export class SubrouterDurableObject extends DurableObject<Env> {
     orgId: string,
     accountId: string,
     quotaKey: string,
-    enabledOnly: boolean
+    enabledOnly: boolean,
+    upstreamProvider: UpstreamProvider | undefined
   ): StoredAccount | null {
     const account = this.getAccount(sql, orgId, accountId, enabledOnly)
     if (!account) return null
-    return accountHasQuotaForModel(account, quotaKey) ? account : null
+    return accountMatchesUpstreamProvider(account, upstreamProvider) &&
+      accountHasQuotaForModel(account, quotaKey)
+      ? account
+      : null
   }
 
   private getAccount(
@@ -2393,12 +2438,14 @@ export class SubrouterDurableObject extends DurableObject<Env> {
     if (type === "route") {
       const sessionId = nonEmptyString(message.sessionId)
       if (!sessionId) throw new Error("route message is missing sessionId")
+      const agentType = normalizeAgentType(nonEmptyString(message.agentType)) || "codex"
       return {
         type: "route",
         ok: true,
         ...(requestId ? { requestId } : {}),
         message: await this.route({
           orgId: websocketOrgId(attachment, message),
+          agentType,
           sessionId,
           ...(nonEmptyString(message.preferAccountId)
             ? { preferAccountId: nonEmptyString(message.preferAccountId)! }
@@ -2531,6 +2578,33 @@ const routeInputForTenant = <T extends { readonly orgId?: string }>(
   orgId: tenantId,
 })
 
+const proxyRouteInputForTenant = (
+  request: Request,
+  input: RouteInput,
+  tenantId: string
+): RouteInput => {
+  const upstreamProvider = upstreamProviderForProxyRequest(request, input)
+  return {
+    ...input,
+    orgId: tenantId,
+    upstreamProvider,
+    ...(upstreamProvider === "claude" ? { agentType: "claude" } : {}),
+  }
+}
+
+const upstreamProviderForProxyRequest = (
+  request: Request,
+  input: RouteInput
+): UpstreamProvider => {
+  const agentType = normalizeAgentType(input.agentType)
+  if (agentType === "claude") return "claude"
+  const path = new URL(request.url).pathname
+  if (path === "/v1/messages" || path.startsWith("/v1/messages/")) {
+    return "claude"
+  }
+  return "codex"
+}
+
 const requestWithTenantOrg = (request: Request, tenantId: string): Request => {
   const url = new URL(request.url)
   url.searchParams.set("orgId", tenantId)
@@ -2538,16 +2612,39 @@ const requestWithTenantOrg = (request: Request, tenantId: string): Request => {
 }
 
 const validateTenantAccountUpload = async (
-  input: UpsertAccountInput
+  input: UpsertAccountInput,
+  options: {
+    readonly timeoutMs?: number
+    readonly fetcher?: typeof fetch
+  } = {}
 ): Promise<"ok" | "failed"> => {
   if (!input.credentials) return "ok"
   if (!isOAuthKind(input.kind)) return "ok"
+  const timeoutMs = options.timeoutMs ?? 10_000
+  const signal = AbortSignal.timeout(timeoutMs)
+  const baseFetcher = options.fetcher ?? fetch
+  const fetcher = Object.assign(
+    ((requestInfo: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) =>
+      baseFetcher(requestInfo, {
+        ...init,
+        signal: init?.signal ?? signal,
+      })) as typeof fetch,
+    { preconnect: baseFetcher.preconnect?.bind(baseFetcher) ?? (() => {}) }
+  )
   try {
-    await fetchProviderUsage(input.kind, input.credentials)
+    await fetchProviderUsage(input.kind, input.credentials, fetcher)
     return "ok"
   } catch {
     return "failed"
   }
+}
+
+const validationTimeoutMs = (env: Env): number => {
+  const parsed = Number(env.VALIDATION_TIMEOUT_MS)
+  if (Number.isFinite(parsed) && parsed > 0 && parsed <= 10_000) {
+    return parsed
+  }
+  return 10_000
 }
 
 const defaultUpstreamForAccount = (
@@ -3249,7 +3346,9 @@ export default {
       const input = await parseTenantAccountUploadInput(request, tenant.tenantId)
       if (input instanceof Response) return input
       const validation = input.validate
-        ? await validateTenantAccountUpload(input.account)
+        ? await validateTenantAccountUpload(input.account, {
+            timeoutMs: validationTimeoutMs(env),
+          })
         : undefined
       if (validation === "failed") {
         return json({ error: "Account validation failed", validation }, { status: 400 })
@@ -3384,7 +3483,7 @@ export default {
     if (tenant instanceof Response) return tenant
     try {
       const routeInput = await parseProxyRouteInput(request)
-      const tenantRouteInput = routeInputForTenant(routeInput, tenant.tenantId)
+      const tenantRouteInput = proxyRouteInputForTenant(request, routeInput, tenant.tenantId)
       const actor = tenantActor(env, tenant)
       if (isWebSocketUpgrade(request)) {
         return await proxyUpstreamWebSocket(request, env, actor, tenantRouteInput)

--- a/cloudflare/packages/worker/src/index.ts
+++ b/cloudflare/packages/worker/src/index.ts
@@ -31,6 +31,7 @@ import {
 import {
   isReservedTenantId,
   isTenantKey,
+  normalizeTenantId,
   tenantKeySha256Hex,
   TenantRegistryDurableObject,
   type TenantResolution,
@@ -3170,7 +3171,14 @@ export default {
     }
 
     if (url.pathname === "/_subrouter/ready") {
-      return json({ ok: true })
+      const tenantId = url.searchParams.get("tenant")
+      if (!tenantId) return json({ ok: true })
+      const normalizedTenantId = normalizeTenantId(tenantId)
+      if (!normalizedTenantId) {
+        return json({ error: "Invalid tenant" }, { status: 400 })
+      }
+      const ready = await adminActor(env, normalizedTenantId).ready()
+      return json(ready, ready.ok ? undefined : { status: 503 })
     }
 
     if (url.pathname === "/ws") {

--- a/cloudflare/packages/worker/src/tenants.ts
+++ b/cloudflare/packages/worker/src/tenants.ts
@@ -166,7 +166,7 @@ const normalizeTenantName = (value: unknown): string => {
   return trimmed
 }
 
-const normalizeTenantId = (value: string): string => {
+export const normalizeTenantId = (value: string): string => {
   const trimmed = value.trim()
   if (!trimmed || trimmed.length > 80) return ""
   return /^[a-z0-9][a-z0-9._-]*$/.test(trimmed) ? trimmed : ""

--- a/cloudflare/packages/worker/src/tenants.ts
+++ b/cloudflare/packages/worker/src/tenants.ts
@@ -1,0 +1,193 @@
+import { DurableObject } from "cloudflare:workers"
+
+export interface TenantRecord {
+  readonly id: string
+  readonly name: string
+  readonly created_at: number
+  readonly revoked_at: number | null
+}
+
+export interface TenantResolution extends TenantRecord {
+  readonly key_sha256: string
+}
+
+interface TenantRow {
+  readonly [key: string]: SqlStorageValue
+  readonly id: string
+  readonly name: string
+  readonly key_sha256: string
+  readonly created_at: number
+  readonly revoked_at: number | null
+}
+
+const tenantKeyPattern = /^srt_[0-9a-f]{32}$/
+const reservedTenantIds = new Set(["legacy", "demo-org"])
+
+export const isTenantKey = (value: string): boolean => tenantKeyPattern.test(value)
+export const isReservedTenantId = (value: string): boolean =>
+  reservedTenantIds.has(value)
+
+export const createTenantKey = (): string => `srt_${randomHex(16)}`
+
+export const tenantKeySha256Hex = async (key: string): Promise<string> => {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(key)
+  )
+  return bytesToHex(new Uint8Array(digest))
+}
+
+export class TenantRegistryDurableObject extends DurableObject<unknown> {
+  constructor(ctx: DurableObjectState, env: unknown) {
+    super(ctx, env)
+    this.ctx.storage.sql.exec(`
+      CREATE TABLE IF NOT EXISTS tenants(
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        key_sha256 TEXT NOT NULL UNIQUE,
+        created_at INTEGER NOT NULL,
+        revoked_at INTEGER
+      );
+      CREATE INDEX IF NOT EXISTS tenants_revoked_idx
+        ON tenants(revoked_at);
+    `)
+  }
+
+  async createTenant(input: { readonly name?: unknown }): Promise<TenantRecord & { readonly key: string }> {
+    const name = normalizeTenantName(input.name)
+    const id = this.uniqueTenantId(name)
+    const key = createTenantKey()
+    const keySha256 = await tenantKeySha256Hex(key)
+    const now = Date.now()
+    this.ctx.storage.sql.exec(
+      `INSERT INTO tenants(id, name, key_sha256, created_at, revoked_at)
+       VALUES (?, ?, ?, ?, NULL)`,
+      id,
+      name,
+      keySha256,
+      now
+    )
+    return { id, name, key, created_at: now, revoked_at: null }
+  }
+
+  async listTenants(): Promise<ReadonlyArray<TenantRecord>> {
+    return this.ctx.storage.sql
+      .exec<TenantRow>(
+        `SELECT id, name, key_sha256, created_at, revoked_at
+         FROM tenants
+         ORDER BY created_at, id`
+      )
+      .toArray()
+      .map(publicTenant)
+  }
+
+  async revokeTenant(id: string): Promise<TenantRecord> {
+    const tenant = this.getTenant(id)
+    if (!tenant) throw new Error("tenant not found")
+    const revokedAt = Date.now()
+    this.ctx.storage.sql.exec(
+      "UPDATE tenants SET revoked_at = ? WHERE id = ?",
+      revokedAt,
+      tenant.id
+    )
+    return { ...publicTenant(tenant), revoked_at: revokedAt }
+  }
+
+  async rotateTenant(id: string): Promise<TenantRecord & { readonly key: string }> {
+    const tenant = this.getTenant(id)
+    if (!tenant) throw new Error("tenant not found")
+    if (tenant.revoked_at !== null) throw new Error("tenant is revoked")
+    const key = createTenantKey()
+    const keySha256 = await tenantKeySha256Hex(key)
+    this.ctx.storage.sql.exec(
+      "UPDATE tenants SET key_sha256 = ? WHERE id = ?",
+      keySha256,
+      tenant.id
+    )
+    return { ...publicTenant(tenant), key }
+  }
+
+  async resolveTenantKeySha256(keySha256: string): Promise<TenantResolution | null> {
+    const row =
+      this.ctx.storage.sql
+        .exec<TenantRow>(
+          `SELECT id, name, key_sha256, created_at, revoked_at
+           FROM tenants
+           WHERE key_sha256 = ?`,
+          keySha256
+        )
+        .toArray()[0] ?? null
+    return row
+  }
+
+  private getTenant(id: string): TenantRow | null {
+    const normalized = normalizeTenantId(id)
+    if (!normalized) throw new Error("invalid tenant id")
+    return (
+      this.ctx.storage.sql
+        .exec<TenantRow>(
+          `SELECT id, name, key_sha256, created_at, revoked_at
+           FROM tenants
+           WHERE id = ?`,
+          normalized
+        )
+        .toArray()[0] ?? null
+    )
+  }
+
+  private uniqueTenantId(name: string): string {
+    const base = slugifyTenantName(name)
+    for (let attempt = 0; attempt < 16; attempt += 1) {
+      const id = attempt === 0 ? base : `${base}-${randomHex(4)}`
+      const exists = this.ctx.storage.sql
+        .exec<{ readonly [key: string]: SqlStorageValue; readonly count: number }>(
+          "SELECT COUNT(*) AS count FROM tenants WHERE id = ?",
+          id
+        )
+        .one().count
+      if (exists === 0 && !isReservedTenantId(id)) return id
+    }
+    return `tenant-${randomHex(8)}`
+  }
+}
+
+const publicTenant = (row: TenantRow): TenantRecord => ({
+  id: row.id,
+  name: row.name,
+  created_at: row.created_at,
+  revoked_at: row.revoked_at,
+})
+
+const normalizeTenantName = (value: unknown): string => {
+  if (typeof value !== "string") throw new Error("Missing name")
+  const trimmed = value.trim()
+  if (!trimmed) throw new Error("Missing name")
+  if (trimmed.length > 120) throw new Error("Tenant name is too long")
+  return trimmed
+}
+
+const normalizeTenantId = (value: string): string => {
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.length > 80) return ""
+  return /^[a-z0-9][a-z0-9._-]*$/.test(trimmed) ? trimmed : ""
+}
+
+const slugifyTenantName = (name: string): string => {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48)
+    .replace(/[-._]+$/g, "")
+  return normalizeTenantId(slug) || `tenant-${randomHex(4)}`
+}
+
+const randomHex = (byteLength: number): string => {
+  const bytes = new Uint8Array(byteLength)
+  crypto.getRandomValues(bytes)
+  return bytesToHex(bytes)
+}
+
+const bytesToHex = (bytes: Uint8Array): string =>
+  [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")

--- a/cloudflare/packages/worker/test/account-upload.test.ts
+++ b/cloudflare/packages/worker/test/account-upload.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const adminToken = "admin-test-token"
+
+const processes: Bun.Subprocess[] = []
+const servers: Array<{ stop: () => void }> = []
+
+afterEach(async () => {
+  for (const proc of processes.splice(0)) {
+    proc.kill()
+    await proc.exited.catch(() => {})
+  }
+  for (const server of servers.splice(0)) server.stop()
+})
+
+describe("tenant account upload API", () => {
+  test("round-trips providers, sanitizes secrets, deletes accounts, and refreshes uploaded OAuth credentials", async () => {
+    const refreshTokens: string[] = []
+    const authServer = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        if (new URL(request.url).pathname !== "/oauth/token") {
+          return new Response("Not Found", { status: 404 })
+        }
+        const body = await request.text()
+        const params = new URLSearchParams(body)
+        const refreshToken = params.get("refresh_token") ?? ""
+        refreshTokens.push(refreshToken)
+        if (refreshToken === "old-refresh-token") {
+          return Response.json({
+            access_token: "rotated-access-token-1",
+            refresh_token: "rotated-refresh-token-1",
+            expires_in: 1,
+          })
+        }
+        if (refreshToken === "rotated-refresh-token-1") {
+          return Response.json({
+            access_token: "rotated-access-token-2",
+            refresh_token: "rotated-refresh-token-2",
+            expires_in: 3600,
+          })
+        }
+        if (refreshToken === "delete-refresh-token") {
+          return Response.json({
+            access_token: "deleted-account-access-token",
+            refresh_token: "deleted-account-refresh-token",
+            expires_in: 3600,
+          })
+        }
+        return Response.json({ error: "unexpected refresh token" }, { status: 400 })
+      },
+    })
+    servers.push(authServer)
+
+    let upstreamAuth: string | null = null
+    const upstream = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        upstreamAuth = request.headers.get("Authorization")
+        return Response.json({ ok: true })
+      },
+    })
+    servers.push(upstream)
+
+    const baseURL = await startWorker(upstream.url.origin)
+    const tenant = await createTenant(baseURL, "Upload Tenant")
+
+    const secrets = [
+      "claude-access-token",
+      "old-refresh-token",
+      "sk-ant-secret-api-key",
+      "codex-access-secret",
+      "codex-refresh-secret",
+      "codex-id-secret",
+      "sk-openai-secret-key",
+    ]
+
+    const claude = await uploadAccount(baseURL, tenant.key, {
+      provider: "claude",
+      label: "claude@example.com",
+      claudeAiOauth: {
+        accessToken: "claude-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: Date.now() + 2_500,
+        subscriptionType: "max",
+        rateLimitTier: "tier-1",
+        tokenEndpoint: `${authServer.url.origin}/oauth/token`,
+      },
+    }, secrets)
+    expect(claude.provider).toBe("claude")
+    expect(claude.auth_mode).toBe("oauth")
+    expect(claude.email).toBe("claude@example.com")
+
+    const anthropic = await uploadAccount(baseURL, tenant.key, {
+      provider: "anthropic-apikey",
+      label: "anthropic key",
+      apiKey: "sk-ant-secret-api-key",
+    }, secrets)
+    expect(anthropic.provider).toBe("claude")
+    expect(anthropic.auth_mode).toBe("apikey")
+
+    const codex = await uploadAccount(baseURL, tenant.key, {
+      provider: "codex",
+      label: "codex@example.com",
+      tokens: {
+        accessToken: "codex-access-secret",
+        refreshToken: "codex-refresh-secret",
+        idToken: "codex-id-secret",
+        accountID: "chatgpt-account-id",
+      },
+    }, secrets)
+    expect(codex.provider).toBe("codex")
+    expect(codex.auth_mode).toBe("oauth")
+
+    const openai = await uploadAccount(baseURL, tenant.key, {
+      provider: "openai-apikey",
+      label: "openai key",
+      apiKey: "sk-openai-secret-key",
+    }, secrets)
+    expect(openai.provider).toBe("codex")
+    expect(openai.auth_mode).toBe("apikey")
+
+    const list = await fetch(`${baseURL}/tenant/accounts`, {
+      headers: { Authorization: `Bearer ${tenant.key}` },
+    })
+    expect(list.status).toBe(200)
+    const listText = await list.text()
+    expect(JSON.parse(listText).accounts).toHaveLength(4)
+    for (const secret of secrets) expect(listText).not.toContain(secret)
+
+    const badShape = await fetch(`${baseURL}/tenant/accounts`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${tenant.key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ provider: "openai-apikey" }),
+    })
+    expect(badShape.status).toBe(400)
+    expect(await badShape.text()).toContain("Missing apiKey")
+
+    await waitForCondition(
+      () => refreshTokens.length >= 1,
+      "uploaded OAuth alarm refresh"
+    )
+    expect(refreshTokens[0]).toBe("old-refresh-token")
+    await Bun.sleep(1_300)
+
+    const proxied = await fetch(`${baseURL}/v1/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${tenant.key}`,
+        "Content-Type": "application/json",
+        "X-Subrouter-Account-ID": claude.id,
+        "X-Subrouter-Session": "upload-refresh-session",
+      },
+      body: JSON.stringify({ model: "claude-3-haiku", messages: [] }),
+    })
+    expect(proxied.status).toBe(200)
+    expect(refreshTokens.slice(0, 2)).toEqual([
+      "old-refresh-token",
+      "rotated-refresh-token-1",
+    ])
+    expect(upstreamAuth as string | null).toBe("Bearer rotated-access-token-2")
+
+    const deleteMe = await uploadAccount(baseURL, tenant.key, {
+      provider: "claude",
+      label: "delete-me@example.com",
+      claudeAiOauth: {
+        accessToken: "delete-access-token",
+        refreshToken: "delete-refresh-token",
+        expiresAt: Date.now() + 2_500,
+        subscriptionType: "max",
+        tokenEndpoint: `${authServer.url.origin}/oauth/token`,
+      },
+    }, ["delete-access-token", "delete-refresh-token"])
+    const beforeDeleteWait = refreshTokens.length
+    const deleted = await fetch(`${baseURL}/tenant/accounts/${deleteMe.id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${tenant.key}` },
+    })
+    expect(deleted.status).toBe(200)
+    await Bun.sleep(3_000)
+    expect(refreshTokens).toHaveLength(beforeDeleteWait)
+  }, 90_000)
+})
+
+const startWorker = async (upstreamOrigin: string): Promise<string> => {
+  const workerPort = 20_000 + Math.floor(Math.random() * 1_000)
+  const persistDir = await mkdtemp(join(tmpdir(), "subrouter-upload-test-"))
+  const worker = Bun.spawn(
+    [
+      "bunx",
+      "wrangler",
+      "dev",
+      "--local",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      String(workerPort),
+      "--persist-to",
+      persistDir,
+      "--var",
+      `ADMIN_TOKEN:${adminToken}`,
+      "--var",
+      `CLAUDE_UPSTREAM:${upstreamOrigin}`,
+      "--log-level",
+      "error",
+    ],
+    {
+      cwd: import.meta.dir.replace(/\/test$/, ""),
+      stdout: "pipe",
+      stderr: "pipe",
+    }
+  )
+  processes.push(worker)
+  const baseURL = `http://127.0.0.1:${workerPort}`
+  await waitForWorker(baseURL)
+  return baseURL
+}
+
+const createTenant = async (
+  baseURL: string,
+  name: string
+): Promise<{ readonly id: string; readonly key: string }> => {
+  const response = await fetch(`${baseURL}/admin/tenants`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ name }),
+  })
+  expect(response.status).toBe(200)
+  return (await response.json()) as { id: string; key: string }
+}
+
+const uploadAccount = async (
+  baseURL: string,
+  tenantKey: string,
+  body: Record<string, unknown>,
+  secrets: ReadonlyArray<string>
+): Promise<Record<string, any>> => {
+  const response = await fetch(`${baseURL}/tenant/accounts`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${tenantKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  })
+  expect(response.status).toBe(200)
+  const text = await response.text()
+  for (const secret of secrets) expect(text).not.toContain(secret)
+  return JSON.parse(text) as Record<string, any>
+}
+
+const waitForCondition = async (
+  condition: () => boolean,
+  label: string
+): Promise<void> => {
+  const deadline = Date.now() + 12_000
+  while (Date.now() < deadline) {
+    if (condition()) return
+    await Bun.sleep(100)
+  }
+  throw new Error(`${label} timed out`)
+}
+
+const waitForWorker = async (baseURL: string): Promise<void> => {
+  const deadline = Date.now() + 20_000
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseURL}/healthz`)
+      if (response.ok) return
+      lastError = new Error(`healthz returned ${response.status}`)
+    } catch (error) {
+      lastError = error
+    }
+    await Bun.sleep(250)
+  }
+  throw lastError ?? new Error("worker did not start")
+}

--- a/cloudflare/packages/worker/test/account-upload.test.ts
+++ b/cloudflare/packages/worker/test/account-upload.test.ts
@@ -1,22 +1,59 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp } from "node:fs/promises"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
+import {
+  cleanupWorkers,
+  createTenant,
+  startWorker,
+  waitForCondition,
+} from "./helpers/worker.ts"
 
-const adminToken = "admin-test-token"
-
-const processes: Bun.Subprocess[] = []
 const servers: Array<{ stop: () => void }> = []
 
 afterEach(async () => {
-  for (const proc of processes.splice(0)) {
-    proc.kill()
-    await proc.exited.catch(() => {})
-  }
+  await cleanupWorkers()
   for (const server of servers.splice(0)) server.stop()
 })
 
 describe("tenant account upload API", () => {
+  test("times out validation fetches without storing the account", async () => {
+    const hangingUsage = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Promise<Response>(() => {})
+      },
+    })
+    servers.push(hangingUsage)
+
+    const worker = await startWorker({ vars: { VALIDATION_TIMEOUT_MS: 50 } })
+    const tenant = await createTenant(worker.baseURL, "Validation Timeout Tenant")
+    const response = await fetch(`${worker.baseURL}/tenant/accounts?validate=1`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${tenant.key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        provider: "claude",
+        label: "slow-validation@example.com",
+        claudeAiOauth: {
+          accessToken: "slow-validation-access",
+          refreshToken: "slow-validation-refresh",
+          expiresAt: Date.now() + 3_600_000,
+          subscriptionType: "max",
+          usageUrl: `${hangingUsage.url.origin}/usage`,
+        },
+      }),
+    })
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("Account validation failed")
+
+    const list = await fetch(`${worker.baseURL}/tenant/accounts`, {
+      headers: { Authorization: `Bearer ${tenant.key}` },
+    })
+    expect(list.status).toBe(200)
+    const body = (await list.json()) as { accounts: unknown[] }
+    expect(body.accounts).toEqual([])
+  }, 60_000)
+
   test("round-trips providers, sanitizes secrets, deletes accounts, and refreshes uploaded OAuth credentials", async () => {
     const refreshTokens: string[] = []
     const authServer = Bun.serve({
@@ -65,7 +102,8 @@ describe("tenant account upload API", () => {
     })
     servers.push(upstream)
 
-    const baseURL = await startWorker(upstream.url.origin)
+    const worker = await startWorker({ claudeUpstream: upstream.url.origin })
+    const baseURL = worker.baseURL
     const tenant = await createTenant(baseURL, "Upload Tenant")
 
     const secrets = [
@@ -188,56 +226,6 @@ describe("tenant account upload API", () => {
   }, 90_000)
 })
 
-const startWorker = async (upstreamOrigin: string): Promise<string> => {
-  const workerPort = 20_000 + Math.floor(Math.random() * 1_000)
-  const persistDir = await mkdtemp(join(tmpdir(), "subrouter-upload-test-"))
-  const worker = Bun.spawn(
-    [
-      "bunx",
-      "wrangler",
-      "dev",
-      "--local",
-      "--ip",
-      "127.0.0.1",
-      "--port",
-      String(workerPort),
-      "--persist-to",
-      persistDir,
-      "--var",
-      `ADMIN_TOKEN:${adminToken}`,
-      "--var",
-      `CLAUDE_UPSTREAM:${upstreamOrigin}`,
-      "--log-level",
-      "error",
-    ],
-    {
-      cwd: import.meta.dir.replace(/\/test$/, ""),
-      stdout: "pipe",
-      stderr: "pipe",
-    }
-  )
-  processes.push(worker)
-  const baseURL = `http://127.0.0.1:${workerPort}`
-  await waitForWorker(baseURL)
-  return baseURL
-}
-
-const createTenant = async (
-  baseURL: string,
-  name: string
-): Promise<{ readonly id: string; readonly key: string }> => {
-  const response = await fetch(`${baseURL}/admin/tenants`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${adminToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ name }),
-  })
-  expect(response.status).toBe(200)
-  return (await response.json()) as { id: string; key: string }
-}
-
 const uploadAccount = async (
   baseURL: string,
   tenantKey: string,
@@ -256,32 +244,4 @@ const uploadAccount = async (
   const text = await response.text()
   for (const secret of secrets) expect(text).not.toContain(secret)
   return JSON.parse(text) as Record<string, any>
-}
-
-const waitForCondition = async (
-  condition: () => boolean,
-  label: string
-): Promise<void> => {
-  const deadline = Date.now() + 12_000
-  while (Date.now() < deadline) {
-    if (condition()) return
-    await Bun.sleep(100)
-  }
-  throw new Error(`${label} timed out`)
-}
-
-const waitForWorker = async (baseURL: string): Promise<void> => {
-  const deadline = Date.now() + 20_000
-  let lastError: unknown
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(`${baseURL}/healthz`)
-      if (response.ok) return
-      lastError = new Error(`healthz returned ${response.status}`)
-    } catch (error) {
-      lastError = error
-    }
-    await Bun.sleep(250)
-  }
-  throw lastError ?? new Error("worker did not start")
 }

--- a/cloudflare/packages/worker/test/contract.test.ts
+++ b/cloudflare/packages/worker/test/contract.test.ts
@@ -105,6 +105,7 @@ describe("subrouter Durable Object contract", () => {
         "X-Subrouter-Session": "session-1",
         "X-Subrouter-Org-ID": "org-a",
         "X-Subrouter-Account-ID": "codex-a",
+        "X-Subrouter-Tenant-Key": "srt_0123456789abcdef0123456789abcdef",
         Authorization: "Bearer caller-token",
       }),
       codexAccount
@@ -113,6 +114,7 @@ describe("subrouter Durable Object contract", () => {
     expect(headers.get("X-Subrouter-Session")).toBeNull()
     expect(headers.get("X-Subrouter-Org-ID")).toBeNull()
     expect(headers.get("X-Subrouter-Account-ID")).toBeNull()
+    expect(headers.get("X-Subrouter-Tenant-Key")).toBeNull()
     expect(headers.get("Authorization")).toBe(`Bearer ${codexAccount.credentials?.accessToken}`)
     expect(headers.get("ChatGPT-Account-ID")).toBe("chatgpt-account")
   })

--- a/cloudflare/packages/worker/test/helpers/worker.ts
+++ b/cloudflare/packages/worker/test/helpers/worker.ts
@@ -1,0 +1,177 @@
+import { expect } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+export const adminToken = "admin-test-token"
+export const proxyToken = "proxy-test-token"
+
+export interface StartedWorker {
+  readonly baseURL: string
+  readonly proc: Bun.Subprocess
+  readonly persistDir: string
+}
+
+export interface StartWorkerOptions {
+  readonly codexUpstream?: string
+  readonly apiUpstream?: string
+  readonly claudeUpstream?: string
+  readonly allowLegacy?: boolean
+  readonly persistDir?: string
+  readonly vars?: Readonly<Record<string, string | number | boolean>>
+}
+
+const workers: StartedWorker[] = []
+const tempDirs = new Set<string>()
+
+export const makePersistDir = async (prefix: string): Promise<string> => {
+  const persistDir = await mkdtemp(join(tmpdir(), prefix))
+  tempDirs.add(persistDir)
+  return persistDir
+}
+
+export const startWorker = async (
+  options: StartWorkerOptions = {}
+): Promise<StartedWorker> => {
+  const workerPort = 18_000 + Math.floor(Math.random() * 20_000)
+  const persistDir =
+    options.persistDir ?? await makePersistDir("subrouter-worker-test-")
+  tempDirs.add(persistDir)
+  const vars: Record<string, string | number | boolean> = {
+    ADMIN_TOKEN: adminToken,
+    ...(options.codexUpstream ? { CODEX_UPSTREAM: options.codexUpstream } : {}),
+    ...(options.apiUpstream ? { API_UPSTREAM: options.apiUpstream } : {}),
+    ...(options.claudeUpstream ? { CLAUDE_UPSTREAM: options.claudeUpstream } : {}),
+    ...(options.allowLegacy ? { PROXY_TOKEN: proxyToken, ALLOW_LEGACY_PROXY_TOKEN: "1" } : {}),
+    ...(options.vars ?? {}),
+  }
+  const args = [
+    "bunx",
+    "wrangler",
+    "dev",
+    "--local",
+    "--ip",
+    "127.0.0.1",
+    "--port",
+    String(workerPort),
+    "--persist-to",
+    persistDir,
+  ]
+  for (const [name, value] of Object.entries(vars)) {
+    args.push("--var", `${name}:${String(value)}`)
+  }
+  args.push("--log-level", "error")
+  const proc = Bun.spawn(args, {
+    cwd: import.meta.dir.replace(/\/test\/helpers$/, ""),
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const worker = { baseURL: `http://127.0.0.1:${workerPort}`, proc, persistDir }
+  workers.push(worker)
+  await waitForWorker(worker.baseURL)
+  return worker
+}
+
+export const stopWorker = async (worker: StartedWorker): Promise<void> => {
+  const index = workers.indexOf(worker)
+  if (index >= 0) workers.splice(index, 1)
+  await killProcessTree(worker.proc.pid)
+  await worker.proc.exited.catch(() => {})
+}
+
+export const cleanupWorkers = async (): Promise<void> => {
+  for (const worker of workers.splice(0)) {
+    await killProcessTree(worker.proc.pid)
+    await worker.proc.exited.catch(() => {})
+  }
+  for (const dir of [...tempDirs]) {
+    await rm(dir, { recursive: true, force: true })
+    tempDirs.delete(dir)
+  }
+}
+
+export const createTenant = async (
+  baseURL: string,
+  name: string
+): Promise<{ readonly id: string; readonly name: string; readonly key: string }> => {
+  const response = await fetch(`${baseURL}/admin/tenants`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ name }),
+  })
+  expect(response.status).toBe(200)
+  const tenant = (await response.json()) as { id: string; name: string; key: string }
+  expect(tenant.key).toMatch(/^srt_[0-9a-f]{32}$/)
+  return tenant
+}
+
+export const adminJSON = async <T>(baseURL: string, path: string): Promise<T> => {
+  const response = await fetch(`${baseURL}${path}`, {
+    headers: { Authorization: `Bearer ${adminToken}` },
+  })
+  expect(response.status).toBe(200)
+  return (await response.json()) as T
+}
+
+export const waitForCondition = async (
+  condition: () => boolean,
+  label: string,
+  timeoutMs = 10_000
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (condition()) return
+    await Bun.sleep(100)
+  }
+  throw new Error(`${label} timed out`)
+}
+
+export const waitForWorker = async (baseURL: string): Promise<void> => {
+  const deadline = Date.now() + 20_000
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseURL}/healthz`)
+      if (response.ok) return
+      lastError = new Error(`healthz returned ${response.status}`)
+    } catch (error) {
+      lastError = error
+    }
+    await Bun.sleep(250)
+  }
+  throw lastError ?? new Error("worker did not start")
+}
+
+const killProcessTree = async (pid: number): Promise<void> => {
+  const children = await childPids(pid)
+  for (const child of children) {
+    await killProcessTree(child)
+  }
+  signalProcess(pid, "SIGTERM")
+  await Bun.sleep(300)
+  signalProcess(pid, "SIGKILL")
+}
+
+const childPids = async (pid: number): Promise<number[]> => {
+  const proc = Bun.spawn(["pgrep", "-P", String(pid)], {
+    stdout: "pipe",
+    stderr: "ignore",
+  })
+  const output = await new Response(proc.stdout).text()
+  await proc.exited.catch(() => {})
+  return output
+    .split(/\s+/)
+    .map((value) => Number(value))
+    .filter((value) => Number.isInteger(value) && value > 0)
+}
+
+const signalProcess = (pid: number, signal: NodeJS.Signals): void => {
+  try {
+    process.kill(pid, signal)
+  } catch {
+    // The process may already be gone.
+  }
+}

--- a/cloudflare/packages/worker/test/legacy-token.test.ts
+++ b/cloudflare/packages/worker/test/legacy-token.test.ts
@@ -1,0 +1,306 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const adminToken = "admin-test-token"
+const proxyToken = "proxy-test-token"
+
+const processes: Bun.Subprocess[] = []
+const servers: Array<{ stop: () => void }> = []
+
+afterEach(async () => {
+  for (const proc of processes.splice(0)) {
+    proc.kill()
+    await proc.exited.catch(() => {})
+  }
+  for (const server of servers.splice(0)) server.stop()
+})
+
+describe("legacy proxy token compatibility", () => {
+  test("rejects PROXY_TOKEN by default", async () => {
+    const baseURL = await startWorker({ allowLegacy: false })
+    const response = await fetch(`${baseURL}/status`, {
+      headers: { Authorization: `Bearer ${proxyToken}` },
+    })
+    expect(response.status).toBe(401)
+  }, 60_000)
+
+  test("routes PROXY_TOKEN to the legacy tenant only when enabled", async () => {
+    let upstreamAuth: string | null = null
+    const upstream = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        upstreamAuth = request.headers.get("Authorization")
+        return Response.json({ ok: true })
+      },
+    })
+    servers.push(upstream)
+
+    const baseURL = await startWorker({
+      allowLegacy: true,
+      apiUpstream: upstream.url.origin,
+    })
+    await upsertLegacyAccount(baseURL)
+
+    const response = await fetch(`${baseURL}/v1/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${proxyToken}`,
+        "Content-Type": "application/json",
+        "X-Subrouter-Session": "legacy-session",
+      },
+      body: JSON.stringify({ model: "gpt-5", input: "hello" }),
+    })
+    expect(response.status).toBe(200)
+    expect(upstreamAuth as string | null).toBe("Bearer sk-legacy")
+  }, 60_000)
+
+  test("keeps reserved-name registry tenants isolated from bare legacy objects", async () => {
+    const upstreamAuths: string[] = []
+    const upstream = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        upstreamAuths.push(request.headers.get("Authorization") ?? "")
+        return Response.json({ ok: true })
+      },
+    })
+    servers.push(upstream)
+
+    const baseURL = await startWorker({
+      allowLegacy: true,
+      apiUpstream: upstream.url.origin,
+    })
+    const legacyNamedTenant = await createTenant(baseURL, "legacy")
+    const demoNamedTenant = await createTenant(baseURL, "demo-org")
+    expect(legacyNamedTenant.id).not.toBe("legacy")
+    expect(demoNamedTenant.id).not.toBe("demo-org")
+
+    const registryLegacyAccount = await uploadOpenAIAccount(
+      baseURL,
+      legacyNamedTenant.key,
+      "registry legacy",
+      "sk-registry-legacy"
+    )
+    const registryDemoAccount = await uploadOpenAIAccount(
+      baseURL,
+      demoNamedTenant.key,
+      "registry demo",
+      "sk-registry-demo"
+    )
+    await upsertBareAccount(baseURL, {
+      id: "legacy-account",
+      orgId: "legacy",
+      apiKey: "sk-legacy",
+    })
+    await upsertBareAccount(baseURL, {
+      id: "demo-org-account",
+      orgId: "demo-org",
+      apiKey: "sk-demo-org",
+    })
+
+    const registryLegacyList = await tenantAccounts(baseURL, legacyNamedTenant.key)
+    const registryDemoList = await tenantAccounts(baseURL, demoNamedTenant.key)
+    const bareLegacyList = await adminJSON<Array<Record<string, any>>>(
+      baseURL,
+      "/_subrouter/accounts?tenant=legacy"
+    )
+    const bareDemoList = await adminJSON<Array<Record<string, any>>>(
+      baseURL,
+      "/_subrouter/accounts?tenant=demo-org"
+    )
+    expect(registryLegacyList.map((account) => account.id)).toEqual([
+      registryLegacyAccount.id,
+    ])
+    expect(registryDemoList.map((account) => account.id)).toEqual([
+      registryDemoAccount.id,
+    ])
+    expect(bareLegacyList.map((account) => account.id)).toEqual(["legacy-account"])
+    expect(bareDemoList.map((account) => account.id)).toEqual(["demo-org-account"])
+
+    const registryLegacyProxy = await fetch(`${baseURL}/v1/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${legacyNamedTenant.key}`,
+        "Content-Type": "application/json",
+        "X-Subrouter-Session": "registry-legacy-session",
+      },
+      body: "{}",
+    })
+    const registryDemoProxy = await fetch(`${baseURL}/v1/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${demoNamedTenant.key}`,
+        "Content-Type": "application/json",
+        "X-Subrouter-Session": "registry-demo-session",
+      },
+      body: "{}",
+    })
+    const legacyProxy = await fetch(`${baseURL}/v1/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${proxyToken}`,
+        "Content-Type": "application/json",
+        "X-Subrouter-Session": "bare-legacy-session",
+      },
+      body: "{}",
+    })
+    expect(registryLegacyProxy.status).toBe(200)
+    expect(registryDemoProxy.status).toBe(200)
+    expect(legacyProxy.status).toBe(200)
+    expect(upstreamAuths).toEqual([
+      "Bearer sk-registry-legacy",
+      "Bearer sk-registry-demo",
+      "Bearer sk-legacy",
+    ])
+  }, 60_000)
+})
+
+const startWorker = async (input: {
+  readonly allowLegacy: boolean
+  readonly apiUpstream?: string
+}): Promise<string> => {
+  const workerPort = 22_000 + Math.floor(Math.random() * 1_000)
+  const persistDir = await mkdtemp(join(tmpdir(), "subrouter-legacy-test-"))
+  const args = [
+    "bunx",
+    "wrangler",
+    "dev",
+    "--local",
+    "--ip",
+    "127.0.0.1",
+    "--port",
+    String(workerPort),
+    "--persist-to",
+    persistDir,
+    "--var",
+    `ADMIN_TOKEN:${adminToken}`,
+    "--var",
+    `PROXY_TOKEN:${proxyToken}`,
+  ]
+  if (input.allowLegacy) {
+    args.push("--var", "ALLOW_LEGACY_PROXY_TOKEN:1")
+  }
+  if (input.apiUpstream) {
+    args.push("--var", `API_UPSTREAM:${input.apiUpstream}`)
+  }
+  args.push("--log-level", "error")
+  const worker = Bun.spawn(args, {
+    cwd: import.meta.dir.replace(/\/test$/, ""),
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  processes.push(worker)
+  const baseURL = `http://127.0.0.1:${workerPort}`
+  await waitForWorker(baseURL)
+  return baseURL
+}
+
+const upsertLegacyAccount = async (baseURL: string): Promise<void> => {
+  await upsertBareAccount(baseURL, {
+    id: "legacy-account",
+    orgId: "legacy",
+    apiKey: "sk-legacy",
+  })
+}
+
+const createTenant = async (
+  baseURL: string,
+  name: string
+): Promise<{ readonly id: string; readonly key: string }> => {
+  const response = await fetch(`${baseURL}/admin/tenants`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ name }),
+  })
+  expect(response.status).toBe(200)
+  return (await response.json()) as { id: string; key: string }
+}
+
+const uploadOpenAIAccount = async (
+  baseURL: string,
+  tenantKey: string,
+  label: string,
+  apiKey: string
+): Promise<Record<string, any>> => {
+  const response = await fetch(`${baseURL}/tenant/accounts`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${tenantKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      provider: "openai-apikey",
+      label,
+      apiKey,
+    }),
+  })
+  expect(response.status).toBe(200)
+  const text = await response.text()
+  expect(text).not.toContain(apiKey)
+  return JSON.parse(text) as Record<string, any>
+}
+
+const tenantAccounts = async (
+  baseURL: string,
+  tenantKey: string
+): Promise<Array<Record<string, any>>> => {
+  const response = await fetch(`${baseURL}/tenant/accounts`, {
+    headers: { Authorization: `Bearer ${tenantKey}` },
+  })
+  expect(response.status).toBe(200)
+  const body = (await response.json()) as { accounts: Array<Record<string, any>> }
+  return body.accounts
+}
+
+const adminJSON = async <T>(baseURL: string, path: string): Promise<T> => {
+  const response = await fetch(`${baseURL}${path}`, {
+    headers: { Authorization: `Bearer ${adminToken}` },
+  })
+  expect(response.status).toBe(200)
+  return (await response.json()) as T
+}
+
+const upsertBareAccount = async (
+  baseURL: string,
+  input: {
+    readonly id: string
+    readonly orgId: string
+    readonly apiKey: string
+  }
+): Promise<void> => {
+  const response = await fetch(`${baseURL}/admin/accounts`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      id: input.id,
+      orgId: input.orgId,
+      kind: "openai_apikey",
+      label: `${input.id}@example.com`,
+      credentials: { apiKey: input.apiKey },
+    }),
+  })
+  expect(response.status).toBe(200)
+}
+
+const waitForWorker = async (baseURL: string): Promise<void> => {
+  const deadline = Date.now() + 20_000
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseURL}/healthz`)
+      if (response.ok) return
+      lastError = new Error(`healthz returned ${response.status}`)
+    } catch (error) {
+      lastError = error
+    }
+    await Bun.sleep(250)
+  }
+  throw lastError ?? new Error("worker did not start")
+}

--- a/cloudflare/packages/worker/test/legacy-token.test.ts
+++ b/cloudflare/packages/worker/test/legacy-token.test.ts
@@ -1,25 +1,24 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp } from "node:fs/promises"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
+import {
+  adminJSON,
+  adminToken,
+  cleanupWorkers,
+  createTenant,
+  proxyToken,
+  startWorker,
+} from "./helpers/worker.ts"
 
-const adminToken = "admin-test-token"
-const proxyToken = "proxy-test-token"
-
-const processes: Bun.Subprocess[] = []
 const servers: Array<{ stop: () => void }> = []
 
 afterEach(async () => {
-  for (const proc of processes.splice(0)) {
-    proc.kill()
-    await proc.exited.catch(() => {})
-  }
+  await cleanupWorkers()
   for (const server of servers.splice(0)) server.stop()
 })
 
 describe("legacy proxy token compatibility", () => {
   test("rejects PROXY_TOKEN by default", async () => {
-    const baseURL = await startWorker({ allowLegacy: false })
+    const worker = await startWorker({ vars: { PROXY_TOKEN: proxyToken } })
+    const baseURL = worker.baseURL
     const response = await fetch(`${baseURL}/status`, {
       headers: { Authorization: `Bearer ${proxyToken}` },
     })
@@ -37,10 +36,11 @@ describe("legacy proxy token compatibility", () => {
     })
     servers.push(upstream)
 
-    const baseURL = await startWorker({
+    const worker = await startWorker({
       allowLegacy: true,
       apiUpstream: upstream.url.origin,
     })
+    const baseURL = worker.baseURL
     await upsertLegacyAccount(baseURL)
 
     const response = await fetch(`${baseURL}/v1/responses`, {
@@ -67,10 +67,11 @@ describe("legacy proxy token compatibility", () => {
     })
     servers.push(upstream)
 
-    const baseURL = await startWorker({
+    const worker = await startWorker({
       allowLegacy: true,
       apiUpstream: upstream.url.origin,
     })
+    const baseURL = worker.baseURL
     const legacyNamedTenant = await createTenant(baseURL, "legacy")
     const demoNamedTenant = await createTenant(baseURL, "demo-org")
     expect(legacyNamedTenant.id).not.toBe("legacy")
@@ -156,68 +157,12 @@ describe("legacy proxy token compatibility", () => {
   }, 60_000)
 })
 
-const startWorker = async (input: {
-  readonly allowLegacy: boolean
-  readonly apiUpstream?: string
-}): Promise<string> => {
-  const workerPort = 22_000 + Math.floor(Math.random() * 1_000)
-  const persistDir = await mkdtemp(join(tmpdir(), "subrouter-legacy-test-"))
-  const args = [
-    "bunx",
-    "wrangler",
-    "dev",
-    "--local",
-    "--ip",
-    "127.0.0.1",
-    "--port",
-    String(workerPort),
-    "--persist-to",
-    persistDir,
-    "--var",
-    `ADMIN_TOKEN:${adminToken}`,
-    "--var",
-    `PROXY_TOKEN:${proxyToken}`,
-  ]
-  if (input.allowLegacy) {
-    args.push("--var", "ALLOW_LEGACY_PROXY_TOKEN:1")
-  }
-  if (input.apiUpstream) {
-    args.push("--var", `API_UPSTREAM:${input.apiUpstream}`)
-  }
-  args.push("--log-level", "error")
-  const worker = Bun.spawn(args, {
-    cwd: import.meta.dir.replace(/\/test$/, ""),
-    stdout: "pipe",
-    stderr: "pipe",
-  })
-  processes.push(worker)
-  const baseURL = `http://127.0.0.1:${workerPort}`
-  await waitForWorker(baseURL)
-  return baseURL
-}
-
 const upsertLegacyAccount = async (baseURL: string): Promise<void> => {
   await upsertBareAccount(baseURL, {
     id: "legacy-account",
     orgId: "legacy",
     apiKey: "sk-legacy",
   })
-}
-
-const createTenant = async (
-  baseURL: string,
-  name: string
-): Promise<{ readonly id: string; readonly key: string }> => {
-  const response = await fetch(`${baseURL}/admin/tenants`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${adminToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ name }),
-  })
-  expect(response.status).toBe(200)
-  return (await response.json()) as { id: string; key: string }
 }
 
 const uploadOpenAIAccount = async (
@@ -256,14 +201,6 @@ const tenantAccounts = async (
   return body.accounts
 }
 
-const adminJSON = async <T>(baseURL: string, path: string): Promise<T> => {
-  const response = await fetch(`${baseURL}${path}`, {
-    headers: { Authorization: `Bearer ${adminToken}` },
-  })
-  expect(response.status).toBe(200)
-  return (await response.json()) as T
-}
-
 const upsertBareAccount = async (
   baseURL: string,
   input: {
@@ -287,20 +224,4 @@ const upsertBareAccount = async (
     }),
   })
   expect(response.status).toBe(200)
-}
-
-const waitForWorker = async (baseURL: string): Promise<void> => {
-  const deadline = Date.now() + 20_000
-  let lastError: unknown
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(`${baseURL}/healthz`)
-      if (response.ok) return
-      lastError = new Error(`healthz returned ${response.status}`)
-    } catch (error) {
-      lastError = error
-    }
-    await Bun.sleep(250)
-  }
-  throw lastError ?? new Error("worker did not start")
 }

--- a/cloudflare/packages/worker/test/tenant-isolation.test.ts
+++ b/cloudflare/packages/worker/test/tenant-isolation.test.ts
@@ -1,18 +1,16 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp } from "node:fs/promises"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
+import {
+  adminJSON,
+  adminToken,
+  cleanupWorkers,
+  createTenant,
+  startWorker,
+} from "./helpers/worker.ts"
 
-const adminToken = "admin-test-token"
-
-const processes: Bun.Subprocess[] = []
 const servers: Array<{ stop: () => void }> = []
 
 afterEach(async () => {
-  for (const proc of processes.splice(0)) {
-    proc.kill()
-    await proc.exited.catch(() => {})
-  }
+  await cleanupWorkers()
   for (const server of servers.splice(0)) server.stop()
 })
 
@@ -46,7 +44,8 @@ describe("tenant isolation", () => {
     })
     servers.push(usage)
 
-    const baseURL = await startWorker(upstream.url.origin)
+    const worker = await startWorker({ claudeUpstream: upstream.url.origin })
+    const baseURL = worker.baseURL
     const tenantA = await createTenant(baseURL, "Tenant A")
     const tenantB = await createTenant(baseURL, "Tenant B")
     const accountA = await uploadClaudeAccount(
@@ -163,6 +162,7 @@ describe("tenant isolation", () => {
       },
       body: JSON.stringify({
         orgId: tenantB.id,
+        agentType: "claude",
         sessionId: "attacker-route-session",
         model: "claude-3-haiku",
       }),
@@ -196,57 +196,119 @@ describe("tenant isolation", () => {
     expect(rawBAfterOverride.status).toBe(200)
     expect(rawBAfterOverrideText).not.toContain("tenant-a-attacker-override")
   }, 90_000)
-})
 
-const startWorker = async (upstreamOrigin: string): Promise<string> => {
-  const workerPort = 21_000 + Math.floor(Math.random() * 1_000)
-  const persistDir = await mkdtemp(join(tmpdir(), "subrouter-isolation-test-"))
-  const worker = Bun.spawn(
-    [
-      "bunx",
-      "wrangler",
-      "dev",
-      "--local",
-      "--ip",
-      "127.0.0.1",
-      "--port",
-      String(workerPort),
-      "--persist-to",
-      persistDir,
-      "--var",
-      `ADMIN_TOKEN:${adminToken}`,
-      "--var",
-      `CLAUDE_UPSTREAM:${upstreamOrigin}`,
-      "--log-level",
-      "error",
-    ],
-    {
-      cwd: import.meta.dir.replace(/\/test$/, ""),
-      stdout: "pipe",
-      stderr: "pipe",
+  test("routes mixed provider accounts by proxy upstream family", async () => {
+    const claudeAuths: string[] = []
+    const claudeUpstream = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        claudeAuths.push(request.headers.get("Authorization") ?? "")
+        return Response.json({ id: "claude-response", type: "message" })
+      },
+    })
+    servers.push(claudeUpstream)
+    const codexAuths: string[] = []
+    const codexUpstream = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        codexAuths.push(request.headers.get("Authorization") ?? "")
+        return Response.json({ id: "codex-response" })
+      },
+    })
+    servers.push(codexUpstream)
+    const usage = Bun.serve({
+      port: 0,
+      async fetch() {
+        return Response.json({
+          five_hour: { utilization: 1, resets_at: "2026-07-03T12:00:00.000Z" },
+        })
+      },
+    })
+    servers.push(usage)
+
+    const worker = await startWorker({
+      claudeUpstream: claudeUpstream.url.origin,
+      codexUpstream: `${codexUpstream.url.origin}/backend-api/codex`,
+    })
+    const baseURL = worker.baseURL
+    const tenant = await createTenant(baseURL, "Mixed Provider Tenant")
+    const claudeAccount = await uploadClaudeAccount(
+      baseURL,
+      tenant.key,
+      "mixed-claude@example.com",
+      "mixed-claude-access-token",
+      `${usage.url.origin}/usage`
+    )
+    const codexAccount = await uploadCodexAccount(
+      baseURL,
+      tenant.key,
+      "mixed-codex@example.com",
+      "mixed-codex-access-token"
+    )
+
+    for (let i = 0; i < 4; i += 1) {
+      const response = await fetch(`${baseURL}/v1/messages`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${tenant.key}`,
+          "Content-Type": "application/json",
+          "X-Subrouter-Session": `mixed-claude-${i}`,
+        },
+        body: JSON.stringify({ model: "claude-haiku-4", messages: [] }),
+      })
+      expect(response.status).toBe(200)
     }
-  )
-  processes.push(worker)
-  const baseURL = `http://127.0.0.1:${workerPort}`
-  await waitForWorker(baseURL)
-  return baseURL
-}
 
-const createTenant = async (
-  baseURL: string,
-  name: string
-): Promise<{ readonly id: string; readonly key: string }> => {
-  const response = await fetch(`${baseURL}/admin/tenants`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${adminToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ name }),
-  })
-  expect(response.status).toBe(200)
-  return (await response.json()) as { id: string; key: string }
-}
+    for (let i = 0; i < 4; i += 1) {
+      const response = await fetch(`${baseURL}/v1/responses`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${tenant.key}`,
+          "Content-Type": "application/json",
+          "X-Subrouter-Session": `mixed-codex-${i}`,
+        },
+        body: JSON.stringify({ model: "gpt-5", input: "hello" }),
+      })
+      expect(response.status).toBe(200)
+    }
+
+    expect(claudeAuths).toEqual([
+      "Bearer mixed-claude-access-token",
+      "Bearer mixed-claude-access-token",
+      "Bearer mixed-claude-access-token",
+      "Bearer mixed-claude-access-token",
+    ])
+    expect(codexAuths).toEqual([
+      "Bearer mixed-codex-access-token",
+      "Bearer mixed-codex-access-token",
+      "Bearer mixed-codex-access-token",
+      "Bearer mixed-codex-access-token",
+    ])
+
+    const socket = new WebSocket(baseURL.replace("http://", "ws://") + "/ws", {
+      headers: { Authorization: `Bearer ${tenant.key}` },
+    } as unknown as string[])
+    await waitForWebSocket(socket, "open")
+    const codexRoute = await sendWebSocketJSON(socket, {
+      type: "route",
+      requestId: "codex-route",
+      sessionId: "ws-route-codex",
+      model: "gpt-5",
+    })
+    const claudeRoute = await sendWebSocketJSON(socket, {
+      type: "route",
+      requestId: "claude-route",
+      agentType: "claude",
+      sessionId: "ws-route-claude",
+      model: "claude-haiku-4",
+    })
+    socket.close()
+    expect(codexRoute.ok).toBe(true)
+    expect(codexRoute.message?.account?.id).toBe(codexAccount.id)
+    expect(claudeRoute.ok).toBe(true)
+    expect(claudeRoute.message?.account?.id).toBe(claudeAccount.id)
+  }, 90_000)
+})
 
 const uploadClaudeAccount = async (
   baseURL: string,
@@ -279,12 +341,33 @@ const uploadClaudeAccount = async (
   return JSON.parse(text) as Record<string, any>
 }
 
-const adminJSON = async <T>(baseURL: string, path: string): Promise<T> => {
-  const response = await fetch(`${baseURL}${path}`, {
-    headers: { Authorization: `Bearer ${adminToken}` },
+const uploadCodexAccount = async (
+  baseURL: string,
+  tenantKey: string,
+  label: string,
+  accessToken: string
+): Promise<Record<string, any>> => {
+  const response = await fetch(`${baseURL}/tenant/accounts`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${tenantKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      provider: "codex",
+      label,
+      tokens: {
+        accessToken,
+        refreshToken: `${accessToken}-refresh`,
+        idToken: `${accessToken}-id`,
+        accountID: `${accessToken}-account`,
+      },
+    }),
   })
   expect(response.status).toBe(200)
-  return (await response.json()) as T
+  const text = await response.text()
+  expect(text).not.toContain(accessToken)
+  return JSON.parse(text) as Record<string, any>
 }
 
 const waitForTranscriptEvents = async (
@@ -305,18 +388,31 @@ const waitForTranscriptEvents = async (
   return summaries
 }
 
-const waitForWorker = async (baseURL: string): Promise<void> => {
-  const deadline = Date.now() + 20_000
-  let lastError: unknown
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(`${baseURL}/healthz`)
-      if (response.ok) return
-      lastError = new Error(`healthz returned ${response.status}`)
-    } catch (error) {
-      lastError = error
-    }
-    await Bun.sleep(250)
-  }
-  throw lastError ?? new Error("worker did not start")
+const sendWebSocketJSON = async (
+  socket: WebSocket,
+  payload: Record<string, unknown>
+): Promise<Record<string, any>> => {
+  socket.send(JSON.stringify(payload))
+  const reply = await waitForWebSocket(socket, "message")
+  return JSON.parse(String(reply.data)) as Record<string, any>
 }
+
+const waitForWebSocket = <Type extends "open" | "message">(
+  socket: WebSocket,
+  type: Type
+): Promise<Type extends "message" ? MessageEvent : Event> =>
+  new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`websocket ${type} timed out`)), 10_000)
+    socket.addEventListener(
+      type,
+      (event) => {
+        clearTimeout(timeout)
+        resolve(event as Type extends "message" ? MessageEvent : Event)
+      },
+      { once: true }
+    )
+    socket.addEventListener("error", () => {
+      clearTimeout(timeout)
+      reject(new Error(`websocket ${type} failed`))
+    }, { once: true })
+  })

--- a/cloudflare/packages/worker/test/tenant-isolation.test.ts
+++ b/cloudflare/packages/worker/test/tenant-isolation.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const adminToken = "admin-test-token"
+
+const processes: Bun.Subprocess[] = []
+const servers: Array<{ stop: () => void }> = []
+
+afterEach(async () => {
+  for (const proc of processes.splice(0)) {
+    proc.kill()
+    await proc.exited.catch(() => {})
+  }
+  for (const server of servers.splice(0)) server.stop()
+})
+
+describe("tenant isolation", () => {
+  test("keeps accounts, sessions, usage status, and transcripts tenant-scoped", async () => {
+    const upstreamAuths: string[] = []
+    const upstream = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        upstreamAuths.push(request.headers.get("Authorization") ?? "")
+        return Response.json({
+          response: {
+            model: "claude-3-haiku",
+            usage: {
+              input_tokens: 12,
+              output_tokens: 4,
+              total_tokens: 16,
+            },
+          },
+        })
+      },
+    })
+    servers.push(upstream)
+    const usage = Bun.serve({
+      port: 0,
+      async fetch() {
+        return Response.json({
+          five_hour: { utilization: 10, resets_at: "2026-07-03T12:00:00.000Z" },
+        })
+      },
+    })
+    servers.push(usage)
+
+    const baseURL = await startWorker(upstream.url.origin)
+    const tenantA = await createTenant(baseURL, "Tenant A")
+    const tenantB = await createTenant(baseURL, "Tenant B")
+    const accountA = await uploadClaudeAccount(
+      baseURL,
+      tenantA.key,
+      "tenant-a@example.com",
+      "tenant-a-access-token",
+      `${usage.url.origin}/usage`
+    )
+    const accountB = await uploadClaudeAccount(
+      baseURL,
+      tenantB.key,
+      "tenant-b@example.com",
+      "tenant-b-access-token",
+      `${usage.url.origin}/usage`
+    )
+
+    const proxyA = await fetch(`${baseURL}/v1/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${tenantA.key}`,
+        "Content-Type": "application/json",
+        "X-Subrouter-Agent": "claude",
+        "X-Subrouter-Session": "shared-session",
+        "X-Subrouter-User-Email": "a@example.com",
+      },
+      body: JSON.stringify({ model: "claude-3-haiku", input: "tenant-a-secret" }),
+    })
+    expect(proxyA.status).toBe(200)
+
+    const proxyB = await fetch(`${baseURL}/v1/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${tenantB.key}`,
+        "Content-Type": "application/json",
+        "X-Subrouter-Agent": "claude",
+        "X-Subrouter-Session": "shared-session",
+        "X-Subrouter-User-Email": "b@example.com",
+      },
+      body: JSON.stringify({ model: "claude-3-haiku", input: "tenant-b-secret" }),
+    })
+    expect(proxyB.status).toBe(200)
+    expect(upstreamAuths).toEqual([
+      "Bearer tenant-a-access-token",
+      "Bearer tenant-b-access-token",
+    ])
+
+    const sessionsA = await adminJSON<Array<Record<string, any>>>(
+      baseURL,
+      `/_subrouter/sessions?tenant=${tenantA.id}`
+    )
+    const sessionsB = await adminJSON<Array<Record<string, any>>>(
+      baseURL,
+      `/_subrouter/sessions?tenant=${tenantB.id}`
+    )
+    expect(sessionsA.map((session) => session.account_id)).toEqual([accountA.id])
+    expect(sessionsB.map((session) => session.account_id)).toEqual([accountB.id])
+
+    const usageA = await adminJSON<Array<Record<string, any>>>(
+      baseURL,
+      `/_subrouter/usage-status?tenant=${tenantA.id}`
+    )
+    const usageB = await adminJSON<Array<Record<string, any>>>(
+      baseURL,
+      `/_subrouter/usage-status?tenant=${tenantB.id}`
+    )
+    expect(usageA.map((account) => account.id)).toEqual([accountA.id])
+    expect(usageB.map((account) => account.id)).toEqual([accountB.id])
+    expect(JSON.stringify(usageB)).not.toContain(accountA.id)
+
+    const transcriptsA = await waitForTranscriptEvents(baseURL, tenantA.id, 3)
+    const transcriptsB = await waitForTranscriptEvents(baseURL, tenantB.id, 3)
+    expect(transcriptsA).toHaveLength(1)
+    expect(transcriptsB).toHaveLength(1)
+    expect(transcriptsA[0]?.account).toBe(accountA.id)
+    expect(transcriptsB[0]?.account).toBe(accountB.id)
+    expect(JSON.stringify(transcriptsB)).not.toContain(accountA.id)
+
+    const rawB = await fetch(
+      `${baseURL}/_subrouter/transcripts/claude/shared-session/raw?tenant=${tenantB.id}`,
+      { headers: { Authorization: `Bearer ${adminToken}` } }
+    )
+    const rawBText = await rawB.text()
+    expect(rawB.status).toBe(200)
+    expect(rawBText).toContain("tenant-b-secret")
+    expect(rawBText).not.toContain("tenant-a-secret")
+    expect(rawBText).not.toContain(tenantA.key)
+    expect(rawBText).not.toContain("tenant-a-access-token")
+
+    const overrideProxy = await fetch(`${baseURL}/v1/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${tenantA.key}`,
+        "Content-Type": "application/json",
+        "X-Subrouter-Agent": "claude",
+        "X-Subrouter-Org-ID": tenantB.id,
+        "X-Subrouter-Session": "attacker-proxy-session",
+      },
+      body: JSON.stringify({
+        model: "claude-3-haiku",
+        input: "tenant-a-attacker-override",
+      }),
+    })
+    expect(overrideProxy.status).toBe(200)
+    expect(upstreamAuths[upstreamAuths.length - 1]).toBe(
+      "Bearer tenant-a-access-token"
+    )
+
+    const overrideRoute = await fetch(`${baseURL}/route`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${tenantA.key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        orgId: tenantB.id,
+        sessionId: "attacker-route-session",
+        model: "claude-3-haiku",
+      }),
+    })
+    expect(overrideRoute.status).toBe(200)
+    const overrideRouteBody = (await overrideRoute.json()) as Record<string, any>
+    expect(overrideRouteBody.account.id).toBe(accountA.id)
+
+    const sessionsBAfterOverride = await adminJSON<Array<Record<string, any>>>(
+      baseURL,
+      `/_subrouter/sessions?tenant=${tenantB.id}`
+    )
+    const usageBAfterOverride = await adminJSON<Array<Record<string, any>>>(
+      baseURL,
+      `/_subrouter/usage-status?tenant=${tenantB.id}`
+    )
+    const transcriptsBAfterOverride = await waitForTranscriptEvents(
+      baseURL,
+      tenantB.id,
+      3
+    )
+    expect(sessionsBAfterOverride).toEqual(sessionsB)
+    expect(usageBAfterOverride).toEqual(usageB)
+    expect(transcriptsBAfterOverride).toEqual(transcriptsB)
+
+    const rawBAfterOverride = await fetch(
+      `${baseURL}/_subrouter/transcripts/claude/shared-session/raw?tenant=${tenantB.id}`,
+      { headers: { Authorization: `Bearer ${adminToken}` } }
+    )
+    const rawBAfterOverrideText = await rawBAfterOverride.text()
+    expect(rawBAfterOverride.status).toBe(200)
+    expect(rawBAfterOverrideText).not.toContain("tenant-a-attacker-override")
+  }, 90_000)
+})
+
+const startWorker = async (upstreamOrigin: string): Promise<string> => {
+  const workerPort = 21_000 + Math.floor(Math.random() * 1_000)
+  const persistDir = await mkdtemp(join(tmpdir(), "subrouter-isolation-test-"))
+  const worker = Bun.spawn(
+    [
+      "bunx",
+      "wrangler",
+      "dev",
+      "--local",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      String(workerPort),
+      "--persist-to",
+      persistDir,
+      "--var",
+      `ADMIN_TOKEN:${adminToken}`,
+      "--var",
+      `CLAUDE_UPSTREAM:${upstreamOrigin}`,
+      "--log-level",
+      "error",
+    ],
+    {
+      cwd: import.meta.dir.replace(/\/test$/, ""),
+      stdout: "pipe",
+      stderr: "pipe",
+    }
+  )
+  processes.push(worker)
+  const baseURL = `http://127.0.0.1:${workerPort}`
+  await waitForWorker(baseURL)
+  return baseURL
+}
+
+const createTenant = async (
+  baseURL: string,
+  name: string
+): Promise<{ readonly id: string; readonly key: string }> => {
+  const response = await fetch(`${baseURL}/admin/tenants`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ name }),
+  })
+  expect(response.status).toBe(200)
+  return (await response.json()) as { id: string; key: string }
+}
+
+const uploadClaudeAccount = async (
+  baseURL: string,
+  tenantKey: string,
+  label: string,
+  accessToken: string,
+  usageUrl: string
+): Promise<Record<string, any>> => {
+  const response = await fetch(`${baseURL}/tenant/accounts`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${tenantKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      provider: "claude",
+      label,
+      claudeAiOauth: {
+        accessToken,
+        refreshToken: `${accessToken}-refresh`,
+        expiresAt: Date.now() + 3_600_000,
+        subscriptionType: "max",
+        usageUrl,
+      },
+    }),
+  })
+  expect(response.status).toBe(200)
+  const text = await response.text()
+  expect(text).not.toContain(accessToken)
+  return JSON.parse(text) as Record<string, any>
+}
+
+const adminJSON = async <T>(baseURL: string, path: string): Promise<T> => {
+  const response = await fetch(`${baseURL}${path}`, {
+    headers: { Authorization: `Bearer ${adminToken}` },
+  })
+  expect(response.status).toBe(200)
+  return (await response.json()) as T
+}
+
+const waitForTranscriptEvents = async (
+  baseURL: string,
+  tenantId: string,
+  eventCount: number
+): Promise<Array<Record<string, any>>> => {
+  const deadline = Date.now() + 10_000
+  let summaries: Array<Record<string, any>> = []
+  while (Date.now() < deadline) {
+    summaries = await adminJSON<Array<Record<string, any>>>(
+      baseURL,
+      `/_subrouter/transcripts?tenant=${tenantId}`
+    )
+    if ((summaries[0]?.event_count ?? 0) >= eventCount) return summaries
+    await Bun.sleep(100)
+  }
+  return summaries
+}
+
+const waitForWorker = async (baseURL: string): Promise<void> => {
+  const deadline = Date.now() + 20_000
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseURL}/healthz`)
+      if (response.ok) return
+      lastError = new Error(`healthz returned ${response.status}`)
+    } catch (error) {
+      lastError = error
+    }
+    await Bun.sleep(250)
+  }
+  throw lastError ?? new Error("worker did not start")
+}

--- a/cloudflare/packages/worker/test/tenants.test.ts
+++ b/cloudflare/packages/worker/test/tenants.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const adminToken = "admin-test-token"
+
+const processes: Bun.Subprocess[] = []
+
+afterEach(async () => {
+  for (const proc of processes.splice(0)) {
+    proc.kill()
+    await proc.exited.catch(() => {})
+  }
+})
+
+describe("tenant registry", () => {
+  test("creates, lists, revokes, rotates, authenticates, and persists tenants", async () => {
+    const persistDir = await mkdtemp(join(tmpdir(), "subrouter-tenants-test-"))
+    const first = await startWorker(persistDir)
+
+    const createA = await createTenant(first.baseURL, "Tenant Alpha")
+    const createText = JSON.stringify(createA)
+    expect(createA.key).toMatch(/^srt_[0-9a-f]{32}$/)
+    expect(createText).toContain(createA.key)
+
+    const createB = await createTenant(first.baseURL, "Tenant Beta")
+    const listBefore = await adminJSON<Array<Record<string, unknown>>>(
+      first.baseURL,
+      "/admin/tenants"
+    )
+    const listText = JSON.stringify(listBefore)
+    expect(listBefore.map((tenant) => tenant.id)).toEqual([
+      createA.id,
+      createB.id,
+    ])
+    expect(listText).not.toContain(createA.key)
+    expect(listText).not.toContain(await sha256Hex(createA.key))
+
+    expect((await fetch(`${first.baseURL}/status`)).status).toBe(401)
+    expect(
+      (
+        await fetch(`${first.baseURL}/status`, {
+          headers: { Authorization: "Bearer srt_not-a-valid-key" },
+        })
+      ).status
+    ).toBe(401)
+    expect(
+      (
+        await fetch(`${first.baseURL}/status`, {
+          headers: { Authorization: `Bearer ${createA.key}` },
+        })
+      ).status
+    ).toBe(200)
+
+    const revoke = await fetch(`${first.baseURL}/admin/tenants/${createA.id}/revoke`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${adminToken}` },
+    })
+    expect(revoke.status).toBe(200)
+    const revokeText = await revoke.text()
+    expect(revokeText).not.toContain(createA.key)
+    expect(
+      (
+        await fetch(`${first.baseURL}/status`, {
+          headers: { Authorization: `Bearer ${createA.key}` },
+        })
+      ).status
+    ).toBe(403)
+
+    const rotate = await fetch(`${first.baseURL}/admin/tenants/${createB.id}/rotate`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${adminToken}` },
+    })
+    expect(rotate.status).toBe(200)
+    const rotated = (await rotate.json()) as { key: string }
+    expect(rotated.key).toMatch(/^srt_[0-9a-f]{32}$/)
+    expect(rotated.key).not.toBe(createB.key)
+    expect(
+      (
+        await fetch(`${first.baseURL}/status`, {
+          headers: { Authorization: `Bearer ${createB.key}` },
+        })
+      ).status
+    ).toBe(401)
+    expect(
+      (
+        await fetch(`${first.baseURL}/status`, {
+          headers: { "X-Subrouter-Tenant-Key": rotated.key },
+        })
+      ).status
+    ).toBe(200)
+
+    await stopWorker(first.proc)
+    const second = await startWorker(persistDir)
+    const listAfter = await adminJSON<Array<Record<string, unknown>>>(
+      second.baseURL,
+      "/admin/tenants"
+    )
+    expect(listAfter.map((tenant) => tenant.id)).toEqual([
+      createA.id,
+      createB.id,
+    ])
+    expect(JSON.stringify(listAfter)).not.toContain(createA.key)
+    expect(JSON.stringify(listAfter)).not.toContain(rotated.key)
+  }, 90_000)
+})
+
+const startWorker = async (
+  persistDir: string
+): Promise<{ readonly baseURL: string; readonly proc: Bun.Subprocess }> => {
+  const workerPort = 19_000 + Math.floor(Math.random() * 1_000)
+  const proc = Bun.spawn(
+    [
+      "bunx",
+      "wrangler",
+      "dev",
+      "--local",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      String(workerPort),
+      "--persist-to",
+      persistDir,
+      "--var",
+      `ADMIN_TOKEN:${adminToken}`,
+      "--log-level",
+      "error",
+    ],
+    {
+      cwd: import.meta.dir.replace(/\/test$/, ""),
+      stdout: "pipe",
+      stderr: "pipe",
+    }
+  )
+  processes.push(proc)
+  const baseURL = `http://127.0.0.1:${workerPort}`
+  await waitForWorker(baseURL)
+  return { baseURL, proc }
+}
+
+const stopWorker = async (proc: Bun.Subprocess): Promise<void> => {
+  const index = processes.indexOf(proc)
+  if (index >= 0) processes.splice(index, 1)
+  proc.kill()
+  await proc.exited.catch(() => {})
+}
+
+const createTenant = async (
+  baseURL: string,
+  name: string
+): Promise<{ readonly id: string; readonly name: string; readonly key: string }> => {
+  const response = await fetch(`${baseURL}/admin/tenants`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ name }),
+  })
+  expect(response.status).toBe(200)
+  return (await response.json()) as { id: string; name: string; key: string }
+}
+
+const adminJSON = async <T>(baseURL: string, path: string): Promise<T> => {
+  const response = await fetch(`${baseURL}${path}`, {
+    headers: { Authorization: `Bearer ${adminToken}` },
+  })
+  expect(response.status).toBe(200)
+  return (await response.json()) as T
+}
+
+const sha256Hex = async (value: string): Promise<string> => {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value)
+  )
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+const waitForWorker = async (baseURL: string): Promise<void> => {
+  const deadline = Date.now() + 20_000
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseURL}/healthz`)
+      if (response.ok) return
+      lastError = new Error(`healthz returned ${response.status}`)
+    } catch (error) {
+      lastError = error
+    }
+    await Bun.sleep(250)
+  }
+  throw lastError ?? new Error("worker did not start")
+}

--- a/cloudflare/packages/worker/test/tenants.test.ts
+++ b/cloudflare/packages/worker/test/tenants.test.ts
@@ -1,23 +1,22 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp } from "node:fs/promises"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
-
-const adminToken = "admin-test-token"
-
-const processes: Bun.Subprocess[] = []
+import {
+  adminJSON,
+  adminToken,
+  cleanupWorkers,
+  createTenant,
+  makePersistDir,
+  startWorker,
+  stopWorker,
+} from "./helpers/worker.ts"
 
 afterEach(async () => {
-  for (const proc of processes.splice(0)) {
-    proc.kill()
-    await proc.exited.catch(() => {})
-  }
+  await cleanupWorkers()
 })
 
 describe("tenant registry", () => {
   test("creates, lists, revokes, rotates, authenticates, and persists tenants", async () => {
-    const persistDir = await mkdtemp(join(tmpdir(), "subrouter-tenants-test-"))
-    const first = await startWorker(persistDir)
+    const persistDir = await makePersistDir("subrouter-tenants-test-")
+    const first = await startWorker({ persistDir })
 
     const createA = await createTenant(first.baseURL, "Tenant Alpha")
     const createText = JSON.stringify(createA)
@@ -91,8 +90,8 @@ describe("tenant registry", () => {
       ).status
     ).toBe(200)
 
-    await stopWorker(first.proc)
-    const second = await startWorker(persistDir)
+    await stopWorker(first)
+    const second = await startWorker({ persistDir })
     const listAfter = await adminJSON<Array<Record<string, unknown>>>(
       second.baseURL,
       "/admin/tenants"
@@ -106,70 +105,6 @@ describe("tenant registry", () => {
   }, 90_000)
 })
 
-const startWorker = async (
-  persistDir: string
-): Promise<{ readonly baseURL: string; readonly proc: Bun.Subprocess }> => {
-  const workerPort = 19_000 + Math.floor(Math.random() * 1_000)
-  const proc = Bun.spawn(
-    [
-      "bunx",
-      "wrangler",
-      "dev",
-      "--local",
-      "--ip",
-      "127.0.0.1",
-      "--port",
-      String(workerPort),
-      "--persist-to",
-      persistDir,
-      "--var",
-      `ADMIN_TOKEN:${adminToken}`,
-      "--log-level",
-      "error",
-    ],
-    {
-      cwd: import.meta.dir.replace(/\/test$/, ""),
-      stdout: "pipe",
-      stderr: "pipe",
-    }
-  )
-  processes.push(proc)
-  const baseURL = `http://127.0.0.1:${workerPort}`
-  await waitForWorker(baseURL)
-  return { baseURL, proc }
-}
-
-const stopWorker = async (proc: Bun.Subprocess): Promise<void> => {
-  const index = processes.indexOf(proc)
-  if (index >= 0) processes.splice(index, 1)
-  proc.kill()
-  await proc.exited.catch(() => {})
-}
-
-const createTenant = async (
-  baseURL: string,
-  name: string
-): Promise<{ readonly id: string; readonly name: string; readonly key: string }> => {
-  const response = await fetch(`${baseURL}/admin/tenants`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${adminToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ name }),
-  })
-  expect(response.status).toBe(200)
-  return (await response.json()) as { id: string; name: string; key: string }
-}
-
-const adminJSON = async <T>(baseURL: string, path: string): Promise<T> => {
-  const response = await fetch(`${baseURL}${path}`, {
-    headers: { Authorization: `Bearer ${adminToken}` },
-  })
-  expect(response.status).toBe(200)
-  return (await response.json()) as T
-}
-
 const sha256Hex = async (value: string): Promise<string> => {
   const digest = await crypto.subtle.digest(
     "SHA-256",
@@ -178,20 +113,4 @@ const sha256Hex = async (value: string): Promise<string> => {
   return [...new Uint8Array(digest)]
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("")
-}
-
-const waitForWorker = async (baseURL: string): Promise<void> => {
-  const deadline = Date.now() + 20_000
-  let lastError: unknown
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(`${baseURL}/healthz`)
-      if (response.ok) return
-      lastError = new Error(`healthz returned ${response.status}`)
-    } catch (error) {
-      lastError = error
-    }
-    await Bun.sleep(250)
-  }
-  throw lastError ?? new Error("worker did not start")
 }

--- a/cloudflare/packages/worker/test/worker-transcripts.test.ts
+++ b/cloudflare/packages/worker/test/worker-transcripts.test.ts
@@ -50,9 +50,10 @@ describe("subrouter Durable Object Worker transcripts", () => {
     servers.push(upstream)
 
     const baseURL = await startWorker(`${upstream.url.origin}/backend-api/codex`)
+    const tenant = await createTenant(baseURL, "Refresh Org")
     await upsertAccount(baseURL, {
       id: "acct-refresh",
-      orgId: "org-refresh",
+      orgId: tenant.id,
       kind: "codex_oauth",
       label: "refresh@example.com",
       credentials: {
@@ -70,9 +71,8 @@ describe("subrouter Durable Object Worker transcripts", () => {
     const proxied = await fetch(`${baseURL}/v1/responses`, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${proxyToken}`,
+        Authorization: `Bearer ${tenant.key}`,
         "Content-Type": "application/json",
-        "X-Subrouter-Org-ID": "org-refresh",
         "X-Subrouter-Session": "refresh-session",
       },
       body: "{}",
@@ -84,16 +84,18 @@ describe("subrouter Durable Object Worker transcripts", () => {
 
   test("keeps admin state, routing, sessions, and lifecycle scoped per org", async () => {
     const baseURL = await startWorker("https://codex.invalid/backend-api/codex")
+    const tenantA = await createTenant(baseURL, "Org A")
+    const tenantB = await createTenant(baseURL, "Org B")
     await upsertAccount(baseURL, {
       id: "acct-a",
-      orgId: "org-a",
+      orgId: tenantA.id,
       kind: "openai_apikey",
       label: "org-a@example.com",
       credentials: { apiKey: "sk-org-a" },
     })
     await upsertAccount(baseURL, {
       id: "acct-b",
-      orgId: "org-b",
+      orgId: tenantB.id,
       kind: "openai_apikey",
       label: "org-b@example.com",
       credentials: { apiKey: "sk-org-b" },
@@ -107,11 +109,11 @@ describe("subrouter Durable Object Worker transcripts", () => {
 
     const orgAAccounts = await adminJSON<Array<Record<string, any>>>(
       baseURL,
-      "/_subrouter/accounts?orgId=org-a"
+      `/_subrouter/accounts?tenant=${tenantA.id}`
     )
     const orgBAccounts = await adminJSON<Array<Record<string, any>>>(
       baseURL,
-      "/_subrouter/accounts?orgId=org-b"
+      `/_subrouter/accounts?tenant=${tenantB.id}`
     )
     expect(orgAAccounts.map((account) => account.id)).toEqual(["acct-a"])
     expect(orgBAccounts.map((account) => account.id)).toEqual(["acct-b"])
@@ -119,21 +121,24 @@ describe("subrouter Durable Object Worker transcripts", () => {
 
     const orgAStatus = await adminJSON<Array<Record<string, any>>>(
       baseURL,
-      "/_subrouter/account-status?orgId=org-a"
+      `/_subrouter/account-status?tenant=${tenantA.id}`
     )
     expect(orgAStatus.map((account) => account.id)).toEqual(["acct-a"])
 
     const orgAUsage = await adminJSON<Array<Record<string, any>>>(
       baseURL,
-      "/_subrouter/usage-status?orgId=org-a"
+      `/_subrouter/usage-status?tenant=${tenantA.id}`
     )
     expect(orgAUsage.map((account) => account.id)).toEqual(["acct-a"])
     expect(orgAUsage[0]?.plan_type).toBe("api key")
 
     const routeA = await fetch(`${baseURL}/route`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ orgId: "org-a", sessionId: "shared-session", model: "gpt-5" }),
+      headers: {
+        Authorization: `Bearer ${tenantA.key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sessionId: "shared-session", model: "gpt-5" }),
     })
     expect(routeA.status).toBe(200)
     const routeABody = (await routeA.json()) as Record<string, any>
@@ -141,8 +146,11 @@ describe("subrouter Durable Object Worker transcripts", () => {
 
     const routeB = await fetch(`${baseURL}/route`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ orgId: "org-b", sessionId: "shared-session", model: "gpt-5" }),
+      headers: {
+        Authorization: `Bearer ${tenantB.key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sessionId: "shared-session", model: "gpt-5" }),
     })
     expect(routeB.status).toBe(200)
     const routeBBody = (await routeB.json()) as Record<string, any>
@@ -150,32 +158,43 @@ describe("subrouter Durable Object Worker transcripts", () => {
 
     const crossOrgUsage = await fetch(`${baseURL}/usage`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ orgId: "org-a", sessionId: "shared-session", accountId: "acct-b" }),
+      headers: {
+        Authorization: `Bearer ${tenantA.key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sessionId: "shared-session", accountId: "acct-b" }),
     })
     expect(crossOrgUsage.status).toBe(400)
 
     const sessionsA = await adminJSON<Array<Record<string, any>>>(
       baseURL,
-      "/_subrouter/sessions?orgId=org-a"
+      `/_subrouter/sessions?tenant=${tenantA.id}`
     )
     const sessionsB = await adminJSON<Array<Record<string, any>>>(
       baseURL,
-      "/_subrouter/sessions?orgId=org-b"
+      `/_subrouter/sessions?tenant=${tenantB.id}`
     )
     expect(sessionsA).toHaveLength(1)
     expect(sessionsA[0]?.account_id).toBe("acct-a")
     expect(sessionsB).toHaveLength(1)
     expect(sessionsB[0]?.account_id).toBe("acct-b")
 
-    expect((await fetch(`${baseURL}/_subrouter/ready?orgId=org-a`)).status).toBe(200)
-    const drainA = await fetch(`${baseURL}/_subrouter/drain?orgId=org-a`, {
+    expect((await fetch(`${baseURL}/_subrouter/ready`)).status).toBe(200)
+    const drainA = await fetch(`${baseURL}/_subrouter/drain?tenant=${tenantA.id}`, {
       method: "POST",
       headers: { Authorization: `Bearer ${adminToken}` },
     })
     expect(drainA.status).toBe(200)
-    expect((await fetch(`${baseURL}/_subrouter/ready?orgId=org-a`)).status).toBe(503)
-    expect((await fetch(`${baseURL}/_subrouter/ready?orgId=org-b`)).status).toBe(200)
+    const drainStatusA = await adminJSON<Record<string, any>>(
+      baseURL,
+      `/_subrouter/drain-status?tenant=${tenantA.id}`
+    )
+    const drainStatusB = await adminJSON<Record<string, any>>(
+      baseURL,
+      `/_subrouter/drain-status?tenant=${tenantB.id}`
+    )
+    expect(drainStatusA.draining).toBe(true)
+    expect(drainStatusB.draining).toBe(false)
   }, 60_000)
 
   test("records scoped HTTP transcripts with sanitized and raw endpoints", async () => {
@@ -204,15 +223,14 @@ describe("subrouter Durable Object Worker transcripts", () => {
     servers.push(upstream)
 
     const baseURL = await startWorker(`${upstream.url.origin}/backend-api/codex`)
-
-    await upsertCodexAccount(baseURL, "org-a", "acct-a")
+    const tenant = await createTenant(baseURL, "Transcript Org")
+    await upsertCodexAccount(baseURL, tenant.id, "acct-a")
 
     const proxied = await fetch(`${baseURL}/v1/responses`, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${proxyToken}`,
+        Authorization: `Bearer ${tenant.key}`,
         "Content-Type": "application/json",
-        "X-Subrouter-Org-ID": "org-a",
         "X-Subrouter-Session": "session-1:turn-0",
         "X-Subrouter-User-Email": "symphony@manaflow.ai",
       },
@@ -223,7 +241,7 @@ describe("subrouter Durable Object Worker transcripts", () => {
     expect(upstreamRequests[0]?.path).toBe("/backend-api/codex/responses")
     expect(upstreamRequests[0]?.auth).toBe("Bearer codex-access-token")
 
-    const list = await fetch(`${baseURL}/_subrouter/transcripts?orgId=org-a`, {
+    const list = await fetch(`${baseURL}/_subrouter/transcripts?tenant=${tenant.id}`, {
       headers: { Authorization: `Bearer ${adminToken}` },
     })
     expect(list.status).toBe(200)
@@ -237,13 +255,13 @@ describe("subrouter Durable Object Worker transcripts", () => {
     expect(summaries[0]?.user).toBe("symphony@manaflow.ai")
     expect(summaries[0]?.account).toBe("acct-a")
 
-    const otherOrgList = await fetch(`${baseURL}/_subrouter/transcripts?orgId=org-b`, {
+    const otherOrgList = await fetch(`${baseURL}/_subrouter/transcripts?tenant=org-b`, {
       headers: { Authorization: `Bearer ${adminToken}` },
     })
     expect((await otherOrgList.json()) as unknown[]).toEqual([])
 
     const detail = await fetch(
-      `${baseURL}/_subrouter/transcripts/codex/session-1?orgId=org-a`,
+      `${baseURL}/_subrouter/transcripts/codex/session-1?tenant=${tenant.id}`,
       { headers: { Authorization: `Bearer ${adminToken}` } }
     )
     const detailText = await detail.text()
@@ -255,7 +273,7 @@ describe("subrouter Durable Object Worker transcripts", () => {
     expect(detailText).toContain("<redacted>")
 
     const raw = await fetch(
-      `${baseURL}/_subrouter/transcripts/codex/session-1/raw?orgId=org-a`,
+      `${baseURL}/_subrouter/transcripts/codex/session-1/raw?tenant=${tenant.id}`,
       { headers: { Authorization: `Bearer ${adminToken}` } }
     )
     const rawText = await raw.text()
@@ -263,7 +281,7 @@ describe("subrouter Durable Object Worker transcripts", () => {
     expect(rawText).toContain("secret body")
     expect(rawText).toContain("gpt-5.5")
 
-    const dashboard = await fetch(`${baseURL}/_subrouter/dashboard?orgId=org-a`, {
+    const dashboard = await fetch(`${baseURL}/_subrouter/dashboard?tenant=${tenant.id}`, {
       headers: { Authorization: `Bearer ${adminToken}` },
     })
     const dashboardText = await dashboard.text()
@@ -311,13 +329,13 @@ describe("subrouter Durable Object Worker transcripts", () => {
     servers.push(upstream)
 
     const baseURL = await startWorker(`${upstream.url.origin}/backend-api/codex`)
-    await upsertCodexAccount(baseURL, "org-ws", "acct-ws")
+    const tenant = await createTenant(baseURL, "WebSocket Org")
+    await upsertCodexAccount(baseURL, tenant.id, "acct-ws")
 
     const wsURL = baseURL.replace("http://", "ws://") + "/v1/responses"
     const socket = new WebSocket(wsURL, {
       headers: {
-        Authorization: `Bearer ${proxyToken}`,
-        "X-Subrouter-Org-ID": "org-ws",
+        Authorization: `Bearer ${tenant.key}`,
         "X-Subrouter-Session": "ws-session:turn-0",
         "X-Subrouter-User-Email": "symphony@manaflow.ai",
       },
@@ -330,14 +348,14 @@ describe("subrouter Durable Object Worker transcripts", () => {
     expect(String(reply.data)).toContain("ws-secret")
     expect(upstreamAuth as string | null).toBe("Bearer codex-access-token")
 
-    const summaries = await waitForTranscriptEvents(baseURL, "org-ws", 3)
+    const summaries = await waitForTranscriptEvents(baseURL, tenant.id, 3)
     expect(summaries).toHaveLength(1)
     expect(summaries[0]?.session_id).toBe("ws-session")
     expect(summaries[0]?.event_count).toBe(3)
     expect(summaries[0]?.usage.total_tokens).toBe(11)
 
     const detail = await fetch(
-      `${baseURL}/_subrouter/transcripts/codex/ws-session?orgId=org-ws`,
+      `${baseURL}/_subrouter/transcripts/codex/ws-session?tenant=${tenant.id}`,
       { headers: { Authorization: `Bearer ${adminToken}` } }
     )
     const detailText = await detail.text()
@@ -347,7 +365,7 @@ describe("subrouter Durable Object Worker transcripts", () => {
     expect(detailText).toContain("body_base64_redacted")
 
     const raw = await fetch(
-      `${baseURL}/_subrouter/transcripts/codex/ws-session/raw?orgId=org-ws`,
+      `${baseURL}/_subrouter/transcripts/codex/ws-session/raw?tenant=${tenant.id}`,
       { headers: { Authorization: `Bearer ${adminToken}` } }
     )
     const rawText = await raw.text()
@@ -391,6 +409,24 @@ const startWorker = async (codexUpstream: string): Promise<string> => {
   const baseURL = `http://127.0.0.1:${workerPort}`
   await waitForWorker(baseURL)
   return baseURL
+}
+
+const createTenant = async (
+  baseURL: string,
+  name: string
+): Promise<{ readonly id: string; readonly name: string; readonly key: string }> => {
+  const response = await fetch(`${baseURL}/admin/tenants`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ name }),
+  })
+  expect(response.status).toBe(200)
+  const tenant = (await response.json()) as { id: string; name: string; key: string }
+  expect(tenant.key).toMatch(/^srt_[0-9a-f]{32}$/)
+  return tenant
 }
 
 const upsertCodexAccount = async (
@@ -440,13 +476,13 @@ const adminJSON = async <T>(baseURL: string, path: string): Promise<T> => {
 
 const waitForTranscriptEvents = async (
   baseURL: string,
-  orgId: string,
+  tenantId: string,
   eventCount: number
 ): Promise<Array<Record<string, any>>> => {
   const deadline = Date.now() + 10_000
   let summaries: Array<Record<string, any>> = []
   while (Date.now() < deadline) {
-    const list = await fetch(`${baseURL}/_subrouter/transcripts?orgId=${orgId}`, {
+    const list = await fetch(`${baseURL}/_subrouter/transcripts?tenant=${tenantId}`, {
       headers: { Authorization: `Bearer ${adminToken}` },
     })
     summaries = (await list.json()) as Array<Record<string, any>>

--- a/cloudflare/packages/worker/test/worker-transcripts.test.ts
+++ b/cloudflare/packages/worker/test/worker-transcripts.test.ts
@@ -180,12 +180,46 @@ describe("subrouter Durable Object Worker transcripts", () => {
     expect(sessionsB).toHaveLength(1)
     expect(sessionsB[0]?.account_id).toBe("acct-b")
 
-    expect((await fetch(`${baseURL}/_subrouter/ready`)).status).toBe(200)
+    const bareReadyBeforeDrain = await fetch(`${baseURL}/_subrouter/ready`)
+    expect(bareReadyBeforeDrain.status).toBe(200)
+    const bareReadyBeforeDrainBody = await bareReadyBeforeDrain.json() as Record<string, unknown>
+    expect(bareReadyBeforeDrainBody).toEqual({ ok: true })
+    const tenantAReadyBeforeDrain = await fetch(
+      `${baseURL}/_subrouter/ready?tenant=${tenantA.id}`
+    )
+    const tenantBReadyBeforeDrain = await fetch(
+      `${baseURL}/_subrouter/ready?tenant=${tenantB.id}`
+    )
+    expect(tenantAReadyBeforeDrain.status).toBe(200)
+    const tenantAReadyBeforeDrainBody = await tenantAReadyBeforeDrain.json() as Record<string, unknown>
+    expect(tenantAReadyBeforeDrainBody).toEqual({ ok: true, draining: false })
+    expect(tenantBReadyBeforeDrain.status).toBe(200)
+    const tenantBReadyBeforeDrainBody = await tenantBReadyBeforeDrain.json() as Record<string, unknown>
+    expect(tenantBReadyBeforeDrainBody).toEqual({ ok: true, draining: false })
+    expect((await fetch(`${baseURL}/_subrouter/ready?tenant=Bad Tenant`)).status).toBe(400)
+
     const drainA = await fetch(`${baseURL}/_subrouter/drain?tenant=${tenantA.id}`, {
       method: "POST",
       headers: { Authorization: `Bearer ${adminToken}` },
     })
     expect(drainA.status).toBe(200)
+    const bareReadyAfterDrain = await fetch(`${baseURL}/_subrouter/ready`)
+    expect(bareReadyAfterDrain.status).toBe(200)
+    const bareReadyAfterDrainBody = await bareReadyAfterDrain.json() as Record<string, unknown>
+    expect(bareReadyAfterDrainBody).toEqual({ ok: true })
+    const tenantAReadyAfterDrain = await fetch(
+      `${baseURL}/_subrouter/ready?tenant=${tenantA.id}`
+    )
+    const tenantBReadyAfterDrain = await fetch(
+      `${baseURL}/_subrouter/ready?tenant=${tenantB.id}`
+    )
+    expect(tenantAReadyAfterDrain.status).toBe(503)
+    const tenantAReadyAfterDrainBody = await tenantAReadyAfterDrain.json() as Record<string, unknown>
+    expect(tenantAReadyAfterDrainBody).toEqual({ ok: false, draining: true })
+    expect(tenantBReadyAfterDrain.status).toBe(200)
+    const tenantBReadyAfterDrainBody = await tenantBReadyAfterDrain.json() as Record<string, unknown>
+    expect(tenantBReadyAfterDrainBody).toEqual({ ok: true, draining: false })
+
     const drainStatusA = await adminJSON<Record<string, any>>(
       baseURL,
       `/_subrouter/drain-status?tenant=${tenantA.id}`

--- a/cloudflare/packages/worker/test/worker-transcripts.test.ts
+++ b/cloudflare/packages/worker/test/worker-transcripts.test.ts
@@ -1,19 +1,18 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp } from "node:fs/promises"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
+import {
+  adminJSON,
+  adminToken,
+  cleanupWorkers,
+  createTenant,
+  proxyToken,
+  startWorker,
+  waitForCondition,
+} from "./helpers/worker.ts"
 
-const adminToken = "admin-test-token"
-const proxyToken = "proxy-test-token"
-
-const processes: Bun.Subprocess[] = []
 const servers: Array<{ stop: () => void }> = []
 
 afterEach(async () => {
-  for (const proc of processes.splice(0)) {
-    proc.kill()
-    await proc.exited.catch(() => {})
-  }
+  await cleanupWorkers()
   for (const server of servers.splice(0)) server.stop()
 })
 
@@ -49,7 +48,8 @@ describe("subrouter Durable Object Worker transcripts", () => {
     })
     servers.push(upstream)
 
-    const baseURL = await startWorker(`${upstream.url.origin}/backend-api/codex`)
+    const worker = await startWorker({ codexUpstream: `${upstream.url.origin}/backend-api/codex` })
+    const baseURL = worker.baseURL
     const tenant = await createTenant(baseURL, "Refresh Org")
     await upsertAccount(baseURL, {
       id: "acct-refresh",
@@ -83,7 +83,8 @@ describe("subrouter Durable Object Worker transcripts", () => {
   }, 60_000)
 
   test("keeps admin state, routing, sessions, and lifecycle scoped per org", async () => {
-    const baseURL = await startWorker("https://codex.invalid/backend-api/codex")
+    const worker = await startWorker({ codexUpstream: "https://codex.invalid/backend-api/codex" })
+    const baseURL = worker.baseURL
     const tenantA = await createTenant(baseURL, "Org A")
     const tenantB = await createTenant(baseURL, "Org B")
     await upsertAccount(baseURL, {
@@ -222,7 +223,8 @@ describe("subrouter Durable Object Worker transcripts", () => {
     })
     servers.push(upstream)
 
-    const baseURL = await startWorker(`${upstream.url.origin}/backend-api/codex`)
+    const worker = await startWorker({ codexUpstream: `${upstream.url.origin}/backend-api/codex` })
+    const baseURL = worker.baseURL
     const tenant = await createTenant(baseURL, "Transcript Org")
     await upsertCodexAccount(baseURL, tenant.id, "acct-a")
 
@@ -328,7 +330,8 @@ describe("subrouter Durable Object Worker transcripts", () => {
     })
     servers.push(upstream)
 
-    const baseURL = await startWorker(`${upstream.url.origin}/backend-api/codex`)
+    const worker = await startWorker({ codexUpstream: `${upstream.url.origin}/backend-api/codex` })
+    const baseURL = worker.baseURL
     const tenant = await createTenant(baseURL, "WebSocket Org")
     await upsertCodexAccount(baseURL, tenant.id, "acct-ws")
 
@@ -375,60 +378,6 @@ describe("subrouter Durable Object Worker transcripts", () => {
   }, 60_000)
 })
 
-const startWorker = async (codexUpstream: string): Promise<string> => {
-  const workerPort = 18_000 + Math.floor(Math.random() * 1_000)
-  const persistDir = await mkdtemp(join(tmpdir(), "subrouter-do-worker-test-"))
-  const worker = Bun.spawn(
-    [
-      "bunx",
-      "wrangler",
-      "dev",
-      "--local",
-      "--ip",
-      "127.0.0.1",
-      "--port",
-      String(workerPort),
-      "--persist-to",
-      persistDir,
-      "--var",
-      `ADMIN_TOKEN:${adminToken}`,
-      "--var",
-      `PROXY_TOKEN:${proxyToken}`,
-      "--var",
-      `CODEX_UPSTREAM:${codexUpstream}`,
-      "--log-level",
-      "error",
-    ],
-    {
-      cwd: import.meta.dir.replace(/\/test$/, ""),
-      stdout: "pipe",
-      stderr: "pipe",
-    }
-  )
-  processes.push(worker)
-  const baseURL = `http://127.0.0.1:${workerPort}`
-  await waitForWorker(baseURL)
-  return baseURL
-}
-
-const createTenant = async (
-  baseURL: string,
-  name: string
-): Promise<{ readonly id: string; readonly name: string; readonly key: string }> => {
-  const response = await fetch(`${baseURL}/admin/tenants`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${adminToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ name }),
-  })
-  expect(response.status).toBe(200)
-  const tenant = (await response.json()) as { id: string; name: string; key: string }
-  expect(tenant.key).toMatch(/^srt_[0-9a-f]{32}$/)
-  return tenant
-}
-
 const upsertCodexAccount = async (
   baseURL: string,
   orgId: string,
@@ -464,14 +413,6 @@ const upsertAccount = async (
     body: JSON.stringify(input),
   })
   expect(upsert.status).toBe(200)
-}
-
-const adminJSON = async <T>(baseURL: string, path: string): Promise<T> => {
-  const response = await fetch(`${baseURL}${path}`, {
-    headers: { Authorization: `Bearer ${adminToken}` },
-  })
-  expect(response.status).toBe(200)
-  return (await response.json()) as T
 }
 
 const waitForTranscriptEvents = async (
@@ -511,31 +452,3 @@ const waitForWebSocket = <Type extends "open" | "message">(
       reject(new Error(`websocket ${type} failed`))
     }, { once: true })
   })
-
-const waitForCondition = async (
-  condition: () => boolean,
-  label: string
-): Promise<void> => {
-  const deadline = Date.now() + 10_000
-  while (Date.now() < deadline) {
-    if (condition()) return
-    await Bun.sleep(100)
-  }
-  throw new Error(`${label} timed out`)
-}
-
-const waitForWorker = async (baseURL: string): Promise<void> => {
-  const deadline = Date.now() + 20_000
-  let lastError: unknown
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(`${baseURL}/healthz`)
-      if (response.ok) return
-      lastError = new Error(`healthz returned ${response.status}`)
-    } catch (error) {
-      lastError = error
-    }
-    await Bun.sleep(250)
-  }
-  throw lastError ?? new Error("worker did not start")
-}

--- a/cloudflare/packages/worker/wrangler.json
+++ b/cloudflare/packages/worker/wrangler.json
@@ -11,6 +11,12 @@
       "new_sqlite_classes": [
         "SubrouterDurableObject"
       ]
+    },
+    {
+      "tag": "v2",
+      "new_sqlite_classes": [
+        "TenantRegistryDurableObject"
+      ]
     }
   ],
   "durable_objects": {
@@ -18,6 +24,10 @@
       {
         "name": "SUBROUTER_DO",
         "class_name": "SubrouterDurableObject"
+      },
+      {
+        "name": "TENANT_REGISTRY_DO",
+        "class_name": "TenantRegistryDurableObject"
       }
     ]
   },
@@ -56,6 +66,12 @@
           "new_sqlite_classes": [
             "SubrouterDurableObject"
           ]
+        },
+        {
+          "tag": "v2",
+          "new_sqlite_classes": [
+            "TenantRegistryDurableObject"
+          ]
         }
       ],
       "durable_objects": {
@@ -63,6 +79,10 @@
           {
             "name": "SUBROUTER_DO",
             "class_name": "SubrouterDurableObject"
+          },
+          {
+            "name": "TENANT_REGISTRY_DO",
+            "class_name": "TenantRegistryDurableObject"
           }
         ]
       }
@@ -91,6 +111,12 @@
           "new_sqlite_classes": [
             "SubrouterDurableObject"
           ]
+        },
+        {
+          "tag": "v2",
+          "new_sqlite_classes": [
+            "TenantRegistryDurableObject"
+          ]
         }
       ],
       "durable_objects": {
@@ -98,6 +124,10 @@
           {
             "name": "SUBROUTER_DO",
             "class_name": "SubrouterDurableObject"
+          },
+          {
+            "name": "TENANT_REGISTRY_DO",
+            "class_name": "TenantRegistryDurableObject"
           }
         ]
       }


### PR DESCRIPTION
Turns the cloudflare/ DO worker into a multi-tenant service.

**Auth model:** admin endpoints stay behind ADMIN_TOKEN. Data-plane requests now require a per-tenant key (srt_*, stored only as sha256). Legacy shared PROXY_TOKEN is disabled by default; set ALLOW_LEGACY_PROXY_TOKEN=1 to bridge existing clients, which routes them only to the bare `legacy` tenant.

**Isolation:** each registry tenant's state lives in `SUBROUTER_DO.getByName("tenant:<id>")`; ids are `[a-z0-9][a-z0-9._-]*` so they can never forge the namespace or collide with the pre-existing bare `legacy`/`demo-org` DOs. Caller-supplied orgId (header or body) is overridden with the authenticated tenant on every path including WebSocket.

**Account upload API:** tenant-key-authed POST/GET/DELETE /tenant/accounts for Claude OAuth, Anthropic API key, Codex OAuth, and OpenAI API key credentials; server-owned refresh via existing DO alarms; responses and transcripts never contain secrets.

**Tests:** 34 bun tests incl. tenant lifecycle, hostile org-override spoofing, legacy-token default-off, reserved-name collision, and header-stripping contract. Reviewed by two adversarial passes (round 1 found and fixed a legacy/demo-org DO-name collision and a missing hostile-override test).

Deploys: staging then production on merge via cloudflare-do.yml (CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID repo secrets are now set; the previously failing staging deploy on main is green as of run 28688732207).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785726849&installation_id=133855650&pr_number=52&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F52&signature=35a54b914dfd14ffddf1cb23b8b1c873e9339d0f2a72491460061990007c468d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts the Cloudflare subrouter into a multi-tenant service with a tenant registry, hashed `srt_*` keys, and per-tenant Durable Object state. Adds provider-aware routing and bootstrap quota pools so mixed-provider tenants stay isolated and uploaded accounts can serve traffic immediately.

- New Features
  - Tenant registry (`TENANT_REGISTRY_DO`) with admin endpoints to create, list, rotate, and revoke tenants; stores only `sha256` of keys.
  - Data-plane auth via tenant key (`srt_*`) in `Authorization` or `X-Subrouter-Tenant-Key`; legacy `PROXY_TOKEN` is off by default and can be temporarily enabled with `ALLOW_LEGACY_PROXY_TOKEN=1` (routes only to `legacy`).
  - Per-tenant state in `SUBROUTER_DO.getByName("tenant:<id>")`; reserved bare DOs like `legacy`/`demo-org` remain isolated; caller-supplied `orgId` is overridden with the authenticated tenant.
  - Provider-aware routing: account selection is filtered by upstream provider family on all proxy, `/route`, and WebSocket paths (incl. sticky/preferred) to prevent cross-upstream usage.
  - Tenant account API: `POST|GET|DELETE /tenant/accounts` for Claude OAuth, Anthropic/OpenAI API keys, and Codex OAuth; responses redact secrets; OAuth refresh reuses existing alarms; `?validate=1` uses a bounded timeout; bootstrap quota pools are seeded on upload (e.g., Anthropics: opus/sonnet; Codex: spark); `X-Subrouter-Tenant-Key` and similar headers are stripped from upstream.
  - Admin reads are tenant-scoped with `?tenant=<id>`; `/_subrouter/ready?tenant=<id>` is drain-aware (503 while draining, boolean only, no tenant data), and bare `/_subrouter/ready` stays service-level.
  - Tests cover tenant lifecycle, isolation (incl. hostile overrides and provider-family filtering), legacy-token default-off, reserved-name separation, header stripping, validation timeout, account uploads, and readiness behavior.

- Migration
  - Add `TENANT_REGISTRY_DO` binding in `wrangler.json` (v2 migration).
  - Create tenants via `POST /admin/tenants` and distribute the shown key once; clients must send the tenant key with requests.
  - Append `?tenant=<id>` to admin reads; data-plane `/route`, `/usage`, `/status`, and `/ws` now require tenant keys.
  - If needed for rollout, set `ALLOW_LEGACY_PROXY_TOKEN=1` to bridge existing `PROXY_TOKEN` clients to the `legacy` tenant only.

<sup>Written for commit 10182262787912430fe2f9f57664ea03ccbfb95a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant-scoped routing and admin flows, including tenant key authentication, tenant creation, rotation, revocation, and account uploads.
  * Introduced support for per-tenant Durable Object state and updated transcript, usage, status, and WebSocket behavior to use tenant scoping.
  * Documented optional legacy token compatibility for reserved legacy access.

* **Bug Fixes**
  * Strengthened header stripping and redaction to prevent tenant key and related routing headers from being forwarded or exposed.
  * Improved tenant isolation so data and transcripts stay separated across tenants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->