### PR TITLE
Fable-chain observability: truthful give-up log, attributed Bedrock gateway traffic (v0.1.33)

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -82,7 +82,7 @@ func (s Server) bedrockHandler() http.Handler {
 		resp, sourceName, err := s.signAndForwardBedrockWithHeaders(r.Context(), r.Method, upstreamPath, r.URL.RawQuery, headers, body)
 		if err != nil {
 			if s.Logger != nil {
-				s.Logger.Error("bedrock upstream request failed", "path", upstreamPath, "error", err)
+				s.Logger.Error("bedrock upstream request failed", "path", upstreamPath, "remote_addr", clientRemoteIP(r), "user_agent", r.UserAgent(), "error", err)
 			}
 			http.Error(w, "bedrock upstream request failed", http.StatusBadGateway)
 			return
@@ -102,7 +102,7 @@ func (s Server) bedrockHandler() http.Handler {
 		model := bedrockModelFromPath(upstreamPath)
 		if resp.StatusCode == http.StatusTooManyRequests {
 			if s.Logger != nil {
-				s.Logger.Warn("bedrock throttled", "model", model, "path", upstreamPath, "bedrock_source", sourceName)
+				s.Logger.Warn("bedrock throttled", "model", model, "path", upstreamPath, "remote_addr", clientRemoteIP(r), "user_agent", r.UserAgent(), "bedrock_source", sourceName)
 			}
 			cfg.onThrottle(sourceName, model)
 		}

--- a/internal/proxy/bedrock_test.go
+++ b/internal/proxy/bedrock_test.go
@@ -1,8 +1,10 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -154,6 +156,38 @@ func TestBedrockHandlerRetriesNextSourceOnThrottle(t *testing.T) {
 	}
 	if got := strings.Join(accessKeys, ","); got != "AKIAONE,AKIATWO" {
 		t.Fatalf("access key order = %s, want AKIAONE,AKIATWO", got)
+	}
+}
+
+func TestBedrockHandlerLogsClientAttributionOnThrottle(t *testing.T) {
+	var logBuf bytes.Buffer
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"throttled"}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+	s := Server{
+		Logger: slog.New(slog.NewTextHandler(&logBuf, nil)),
+		Bedrock: &BedrockConfig{
+			Region:    "us-east-1",
+			Sources:   []BedrockCredentialSource{{Name: "aw0", Credentials: namedBedrockCreds("AKIAONE")}},
+			Transport: rt,
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/bedrock/model/us.anthropic.claude-fable-5/invoke", strings.NewReader(`{"anthropic_version":"bedrock-2023-05-31"}`))
+	req.Header.Set("User-Agent", "sr claude-aws")
+	rec := httptest.NewRecorder()
+	s.bedrockHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (body %q)", rec.Code, rec.Body.String())
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, "bedrock throttled") || !strings.Contains(logs, "remote_addr=") || !strings.Contains(logs, "user_agent=\"sr claude-aws\"") {
+		t.Fatalf("expected throttle log with remote_addr and user_agent; logs=\n%s", logs)
 	}
 }
 

--- a/internal/proxy/claude_fable_test.go
+++ b/internal/proxy/claude_fable_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -361,6 +362,125 @@ func TestUsageLimitRetryTransportClaudeFableFallsBackAfterPoolExhausted(t *testi
 	body, _ := io.ReadAll(response.Body)
 	if !strings.Contains(string(body), `"type":"message"`) {
 		t.Fatalf("fallback body = %q, want bedrock message", body)
+	}
+}
+
+func TestUsageLimitRetryTransportClaudeFableFallbackSuppressesExhaustedLog(t *testing.T) {
+	server, store := claudeFailoverServer(t)
+	if _, err := store.Put("claude", "session-fable", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		h := http.Header{}
+		h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}`)),
+			Header:     h,
+		}
+	}}
+	bedrockRT := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"type":"message","usage":{"output_tokens":3}}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+	server.Bedrock = &BedrockConfig{
+		Region:    "us-east-1",
+		Sources:   []BedrockCredentialSource{{Name: "aw0", Credentials: staticBedrockCreds()}},
+		Transport: bedrockRT,
+	}
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+	fableBody := []byte(`{"model":"claude-fable-5","max_tokens":8,"messages":[]}`)
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader(fableBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(fableBody)), nil }
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	transport := usageLimitRetryTransport{
+		base:        stub,
+		server:      &server,
+		logger:      logger,
+		provider:    accounts.ProviderClaude,
+		agent:       "claude",
+		session:     "session-fable",
+		account:     "cooked@example.com",
+		method:      http.MethodPost,
+		path:        "/v1/messages",
+		maxAttempts: 4,
+		fableFallback: func() (*http.Response, bool) {
+			return server.claudeFableFallbackResponse(req, fableBody)
+		},
+	}
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 from bedrock after pool exhausted", response.StatusCode)
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, "serving claude fable via fallback chain") {
+		t.Fatalf("expected fable fallback save log; logs=\n%s", logs)
+	}
+	if strings.Contains(logs, "returned to client after failover exhausted") {
+		t.Fatalf("did not expect client-facing failover-exhaustion signal on fallback save; logs=\n%s", logs)
+	}
+}
+
+func TestUsageLimitRetryTransportClaudeFableFallbackFailureLogsExhausted(t *testing.T) {
+	server, store := claudeFailoverServer(t)
+	if _, err := store.Put("claude", "session-fable", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		h := http.Header{}
+		h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}`)),
+			Header:     h,
+		}
+	}}
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+	fableBody := []byte(`{"model":"claude-fable-5","max_tokens":8,"messages":[]}`)
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader(fableBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(fableBody)), nil }
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	transport := usageLimitRetryTransport{
+		base:        stub,
+		server:      &server,
+		logger:      logger,
+		provider:    accounts.ProviderClaude,
+		agent:       "claude",
+		session:     "session-fable",
+		account:     "cooked@example.com",
+		method:      http.MethodPost,
+		path:        "/v1/messages",
+		maxAttempts: 4,
+		fableFallback: func() (*http.Response, bool) {
+			return nil, false
+		},
+	}
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want pool 429", response.StatusCode)
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, "claude rate-limit returned to client after failover exhausted") {
+		t.Fatalf("expected client-facing failover-exhaustion signal; logs=\n%s", logs)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3404,10 +3404,10 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			if t.server == nil {
 				reason = "no_server"
 			}
-			t.logClaudeFailoverExhausted(response, accountID, reason, attempt, maxAttempts, len(tried))
 			if fallback, ok := t.fableFallbackResponse(response, accountID, reason); ok {
 				return fallback, nil
 			}
+			t.logClaudeFailoverExhausted(response, accountID, reason, attempt, maxAttempts, len(tried))
 			return response, nil
 		}
 		nextAccount, pickErr := t.server.oauthRetryAccount(req.Context(), t.provider, t.agent, t.session, t.userEmail, t.poolModel, tried, t.fableFallback != nil)
