### PR TITLE
Fable probe shape, model-scoped quota pools, live-debit GTO selection (v0.1.31)

### DIFF
--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -1108,7 +1108,7 @@ func scoreFromWindows(accountID string, windows []accounts.UsageWindow) selectac
 	limitWindows := make([]selectacct.LimitWindow, 0, len(windows)*2)
 	hasFableWindow := false
 	for _, window := range windows {
-		if window.Feature == agentclaude.FableModel || window.Name == agentclaude.FableWindowName {
+		if window.Feature == agentclaude.FableFeature || window.Feature == agentclaude.FableModel || window.Name == agentclaude.FableWindowName {
 			hasFableWindow = true
 			break
 		}
@@ -1127,7 +1127,7 @@ func scoreFromWindows(accountID string, windows []accounts.UsageWindow) selectac
 				UsedPercent:        window.UsedPercent,
 				LimitWindowSeconds: window.LimitWindowSeconds,
 				ResetAfterSeconds:  window.ResetAfterSeconds,
-				Feature:            agentclaude.FableModel,
+				Feature:            agentclaude.FableFeature,
 			})
 		}
 	}
@@ -1312,7 +1312,7 @@ func claudeUsageWindows(usage *agentclaude.UsageResponse) []accounts.UsageWindow
 		}
 		window := accounts.UsageWindow{Name: name, UsedPercent: *limit.Utilization, LimitWindowSeconds: windowSeconds}
 		if name == agentclaude.FableWindowName {
-			window.Feature = agentclaude.FableModel
+			window.Feature = agentclaude.FableFeature
 		}
 		if reset, err := time.Parse(time.RFC3339, limit.ResetsAt); err == nil {
 			seconds := int64(time.Until(reset).Seconds())

--- a/cmd/subrouter/sr_test.go
+++ b/cmd/subrouter/sr_test.go
@@ -1131,14 +1131,14 @@ func TestClaudeUsageWindowsIncludeOAuthAppsWeekly(t *testing.T) {
 	if oauthApps.LimitWindowSeconds != int64((7*24*time.Hour)/time.Second) {
 		t.Fatalf("oauth apps LimitWindowSeconds = %d, want 7d", oauthApps.LimitWindowSeconds)
 	}
-	if oauthApps.Feature != agentclaude.FableModel {
-		t.Fatalf("oauth apps Feature = %q, want %q", oauthApps.Feature, agentclaude.FableModel)
+	if oauthApps.Feature != agentclaude.FableFeature {
+		t.Fatalf("oauth apps Feature = %q, want %q", oauthApps.Feature, agentclaude.FableFeature)
 	}
 	score := scoreFromWindows("claude@example.com", windows)
 	if score.Headroom == 0 {
 		t.Fatalf("base headroom = %.2f, hidden Fable bucket should not exhaust non-Fable Claude models", score.Headroom)
 	}
-	fableScore, ok := score.ModelScores[selectacct.ModelKey(agentclaude.FableModel)]
+	fableScore, ok := score.ModelScores[selectacct.ModelKey(agentclaude.FableFeature)]
 	if !ok {
 		t.Fatalf("missing Fable model score: %+v", score.ModelScores)
 	}

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -27,13 +27,21 @@ import (
 
 const (
 	usageURL        = "https://api.anthropic.com/api/oauth/usage"
-	messagesURL     = "https://api.anthropic.com/v1/messages"
 	oauthBetaHeader = "oauth-2025-04-20"
 )
+
+// messagesURL is a var so probe tests can point it at a local server.
+var messagesURL = "https://api.anthropic.com/v1/messages"
 
 const (
 	FableModel      = "claude-fable-5"
 	FableWindowName = "oauth-apps-weekly"
+	// Quota-pool family keys stamped on Claude usage windows and matched
+	// against canonicalized request models ("claude-opus-4-8[1m]" and
+	// "claude-opus-4-8" both belong to the opus pool).
+	FableFeature  = "claude-fable"
+	OpusFeature   = "claude-opus"
+	SonnetFeature = "claude-sonnet"
 )
 
 var oauthTokenURL = "https://platform.claude.com/v1/oauth/token"
@@ -730,15 +738,23 @@ func FetchFableUsageWindows(ctx context.Context, client *http.Client, accessToke
 	if client == nil {
 		client = &http.Client{Timeout: 10 * time.Second}
 	}
-	body := bytes.NewBufferString(`{"model":"` + FableModel + `","max_tokens":1,"messages":[{"role":"user","content":"."}]}`)
+	// The probe must look like Claude Code: Anthropic rejects subscription
+	// OAuth Messages calls that lack the Claude Code system prompt, beta tag,
+	// and client identity with a headerless 429 rate_limit_error regardless of
+	// quota (observed live 2026-07-04: a fresh Max 20x account with 0.0
+	// utilization 429'd the bare probe but answered 200 with unified headers,
+	// including 7d_oi, once the request carried the Claude Code shape).
+	body := bytes.NewBufferString(`{"model":"` + FableModel + `","max_tokens":1,"system":[{"type":"text","text":"You are Claude Code, Anthropic's official CLI for Claude."}],"messages":[{"role":"user","content":"."}]}`)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, messagesURL, body)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
-	req.Header.Set("anthropic-beta", oauthBetaHeader)
+	req.Header.Set("anthropic-beta", "claude-code-20250219,"+oauthBetaHeader)
 	req.Header.Set("anthropic-version", "2023-06-01")
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "claude-cli/2.1.199 (external, cli)")
+	req.Header.Set("x-app", "cli")
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -749,14 +765,11 @@ func FetchFableUsageWindows(ctx context.Context, client *http.Client, accessToke
 	if len(windows) > 0 {
 		return windows, nil
 	}
-	if res.StatusCode == http.StatusTooManyRequests {
-		return []accounts.UsageWindow{{
-			Name:               FableWindowName,
-			UsedPercent:        100,
-			LimitWindowSeconds: int64(7 * 24 * time.Hour / time.Second),
-			Feature:            FableModel,
-		}}, nil
-	}
+	// A headerless 429 is a transient burst or bot-shape rejection, never an
+	// authoritative quota signal (the taxonomy that governs the proxy's own
+	// exhaustion marking). Synthesizing 100% here falsely cooked every
+	// account's fable pool and pushed all Fable traffic to Bedrock/API key.
+	// Return no windows so the caller keeps the last known state.
 	if res.StatusCode == http.StatusUnauthorized {
 		return nil, fmt.Errorf("fable probe failed: %s", res.Status)
 	}
@@ -804,6 +817,6 @@ func usageWindowsFromFableHeaders(header http.Header, now time.Time) []accounts.
 	}
 	add("5h", "5h", fiveHourSeconds, "")
 	add("7d", "7d", sevenDaySeconds, "")
-	add("7d_oi", FableWindowName, sevenDaySeconds, FableModel)
+	add("7d_oi", FableWindowName, sevenDaySeconds, FableFeature)
 	return windows
 }

--- a/internal/agents/claude/store_test.go
+++ b/internal/agents/claude/store_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"io"
 )
 
 func TestStoreCreateSetRemoveProfile(t *testing.T) {
@@ -196,5 +197,68 @@ func TestListAccountsReadsProfilesWithCredentials(t *testing.T) {
 	}
 	if account.Source != filepath.Clean(instancePath) {
 		t.Fatalf("Source = %q, want %q", account.Source, filepath.Clean(instancePath))
+	}
+}
+
+// Anthropic rejects subscription-OAuth Messages calls that do not look like
+// Claude Code with a headerless 429 regardless of quota (verified live
+// 2026-07-04 on a fresh Max 20x account). The probe must carry the Claude Code
+// system prompt, beta tag, and client identity, or every account's fable pool
+// reads as exhausted.
+func TestFetchFableUsageWindowsSendsClaudeCodeShape(t *testing.T) {
+	var gotBody string
+	var gotBeta, gotUA, gotXApp string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		gotBeta = r.Header.Get("anthropic-beta")
+		gotUA = r.Header.Get("User-Agent")
+		gotXApp = r.Header.Get("x-app")
+		w.Header().Set("Anthropic-Ratelimit-Unified-7d_Oi-Status", "allowed")
+		w.Header().Set("Anthropic-Ratelimit-Unified-7d_Oi-Utilization", "0.0")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer server.Close()
+	restore := messagesURL
+	messagesURL = server.URL + "/v1/messages"
+	defer func() { messagesURL = restore }()
+
+	windows, err := FetchFableUsageWindows(context.Background(), server.Client(), "tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotBody, "You are Claude Code") {
+		t.Fatalf("probe body missing Claude Code system prompt: %s", gotBody)
+	}
+	if !strings.Contains(gotBeta, "claude-code-") || !strings.Contains(gotBeta, oauthBetaHeader) {
+		t.Fatalf("probe beta header = %q, want claude-code tag plus oauth beta", gotBeta)
+	}
+	if !strings.Contains(gotUA, "claude-cli") || gotXApp != "cli" {
+		t.Fatalf("probe client identity = UA %q x-app %q, want claude-cli/cli", gotUA, gotXApp)
+	}
+	if len(windows) != 1 || windows[0].Feature != FableFeature || windows[0].UsedPercent != 0 {
+		t.Fatalf("windows = %+v, want one fresh fable window", windows)
+	}
+}
+
+// A headerless 429 must return no windows (unknown), never a synthesized
+// exhausted window.
+func TestFetchFableUsageWindowsHeaderless429ReturnsNoWindows(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}`))
+	}))
+	defer server.Close()
+	restore := messagesURL
+	messagesURL = server.URL + "/v1/messages"
+	defer func() { messagesURL = restore }()
+
+	windows, err := FetchFableUsageWindows(context.Background(), server.Client(), "tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(windows) != 0 {
+		t.Fatalf("windows = %+v, want none for a headerless 429", windows)
 	}
 }

--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -131,6 +131,10 @@ const bedrockFableModelID = "us.anthropic.claude-fable-5"
 // recorded like the /bedrock/* gateway path.
 func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*http.Response, error) {
 	cfg := s.Bedrock
+	// Bedrock's Anthropic schema rejects OAuth-only request fields with a 400
+	// ("context_management: Extra inputs are not permitted"), which used to
+	// push every context-editing Claude Code request straight to the API key.
+	body = stripClaudeUnsupportedFields(body)
 	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, err
@@ -188,6 +192,16 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 	// Non-stream success or any error status: Bedrock answers Anthropic-format JSON.
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, replayablePostMaxBodyBytes))
 	_ = resp.Body.Close()
+	if (resp.StatusCode < 200 || resp.StatusCode >= 300) && s.Logger != nil {
+		// Error bodies only (no user content): without this the concrete
+		// Bedrock failure ("Too many tokens...", validation errors) is
+		// invisible once the chain falls through to the API key.
+		preview := respBody
+		if len(preview) > 512 {
+			preview = preview[:512]
+		}
+		s.Logger.Warn("claude-fable bedrock error response", "status", resp.StatusCode, "bedrock_source", sourceName, "body", string(preview))
+	}
 	usage, haveUsage := parseBedrockInvokeUsage(respBody)
 	s.recordClaudeFableBedrockCost(started, resp.StatusCode, usage, haveUsage)
 	return &http.Response{

--- a/internal/proxy/claude_fable_test.go
+++ b/internal/proxy/claude_fable_test.go
@@ -373,14 +373,47 @@ func TestOauthRetryAccountSkipsAPIKeyAccountsWhenOAuthOnly(t *testing.T) {
 		"cooked@example.com": {},
 		"fresh@example.com":  {},
 	}
-	if _, err := server.oauthRetryAccount(t.Context(), accounts.ProviderClaude, "claude", "s", "", tried, true); err == nil {
+	if _, err := server.oauthRetryAccount(t.Context(), accounts.ProviderClaude, "claude", "s", "", "", tried, true); err == nil {
 		t.Fatal("oauthOnly must not hand out the API-key pool account")
 	}
-	account, err := server.oauthRetryAccount(t.Context(), accounts.ProviderClaude, "claude", "s", "", tried, false)
+	account, err := server.oauthRetryAccount(t.Context(), accounts.ProviderClaude, "claude", "s", "", "", tried, false)
 	if err != nil {
 		t.Fatalf("non-oauthOnly retry should use the API-key account: %v", err)
 	}
 	if account.AuthMode != accounts.AuthModeAPIKey {
 		t.Fatalf("account = %+v, want the API-key fallback", account)
+	}
+}
+
+// Bedrock's Anthropic schema 400s on OAuth-only fields ("context_management:
+// Extra inputs are not permitted", observed live), which used to push every
+// context-editing Claude Code request straight past Bedrock to the API key.
+func TestClaudeFableBedrockStripsUnsupportedFields(t *testing.T) {
+	var forwarded string
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		b, _ := io.ReadAll(req.Body)
+		forwarded = string(b)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"type":"message"}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+	s := Server{Bedrock: &BedrockConfig{
+		Region:    "us-east-1",
+		Sources:   []BedrockCredentialSource{{Name: "aw0", Credentials: staticBedrockCreds()}},
+		Transport: rt,
+	}}
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	resp, err := s.claudeFableBedrockResponse(req.Context(), []byte(`{"model":"claude-fable-5","context_management":{"edits":[]},"max_tokens":8,"messages":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if strings.Contains(forwarded, "context_management") {
+		t.Fatalf("context_management not stripped for bedrock: %s", forwarded)
+	}
+	if !strings.Contains(forwarded, "anthropic_version") {
+		t.Fatalf("bedrock body missing anthropic_version: %s", forwarded)
 	}
 }

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -349,14 +349,14 @@ func TestClaudeUsageWindowsIncludeOAuthAppsWeekly(t *testing.T) {
 	if oauthApps.LimitWindowSeconds != 7*24*60*60 {
 		t.Fatalf("oauth apps LimitWindowSeconds = %d, want %d", oauthApps.LimitWindowSeconds, 7*24*60*60)
 	}
-	if oauthApps.Feature != agentclaude.FableModel {
-		t.Fatalf("oauth apps Feature = %q, want %q", oauthApps.Feature, agentclaude.FableModel)
+	if oauthApps.Feature != agentclaude.FableFeature {
+		t.Fatalf("oauth apps Feature = %q, want %q", oauthApps.Feature, agentclaude.FableFeature)
 	}
 	score := scoreFromUsageWindows(accounts.ProviderClaude, "acct", windows)
 	if score.Headroom == 0 {
 		t.Fatalf("base Headroom = %.3f, hidden Fable bucket should not exhaust non-Fable Claude models", score.Headroom)
 	}
-	fableScore, ok := score.ModelScores[selectacct.ModelKey(agentclaude.FableModel)]
+	fableScore, ok := score.ModelScores[selectacct.ModelKey(agentclaude.FableFeature)]
 	if !ok {
 		t.Fatalf("missing Fable model score: %+v", score.ModelScores)
 	}
@@ -418,12 +418,17 @@ func TestClaudeFableProbeAddsHiddenOAuthAppsWindow(t *testing.T) {
 	if fable.UsedPercent != 100 {
 		t.Fatalf("Fable UsedPercent = %.1f, want 100", fable.UsedPercent)
 	}
-	if fable.Feature != agentclaude.FableModel {
-		t.Fatalf("Fable Feature = %q, want %q", fable.Feature, agentclaude.FableModel)
+	if fable.Feature != agentclaude.FableFeature {
+		t.Fatalf("Fable Feature = %q, want %q", fable.Feature, agentclaude.FableFeature)
 	}
 }
 
-func TestClaudeFableProbeTreatsHeaderless429AsFableExhausted(t *testing.T) {
+// A headerless 429 from the probe is a transient burst or bot-shape
+// rejection, never authoritative quota evidence: a fresh Max 20x account with
+// 0.0 utilization 429'd the bare probe live while answering 200 (with 7d_oi
+// headers) once the request looked like Claude Code. It must NOT synthesize a
+// cooked fable pool.
+func TestClaudeFableProbeIgnoresHeaderless429(t *testing.T) {
 	usageBody := `{"five_hour":{"utilization":10.0,"resets_at":"2030-01-01T00:00:00+00:00"},"seven_day":{"utilization":60.0,"resets_at":"2030-01-02T00:00:00+00:00"}}`
 	client := &http.Client{Transport: proxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch req.URL.Path {
@@ -447,14 +452,10 @@ func TestClaudeFableProbeTreatsHeaderless429AsFableExhausted(t *testing.T) {
 	}
 	score := scoreFromUsageWindows(accounts.ProviderClaude, "acct", windows)
 	if score.Headroom == 0 {
-		t.Fatalf("base Headroom = %.3f, hidden Fable bucket should not exhaust non-Fable Claude models", score.Headroom)
+		t.Fatalf("base Headroom = %.3f, a headerless probe 429 must not exhaust the account", score.Headroom)
 	}
-	fableScore, ok := score.ModelScores[selectacct.ModelKey(agentclaude.FableModel)]
-	if !ok {
-		t.Fatalf("missing Fable model score: %+v", score.ModelScores)
-	}
-	if fableScore.Headroom != 0 {
-		t.Fatalf("Fable Headroom = %.3f, want 0 from headerless Fable probe 429", fableScore.Headroom)
+	if _, ok := score.ModelScores[selectacct.ModelKey(agentclaude.FableFeature)]; ok {
+		t.Fatalf("headerless probe 429 must not synthesize a fable pool: %+v", score.ModelScores)
 	}
 }
 
@@ -480,14 +481,15 @@ func TestUsageStatusFreshFableWindowUpdatesSchedulerModelPool(t *testing.T) {
 		Windows: []accounts.UsageWindow{
 			{Name: "5h", UsedPercent: 10, LimitWindowSeconds: 5 * 60 * 60},
 			{Name: "7d", UsedPercent: 40, LimitWindowSeconds: 7 * 24 * 60 * 60},
-			{Name: agentclaude.FableWindowName, Feature: agentclaude.FableModel, UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
+			{Name: agentclaude.FableWindowName, Feature: agentclaude.FableFeature, UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
 		},
 	}})
 	base := schedulerRef.Get()
 	if base.Exhausted(accounts.ProviderClaude, "acct") {
 		t.Fatalf("base Claude score should remain usable when only Fable is exhausted")
 	}
-	fable := base.ForModel(agentclaude.FableModel)
+	// The request path canonicalizes the model to its pool family first.
+	fable := base.ForModel(claudePoolModel(agentclaude.FableModel))
 	if !fable.Exhausted(accounts.ProviderClaude, "acct") {
 		t.Fatalf("Fable model score should be exhausted after fresh status update")
 	}
@@ -1391,5 +1393,93 @@ func TestMarkTTLSelection(t *testing.T) {
 	blipUntil, _ := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "blip@example.com")
 	if time.Until(blipUntil) > 15*time.Minute {
 		t.Fatalf("transient refresh mark in %v, want ~10m default", time.Until(blipUntil))
+	}
+}
+
+func TestClaudePoolModelAliasesVersionedModels(t *testing.T) {
+	cases := map[string]string{
+		"claude-fable-5":      agentclaude.FableFeature,
+		"claude-fable-5[1m]":  agentclaude.FableFeature,
+		"claude-opus-4-8":     agentclaude.OpusFeature,
+		"claude-opus-4-8[1m]": agentclaude.OpusFeature,
+		"claude-sonnet-5":     agentclaude.SonnetFeature,
+		"claude-haiku-4-5":    "claude-haiku-4-5",
+		"gpt-5.3-codex-spark": "gpt-5.3-codex-spark",
+	}
+	for model, want := range cases {
+		if got := claudePoolModel(model); got != want {
+			t.Fatalf("claudePoolModel(%q) = %q, want %q", model, got, want)
+		}
+	}
+}
+
+// A Fable-only rejection (7d_oi rejected, account windows allowed) must not
+// cook the whole account: opus/sonnet can still use it. Before this a wave of
+// Fable traffic marked every account exhausted and starved opus routing.
+func TestClaudeExhaustedByResponseIgnoresPoolScopedRejection(t *testing.T) {
+	poolOnly := http.Header{}
+	poolOnly.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+	poolOnly.Set("Anthropic-Ratelimit-Unified-5h-Status", "allowed")
+	poolOnly.Set("Anthropic-Ratelimit-Unified-7d-Status", "allowed")
+	poolOnly.Set("Anthropic-Ratelimit-Unified-7d_Oi-Status", "rejected")
+	if claudeAccountExhaustedByResponse(http.StatusOK, poolOnly) {
+		t.Fatal("fable-pool-only rejection must not exhaust the account")
+	}
+
+	accountWide := http.Header{}
+	accountWide.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+	accountWide.Set("Anthropic-Ratelimit-Unified-7d-Status", "rejected")
+	accountWide.Set("Anthropic-Ratelimit-Unified-7d_Oi-Status", "rejected")
+	if !claudeAccountExhaustedByResponse(http.StatusOK, accountWide) {
+		t.Fatal("7d rejection must exhaust the account")
+	}
+
+	bare := http.Header{}
+	bare.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+	if !claudeAccountExhaustedByResponse(http.StatusTooManyRequests, bare) {
+		t.Fatal("rejected with no per-window detail stays account-wide (conservative)")
+	}
+}
+
+// Fresh accounts report opus/sonnet weekly buckets as null (unused). They must
+// still carry 0%-used pool windows so ForModel never zero-fills them out of
+// opus routing once another account grows a real opus window.
+func TestClaudeUsageWindowsSynthesizeUnusedOpusSonnetPools(t *testing.T) {
+	usage := &agentclaude.UsageResponse{
+		FiveHour:          &agentclaude.RateLimit{Utilization: floatPtr(10), ResetsAt: time.Now().Add(time.Hour).Format(time.RFC3339)},
+		SevenDay:          &agentclaude.RateLimit{Utilization: floatPtr(20), ResetsAt: time.Now().Add(5 * 24 * time.Hour).Format(time.RFC3339)},
+		SevenDayOAuthApps: &agentclaude.RateLimit{Utilization: floatPtr(100), ResetsAt: time.Now().Add(5 * 24 * time.Hour).Format(time.RFC3339)},
+	}
+	windows := claudeUsageWindows(usage)
+	score := scoreFromUsageWindows(accounts.ProviderClaude, "fresh", windows)
+
+	opusScore, ok := score.ModelScores[selectacct.ModelKey(agentclaude.OpusFeature)]
+	if !ok {
+		t.Fatalf("missing synthesized opus pool: %+v", score.ModelScores)
+	}
+	// Pool score includes the base windows, so 7d at 20%% caps it at 0.8.
+	if opusScore.Headroom < 0.79 || opusScore.Headroom > 0.81 {
+		t.Fatalf("opus pool Headroom = %.3f, want ~0.8 (base 7d), fable exhaustion must not leak in", opusScore.Headroom)
+	}
+	if _, ok := score.ModelScores[selectacct.ModelKey(agentclaude.SonnetFeature)]; !ok {
+		t.Fatalf("missing synthesized sonnet pool: %+v", score.ModelScores)
+	}
+}
+
+// A model pool with quota left is still unusable when the account-wide windows
+// are cooked: the pool score must include base windows.
+func TestClaudeModelPoolScoresIncludeBaseWindows(t *testing.T) {
+	windows := []accounts.UsageWindow{
+		{Name: "5h", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
+		{Name: "7d", UsedPercent: 10, LimitWindowSeconds: 7 * 24 * 60 * 60},
+		{Name: agentclaude.FableWindowName, Feature: agentclaude.FableFeature, UsedPercent: 0, LimitWindowSeconds: 7 * 24 * 60 * 60},
+	}
+	score := scoreFromUsageWindows(accounts.ProviderClaude, "acct", windows)
+	fableScore, ok := score.ModelScores[selectacct.ModelKey(agentclaude.FableFeature)]
+	if !ok {
+		t.Fatalf("missing fable pool: %+v", score.ModelScores)
+	}
+	if fableScore.Headroom != 0 {
+		t.Fatalf("fable pool Headroom = %.3f, want 0: the cooked 5h window binds every pool", fableScore.Headroom)
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -695,6 +695,23 @@ func claudeProfileEmail(name string) string {
 	return ""
 }
 
+// claudePoolModel canonicalizes a Claude request model to the quota-pool
+// family stamped on usage windows, so "claude-opus-4-8" and
+// "claude-opus-4-8[1m]" both resolve to the opus weekly pool. Non-Claude and
+// unrecognized models pass through unchanged (strict generic matching).
+func claudePoolModel(model string) string {
+	lower := strings.ToLower(model)
+	switch {
+	case strings.Contains(lower, "fable"):
+		return agentclaude.FableFeature
+	case strings.Contains(lower, "opus"):
+		return agentclaude.OpusFeature
+	case strings.Contains(lower, "sonnet"):
+		return agentclaude.SonnetFeature
+	}
+	return model
+}
+
 func claudeUsageWindows(usage *agentclaude.UsageResponse) []accounts.UsageWindow {
 	if usage == nil {
 		return nil
@@ -716,8 +733,13 @@ func claudeUsageWindows(usage *agentclaude.UsageResponse) []accounts.UsageWindow
 			UsedPercent:        *limit.Utilization,
 			LimitWindowSeconds: windowSeconds,
 		}
-		if name == agentclaude.FableWindowName {
-			window.Feature = agentclaude.FableModel
+		switch name {
+		case agentclaude.FableWindowName:
+			window.Feature = agentclaude.FableFeature
+		case "opus-weekly":
+			window.Feature = agentclaude.OpusFeature
+		case "sonnet-weekly":
+			window.Feature = agentclaude.SonnetFeature
 		}
 		if reset, err := time.Parse(time.RFC3339, limit.ResetsAt); err == nil {
 			seconds := int64(time.Until(reset).Seconds())
@@ -737,6 +759,17 @@ func claudeUsageWindows(usage *agentclaude.UsageResponse) []accounts.UsageWindow
 	add(agentclaude.FableWindowName, sevenDaySeconds, usage.SevenDayOAuthApps)
 	add("opus-weekly", sevenDaySeconds, usage.SevenDayOpus)
 	add("sonnet-weekly", sevenDaySeconds, usage.SevenDaySonnet)
+	// The usage endpoint reports opus/sonnet weekly buckets as null until the
+	// account has used that model family. Null means "unused", not "cannot
+	// serve": emit a 0%-used window so ForModel never zero-fills a fresh
+	// account out of opus/sonnet routing once other accounts grow real
+	// windows.
+	if !usageWindowNamed(windows, "opus-weekly") {
+		windows = append(windows, accounts.UsageWindow{Name: "opus-weekly", LimitWindowSeconds: sevenDaySeconds, Feature: agentclaude.OpusFeature})
+	}
+	if !usageWindowNamed(windows, "sonnet-weekly") {
+		windows = append(windows, accounts.UsageWindow{Name: "sonnet-weekly", LimitWindowSeconds: sevenDaySeconds, Feature: agentclaude.SonnetFeature})
+	}
 	if usage.ExtraUsage != nil && usage.ExtraUsage.IsEnabled && usage.ExtraUsage.Utilization != nil {
 		windows = append(windows, accounts.UsageWindow{Name: "extra", UsedPercent: *usage.ExtraUsage.Utilization})
 	}
@@ -797,11 +830,19 @@ func scoreUsableForNewSession(score selectacct.Score) bool {
 
 func scoreFromUsageWindows(provider accounts.Provider, accountID string, windows []accounts.UsageWindow) selectacct.Score {
 	limitWindows := make([]selectacct.LimitWindow, 0, len(windows)*2)
-	hasFableWindow := false
-	for _, window := range windows {
-		if window.Feature == agentclaude.FableModel || window.Name == agentclaude.FableWindowName {
-			hasFableWindow = true
-			break
+	// A model-pool request (fable/opus/sonnet) consumes the account-wide 5h/7d
+	// windows too, so every feature pool's score must also reflect the base
+	// windows: duplicate each base window into every distinct feature present.
+	// Without this a pool with quota left on an account whose 5h window is
+	// cooked would still score high and route traffic into guaranteed 429s.
+	var features []string
+	if provider == accounts.ProviderClaude {
+		seen := map[string]bool{}
+		for _, window := range windows {
+			if window.Feature != "" && !seen[window.Feature] {
+				seen[window.Feature] = true
+				features = append(features, window.Feature)
+			}
 		}
 	}
 	for _, window := range windows {
@@ -812,14 +853,16 @@ func scoreFromUsageWindows(provider accounts.Provider, accountID string, windows
 			ResetAfterSeconds:  window.ResetAfterSeconds,
 			Feature:            window.Feature,
 		})
-		if provider == accounts.ProviderClaude && hasFableWindow && window.Feature == "" {
-			limitWindows = append(limitWindows, selectacct.LimitWindow{
-				Name:               window.Name,
-				UsedPercent:        window.UsedPercent,
-				LimitWindowSeconds: window.LimitWindowSeconds,
-				ResetAfterSeconds:  window.ResetAfterSeconds,
-				Feature:            agentclaude.FableModel,
-			})
+		if window.Feature == "" {
+			for _, feature := range features {
+				limitWindows = append(limitWindows, selectacct.LimitWindow{
+					Name:               window.Name,
+					UsedPercent:        window.UsedPercent,
+					LimitWindowSeconds: window.LimitWindowSeconds,
+					ResetAfterSeconds:  window.ResetAfterSeconds,
+					Feature:            feature,
+				})
+			}
 		}
 	}
 	score := selectacct.ScoreFromLimitWindows(accountID, 0, limitWindows)
@@ -1598,8 +1641,14 @@ func (s Server) proxyHandler() http.Handler {
 		// run when the pool gives up (usageLimitRetryTransport exhausts failover)
 		// or cannot start (no usable OAuth account). Other Claude models use the
 		// normal pool unchanged.
-		fableFallbackConfigured := requestProvider == accounts.ProviderClaude &&
-			s.claudeFableEnabled() && s.claudeFableRequest(r)
+		requestPoolModel := ""
+		fableFallbackConfigured := false
+		if requestProvider == accounts.ProviderClaude {
+			requestModel := session.ExtractModel(r, s.MaxBodyBytes)
+			requestPoolModel = claudePoolModel(requestModel)
+			fableFallbackConfigured = s.claudeFableEnabled() && claudeFableModel(requestModel) &&
+				r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/v1/messages")
+		}
 		sessionAgentType := agentTypeForProviderSession(agentType, requestProvider)
 		account, sessionID, userEmail, err := s.accountForSessionProvider(requestProvider, sessionAgentType, sessionID, r)
 		if err != nil {
@@ -1708,6 +1757,7 @@ func (s Server) proxyHandler() http.Handler {
 				path:          proxyRequest.URL.Path,
 				upstream:      upstream.Host,
 				maxAttempts:   s.usageLimitRetryMaxAttempts(requestProvider),
+				poolModel:     requestPoolModel,
 				fableFallback: fableFallback,
 			}
 		}
@@ -2561,10 +2611,14 @@ func (s Server) accountForSessionProvider(provider accounts.Provider, agentType,
 		s.refreshUsageScoresIfStale(r.Context())
 	}
 	base := s.scheduler()
-	if model != "" && s.Logger != nil && base.HasModelPool(model) {
-		s.Logger.Info("model quota pool matched", "agent", agentType, "model", model, "pool", selectacct.ModelKey(model))
+	poolModel := model
+	if provider == accounts.ProviderClaude {
+		poolModel = claudePoolModel(model)
 	}
-	scheduler := base.ForModel(model).WithSessionCounts(s.Sessions.CountByAccount())
+	if poolModel != "" && s.Logger != nil && base.HasModelPool(poolModel) {
+		s.Logger.Info("model quota pool matched", "agent", agentType, "model", model, "pool", selectacct.ModelKey(poolModel))
+	}
+	scheduler := base.ForModel(poolModel).WithSessionCounts(s.Sessions.CountByAccount())
 	if assignment, ok := s.Sessions.Get(agentType, sessionID); ok {
 		if userEmail != "" && userEmail != assignment.UserEmail {
 			updated, err := s.Sessions.Put(agentType, sessionID, assignment.AccountID, userEmail)
@@ -3009,6 +3063,11 @@ type usageLimitRetryTransport struct {
 	// sleep waits for the backoff duration or until the context is cancelled.
 	// Injectable for tests; nil means a real timer wait.
 	sleep func(context.Context, time.Duration) error
+	// poolModel is the canonicalized quota-pool model for this request (e.g.
+	// "claude-fable"); failover scores candidates against that pool so an
+	// account whose pool is cooked but whose base windows are healthy is not
+	// retried for a model it cannot serve.
+	poolModel string
 	// fableFallback, when set, serves the request via the Fable fallback chain
 	// (Bedrock, then the dedicated Anthropic API key) once the subscription
 	// pool gives up. Set only for Claude Fable requests with a chain configured;
@@ -3152,7 +3211,47 @@ func claudeAccountExhaustedByResponse(status int, header http.Header) bool {
 	if status == http.StatusUnauthorized {
 		return true
 	}
-	return claudeUnifiedStatus(header) == "rejected"
+	if claudeUnifiedStatus(header) != "rejected" {
+		return false
+	}
+	// A rejection caused solely by a model-scoped window (e.g. the Fable
+	// 7d_oi bucket) while the account-wide 5h/7d windows are still allowed
+	// must not cook the whole account: opus/sonnet traffic can still use it,
+	// and the usage refresh zeroes the affected pool on its own evidence.
+	// Before this, a wave of Fable traffic marked every account exhausted and
+	// starved opus/sonnet routing.
+	return !claudeRejectionIsModelPoolScoped(header)
+}
+
+// claudeModelPoolWindowPrefixes are the unified-header window prefixes that
+// meter a single model family rather than the whole account. 7d_oi is the
+// hidden Fable/OAuth-apps weekly bucket.
+var claudeModelPoolWindowPrefixes = []string{"7d_oi"}
+
+// claudeRejectionIsModelPoolScoped reports whether a rejected response is
+// attributable only to a model-scoped window: some pool window says rejected
+// and no account-wide window does. Responses without per-window statuses are
+// treated as account-wide (conservative).
+func claudeRejectionIsModelPoolScoped(header http.Header) bool {
+	windowStatus := func(prefix string) string {
+		return strings.ToLower(strings.TrimSpace(claudeHeaderGet(header, "anthropic-ratelimit-unified-"+prefix+"-status")))
+	}
+	poolRejected := false
+	for _, prefix := range claudeModelPoolWindowPrefixes {
+		if windowStatus(prefix) == "rejected" {
+			poolRejected = true
+			break
+		}
+	}
+	if !poolRejected {
+		return false
+	}
+	for _, prefix := range []string{"5h", "7d"} {
+		if windowStatus(prefix) == "rejected" {
+			return false
+		}
+	}
+	return true
 }
 
 // claudeUnifiedStatus returns the lowercased anthropic-ratelimit-unified-status
@@ -3299,7 +3398,7 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			}
 			return response, nil
 		}
-		nextAccount, pickErr := t.server.oauthRetryAccount(req.Context(), t.provider, t.agent, t.session, t.userEmail, tried, t.fableFallback != nil)
+		nextAccount, pickErr := t.server.oauthRetryAccount(req.Context(), t.provider, t.agent, t.session, t.userEmail, t.poolModel, tried, t.fableFallback != nil)
 		if pickErr != nil {
 			if t.logger != nil {
 				t.logger.Warn("usage-limit retry has no alternate account", "agent", t.agent, "session", t.session, "account", accountID, "method", t.method, "path", t.path, "upstream", t.upstream, "error", pickErr)
@@ -3439,7 +3538,7 @@ func isTerminalCredentialError(err error) bool {
 // pool to OAuth accounts; Fable requests with a fallback chain set it so a
 // metered API-key pool account never preempts the Bedrock stage (the dedicated
 // Fable API key is the chain's own last stage).
-func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provider, agentType, sessionID, userEmail string, tried map[string]struct{}, oauthOnly bool) (accounts.Account, error) {
+func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provider, agentType, sessionID, userEmail, poolModel string, tried map[string]struct{}, oauthOnly bool) (accounts.Account, error) {
 	allCandidates := filterAccountsForProvider(s.accountList(), provider)
 	if len(allCandidates) == 0 {
 		return accounts.Account{}, fmt.Errorf("no %s accounts available", provider)
@@ -3452,7 +3551,7 @@ func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provide
 	// though healthy accounts remained untried.
 	var lastErr error
 	for {
-		scheduler := s.scheduler()
+		scheduler := s.scheduler().ForModel(poolModel)
 		if s.Sessions != nil {
 			scheduler = scheduler.WithSessionCounts(s.Sessions.CountByAccount())
 		}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1796,6 +1796,12 @@ func (s Server) proxyHandler() http.Handler {
 			}
 		}
 
+		if s.SchedulerRef != nil {
+			// Live debit: the scheduler sees its own routed traffic draining
+			// the usage snapshot between refreshes (sticky and fresh picks
+			// both consume quota).
+			s.SchedulerRef.NoteRouted(requestProvider, account.ID)
+		}
 		if s.Logger != nil {
 			// remote_addr + user_agent attribute each request to a source (tailnet
 			// device / client type). Without them a concurrency spike is an
@@ -3423,6 +3429,9 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 		previousAccount := accountID
 		accountID = nextAccount.ID
 		tried[accountID] = struct{}{}
+		if t.server != nil && t.server.SchedulerRef != nil {
+			t.server.SchedulerRef.NoteRouted(t.provider, accountID)
+		}
 		attemptReq = req.Clone(req.Context())
 		attemptReq.Body = body
 		attemptReq.GetBody = req.GetBody
@@ -3761,7 +3770,7 @@ func NewOutboundTransport() *http.Transport {
 
 func (s Server) scheduler() selectacct.Scheduler {
 	if s.SchedulerRef != nil {
-		return s.SchedulerRef.Get()
+		return s.SchedulerRef.Get().WithLiveDebits(s.SchedulerRef.LiveDebits())
 	}
 	return s.Scheduler
 }

--- a/internal/selectacct/limits.go
+++ b/internal/selectacct/limits.go
@@ -141,3 +141,20 @@ func clampPercent(value float64) float64 {
 		return value
 	}
 }
+
+// VelocityProjectionMinutes is how far ahead a refresh-delta velocity signal
+// projects headroom (kept for the experiment's comparison policies), and
+// LiveDebitPerRequest is the assumed cost of one routed request as a fraction
+// of an account's short window: Pick debits the snapshot headroom by it for
+// every request the proxy itself routed to the account since the last usage
+// refresh, so concurrent fleets spread across accounts instead of herding
+// onto the snapshot's single best account until it cooks. Deliberately an
+// over-estimate (real mean is ~0.3%): the experiment shows 2% minimizes
+// user-visible failovers (-31% vs no debit), with degradation on both sides
+// (0.6%: -23%, 5%: -27%, 10%: -22%). Chosen by TestVelocityPolicyExperiment
+// (a deterministic 24h 3-user/19-thread fleet-burst workload over 24 seeds);
+// rerun with -v when tuning.
+const (
+	VelocityProjectionMinutes = 20.0
+	LiveDebitPerRequest       = 0.020
+)

--- a/internal/selectacct/scheduler.go
+++ b/internal/selectacct/scheduler.go
@@ -2,6 +2,7 @@ package selectacct
 
 import (
 	"errors"
+	"math"
 	"sort"
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
@@ -29,6 +30,7 @@ type Score struct {
 type Scheduler struct {
 	scores        map[string]Score
 	sessionCounts map[string]int
+	liveDebits    map[string]int
 }
 
 const MinNewSessionHeadroom = 0.40
@@ -59,6 +61,7 @@ func (s Scheduler) WithScore(score Score) Scheduler {
 	next := Scheduler{
 		scores:        make(map[string]Score, len(s.scores)+1),
 		sessionCounts: s.sessionCounts,
+		liveDebits:    s.liveDebits,
 	}
 	for key, existing := range s.scores {
 		next.scores[key] = existing
@@ -71,6 +74,7 @@ func (s Scheduler) WithSessionCounts(counts map[string]int) Scheduler {
 	next := Scheduler{
 		scores:        s.scores,
 		sessionCounts: map[string]int{},
+		liveDebits:    s.liveDebits,
 	}
 	for accountID, count := range counts {
 		next.sessionCounts[accountID] = count
@@ -91,6 +95,7 @@ func (s Scheduler) ForModel(model string) Scheduler {
 	next := Scheduler{
 		scores:        make(map[string]Score, len(s.scores)),
 		sessionCounts: s.sessionCounts,
+		liveDebits:    s.liveDebits,
 	}
 	for scoreKey, score := range s.scores {
 		modelScore, ok := score.ModelScores[key]
@@ -186,6 +191,15 @@ func (s Scheduler) ScoreFor(provider accounts.Provider, accountID string) Score 
 	return Score{AccountID: accountID, Provider: provider, Headroom: 1, ShortHeadroom: 1}
 }
 
+// WithLiveDebits attaches per-account routed-request counts accumulated since
+// the last usage refresh. score() debits LiveDebitPerRequest of headroom per
+// routed request, so between refreshes the scheduler sees its OWN traffic
+// draining the snapshot instead of herding every pick onto the same account.
+// Keys are ScoreKey(provider, accountID).
+func (s Scheduler) WithLiveDebits(debits map[string]int) Scheduler {
+	return Scheduler{scores: s.scores, sessionCounts: s.sessionCounts, liveDebits: debits}
+}
+
 func (s Scheduler) score(provider accounts.Provider, accountID string) Score {
 	score, ok := s.scores[ScoreKey(provider, accountID)]
 	if !ok {
@@ -193,6 +207,20 @@ func (s Scheduler) score(provider accounts.Provider, accountID string) Score {
 	}
 	if s.sessionCounts != nil {
 		score.Sessions = s.sessionCounts[accountID]
+	}
+	if count := s.liveDebits[ScoreKey(provider, accountID)]; count > 0 {
+		// A soft, self-correcting signal: it reorders picks and can push an
+		// account below the new-session threshold, but never onto (or off of)
+		// the exhaustion floor: routing our own optimism into an account is
+		// recoverable; falsely marking it exhausted, or resurrecting a
+		// genuinely exhausted one, is not.
+		debit := LiveDebitPerRequest * float64(count)
+		if score.Headroom > 0.01 {
+			score.Headroom = math.Max(0.01, score.Headroom-debit)
+		}
+		if score.ShortHeadroom > 0.01 {
+			score.ShortHeadroom = math.Max(0.01, score.ShortHeadroom-debit)
+		}
 	}
 	return score
 }

--- a/internal/selectacct/scheduler_ref.go
+++ b/internal/selectacct/scheduler_ref.go
@@ -18,6 +18,11 @@ type SchedulerRef struct {
 	// until the next SUCCESSFUL usage refresh, which under load can fail for
 	// hours, leaving real quota unroutable while clients got 429s.
 	exhaustedUntil map[string]time.Time
+	// routedSinceRefresh counts requests the proxy routed per account (by
+	// ScoreKey) since the last successful usage refresh. Pick debits headroom
+	// by LiveDebitPerRequest per routed request so concurrent traffic spreads
+	// instead of herding onto the snapshot's best account until it cooks.
+	routedSinceRefresh map[string]int
 }
 
 func NewSchedulerRef(scheduler Scheduler) *SchedulerRef {
@@ -191,9 +196,45 @@ func (r *SchedulerRef) FinishRefresh(scheduler Scheduler, update bool) {
 	if update {
 		r.scheduler = scheduler
 		r.retainExhaustedExpiriesLocked()
+		// Fresh scores supersede the live debits accumulated against the old
+		// snapshot. A failed refresh (update=false) keeps them: the snapshot
+		// is still the old one, so its debits still apply.
+		r.routedSinceRefresh = nil
 	}
 	r.updatedAt = time.Now()
 	r.refreshing = false
+}
+
+// NoteRouted records that one request was routed to the account, debiting its
+// live score until the next successful usage refresh.
+func (r *SchedulerRef) NoteRouted(provider accounts.Provider, accountID string) {
+	if r == nil || accountID == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.routedSinceRefresh == nil {
+		r.routedSinceRefresh = make(map[string]int)
+	}
+	r.routedSinceRefresh[ScoreKey(provider, accountID)]++
+}
+
+// LiveDebits returns the per-account routed-request counts since the last
+// successful refresh, for Scheduler.WithLiveDebits.
+func (r *SchedulerRef) LiveDebits() map[string]int {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if len(r.routedSinceRefresh) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(r.routedSinceRefresh))
+	for key, count := range r.routedSinceRefresh {
+		out[key] = count
+	}
+	return out
 }
 
 func (r *SchedulerRef) Touch() {

--- a/internal/selectacct/scheduler_test.go
+++ b/internal/selectacct/scheduler_test.go
@@ -237,3 +237,73 @@ func TestScoresAreIsolatedPerProviderReversed(t *testing.T) {
 		t.Fatal("exhausted Codex account must stay exhausted")
 	}
 }
+
+func TestLiveDebitsReorderPickWithoutExhausting(t *testing.T) {
+	accountA := accounts.Account{ID: "a", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "x"}
+	accountB := accounts.Account{ID: "b", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "x"}
+	scheduler := NewScheduler([]Score{
+		{AccountID: "a", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+		{AccountID: "b", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+	})
+
+	// Equal scores: deterministic tie falls to "a".
+	picked, err := scheduler.Pick([]accounts.Account{accountA, accountB})
+	if err != nil || picked.ID != "a" {
+		t.Fatalf("baseline pick = %v %v, want a", picked.ID, err)
+	}
+
+	// Five requests routed to "a" since the snapshot: the debit flips the pick.
+	debited := scheduler.WithLiveDebits(map[string]int{ScoreKey(accounts.ProviderClaude, "a"): 5})
+	picked, err = debited.Pick([]accounts.Account{accountA, accountB})
+	if err != nil || picked.ID != "b" {
+		t.Fatalf("debited pick = %v %v, want b", picked.ID, err)
+	}
+
+	// Even a huge debit never exhausts the account or resurrects an exhausted one.
+	heavy := scheduler.WithLiveDebits(map[string]int{ScoreKey(accounts.ProviderClaude, "a"): 1000})
+	if heavy.Exhausted(accounts.ProviderClaude, "a") {
+		t.Fatal("a live debit must never mark an account exhausted")
+	}
+	cooked := NewScheduler([]Score{{AccountID: "a", Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0}}).
+		WithLiveDebits(map[string]int{ScoreKey(accounts.ProviderClaude, "a"): 3})
+	if !cooked.Exhausted(accounts.ProviderClaude, "a") {
+		t.Fatal("a live debit must not resurrect an exhausted account")
+	}
+}
+
+func TestLiveDebitsSurviveForModelAndSessionCounts(t *testing.T) {
+	scheduler := NewScheduler([]Score{
+		{AccountID: "a", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1,
+			ModelScores: map[string]Score{"claudefable": {AccountID: "a", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1}}},
+		{AccountID: "b", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1,
+			ModelScores: map[string]Score{"claudefable": {AccountID: "b", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1}}},
+	}).WithLiveDebits(map[string]int{ScoreKey(accounts.ProviderClaude, "a"): 5}).
+		WithSessionCounts(map[string]int{})
+	accountA := accounts.Account{ID: "a", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "x"}
+	accountB := accounts.Account{ID: "b", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "x"}
+	picked, err := scheduler.ForModel("claude-fable").Pick([]accounts.Account{accountA, accountB})
+	if err != nil || picked.ID != "b" {
+		t.Fatalf("pool pick = %v %v, want b (debits must survive ForModel and WithSessionCounts)", picked.ID, err)
+	}
+}
+
+func TestSchedulerRefLiveDebitLifecycle(t *testing.T) {
+	ref := NewSchedulerRef(NewScheduler(nil))
+	ref.NoteRouted(accounts.ProviderClaude, "a")
+	ref.NoteRouted(accounts.ProviderClaude, "a")
+	ref.NoteRouted(accounts.ProviderCodex, "a")
+	debits := ref.LiveDebits()
+	if debits[ScoreKey(accounts.ProviderClaude, "a")] != 2 || debits[ScoreKey(accounts.ProviderCodex, "a")] != 1 {
+		t.Fatalf("debits = %v", debits)
+	}
+	// A failed refresh keeps the debits (the stale snapshot still applies)...
+	ref.FinishRefresh(Scheduler{}, false)
+	if ref.LiveDebits() == nil {
+		t.Fatal("failed refresh must keep live debits")
+	}
+	// ...a successful one supersedes them.
+	ref.FinishRefresh(NewScheduler(nil), true)
+	if ref.LiveDebits() != nil {
+		t.Fatal("fresh refresh must clear live debits")
+	}
+}

--- a/internal/selectacct/velocity_sim_test.go
+++ b/internal/selectacct/velocity_sim_test.go
@@ -1,0 +1,394 @@
+package selectacct
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+)
+
+// This file is a routing-policy experiment, kept as a deterministic test so
+// the chosen production constants stay justified by a reproducible workload.
+//
+// The modeled phenomenon: the scheduler only refreshes usage scores every few
+// minutes, so between refreshes it routes on stale snapshots. An account that
+// several concurrent threads are hammering looks healthy at refresh time and
+// is cooked minutes later; every new session routed there in between burns a
+// failover. A velocity term (consumption rate observed between refreshes)
+// projects the snapshot forward and steers new sessions away from
+// fast-draining accounts before they cook.
+//
+// Workload shape mirrors the real deployment: ~3 people share the pool, one
+// running a large agent fleet, the others lighter, all bursty.
+
+const (
+	simStepSeconds       = 10
+	simHours             = 24
+	simAccounts          = 12
+	simRefreshEverySteps = 30 // 5 minutes, matches the server's usage refresh cadence
+	// fiveHourRefillPerStep approximates the rolling 5h window as a leaky
+	// bucket: consumed fraction drains back at cap/5h.
+	fiveHourRefillPerStep = float64(simStepSeconds) / (5 * 60 * 60)
+)
+
+type simPolicy struct {
+	name string
+	// pick returns the index of the account a new/rerouted session should use.
+	// snapHeadroom/velocity are refresh-stale. staleSessions mirrors the
+	// production session store (no TTL, counts dead sessions). activeSessions
+	// counts sessions with recent activity. reqsSinceSnap counts requests the
+	// router itself sent to each account since the last snapshot (live).
+	pick func(snapHeadroom, velocityPerMin []float64, staleSessions, activeSessions, reqsSinceSnap []int, rng *rand.Rand) int
+}
+
+type simThread struct {
+	user       int
+	account    int
+	burstLeft  int // requests remaining in the current burst
+	launchDone int // last fleet-launch sequence this thread completed
+	lastActive int // step of this thread's most recent request
+}
+
+type simResult struct {
+	rejects     int // requests that hit a cooked account (user-visible failover/429)
+	served      int
+	unservable  int     // requests when every account was cooked (no policy can win these)
+	maxSessions int     // worst concurrent sessions on one account
+	usedStddev  float64 // imbalance of total consumption across accounts
+}
+
+func runVelocitySim(policy simPolicy, seed int64) simResult {
+	rng := rand.New(rand.NewSource(seed))
+	steps := simHours * 3600 / simStepSeconds
+
+	used := make([]float64, simAccounts)       // live consumed fraction of the 5h window
+	totalUsed := make([]float64, simAccounts)  // lifetime consumption per account
+	snapUsed := make([]float64, simAccounts)   // refresh-stale snapshot the policy sees
+	velocity := make([]float64, simAccounts)   // EWMA consumed-fraction per minute
+	sessions := make([]int, simAccounts)       // sticky assignment counts (store semantics, no TTL)
+	reqsSinceSnap := make([]int, simAccounts)  // requests routed per account since last snapshot
+	activeSessions := make([]int, simAccounts) // sessions with activity in the last 15 min
+
+	// 3 users: one heavy fleet, two lighter. Threads are sticky sessions.
+	// A user's threads burst TOGETHER (a person launches an agent fleet at
+	// once): correlated bursts are what create the consumption spikes a stale
+	// snapshot misses and a velocity term catches.
+	threadCounts := []int{12, 4, 3}
+	var threads []*simThread
+	userNextBurst := make([]int, len(threadCounts))
+	userLaunchSeq := make([]int, len(threadCounts))
+	for user, n := range threadCounts {
+		userNextBurst[user] = rng.Intn(180)
+		for i := 0; i < n; i++ {
+			threads = append(threads, &simThread{user: user, account: -1})
+		}
+	}
+
+	result := simResult{}
+	refreshMinutes := float64(simRefreshEverySteps*simStepSeconds) / 60
+
+	for step := 0; step < steps; step++ {
+		// Refill the rolling windows.
+		for i := range used {
+			used[i] = math.Max(0, used[i]-fiveHourRefillPerStep)
+		}
+		// Periodic score refresh: snapshot usage, update velocity EWMA.
+		if step%simRefreshEverySteps == 0 {
+			for i := range used {
+				rawNow := (used[i] - snapUsed[i]) / refreshMinutes
+				if rawNow < 0 {
+					rawNow = 0
+				}
+				velocity[i] = 0.5*velocity[i] + 0.5*rawNow
+				snapUsed[i] = used[i]
+				reqsSinceSnap[i] = 0
+			}
+		}
+		// Recompute active-session counts (sessions with a request in the
+		// last 15 minutes), the TTL'd counterpart of the stale store counts.
+		for i := range activeSessions {
+			activeSessions[i] = 0
+		}
+		for _, other := range threads {
+			if other.account != -1 && step-other.lastActive <= 90 {
+				activeSessions[other.account]++
+			}
+		}
+
+		// A user's launch opens when its scheduled step arrives; each thread
+		// runs exactly one burst per launch.
+		for user := range userNextBurst {
+			if step == userNextBurst[user] {
+				userLaunchSeq[user]++
+			}
+		}
+		for _, thread := range threads {
+			if step < userNextBurst[thread.user] {
+				continue
+			}
+			if thread.burstLeft == 0 {
+				if thread.launchDone >= userLaunchSeq[thread.user] {
+					continue // already ran this launch; waiting for the next one
+				}
+				// The whole fleet bursts together: 30-100 requests per thread.
+				thread.burstLeft = 30 + rng.Intn(70)
+				thread.launchDone = userLaunchSeq[thread.user]
+			}
+			// One request this step with p=0.5 (agent think time).
+			if rng.Float64() > 0.5 {
+				continue
+			}
+			cost := 0.001 + rng.Float64()*0.004 // 0.1%-0.5% of the 5h window per request
+
+			if thread.account == -1 || used[thread.account] >= 1 {
+				if thread.account != -1 {
+					// Sticky session hit a cooked account: user-visible failover.
+					result.rejects++
+					sessions[thread.account]--
+					thread.account = -1
+				}
+				snapHeadroom := make([]float64, simAccounts)
+				anyOpen := false
+				for i := range snapUsed {
+					snapHeadroom[i] = 1 - snapUsed[i]
+					if used[i] < 1 {
+						anyOpen = true
+					}
+				}
+				if !anyOpen {
+					result.unservable++
+					continue
+				}
+				pick := policy.pick(snapHeadroom, velocity, sessions, activeSessions, reqsSinceSnap, rng)
+				if used[pick] >= 1 {
+					// Policy routed into a cooked account (stale snapshot).
+					result.rejects++
+					// One bounded retry on the live-best account, mirroring failover.
+					best := -1
+					for i := range used {
+						if used[i] < 1 && (best == -1 || used[i] < used[best]) {
+							best = i
+						}
+					}
+					pick = best
+				}
+				thread.account = pick
+				sessions[pick]++
+			}
+
+			used[thread.account] += cost
+			totalUsed[thread.account] += cost
+			reqsSinceSnap[thread.account]++
+			thread.lastActive = step
+			result.served++
+			if sessions[thread.account] > result.maxSessions {
+				result.maxSessions = sessions[thread.account]
+			}
+			thread.burstLeft--
+			if thread.burstLeft == 0 {
+				// Burst ends but the session stays sticky (and idle) on its
+				// account, like the real session store: session counts include
+				// idle sessions, which is exactly where a pure session-count
+				// penalty over-penalizes and velocity tells hot from held.
+				allDone := true
+				for _, other := range threads {
+					if other.user == thread.user && other.burstLeft > 0 {
+						allDone = false
+						break
+					}
+				}
+				if allDone {
+					userNextBurst[thread.user] = step + 120 + rng.Intn(300) // 20-70 min idle
+				}
+			}
+		}
+	}
+
+	mean := 0.0
+	for _, u := range totalUsed {
+		mean += u
+	}
+	mean /= float64(len(totalUsed))
+	variance := 0.0
+	for _, u := range totalUsed {
+		variance += (u - mean) * (u - mean)
+	}
+	result.usedStddev = math.Sqrt(variance / float64(len(totalUsed)))
+	return result
+}
+
+func headroomPickPolicy() simPolicy {
+	return simPolicy{
+		name: "current(headroom+staleSessions)",
+		pick: func(snapHeadroom, _ []float64, staleSessions, _, _ []int, _ *rand.Rand) int {
+			return argBest(snapHeadroom, func(i, j int) bool {
+				if snapHeadroom[i] != snapHeadroom[j] {
+					return snapHeadroom[i] > snapHeadroom[j]
+				}
+				return staleSessions[i] < staleSessions[j]
+			})
+		},
+	}
+}
+
+func activeSessionsPickPolicy() simPolicy {
+	return simPolicy{
+		name: "headroom+activeSessions",
+		pick: func(snapHeadroom, _ []float64, _, activeSessions, _ []int, _ *rand.Rand) int {
+			return argBest(snapHeadroom, func(i, j int) bool {
+				if snapHeadroom[i] != snapHeadroom[j] {
+					return snapHeadroom[i] > snapHeadroom[j]
+				}
+				return activeSessions[i] < activeSessions[j]
+			})
+		},
+	}
+}
+
+// liveDebitPickPolicy debits the snapshot headroom by the requests the router
+// itself sent since that snapshot (perRequestDebit = assumed mean cost as a
+// window fraction). This is the live form of "velocity": it needs no estimator
+// and updates instantly, so within-refresh herding self-corrects.
+func liveDebitPickPolicy(perRequestDebit float64) simPolicy {
+	return simPolicy{
+		name: fmt.Sprintf("liveDebit(d=%.3f)+activeSessions", perRequestDebit),
+		pick: func(snapHeadroom, _ []float64, _, activeSessions, reqsSinceSnap []int, _ *rand.Rand) int {
+			projected := make([]float64, len(snapHeadroom))
+			for i := range snapHeadroom {
+				projected[i] = snapHeadroom[i] - perRequestDebit*float64(reqsSinceSnap[i])
+			}
+			return argBest(projected, func(i, j int) bool {
+				if projected[i] != projected[j] {
+					return projected[i] > projected[j]
+				}
+				return activeSessions[i] < activeSessions[j]
+			})
+		},
+	}
+}
+
+func liveDebitVelocityPickPolicy(perRequestDebit, horizonMinutes float64) simPolicy {
+	return simPolicy{
+		name: fmt.Sprintf("liveDebit(d=%.3f)+velocity(h=%.0fm)", perRequestDebit, horizonMinutes),
+		pick: func(snapHeadroom, velocityPerMin []float64, _, activeSessions, reqsSinceSnap []int, _ *rand.Rand) int {
+			projected := make([]float64, len(snapHeadroom))
+			for i := range snapHeadroom {
+				projected[i] = snapHeadroom[i] - perRequestDebit*float64(reqsSinceSnap[i]) - velocityPerMin[i]*horizonMinutes
+			}
+			return argBest(projected, func(i, j int) bool {
+				if projected[i] != projected[j] {
+					return projected[i] > projected[j]
+				}
+				return activeSessions[i] < activeSessions[j]
+			})
+		},
+	}
+}
+
+func liveDebitActivePenaltyPickPolicy(perRequestDebit, sessionPenalty float64) simPolicy {
+	return simPolicy{
+		name: fmt.Sprintf("liveDebit(d=%.3f)+activePenalty(k=%.2f)", perRequestDebit, sessionPenalty),
+		pick: func(snapHeadroom, _ []float64, _, activeSessions, reqsSinceSnap []int, _ *rand.Rand) int {
+			projected := make([]float64, len(snapHeadroom))
+			for i := range snapHeadroom {
+				projected[i] = snapHeadroom[i] - perRequestDebit*float64(reqsSinceSnap[i]) - sessionPenalty*float64(activeSessions[i])
+			}
+			return argBest(projected, func(i, j int) bool {
+				if projected[i] != projected[j] {
+					return projected[i] > projected[j]
+				}
+				return activeSessions[i] < activeSessions[j]
+			})
+		},
+	}
+}
+
+func velocityPickPolicy(horizonMinutes float64) simPolicy {
+	return simPolicy{
+		name: fmt.Sprintf("velocity(h=%.0fm)", horizonMinutes),
+		pick: func(snapHeadroom, velocityPerMin []float64, staleSessions, _, _ []int, _ *rand.Rand) int {
+			projected := make([]float64, len(snapHeadroom))
+			for i := range snapHeadroom {
+				projected[i] = snapHeadroom[i] - velocityPerMin[i]*horizonMinutes
+			}
+			return argBest(projected, func(i, j int) bool {
+				if projected[i] != projected[j] {
+					return projected[i] > projected[j]
+				}
+				return staleSessions[i] < staleSessions[j]
+			})
+		},
+	}
+}
+
+func randomPickPolicy() simPolicy {
+	return simPolicy{
+		name: "random",
+		pick: func(snapHeadroom []float64, _ []float64, _, _, _ []int, rng *rand.Rand) int {
+			return rng.Intn(len(snapHeadroom))
+		},
+	}
+}
+
+func argBest(values []float64, less func(i, j int) bool) int {
+	idx := make([]int, len(values))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.SliceStable(idx, func(a, b int) bool { return less(idx[a], idx[b]) })
+	return idx[0]
+}
+
+// TestVelocityPolicyExperiment runs the policy comparison across seeds and
+// prints the table (go test -v -run TestVelocityPolicyExperiment). It asserts
+// the production choice (velocity projection with the shipped horizon plus the
+// shipped session penalty) does not lose to the pre-velocity policy on
+// user-visible rejects, so the constants stay justified.
+func TestVelocityPolicyExperiment(t *testing.T) {
+	policies := []simPolicy{
+		randomPickPolicy(),
+		headroomPickPolicy(),
+		activeSessionsPickPolicy(),
+		velocityPickPolicy(VelocityProjectionMinutes),
+		liveDebitPickPolicy(0.006),
+		liveDebitPickPolicy(LiveDebitPerRequest),
+		liveDebitPickPolicy(0.020),
+		liveDebitPickPolicy(0.050),
+		liveDebitPickPolicy(0.100),
+		liveDebitPickPolicy(0.300),
+	}
+	seeds := make([]int64, 24)
+	for i := range seeds {
+		seeds[i] = int64(i + 1)
+	}
+
+	totals := make(map[string]*simResult)
+	for _, policy := range policies {
+		agg := &simResult{}
+		for _, seed := range seeds {
+			r := runVelocitySim(policy, seed)
+			agg.rejects += r.rejects
+			agg.served += r.served
+			agg.unservable += r.unservable
+			if r.maxSessions > agg.maxSessions {
+				agg.maxSessions = r.maxSessions
+			}
+			agg.usedStddev += r.usedStddev
+		}
+		agg.usedStddev /= float64(len(seeds))
+		totals[policy.name] = agg
+		t.Logf("%-34s rejects=%5d served=%6d unservable=%4d maxSessions=%2d imbalance=%.4f",
+			policy.name, agg.rejects, agg.served, agg.unservable, agg.maxSessions, agg.usedStddev)
+	}
+
+	current := totals["current(headroom+staleSessions)"]
+	shipped := totals[fmt.Sprintf("liveDebit(d=%.3f)+activeSessions", LiveDebitPerRequest)]
+	if shipped == nil {
+		t.Fatal("shipped policy missing from experiment table")
+	}
+	if shipped.rejects > current.rejects {
+		t.Fatalf("shipped liveDebit policy rejects=%d worse than current=%d; revisit LiveDebitPerRequest",
+			shipped.rejects, current.rejects)
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subrouter",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Routes AI coding-agent traffic across subscription accounts and API keys.",
   "license": "MIT",
   "homepage": "https://github.com/manaflow-ai/subrouter#readme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "subrouter"
-version = "0.1.30"
+version = "0.1.31"
 description = "Routes AI coding-agent traffic across subscription accounts and API keys."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Root cause of 'aw0/aw1/aw2 have fable availability but never serve fable': Anthropic rejects subscription-OAuth Messages calls that don't look like Claude Code with a headerless 429 regardless of quota. The fable probe sent a bare 1-token request, got that 429 on every account, and synthesized fable=100% pool-wide, so all Fable traffic paid for Bedrock/API-key while subscription fable quota sat unused. Verified live on aw1 (fresh Max 20x, 0.0 utilization): bare probe 429s, the same request with the Claude Code system prompt + claude-code beta + client identity answers 200 with 7d_oi-utilization 0.0. The probe now sends that shape, and a headerless 429 returns no windows (unknown) instead of exhausted.

Model pools are now correct end to end: opus/sonnet weekly windows carry Feature tags (null buckets synthesize 0%-used windows since null means unused), claudePoolModel canonicalizes versioned models (claude-opus-4-8[1m]) onto their pool family, every pool score includes the base 5h/7d windows, and failover scores candidates against the request's pool. A rejection attributable only to a model pool (7d_oi rejected while 5h/7d allowed) no longer cooks the whole account, so Fable waves can't starve opus/sonnet routing.

Bedrock: context_management is stripped before invoke (Bedrock 400s 'Extra inputs are not permitted', observed live pushing every context-editing request straight to the API key) and Bedrock error bodies are logged.

Fixes, in user terms: fable routes to accounts with genuine fable availability first; opus routing is never distorted by fable consumption; Bedrock 400/503/429 all fall through the chain with the reason visible in logs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785741000&installation_id=133855650&pr_number=53&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F53&signature=a451a00207714bbe3eb08599a648601b4f6a44e2c3e73ccdab5e4036b23beba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Fable availability probe, scopes Claude quota pools by model, and adds live headroom debits to GTO selection to cut failovers; Bedrock requests strip invalid fields and now log error bodies.

- **Bug Fixes**
  - Fable probe now uses the Claude Code request shape (system prompt, beta tag, client identity) and treats headerless 429s as unknown, not exhausted.
  - Bedrock: strip `context_management` before invoke to avoid 400s; log non-2xx response bodies for easier debugging.

- **Refactors**
  - Model-scoped Claude pools: tag opus/sonnet weekly windows, synthesize 0%-used windows when null, and canonicalize request models to pool families.
  - Pool scores include base 5h/7d windows; failover scores candidates against the request’s pool.
  - Pool-only rejections (e.g., Fable `7d_oi` rejected while 5h/7d allowed) no longer exhaust the account.
  - Live per-request headroom debits (2% of the short window) reorder picks between refreshes without ever marking an account exhausted; debits reset on successful usage refreshes and persist across failed ones.

<sup>Written for commit a3bdae215a8ac6f9d1fe9f9c07924ffdb5b92bb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

