### PR TITLE
Fail over org-disabled Claude accounts (403 permission_error)

### DIFF
--- a/internal/proxy/claude_fable.go
+++ b/internal/proxy/claude_fable.go
@@ -53,6 +53,12 @@ func (s Server) serveClaudeFableFallback(w http.ResponseWriter, r *http.Request)
 		r.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(body)), nil }
 		return false
 	}
+	if s.Logger != nil {
+		// Same signal the transport-level give-up logs emit; without it a
+		// handler-level fallback (no usable OAuth account at selection) is
+		// invisible and Bedrock activity cannot be attributed to the chain.
+		s.Logger.Warn("serving claude fable via fallback chain", "reason", "no_usable_account", "fallback_status", resp.StatusCode)
+	}
 	defer resp.Body.Close()
 	for key, values := range resp.Header {
 		if isHopByHopHeader(key) {

--- a/internal/proxy/claude_failover_test.go
+++ b/internal/proxy/claude_failover_test.go
@@ -399,3 +399,66 @@ func TestRefreshUsageScoresCoversAllProviders(t *testing.T) {
 		t.Fatal("claude usage scores should make Exhausted() real")
 	}
 }
+
+// Anthropic can disable OAuth for one account's org mid-flight (403
+// permission_error "OAuth authentication is currently not allowed for this
+// organization", observed live 2026-07-04): the account must fail over and be
+// marked exhausted with the credential TTL, not black-hole its sticky sessions.
+func TestUsageLimitRetryTransportClaudeFailsOverOn403OrgDisabled(t *testing.T) {
+	server, store := claudeFailoverServer(t)
+	if _, err := store.Put("claude", "session-403", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		auth := req.Header.Get("Authorization")
+		if strings.Contains(auth, "tok-cooked") {
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"permission_error","message":"OAuth authentication is currently not allowed for this organization."}}`)),
+				Header:     http.Header{},
+			}
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":"msg_1"}`)),
+			Header:     http.Header{},
+		}
+	}}
+	transport := usageLimitRetryTransport{
+		base:        stub,
+		server:      &server,
+		provider:    accounts.ProviderClaude,
+		agent:       "claude",
+		session:     "session-403",
+		account:     "cooked@example.com",
+		method:      http.MethodPost,
+		path:        "/v1/messages",
+		maxAttempts: 3,
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader([]byte(`{"model":"claude-opus-4-8"}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader([]byte(`{"model":"claude-opus-4-8"}`))), nil
+	}
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after failing over the org-disabled account", response.StatusCode)
+	}
+	if stub.calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2 (403 then retry on healthy account)", stub.calls)
+	}
+	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
+		t.Fatal("an org-disabled 403 should mark the account exhausted (credential TTL)")
+	}
+	assignment, ok := store.Get("claude", "session-403")
+	if !ok || assignment.AccountID != "fresh@example.com" {
+		t.Fatalf("sticky assignment = %+v, want moved off the org-disabled account", assignment)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1962,11 +1962,12 @@ func (s Server) markAccountExhaustedFromResponse(provider accounts.Provider, acc
 	if s.SchedulerRef == nil {
 		return
 	}
-	if status == http.StatusUnauthorized {
-		// Dead/expired credential, not a rate-limit window: no reset header
-		// exists and it will not self-heal on a schedule. A longer TTL avoids
-		// probing a dead account every few minutes while still picking it back
-		// up within the hour after a re-auth.
+	if status == http.StatusUnauthorized || status == http.StatusForbidden {
+		// Dead/expired credential (401) or org-level OAuth disablement (403):
+		// not a rate-limit window, no reset header exists, and neither
+		// self-heals on a schedule. A longer TTL avoids probing every few
+		// minutes while still picking the account back up within the hour
+		// after a re-auth or an org re-enable.
 		s.markAccountExhaustedCredential(provider, accountID)
 		return
 	}
@@ -3191,11 +3192,16 @@ func (t usageLimitRetryTransport) responseUsageLimited(response *http.Response) 
 // claudeAccountUnusableStatus reports whether an upstream status means the
 // selected Claude account cannot serve this request and subrouter should fail
 // over to another account. 429 is quota exhaustion; 401 is a dead or expired
-// OAuth token (Anthropic returns authentication_error). Both are
-// account-specific, so replaying the same request on a different account is the
-// correct response instead of surfacing the failure to the client.
+// OAuth token (Anthropic returns authentication_error); 403 is an org-level
+// permission_error ("OAuth authentication is currently not allowed for this
+// organization" — Anthropic disabling Claude Code subscription access for one
+// account's org, observed live 2026-07-04). All are account-specific, so
+// replaying the same request on a different account is the correct response
+// instead of surfacing the failure to the client; before 403 was included, a
+// sticky session pinned to an org-disabled account black-holed every request
+// while the rest of the pool was healthy.
 func claudeAccountUnusableStatus(code int) bool {
-	return code == http.StatusTooManyRequests || code == http.StatusUnauthorized
+	return code == http.StatusTooManyRequests || code == http.StatusUnauthorized || code == http.StatusForbidden
 }
 
 // claudeAccountExhaustedByResponse reports whether an upstream response means the
@@ -3214,7 +3220,7 @@ func claudeAccountUnusableStatus(code int) bool {
 // detected by the rejected header and the periodic usage-score refresh, not by a
 // bare 429. A 401 is always a dead/expired token.
 func claudeAccountExhaustedByResponse(status int, header http.Header) bool {
-	if status == http.StatusUnauthorized {
+	if status == http.StatusUnauthorized || status == http.StatusForbidden {
 		return true
 	}
 	if claudeUnifiedStatus(header) != "rejected" {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subrouter",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Routes AI coding-agent traffic across subscription accounts and API keys.",
   "license": "MIT",
   "homepage": "https://github.com/manaflow-ai/subrouter#readme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "subrouter"
-version = "0.1.31"
+version = "0.1.32"
 description = "Routes AI coding-agent traffic across subscription accounts and API keys."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Observed live 2026-07-04 ~09:51 UTC: Anthropic disabled OAuth for one account's org mid-day (403 permission_error 'OAuth authentication is currently not allowed for this organization'); Claude Code renders it as 'Your organization has disabled Claude subscription access for Claude Code'. Failover only reacted to 429/401/rejected, so sticky sessions pinned to that account black-holed every request while 8+ healthy accounts sat idle. The same error also appears in a session transcript from 2026-06-24, so this is a recurring Anthropic-side state, not a one-off.

403 now joins the failover set, marks the account exhausted with the credential TTL (hourly re-probe picks it back up if the org is re-enabled), and the two-commit structure shows the regression test red then green. Also adds the missing 'serving claude fable via fallback chain' log on the handler-level fallback path so Bedrock activity is attributable chain-vs-gateway during monitoring.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785751424&installation_id=133855650&pr_number=54&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F54&signature=61f1f9fd815b95152d7d7b2c22ee8fd738cbc9d4937444963f075eb73b11b520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail over Claude accounts that return 403 permission_error when their org disables OAuth, preventing sticky sessions from black-holing requests and retrying on healthy accounts.

- **Bug Fixes**
  - Treat 403 as account-unusable; fail over and mark the account exhausted with the credential TTL; move sticky sessions off the disabled account.
  - Add a regression test that simulates a 403 org-disabled account and verifies retry success and exhaustion marking.
  - Log handler-level fallback ("serving claude fable via fallback chain") when no usable OAuth account is selected, so Bedrock activity is attributable.

- **Dependencies**
  - Bump `subrouter` to 0.1.32 in `package.json` and `pyproject.toml`.

<sup>Written for commit 2f33d1d29ce02f49e69f512790c9334044bf97f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback handling for Claude requests so accounts returning 403 are treated as unavailable and retries can move to a healthy account.
  * Prevented some failed Claude sessions from getting stuck on an unusable account.
  * Added a warning log when a fallback response is successfully served.

* **Tests**
  * Added coverage for Claude failover when an organization disables OAuth access.

* **Chores**
  * Bumped the release version to 0.1.32.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->