### PR TITLE
DO worker: env-gated OTLP span export to Axiom

### DIFF
--- a/cloudflare/packages/worker/README.md
+++ b/cloudflare/packages/worker/README.md
@@ -177,6 +177,29 @@ Required Actions secrets:
   permissions for both `regatta-subrouter-do-staging` and
   `regatta-subrouter-do-production`.
 
+## Observability
+
+Request spans export to Axiom only when both secrets are configured:
+
+- `AXIOM_TOKEN`
+- `AXIOM_DATASET`
+
+Optional:
+
+- `AXIOM_DOMAIN` - defaults to `api.axiom.co`.
+
+When either required Axiom setting is missing, telemetry is inert and performs
+no export fetch. OAuth refresh alarm events are not emitted as spans in this
+round; only the top-level Worker request span is exported.
+
+Example Axiom APL:
+
+```apl
+['cmux-prod-otel-traces']
+| where ['service.name'] == 'subrouter-do'
+| summarize requests=count() by ['url.path'], ['subrouter.auth'], bin(_time, 5m)
+```
+
 ## Local Dev
 
 Create `.dev.vars` (gitignored) with at least:

--- a/cloudflare/packages/worker/src/index.ts
+++ b/cloudflare/packages/worker/src/index.ts
@@ -36,6 +36,14 @@ import {
   TenantRegistryDurableObject,
   type TenantResolution,
 } from "./tenants.ts"
+import {
+  createRequestTelemetryContext,
+  errorTypeFor,
+  isAxiomTelemetryConfigured,
+  routePatternForRequest,
+  scheduleAxiomSpanExport,
+  type MutableRequestTelemetryContext,
+} from "./telemetry.ts"
 
 export { TenantRegistryDurableObject }
 
@@ -304,6 +312,10 @@ export interface Env {
   readonly API_UPSTREAM?: string
   readonly CLAUDE_UPSTREAM?: string
   readonly VALIDATION_TIMEOUT_MS?: string
+  readonly AXIOM_TOKEN?: string
+  readonly AXIOM_DATASET?: string
+  readonly AXIOM_DOMAIN?: string
+  readonly SUBROUTER_ENV?: string
 }
 
 const json = (body: unknown, init?: ResponseInit): Response =>
@@ -677,7 +689,11 @@ const clampPercent = (value: number): number => {
   return Math.max(0, Math.min(100, value))
 }
 