@@ -3415,10 +3415,10 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			if t.logger != nil {
 				t.logger.Warn("usage-limit retry has no alternate account", "agent", t.agent, "session", t.session, "account", accountID, "method", t.method, "path", t.path, "upstream", t.upstream, "error", pickErr)
 			}
-			t.logClaudeFailoverExhausted(response, accountID, "no_alternate_account", attempt, maxAttempts, len(tried))
 			if fallback, ok := t.fableFallbackResponse(response, accountID, "no_alternate_account"); ok {
 				return fallback, nil
 			}
+			t.logClaudeFailoverExhausted(response, accountID, "no_alternate_account", attempt, maxAttempts, len(tried))
 			return response, nil
 		}
 		body, bodyErr := req.GetBody()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subrouter",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "Routes AI coding-agent traffic across subscription accounts and API keys.",
   "license": "MIT",
   "homepage": "https://github.com/manaflow-ai/subrouter#readme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "subrouter"
-version = "0.1.32"
+version = "0.1.33"
 description = "Routes AI coding-agent traffic across subscription accounts and API keys."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Two logging-only defects found while monitoring the live fable chain during the 2026-07-04 10:32 UTC burst.

The give-up log lied during healthy saves: "claude rate-limit returned to client after failover exhausted" was emitted before the fable fallback ran, so it claimed client-visible 429s for ~10 requests the chain then served with 200 via the API key seconds later. The give-up sites now try the fallback first and emit the line (byte-identical, still the single grep-able signal that a client actually received the failure) only when the failure response is truly returned. Successful saves keep logging only "serving claude fable via fallback chain".

/bedrock/* gateway traffic was untraceable: throttle bursts from Claude Code sessions in Bedrock gateway mode (sr claude-aws) could not be attributed to a machine. bedrockHandler's throttle warn and upstream-failed error now carry remote_addr (clientRemoteIP, socket peer) and user_agent. No per-request info logging added; chain-side logs untouched.

Tests: chain-rescued give-up suppresses the exhausted line, chain-failed give-up emits it, gateway throttle log carries attribution. Coded by GPT 5.5 (codex exec, high), judged by fable-judge (APPROVE, round 1). Note: main also contains the multi-tenant Cloudflare work (#52) merged since v0.1.32, so v0.1.33 is the first release tag to include it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785754086&installation_id=133855650&pr_number=55&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F55&signature=71ac2b8454ed0f7754cfeb372635a89b09da4f4d74883a2919240bbba836ef7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misleading fable chain "give-up" logging and adds client attribution to `/bedrock/*` gateway logs to make throttle bursts traceable. Release v0.1.33.

- Bug Fixes
  - Emit "claude rate-limit returned to client after failover exhausted" only when a 429 is actually sent; fallback success logs only "serving claude fable via fallback chain".
  - Add remote_addr and user_agent to Bedrock "upstream request failed" and "throttled" logs.
  - Tests cover fallback-success suppression, fallback-failure emission, and Bedrock throttle attribution.

<sup>Written for commit abfaf7f978daaf1a0788c066918594e121ef7091. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