-const authorizeAdmin = (request: Request, env: Env): Response | null => {
+const authorizeAdmin = (
+  request: Request,
+  env: Env,
+  telemetry?: MutableRequestTelemetryContext
+): Response | null => {
   if (!env.ADMIN_TOKEN) {
     return json({ error: "ADMIN_TOKEN secret is not configured" }, { status: 500 })
   }
@@ -691,6 +707,7 @@ const authorizeAdmin = (request: Request, env: Env): Response | null => {
   if (!constantTimeStringEqual(token, env.ADMIN_TOKEN)) {
     return json({ error: "Unauthorized" }, { status: 401 })
   }
+  if (telemetry) telemetry.auth = "admin"
   return null
 }
 
@@ -717,7 +734,8 @@ const tenantActor = (
 
 const authorizeTenant = async (
   request: Request,
-  env: Env
+  env: Env,
+  telemetry?: MutableRequestTelemetryContext
 ): Promise<Response | TenantAuth> => {
   const header = request.headers.get("authorization") ?? ""
   const bearer = header.startsWith("Bearer ") ? header.slice("Bearer ".length) : ""
@@ -735,6 +753,10 @@ const authorizeTenant = async (
     if (resolved.revoked_at !== null) {
       return json({ error: "Tenant key revoked" }, { status: 403 })
     }
+    if (telemetry) {
+      telemetry.auth = "tenant"
+      telemetry.tenantId = resolved.id
+    }
     return { tenantId: resolved.id, legacy: false }
   }
 
@@ -745,6 +767,10 @@ const authorizeTenant = async (
     env.PROXY_TOKEN &&
     constantTimeStringEqual(legacyToken, env.PROXY_TOKEN)
   ) {
+    if (telemetry) {
+      telemetry.auth = "legacy"
+      telemetry.tenantId = "legacy"
+    }
     return { tenantId: "legacy", legacy: true }
   }
 
@@ -2661,17 +2687,29 @@ const defaultUpstreamForAccount = (
   return env.CODEX_UPSTREAM ?? "https://chatgpt.com/backend-api/codex"
 }
 
+const recordTelemetryAccount = (
+  telemetry: MutableRequestTelemetryContext | undefined,
+  account: StoredAccountContract
+): void => {
+  if (!telemetry) return
+  telemetry.accountId = account.id
+  telemetry.accountKind = account.kind
+  telemetry.upstreamProvider = providerForAccount(account.kind)
+}
+
 const proxyUpstream = async (
   request: Request,
   env: Env,
   actor: DurableObjectStub<SubrouterDurableObject>,
-  routeInput: RouteInput
+  routeInput: RouteInput,
+  telemetry?: MutableRequestTelemetryContext
 ): Promise<Response> => {
   if (!routeInput.orgId) {
     return json({ error: "tenant id required" }, { status: 401 })
   }
   const routed = await actor.routeForProxy(routeInput)
   const account = routed.account
+  recordTelemetryAccount(telemetry, account)
   if (!account.credentials?.apiKey && !account.credentials?.accessToken) {
     return json(
       { error: "selected account has no usable credential", accountId: account.id },
@@ -2717,6 +2755,7 @@ const proxyUpstream = async (
   }
   const upstreamRequest = new Request(upstreamURL, init)
   const response = await fetch(upstreamRequest)
+  if (telemetry) telemetry.upstreamStatus = response.status
   await recordTranscriptBodyFromArrayBuffer(actor, {
     orgId: routeInput.orgId,
     agentType: routeInput.agentType ?? "codex",
@@ -2737,13 +2776,15 @@ const proxyUpstreamWebSocket = async (
   request: Request,
   env: Env,
   actor: DurableObjectStub<SubrouterDurableObject>,
-  routeInput: RouteInput
+  routeInput: RouteInput,
+  telemetry?: MutableRequestTelemetryContext
 ): Promise<Response> => {
   if (!routeInput.orgId) {
     return json({ error: "tenant id required" }, { status: 401 })
   }
   const routed = await actor.routeForProxy(routeInput)
   const account = routed.account
+  recordTelemetryAccount(telemetry, account)
   if (!account.credentials?.apiKey && !account.credentials?.accessToken) {
     return json(
       { error: "selected account has no usable credential", accountId: account.id },
@@ -2780,6 +2821,7 @@ const proxyUpstreamWebSocket = async (
       redirect: "manual",
     })
   )
+  if (telemetry) telemetry.upstreamStatus = response.status
   if (response.status !== 101 || !response.webSocket) {
     return new Response(await response.text().catch(() => "websocket upgrade failed"), {
       status: response.status === 101 ? 502 : response.status,
@@ -3158,8 +3200,11 @@ const escapeHTML = (value: string): string =>
     .replaceAll('"', "&quot;")
     .replaceAll("'", "&#39;")
 
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
+const handleFetch = async (
+  request: Request,
+  env: Env,
+  telemetry?: MutableRequestTelemetryContext
+): Promise<Response> => {
     const url = new URL(request.url)
 
     if (url.pathname === "/healthz") {
@@ -3191,13 +3236,13 @@ export default {
           { status: 426 }
         )
       }
-      const tenant = await authorizeTenant(request, env)
+      const tenant = await authorizeTenant(request, env, telemetry)
       if (tenant instanceof Response) return tenant
       return tenantActor(env, tenant).fetch(requestWithTenantOrg(request, tenant.tenantId))
     }
 
     if (url.pathname === "/websocket-status") {
-      const unauthorized = authorizeAdmin(request, env)
+      const unauthorized = authorizeAdmin(request, env, telemetry)
       if (unauthorized) return unauthorized
       const scoped = tenantScopedAdminActor(env, url)
       if (scoped instanceof Response) return scoped
@@ -3205,19 +3250,22 @@ export default {
     }
 
     if (url.pathname === "/route" && request.method === "POST") {
-      const tenant = await authorizeTenant(request, env)
+      const tenant = await authorizeTenant(request, env, telemetry)
       if (tenant instanceof Response) return tenant
       try {
         const input = await parseRouteInput(request)
         const actor = tenantActor(env, tenant)
-        return json(await actor.route(routeInputForTenant(input, tenant.tenantId)))
+        const routed = await actor.route(routeInputForTenant(input, tenant.tenantId))
+        recordTelemetryAccount(telemetry, routed.account)
+        return json(routed)
       } catch (error) {
+        if (telemetry) telemetry.errorType = errorTypeFor(error)
         return errorJson(error, 409)
       }
     }
 
     if (url.pathname === "/_subrouter/drain") {
-      const unauthorized = authorizeAdmin(request, env)
+      const unauthorized = authorizeAdmin(request, env, telemetry)
       if (unauthorized) return unauthorized
       if (request.method !== "POST") {
         return json({ error: "method not allowed" }, { status: 405 })
@@ -3228,7 +3276,7 @@ export default {
     }
 
     if (url.pathname === "/_subrouter/drain-status") {
-      const unauthorized = authorizeAdmin(request, env)
+      const unauthorized = authorizeAdmin(request, env, telemetry)
       if (unauthorized) return unauthorized
       if (request.method !== "GET") {
         return json({ error: "method not allowed" }, { status: 405 })
@@ -3239,7 +3287,7 @@ export default {
     }
 
     if (url.pathname === "/usage" && request.method === "POST") {
-      const tenant = await authorizeTenant(request, env)
+      const tenant = await authorizeTenant(request, env, telemetry)
       if (tenant instanceof Response) return tenant
       const input = await parseUsageInput(request)
       if (input instanceof Response) {
@@ -3249,23 +3297,25 @@ export default {
       try {
         return json(await actor.recordUsage(routeInputForTenant(input, tenant.tenantId)))
       } catch (error) {
+        if (telemetry) telemetry.errorType = errorTypeFor(error)
         return errorJson(error, 400)
       }
     }
 
     if (url.pathname === "/status") {
-      const tenant = await authorizeTenant(request, env)
+      const tenant = await authorizeTenant(request, env, telemetry)
       if (tenant instanceof Response) return tenant
       const actor = tenantActor(env, tenant)
       try {
         return json(await actor.status())
       } catch (error) {
+        if (telemetry) telemetry.errorType = errorTypeFor(error)
         return errorJson(error, 400)
       }
     }
 
     if (url.pathname === "/_subrouter/sessions") {
-      const unauthorized = authorizeAdmin(request, env)
+      const unauthorized = authorizeAdmin(request, env, telemetry)
       if (unauthorized) return unauthorized
       const scoped = tenantScopedAdminActor(env, url)
       if (scoped instanceof Response) return scoped
@@ -3273,7 +3323,7 @@ export default {
     }
 
     if (url.pathname === "/_subrouter/accounts") {
-      const unauthorized = authorizeAdmin(request, env)
+      const unauthorized = authorizeAdmin(request, env, telemetry)
       if (unauthorized) return unauthorized
       const scoped = tenantScopedAdminActor(env, url)
       if (scoped instanceof Response) return scoped
@@ -3282,7 +3332,7 @@ export default {
     }
 
     if (url.pathname === "/_subrouter/account-status") {
-      const unauthorized = authorizeAdmin(request, env)
+      const unauthorized = authorizeAdmin(request, env, telemetry)
       if (unauthorized) return unauthorized
       if (request.method !== "GET" && request.method !== "POST") {
         return json({ error: "method not allowed" }, { status: 405 })
@@ -3293,7 +3343,7 @@ export default {
     }
 
     if (url.pathname === "/_subrouter/usage-status") {
-      const unauthorized = authorizeAdmin(request, env)
+      const unauthorized = authorizeAdmin(request, env, telemetry)
       if (unauthorized) return unauthorized
       if (request.method !== "GET") {
         return json({ error: "method not allowed" }, { status: 405 })
@@ -3304,7 +3354,7 @@ export default {
     }
 
     if (url.pathname === "/_subrouter/reload-accounts") {
-      const unauthorized = authorizeAdmin(request, env)
+      const unauthorized = authorizeAdmin(request, env, telemetry)
       if (unauthorized) return unauthorized
       if (request.method !== "POST") {
         return json({ error: "method not allowed" }, { status: 405 })
@@ -3316,7 +3366,7 @@ export default {
     }
 
     if (url.pathname === "/_subrouter/dashboard") {
-      const unauthorized = authorizeAdmin(request, env)
+      const unauthorized = authorizeAdmin(request, env, telemetry)
       if (unauthorized) return unauthorized
       const scoped = tenantScopedAdminActor(env, url)
       if (scoped instanceof Response) return scoped
@@ -3329,7 +3379,7 @@ export default {
       url.pathname === "/_subrouter/transcripts" ||
       url.pathname.startsWith("/_subrouter/transcripts/")
     ) {
-      const unauthorized = authorizeAdmin(request, env)
+      const unauthorized = authorizeAdmin(request, env, telemetry)
       if (unauthorized) return unauthorized
       const scoped = tenantScopedAdminActor(env, url)
       if (scoped instanceof Response) return scoped
@@ -3341,12 +3391,13 @@ export default {
       try {
         return json(await scoped.actor.readTranscriptSession({ orgId: scoped.tenantId, ...parsed }))
       } catch (error) {
+        if (telemetry) telemetry.errorType = errorTypeFor(error)
         return errorJson(error, 404)
       }
     }
 
     if (url.pathname === "/tenant/accounts" && request.method === "POST") {
-      const tenant = await authorizeTenant(request, env)
+      const tenant = await authorizeTenant(request, env, telemetry)
       if (tenant instanceof Response) return tenant
       if (tenant.legacy) {
         return json({ error: "Tenant key required" }, { status: 401 })
@@ -3366,12 +3417,13 @@ export default {
         const { account } = await actor.upsertAccount(input.account)
         return json(safeTenantAccount(account, validation))
       } catch (error) {
+        if (telemetry) telemetry.errorType = errorTypeFor(error)
         return errorJson(error, 400)
       }
     }
 
     if (url.pathname === "/tenant/accounts" && request.method === "GET") {
-      const tenant = await authorizeTenant(request, env)
+      const tenant = await authorizeTenant(request, env, telemetry)
       if (tenant instanceof Response) return tenant
       if (tenant.legacy) {
         return json({ error: "Tenant key required" }, { status: 401 })
@@ -3382,7 +3434,7 @@ export default {
 
     const tenantAccountDeleteMatch = url.pathname.match(/^\/tenant\/accounts\/([^/]+)$/)
     if (tenantAccountDeleteMatch && request.method === "DELETE") {
-      const tenant = await authorizeTenant(request, env)
+      const tenant = await authorizeTenant(request, env, telemetry)
       if (tenant instanceof Response) return tenant
       if (tenant.legacy) {
         return json({ error: "Tenant key required" }, { status: 401 })
@@ -3396,12 +3448,13 @@ export default {
           })
         )
       } catch (error) {
+        if (telemetry) telemetry.errorType = errorTypeFor(error)
         return errorJson(error, 404)
       }
     }
 
     if (url.pathname.startsWith("/admin/")) {
-      const unauthorized = authorizeAdmin(request, env)
+      const unauthorized = authorizeAdmin(request, env, telemetry)
       if (unauthorized) return unauthorized
 
       if (url.pathname === "/admin/tenants" && request.method === "POST") {
@@ -3410,6 +3463,7 @@ export default {
         try {
           return json(await registryActor(env).createTenant({ name: record["name"] }))
         } catch (error) {
+          if (telemetry) telemetry.errorType = errorTypeFor(error)
           return errorJson(error, 400)
         }
       }
@@ -3424,6 +3478,7 @@ export default {
         try {
           return json(await registryActor(env).revokeTenant(tenantId))
         } catch (error) {
+          if (telemetry) telemetry.errorType = errorTypeFor(error)
           return errorJson(error, 404)
         }
       }
@@ -3434,6 +3489,7 @@ export default {
         try {
           return json(await registryActor(env).rotateTenant(tenantId))
         } catch (error) {
+          if (telemetry) telemetry.errorType = errorTypeFor(error)
           return errorJson(error, 400)
         }
       }
@@ -3450,6 +3506,7 @@ export default {
           if (input instanceof Response) return input
           return json(await adminActor(env, input.orgId).upsertAccount(input))
         } catch (error) {
+          if (telemetry) telemetry.errorType = errorTypeFor(error)
           return json({ error: String((error as Error).message ?? error) }, { status: 400 })
         }
       }
@@ -3462,6 +3519,7 @@ export default {
         try {
           return json(await scoped.actor.totpCode({ orgId: scoped.tenantId, accountId }))
         } catch (error) {
+          if (telemetry) telemetry.errorType = errorTypeFor(error)
           return errorJson(error, 400)
         }
       }
@@ -3474,6 +3532,7 @@ export default {
           if (!tenantId) return json({ error: "Missing tenant" }, { status: 400 })
           return json(await adminActor(env, tenantId).modelProbe(routeInputForTenant(input, tenantId)))
         } catch (error) {
+          if (telemetry) telemetry.errorType = errorTypeFor(error)
           return errorJson(error, 400)
         }
       }
@@ -3487,18 +3546,64 @@ export default {
       return new Response("Not Found", { status: 404 })
     }
 
-    const tenant = await authorizeTenant(request, env)
+    const tenant = await authorizeTenant(request, env, telemetry)
     if (tenant instanceof Response) return tenant
     try {
       const routeInput = await parseProxyRouteInput(request)
       const tenantRouteInput = proxyRouteInputForTenant(request, routeInput, tenant.tenantId)
+      if (telemetry) {
+        telemetry.routePattern = routePatternForRequest(request, {
+          upstreamProvider: tenantRouteInput.upstreamProvider,
+          websocket: isWebSocketUpgrade(request),
+        })
+      }
       const actor = tenantActor(env, tenant)
       if (isWebSocketUpgrade(request)) {
-        return await proxyUpstreamWebSocket(request, env, actor, tenantRouteInput)
+        return await proxyUpstreamWebSocket(request, env, actor, tenantRouteInput, telemetry)
       }
-      return await proxyUpstream(request, env, actor, tenantRouteInput)
+      return await proxyUpstream(request, env, actor, tenantRouteInput, telemetry)
     } catch (error) {
+      if (telemetry) telemetry.errorType = errorTypeFor(error)
       return errorJson(error, 503)
     }
+}
+
+export default {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx?: ExecutionContext
+  ): Promise<Response> {
+    if (!isAxiomTelemetryConfigured(env)) {
+      return handleFetch(request, env)
+    }
+
+    const startTimeMs = Date.now()
+    const telemetry = createRequestTelemetryContext(request)
+    let response: Response
+    try {
+      response = await handleFetch(request, env, telemetry)
+    } catch (error) {
+      telemetry.errorType = errorTypeFor(error)
+      response = new Response("Internal Server Error", { status: 500 })
+      scheduleAxiomSpanExport(ctx, {
+        env,
+        request,
+        telemetry,
+        response,
+        startTimeMs,
+        endTimeMs: Date.now(),
+      })
+      throw error
+    }
+    scheduleAxiomSpanExport(ctx, {
+      env,
+      request,
+      telemetry,
+      response,
+      startTimeMs,
+      endTimeMs: Date.now(),
+    })
+    return response
   },
 } satisfies ExportedHandler<Env>

--- a/cloudflare/packages/worker/src/telemetry.ts
+++ b/cloudflare/packages/worker/src/telemetry.ts
@@ -1,0 +1,312 @@
+export type SubrouterAuthClassification = "tenant" | "admin" | "legacy" | "none"
+
+export interface AxiomTelemetryEnv {
+  readonly AXIOM_TOKEN?: string
+  readonly AXIOM_DATASET?: string
+  readonly AXIOM_DOMAIN?: string
+  readonly SUBROUTER_ENV?: string
+}
+
+export interface MutableRequestTelemetryContext {
+  routePattern: string
+  tenantId?: string
+  auth: SubrouterAuthClassification
+  accountId?: string
+  accountKind?: string
+  upstreamProvider?: string
+  upstreamStatus?: number
+  errorType?: string
+}
+
+export interface RequestSpanInput {
+  readonly method: string
+  readonly routePattern: string
+  readonly statusCode: number
+  readonly durationMs: number
+  readonly environment?: string
+  readonly tenantId?: string
+  readonly auth: SubrouterAuthClassification
+  readonly accountId?: string
+  readonly accountKind?: string
+  readonly upstreamProvider?: string
+  readonly upstreamStatus?: number
+  readonly errorType?: string
+}
+
+export interface TraceExportInput {
+  readonly env: AxiomTelemetryEnv
+  readonly request: Request
+  readonly telemetry: MutableRequestTelemetryContext
+  readonly response: Response
+  readonly startTimeMs: number
+  readonly endTimeMs?: number
+  readonly fetcher?: typeof fetch
+}
+
+type OtlpAttributeValue =
+  | { readonly stringValue: string }
+  | { readonly intValue: string }
+  | { readonly doubleValue: number }
+  | { readonly boolValue: boolean }
+
+export interface OtlpAttribute {
+  readonly key: string
+  readonly value: OtlpAttributeValue
+}
+
+interface OtlpSpan {
+  readonly traceId: string
+  readonly spanId: string
+  readonly name: string
+  readonly kind: number
+  readonly startTimeUnixNano: string
+  readonly endTimeUnixNano: string
+  readonly attributes: OtlpAttribute[]
+  readonly status?: { readonly code: number }
+}
+
+interface OtlpBody {
+  readonly resourceSpans: ReadonlyArray<{
+    readonly resource: { readonly attributes: OtlpAttribute[] }
+    readonly scopeSpans: ReadonlyArray<{
+      readonly scope: { readonly name: string }
+      readonly spans: ReadonlyArray<OtlpSpan>
+    }>
+  }>
+}
+
+const defaultAxiomDomain = "api.axiom.co"
+const serviceName = "subrouter-do"
+
+export const isAxiomTelemetryConfigured = (env: AxiomTelemetryEnv): boolean =>
+  nonEmpty(env.AXIOM_TOKEN) !== null && nonEmpty(env.AXIOM_DATASET) !== null
+
+export const createRequestTelemetryContext = (
+  request: Request
+): MutableRequestTelemetryContext => ({
+  routePattern: routePatternForRequest(request),
+  auth: "none",
+})
+
+export const routePatternForRequest = (
+  request: Request,
+  options: { readonly upstreamProvider?: string; readonly websocket?: boolean } = {}
+): string => {
+  const url = new URL(request.url)
+  const path = url.pathname
+  if (options.websocket && path !== "/ws") return "/proxy/websocket"
+  if (options.upstreamProvider === "claude") return "/proxy/claude"
+  if (options.upstreamProvider === "codex") return "/proxy/codex"
+
+  if (path === "/healthz") return "/healthz"
+  if (path === "/_subrouter/health") return "/_subrouter/health"
+  if (path === "/_subrouter/ready") return "/_subrouter/ready"
+  if (path === "/ws") return "/ws"
+  if (path === "/websocket-status") return "/websocket-status"
+  if (path === "/route") return "/route"
+  if (path === "/usage") return "/usage"
+  if (path === "/status") return "/status"
+  if (path === "/tenant/accounts") return "/tenant/accounts"
+  if (/^\/tenant\/accounts\/[^/]+$/.test(path)) return "/tenant/accounts/:id"
+  if (path === "/admin/tenants") return "/admin/tenants"
+  if (/^\/admin\/tenants\/[^/]+\/revoke$/.test(path)) return "/admin/tenants/:id/revoke"
+  if (/^\/admin\/tenants\/[^/]+\/rotate$/.test(path)) return "/admin/tenants/:id/rotate"
+  if (path === "/admin/accounts") return "/admin/accounts"
+  if (/^\/admin\/accounts\/[^/]+\/totp$/.test(path)) return "/admin/accounts/:id/totp"
+  if (path === "/admin/model-probe") return "/admin/model-probe"
+  if (path === "/_subrouter/drain") return "/_subrouter/drain"
+  if (path === "/_subrouter/drain-status") return "/_subrouter/drain-status"
+  if (path === "/_subrouter/sessions") return "/_subrouter/sessions"
+  if (path === "/_subrouter/accounts") return "/_subrouter/accounts"
+  if (path === "/_subrouter/account-status") return "/_subrouter/account-status"
+  if (path === "/_subrouter/usage-status") return "/_subrouter/usage-status"
+  if (path === "/_subrouter/reload-accounts") return "/_subrouter/reload-accounts"
+  if (path === "/_subrouter/dashboard") return "/_subrouter/dashboard"
+  if (path === "/_subrouter/transcripts") return "/_subrouter/transcripts"
+  if (/^\/_subrouter\/transcripts\/[^/]+\/[^/]+\/raw$/.test(path)) {
+    return "/_subrouter/transcripts/:agent/:session/raw"
+  }
+  if (/^\/_subrouter\/transcripts\/[^/]+\/[^/]+$/.test(path)) {
+    return "/_subrouter/transcripts/:agent/:session"
+  }
+  if (path.startsWith("/admin/")) return "/admin/*"
+  if (path.startsWith("/tenant/")) return "/tenant/*"
+  if (path.startsWith("/_subrouter/")) return "/_subrouter/*"
+  if (path === "/v1/messages" || path.startsWith("/v1/messages/")) {
+    return "/proxy/claude"
+  }
+  return "/proxy/codex"
+}
+
+export const errorTypeFor = (error: unknown): string => {
+  if (error && typeof error === "object") {
+    const name = (error as { readonly name?: unknown }).name
+    if (typeof name === "string" && name.trim()) return name
+    const constructorName = (error as { readonly constructor?: { readonly name?: string } }).constructor?.name
+    if (constructorName) return constructorName
+  }
+  return "Error"
+}
+
+export const buildSpanAttributes = (input: RequestSpanInput): OtlpAttribute[] => {
+  const errorType =
+    input.errorType ?? (input.statusCode >= 500 ? "HttpError" : undefined)
+  return [
+    stringAttribute("service.name", serviceName),
+    stringAttribute("deployment.environment", input.environment ?? "unknown"),
+    stringAttribute("http.request.method", input.method),
+    stringAttribute("url.path", input.routePattern),
+    intAttribute("http.response.status_code", input.statusCode),
+    doubleAttribute("duration", input.durationMs),
+    doubleAttribute("duration_ms", input.durationMs),
+    stringAttribute("subrouter.auth", input.auth),
+    ...optionalStringAttribute("subrouter.tenant_id", input.tenantId),
+    ...optionalStringAttribute("subrouter.account_id", input.accountId),
+    ...optionalStringAttribute("subrouter.account_kind", input.accountKind),
+    ...optionalStringAttribute("subrouter.upstream_provider", input.upstreamProvider),
+    ...optionalIntAttribute("subrouter.upstream_status_code", input.upstreamStatus),
+    ...optionalStringAttribute("error.type", errorType),
+  ]
+}
+
+export const buildOtlpTraceBody = (input: {
+  readonly span: RequestSpanInput
+  readonly startTimeMs: number
+  readonly endTimeMs: number
+  readonly traceId?: string
+  readonly spanId?: string
+}): OtlpBody => {
+  const attributes = buildSpanAttributes(input.span)
+  const resourceAttributes = attributes.filter(
+    (attribute) =>
+      attribute.key === "service.name" ||
+      attribute.key === "deployment.environment"
+  )
+  const span: OtlpSpan = {
+    traceId: input.traceId ?? randomHex(16),
+    spanId: input.spanId ?? randomHex(8),
+    name: `${input.span.method} ${input.span.routePattern}`,
+    kind: 2,
+    startTimeUnixNano: msToUnixNano(input.startTimeMs),
+    endTimeUnixNano: msToUnixNano(input.endTimeMs),
+    attributes,
+    ...(input.span.statusCode >= 500 || input.span.errorType
+      ? { status: { code: 2 } }
+      : {}),
+  }
+  return {
+    resourceSpans: [
+      {
+        resource: { attributes: resourceAttributes },
+        scopeSpans: [
+          {
+            scope: { name: "subrouter.worker" },
+            spans: [span],
+          },
+        ],
+      },
+    ],
+  }
+}
+
+export const exportAxiomSpan = async (input: TraceExportInput): Promise<void> => {
+  const token = nonEmpty(input.env.AXIOM_TOKEN)
+  const dataset = nonEmpty(input.env.AXIOM_DATASET)
+  if (!token || !dataset) return
+
+  const endTimeMs = input.endTimeMs ?? Date.now()
+  const durationMs = Math.max(0, endTimeMs - input.startTimeMs)
+  const body = buildOtlpTraceBody({
+    span: {
+      method: input.request.method,
+      routePattern: input.telemetry.routePattern,
+      statusCode: input.response.status,
+      durationMs,
+      environment: input.env.SUBROUTER_ENV,
+      tenantId: input.telemetry.tenantId,
+      auth: input.telemetry.auth,
+      accountId: input.telemetry.accountId,
+      accountKind: input.telemetry.accountKind,
+      upstreamProvider: input.telemetry.upstreamProvider,
+      upstreamStatus: input.telemetry.upstreamStatus,
+      errorType: input.telemetry.errorType,
+    },
+    startTimeMs: input.startTimeMs,
+    endTimeMs,
+  })
+  const domain = nonEmpty(input.env.AXIOM_DOMAIN) ?? defaultAxiomDomain
+  const fetcher = input.fetcher ?? fetch
+  const response = await fetcher(`https://${domain}/v1/traces`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-Axiom-Dataset": dataset,
+    },
+    body: JSON.stringify(body),
+  })
+  await response.arrayBuffer().catch(() => undefined)
+}
+
+export const scheduleAxiomSpanExport = (
+  ctx: Pick<ExecutionContext, "waitUntil"> | undefined,
+  input: TraceExportInput
+): void => {
+  if (!isAxiomTelemetryConfigured(input.env)) return
+  const task = Promise.resolve()
+    .then(() => exportAxiomSpan(input))
+    .catch(() => undefined)
+  if (ctx) {
+    ctx.waitUntil(task)
+    return
+  }
+  void task
+}
+
+const stringAttribute = (key: string, value: string): OtlpAttribute => ({
+  key,
+  value: { stringValue: sanitizeAttributeString(value) },
+})
+
+const intAttribute = (key: string, value: number): OtlpAttribute => ({
+  key,
+  value: { intValue: String(Math.trunc(value)) },
+})
+
+const doubleAttribute = (key: string, value: number): OtlpAttribute => ({
+  key,
+  value: { doubleValue: value },
+})
+
+const optionalStringAttribute = (
+  key: string,
+  value: string | undefined
+): OtlpAttribute[] => {
+  const parsed = nonEmpty(value)
+  return parsed ? [stringAttribute(key, parsed)] : []
+}
+
+const optionalIntAttribute = (
+  key: string,
+  value: number | undefined
+): OtlpAttribute[] =>
+  typeof value === "number" && Number.isFinite(value)
+    ? [intAttribute(key, value)]
+    : []
+
+const nonEmpty = (value: string | undefined): string | null =>
+  typeof value === "string" && value.trim().length > 0 ? value : null
+
+const sanitizeAttributeString = (value: string): string =>
+  /srt_|sk-ant-|Bearer /.test(value) ? "[redacted]" : value
+
+const msToUnixNano = (ms: number): string => {
+  const wholeMs = Math.trunc(ms)
+  return String(BigInt(wholeMs) * 1_000_000n)
+}
+
+const randomHex = (byteLength: number): string => {
+  const bytes = new Uint8Array(byteLength)
+  crypto.getRandomValues(bytes)
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")
+}

--- a/cloudflare/packages/worker/test/telemetry.test.ts
+++ b/cloudflare/packages/worker/test/telemetry.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, test } from "bun:test"
+import {
+  buildOtlpTraceBody,
+  buildSpanAttributes,
+  createRequestTelemetryContext,
+  exportAxiomSpan,
+  routePatternForRequest,
+  scheduleAxiomSpanExport,
+  type OtlpAttribute,
+} from "../src/telemetry.ts"
+
+const attrValue = (
+  attributes: ReadonlyArray<OtlpAttribute>,
+  key: string
+): string | number | boolean | undefined => {
+  const value = attributes.find((attribute) => attribute.key === key)?.value
+  if (!value) return undefined
+  if ("stringValue" in value) return value.stringValue
+  if ("intValue" in value) return value.intValue
+  if ("doubleValue" in value) return value.doubleValue
+  return value.boolValue
+}
+
+describe("Axiom telemetry", () => {
+  test("classifies route patterns without raw account or tenant ids", () => {
+    expect(routePatternForRequest(new Request("https://subrouter.test/v1/responses"))).toBe("/proxy/codex")
+    expect(routePatternForRequest(new Request("https://subrouter.test/v1/messages"))).toBe("/proxy/claude")
+    expect(
+      routePatternForRequest(new Request("https://subrouter.test/v1/responses"), {
+        websocket: true,
+      })
+    ).toBe("/proxy/websocket")
+    expect(routePatternForRequest(new Request("https://subrouter.test/route"))).toBe("/route")
+    expect(routePatternForRequest(new Request("https://subrouter.test/admin/tenants/acme/rotate"))).toBe(
+      "/admin/tenants/:id/rotate"
+    )
+    expect(routePatternForRequest(new Request("https://subrouter.test/tenant/accounts/claude-123"))).toBe(
+      "/tenant/accounts/:id"
+    )
+  })
+
+  test("builds auth and routed-account span attributes", () => {
+    const attributes = buildSpanAttributes({
+      method: "POST",
+      routePattern: "/proxy/claude",
+      statusCode: 200,
+      durationMs: 12.5,
+      environment: "staging",
+      tenantId: "tenant-a",
+      auth: "tenant",
+      accountId: "claude-1",
+      accountKind: "anthropic_oauth",
+      upstreamProvider: "claude",
+      upstreamStatus: 200,
+    })
+
+    expect(attrValue(attributes, "service.name")).toBe("subrouter-do")
+    expect(attrValue(attributes, "deployment.environment")).toBe("staging")
+    expect(attrValue(attributes, "http.request.method")).toBe("POST")
+    expect(attrValue(attributes, "url.path")).toBe("/proxy/claude")
+    expect(attrValue(attributes, "http.response.status_code")).toBe("200")
+    expect(attrValue(attributes, "duration_ms")).toBe(12.5)
+    expect(attrValue(attributes, "subrouter.tenant_id")).toBe("tenant-a")
+    expect(attrValue(attributes, "subrouter.auth")).toBe("tenant")
+    expect(attrValue(attributes, "subrouter.account_id")).toBe("claude-1")
+    expect(attrValue(attributes, "subrouter.account_kind")).toBe("anthropic_oauth")
+    expect(attrValue(attributes, "subrouter.upstream_provider")).toBe("claude")
+    expect(attrValue(attributes, "subrouter.upstream_status_code")).toBe("200")
+  })
+
+  test("adds error.type for explicit errors and 5xx responses", () => {
+    expect(
+      attrValue(
+        buildSpanAttributes({
+          method: "GET",
+          routePattern: "/status",
+          statusCode: 400,
+          durationMs: 1,
+          auth: "legacy",
+          errorType: "TypeError",
+        }),
+        "error.type"
+      )
+    ).toBe("TypeError")
+    expect(
+      attrValue(
+        buildSpanAttributes({
+          method: "GET",
+          routePattern: "/status",
+          statusCode: 503,
+          durationMs: 1,
+          auth: "none",
+        }),
+        "error.type"
+      )
+    ).toBe("HttpError")
+  })
+
+  test("does not schedule or fetch when Axiom env is incomplete", async () => {
+    let fetchCount = 0
+    let waitUntilCount = 0
+    const request = new Request("https://subrouter.test/healthz")
+    const telemetry = createRequestTelemetryContext(request)
+
+    for (const env of [{ AXIOM_TOKEN: "token" }, { AXIOM_DATASET: "dataset" }, {}]) {
+      scheduleAxiomSpanExport(
+        { waitUntil: () => { waitUntilCount += 1 } },
+        {
+          env,
+          request,
+          telemetry,
+          response: new Response("ok"),
+          startTimeMs: 1,
+          endTimeMs: 2,
+          fetcher: (async () => {
+            fetchCount += 1
+            return new Response("unexpected")
+          }) as unknown as typeof fetch,
+        }
+      )
+    }
+
+    await Promise.resolve()
+    expect(waitUntilCount).toBe(0)
+    expect(fetchCount).toBe(0)
+  })
+
+  test("exports one OTLP HTTP JSON POST with Axiom headers", async () => {
+    const calls: Array<{ readonly input: RequestInfo | URL; readonly init?: RequestInit }> = []
+    const request = new Request("https://subrouter.test/healthz")
+    const telemetry = createRequestTelemetryContext(request)
+    const waitUntilTasks: Promise<unknown>[] = []
+
+    scheduleAxiomSpanExport(
+      {
+        waitUntil: (task) => {
+          waitUntilTasks.push(task)
+        },
+      },
+      {
+        env: {
+          AXIOM_TOKEN: "axiom-token",
+          AXIOM_DATASET: "otel-traces",
+          AXIOM_DOMAIN: "axiom.example",
+          SUBROUTER_ENV: "production",
+        },
+        request,
+        telemetry,
+        response: new Response("ok", { status: 204 }),
+        startTimeMs: 1_000,
+        endTimeMs: 1_025,
+        fetcher: (async (input, init) => {
+          calls.push({ input, init })
+          return new Response("ok", { status: 200 })
+        }) as typeof fetch,
+      }
+    )
+
+    expect(waitUntilTasks).toHaveLength(1)
+    await waitUntilTasks[0]
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.input).toBe("https://axiom.example/v1/traces")
+    expect(calls[0]?.init?.method).toBe("POST")
+    const headers = new Headers(calls[0]?.init?.headers)
+    expect(headers.get("Authorization")).toBe("Bearer axiom-token")
+    expect(headers.get("X-Axiom-Dataset")).toBe("otel-traces")
+    expect(headers.get("Content-Type")).toBe("application/json")
+    const body = JSON.parse(String(calls[0]?.init?.body))
+    expect(body.resourceSpans[0].scopeSpans[0].spans).toHaveLength(1)
+    expect(
+      body.resourceSpans[0].scopeSpans[0].spans[0].attributes.some(
+        (attribute: OtlpAttribute) => attribute.key === "duration_ms"
+      )
+    ).toBe(true)
+  })
+
+  test("export failures are swallowed by waitUntil task", async () => {
+    const request = new Request("https://subrouter.test/healthz")
+    const waitUntilTasks: Promise<unknown>[] = []
+    scheduleAxiomSpanExport(
+      {
+        waitUntil: (task) => {
+          waitUntilTasks.push(task)
+        },
+      },
+      {
+        env: { AXIOM_TOKEN: "token", AXIOM_DATASET: "dataset" },
+        request,
+        telemetry: createRequestTelemetryContext(request),
+        response: new Response("still ok", { status: 200 }),
+        startTimeMs: 1,
+        endTimeMs: 2,
+        fetcher: (async () => {
+          throw new TypeError("network down")
+        }) as unknown as typeof fetch,
+      }
+    )
+
+    await expect(waitUntilTasks[0]).resolves.toBeUndefined()
+  })
+
+  test("serialized span JSON does not contain tenant keys, Anthropic keys, or Bearer material", async () => {
+    const request = new Request("https://subrouter.test/tenant/accounts/sk-ant-secret?key=srt_secret", {
+      method: "DELETE",
+      headers: {
+        Authorization: "Bearer srt_0123456789abcdef0123456789abcdef",
+        "X-Subrouter-Tenant-Key": "srt_0123456789abcdef0123456789abcdef",
+        "X-Test-Api-Key": "sk-ant-test",
+      },
+      body: "Bearer srt_body sk-ant-body",
+    })
+    const telemetry = createRequestTelemetryContext(request)
+    telemetry.auth = "tenant"
+    telemetry.tenantId = "srt_tenant"
+    telemetry.accountId = "sk-ant-account"
+    telemetry.accountKind = "Bearer kind"
+    telemetry.upstreamProvider = "claude"
+
+    const bodies: string[] = []
+    await exportAxiomSpan({
+      env: { AXIOM_TOKEN: "token", AXIOM_DATASET: "dataset" },
+      request,
+      telemetry,
+      response: new Response("ok", { status: 200 }),
+      startTimeMs: 1,
+      endTimeMs: 2,
+      fetcher: (async (_input, init) => {
+        bodies.push(String(init?.body))
+        return new Response("ok", { status: 200 })
+      }) as typeof fetch,
+    })
+
+    expect(bodies).toHaveLength(1)
+    expect(bodies[0]).not.toContain("srt_")
+    expect(bodies[0]).not.toContain("sk-ant-")
+    expect(bodies[0]).not.toContain("Bearer ")
+  })
+
+  test("OTLP body uses hex ids and nano timestamps", () => {
+    const body = buildOtlpTraceBody({
+      traceId: "0".repeat(32),
+      spanId: "1".repeat(16),
+      startTimeMs: 1_000,
+      endTimeMs: 1_001,
+      span: {
+        method: "GET",
+        routePattern: "/healthz",
+        statusCode: 200,
+        durationMs: 1,
+        environment: "staging",
+        auth: "none",
+      },
+    })
+    const span = body.resourceSpans[0]!.scopeSpans[0]!.spans[0]!
+    expect(span.traceId).toBe("0".repeat(32))
+    expect(span.spanId).toBe("1".repeat(16))
+    expect(span.startTimeUnixNano).toBe("1000000000")
+    expect(span.endTimeUnixNano).toBe("1001000000")
+  })
+})

--- a/cloudflare/packages/worker/wrangler.json
+++ b/cloudflare/packages/worker/wrangler.json
@@ -56,6 +56,7 @@
         ]
       },
       "vars": {
+        "SUBROUTER_ENV": "staging",
         "CODEX_UPSTREAM": "https://chatgpt.com/backend-api/codex",
         "API_UPSTREAM": "https://api.openai.com/v1",
         "CLAUDE_UPSTREAM": "https://api.anthropic.com"
@@ -101,6 +102,7 @@
         ]
       },
       "vars": {
+        "SUBROUTER_ENV": "production",
         "CODEX_UPSTREAM": "https://chatgpt.com/backend-api/codex",
         "API_UPSTREAM": "https://api.openai.com/v1",
         "CLAUDE_UPSTREAM": "https://api.anthropic.com"


### PR DESCRIPTION
One span per request from the Cloudflare worker to Axiom (`service.name=subrouter-do`), shipping into the existing `cmux-prod-otel-traces` dataset. Hand-rolled minimal OTLP/HTTP JSON (no new runtime deps), fully inert unless `AXIOM_TOKEN`+`AXIOM_DATASET` secrets are set, exported via `ctx.waitUntil` after the response so the request path never blocks on telemetry. Attributes: templated route pattern (never raw paths), tenant id, auth classification, routed account id/kind, upstream provider/status, error type. A redaction test plants tenant keys/API keys/Bearer material in every request surface and asserts the serialized OTLP body is clean. `SUBROUTER_ENV` plain var added for staging/production.

Verified: 44 bun tests green, tsc clean (worker+core), wrangler dry-run green for both envs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add env-gated OTLP trace export from the DO worker to Axiom, sending one span per request. Exports are non-blocking via waitUntil and are inert unless Axiom secrets are set.

- **New Features**
  - Exports a single OTLP/HTTP JSON span per request when `AXIOM_TOKEN` and `AXIOM_DATASET` are set; `AXIOM_DOMAIN` is optional.
  - Spans include templated route pattern, tenant/auth classification, routed account id/kind, upstream provider/status, error type, and `SUBROUTER_ENV`.
  - Export runs in `ctx.waitUntil` after the response; failures are swallowed and never affect request latency.
  - Redaction prevents any `srt_`, `sk-ant-`, or `Bearer` material from appearing in span data; unit tests cover serialization and config gating.
  - Added `SUBROUTER_ENV` defaults for staging/production and updated README with observability setup.

<sup>Written for commit 5837dfbe6bec0cf26c468b64513e55bdadabae29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request observability exports for worker traffic, with trace data sent to Axiom when telemetry settings are configured.
  * Improved request and error tracking across routing, authentication, and upstream proxy flows.

* **Bug Fixes**
  * Telemetry now stays inactive when required Axiom settings are missing, avoiding partial exports.
  * Error responses and status handling are more consistent for failed requests.

* **Documentation**
  * Expanded the worker README with observability setup details and a trace-query example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->