### PR TITLE
worker: stream proxied responses through, record transcripts off-path

### DIFF
--- a/cloudflare/packages/worker/src/index.ts
+++ b/cloudflare/packages/worker/src/index.ts
@@ -108,6 +108,7 @@ interface TenantAccountOutput {
 }
 
 type UpstreamProvider = "claude" | "codex"
+type WaitUntil = (promise: Promise<unknown>) => void
 
 const anthropicBootstrapModelQuotas: AccountModelQuotas = {
   opus: { remainingPercent: 100 },
@@ -2702,7 +2703,8 @@ const proxyUpstream = async (
   env: Env,
   actor: DurableObjectStub<SubrouterDurableObject>,
   routeInput: RouteInput,
-  telemetry?: MutableRequestTelemetryContext
+  telemetry?: MutableRequestTelemetryContext,
+  waitUntil?: WaitUntil
 ): Promise<Response> => {
   if (!routeInput.orgId) {
     return json({ error: "tenant id required" }, { status: 401 })
@@ -2722,9 +2724,10 @@ const proxyUpstream = async (
     defaultUpstreamForAccount(env, account)
   )
   const headers = setUpstreamAuthHeaders(request.headers, account)
-  await actor.recordTranscriptMeta({
+  const agentType = routeInput.agentType ?? "codex"
+  const transcriptMetaInput = {
     orgId: routeInput.orgId,
-    agentType: routeInput.agentType ?? "codex",
+    agentType,
     sessionId: routeInput.sessionId,
     type: "subrouter_meta",
     payload: {
@@ -2736,36 +2739,56 @@ const proxyUpstream = async (
       upstream: upstreamURL.toString(),
       headers: redactedHeaders(stripSubrouterHeaders(request.headers)),
     },
-  })
+  } satisfies TranscriptEventInput
   const init: RequestInit = {
     method: request.method,
     headers,
     redirect: "manual",
   }
+  let requestBody: Promise<ArrayBuffer> | undefined
   if (request.method !== "GET" && request.method !== "HEAD") {
-    await recordTranscriptBodyFromArrayBuffer(actor, {
-      orgId: routeInput.orgId,
-      agentType: routeInput.agentType ?? "codex",
-      sessionId: routeInput.sessionId,
-      eventType: "http_body",
-      direction: "client_to_upstream",
-      body: await request.clone().arrayBuffer(),
-    })
+    requestBody = request.clone().arrayBuffer()
+    void requestBody.catch(() => {})
     init.body = request.body
   }
   const upstreamRequest = new Request(upstreamURL, init)
   const response = await fetch(upstreamRequest)
   if (telemetry) telemetry.upstreamStatus = response.status
-  await recordTranscriptBodyFromArrayBuffer(actor, {
-    orgId: routeInput.orgId,
-    agentType: routeInput.agentType ?? "codex",
-    sessionId: routeInput.sessionId,
-    eventType: "http_body",
-    direction: "upstream_to_client",
-    body: await response.clone().arrayBuffer(),
-    payload: { status: response.status },
-  })
-  return new Response(response.body, {
+  const [clientBody, transcriptBody] = response.body
+    ? response.body.tee()
+    : [null, null]
+  const transcriptBodyBuffer = transcriptBody
+    ? new Response(transcriptBody).arrayBuffer()
+    : Promise.resolve(new ArrayBuffer(0))
+  void transcriptBodyBuffer.catch(() => {})
+  const recordTranscripts = async (): Promise<void> => {
+    await actor.recordTranscriptMeta(transcriptMetaInput)
+    if (requestBody) {
+      await recordTranscriptBodyFromArrayBuffer(actor, {
+        orgId: routeInput.orgId,
+        agentType,
+        sessionId: routeInput.sessionId,
+        eventType: "http_body",
+        direction: "client_to_upstream",
+        body: await requestBody,
+      })
+    }
+    await recordTranscriptBodyFromArrayBuffer(actor, {
+      orgId: routeInput.orgId,
+      agentType,
+      sessionId: routeInput.sessionId,
+      eventType: "http_body",
+      direction: "upstream_to_client",
+      body: await transcriptBodyBuffer,
+      payload: { status: response.status },
+    })
+  }
+  if (waitUntil) {
+    waitUntil(recordTranscripts().catch(() => {}))
+  } else {
+    await recordTranscripts()
+  }
+  return new Response(clientBody, {
     status: response.status,
     statusText: response.statusText,
     headers: response.headers,
@@ -3203,7 +3226,8 @@ const escapeHTML = (value: string): string =>
 const handleFetch = async (
   request: Request,
   env: Env,
-  telemetry?: MutableRequestTelemetryContext
+  telemetry?: MutableRequestTelemetryContext,
+  ctx?: ExecutionContext
 ): Promise<Response> => {
     const url = new URL(request.url)
 
@@ -3561,12 +3585,21 @@ const handleFetch = async (
       if (isWebSocketUpgrade(request)) {
         return await proxyUpstreamWebSocket(request, env, actor, tenantRouteInput, telemetry)
       }
-      return await proxyUpstream(request, env, actor, tenantRouteInput, telemetry)
+      return await proxyUpstream(
+        request,
+        env,
+        actor,
+        tenantRouteInput,
+        telemetry,
+        ctx?.waitUntil.bind(ctx)
+      )
     } catch (error) {
       if (telemetry) telemetry.errorType = errorTypeFor(error)
       return errorJson(error, 503)
     }
 }
+
+export const __test = { proxyUpstream }
 
 export default {
   async fetch(
@@ -3575,14 +3608,14 @@ export default {
     ctx?: ExecutionContext
   ): Promise<Response> {
     if (!isAxiomTelemetryConfigured(env)) {
-      return handleFetch(request, env)
+      return handleFetch(request, env, undefined, ctx)
     }
 
     const startTimeMs = Date.now()
     const telemetry = createRequestTelemetryContext(request)
     let response: Response
     try {
-      response = await handleFetch(request, env, telemetry)
+      response = await handleFetch(request, env, telemetry, ctx)
     } catch (error) {
       telemetry.errorType = errorTypeFor(error)
       response = new Response("Internal Server Error", { status: 500 })

--- a/cloudflare/packages/worker/test/proxy-streaming.test.ts
+++ b/cloudflare/packages/worker/test/proxy-streaming.test.ts
@@ -1,0 +1,380 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import { Buffer } from "node:buffer"
+
+mock.module("cloudflare:workers", () => ({ DurableObject: class {} }))
+mock.module("@subrouter/core", () => ({
+  accountHasQuotaForModel: () => true,
+  quotaKeyForModel: (model: string | undefined) => model ?? "default",
+}))
+
+const { __test } = await import("../src/index.ts")
+
+const proxyUpstream = __test.proxyUpstream as unknown as (
+  request: Request,
+  env: Record<string, unknown>,
+  actor: Record<string, unknown>,
+  routeInput: Record<string, unknown>,
+  telemetry: undefined,
+  waitUntil: (promise: Promise<unknown>) => void
+) => Promise<Response>
+const originalFetch = globalThis.fetch
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("HTTP proxy streaming transcripts", () => {
+  test("passes through the first upstream chunk while transcript body RPC is pending", async () => {
+    let upstreamController: ReadableStreamDefaultController<Uint8Array> | undefined
+    const waitUntilPromises: Promise<unknown>[] = []
+    const bodyRecordStarted = deferred<void>()
+    const bodyRecordBlocked = deferred<void>()
+    const actor = fakeActor({
+      async recordTranscriptBody(input) {
+        if (input.direction === "client_to_upstream") {
+          bodyRecordStarted.resolve()
+          await bodyRecordBlocked.promise
+        }
+        return { ok: true }
+      },
+    })
+
+    setFetch(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              upstreamController = controller
+              controller.enqueue(encoder.encode("first\n"))
+            },
+          }),
+          { status: 200 }
+        )
+    )
+
+    const response = await proxyUpstream(
+      proxyRequest({ body: "client-body", sessionId: "stream-session" }),
+      fakeEnv(),
+      actor,
+      routeInput("stream-session"),
+      undefined,
+      (promise: Promise<unknown>) => waitUntilPromises.push(promise)
+    )
+
+    expect(response.status).toBe(200)
+    await withTimeout(bodyRecordStarted.promise, "body recording did not start")
+    const reader = response.body?.getReader()
+    expect(reader).toBeDefined()
+    const first = await withTimeout(reader!.read(), "first response chunk")
+    expect(decoder.decode(first.value)).toBe("first\n")
+    expect(first.done).toBe(false)
+
+    bodyRecordBlocked.resolve()
+    upstreamController?.enqueue(encoder.encode("last\n"))
+    upstreamController?.close()
+    const second = await withTimeout(reader!.read(), "second response chunk")
+    const done = await withTimeout(reader!.read(), "response stream close")
+    expect(decoder.decode(second.value)).toBe("last\n")
+    expect(done.done).toBe(true)
+    await Promise.all(waitUntilPromises)
+  })
+
+  test("records streamed HTTP transcript events in order with body hashes", async () => {
+    const events: TranscriptEvent[] = []
+    const waitUntilPromises: Promise<unknown>[] = []
+    const actor = fakeActor({
+      async recordTranscriptMeta(input) {
+        events.push({ kind: "meta", input })
+        return { ok: true }
+      },
+      async recordTranscriptBody(input) {
+        events.push({ kind: "body", input })
+        return { ok: true }
+      },
+    })
+
+    setFetch(async () => new Response("upstream-body", { status: 201 }))
+    const response = await proxyUpstream(
+      proxyRequest({ body: "client-body", sessionId: "integrity-session" }),
+      fakeEnv(),
+      actor,
+      routeInput("integrity-session"),
+      undefined,
+      (promise: Promise<unknown>) => waitUntilPromises.push(promise)
+    )
+
+    expect(response.status).toBe(201)
+    expect(await response.text()).toBe("upstream-body")
+    await Promise.all(waitUntilPromises)
+
+    expect(events.map((event) => event.kind)).toEqual(["meta", "body", "body"])
+    expect(events[0]?.input.payload).toMatchObject({
+      transport: "http",
+      account: "acct-test",
+      method: "POST",
+      path: "/v1/responses",
+    })
+    expect(events[1]?.input).toMatchObject({
+      direction: "client_to_upstream",
+      bytes: byteLength("client-body"),
+      bodyBase64: base64("client-body"),
+      sha256: await sha256("client-body"),
+    })
+    expect(events[2]?.input).toMatchObject({
+      direction: "upstream_to_client",
+      bytes: byteLength("upstream-body"),
+      bodyBase64: base64("upstream-body"),
+      sha256: await sha256("upstream-body"),
+      payload: { status: 201 },
+    })
+  })
+
+  test("isolates deferred transcript RPC failures from the client response", async () => {
+    const waitUntilPromises: Promise<unknown>[] = []
+    const actor = fakeActor({
+      async recordTranscriptBody() {
+        throw new Error("transcript write failed")
+      },
+    })
+
+    setFetch(async () => new Response("still returned", { status: 202 }))
+    const response = await proxyUpstream(
+      proxyRequest({ body: "client-body", sessionId: "failure-session" }),
+      fakeEnv(),
+      actor,
+      routeInput("failure-session"),
+      undefined,
+      (promise: Promise<unknown>) => waitUntilPromises.push(promise)
+    )
+
+    expect(response.status).toBe(202)
+    expect(await response.text()).toBe("still returned")
+    await expect(Promise.all(waitUntilPromises)).resolves.toEqual([undefined])
+  })
+
+  test("drains the response tee when transcript meta recording rejects", async () => {
+    const waitUntilPromises: Promise<unknown>[] = []
+    const upstreamDrained = deferred<void>()
+    let chunk = 0
+    const actor = fakeActor({
+      async recordTranscriptMeta() {
+        throw new Error("meta write failed")
+      },
+    })
+
+    setFetch(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              chunk += 1
+              if (chunk <= 3) {
+                controller.enqueue(encoder.encode(`chunk-${chunk}\n`))
+                return
+              }
+              controller.close()
+              upstreamDrained.resolve()
+            },
+          }),
+          { status: 200 }
+        )
+    )
+
+    const response = await proxyUpstream(
+      proxyRequest({ body: "client-body", sessionId: "meta-failure-session" }),
+      fakeEnv(),
+      actor,
+      routeInput("meta-failure-session"),
+      undefined,
+      (promise: Promise<unknown>) => waitUntilPromises.push(promise)
+    )
+
+    expect(response.status).toBe(200)
+    await expect(Promise.all(waitUntilPromises)).resolves.toEqual([undefined])
+    await withTimeout(upstreamDrained.promise, "response tee drain")
+    await response.body?.cancel()
+  })
+
+  test("handles rejected request body recording promises before fetch fails", async () => {
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason)
+    }
+    process.on("unhandledRejection", onUnhandled)
+    const actor = fakeActor({})
+    const request = new Request("https://subrouter.example/v1/responses", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer tenant-key",
+        "Content-Type": "application/octet-stream",
+        "X-Subrouter-Session": "request-abort-session",
+      },
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          queueMicrotask(() => controller.error(new Error("client aborted upload")))
+        },
+      }),
+      duplex: "half",
+    } as RequestInit & { duplex: "half" })
+
+    setFetch(async () => {
+      throw new Error("upstream fetch failed")
+    })
+    try {
+      await expect(
+        proxyUpstream(
+          request,
+          fakeEnv(),
+          actor,
+          routeInput("request-abort-session"),
+          undefined,
+          () => {}
+        )
+      ).rejects.toThrow("upstream fetch failed")
+      await Bun.sleep(20)
+      expect(unhandled).toEqual([])
+    } finally {
+      process.off("unhandledRejection", onUnhandled)
+    }
+  })
+
+  test("records an empty upstream body for null-body 204 responses", async () => {
+    const events: TranscriptEvent[] = []
+    const waitUntilPromises: Promise<unknown>[] = []
+    const actor = fakeActor({
+      async recordTranscriptMeta(input) {
+        events.push({ kind: "meta", input })
+        return { ok: true }
+      },
+      async recordTranscriptBody(input) {
+        events.push({ kind: "body", input })
+        return { ok: true }
+      },
+    })
+
+    setFetch(async () => new Response(null, { status: 204 }))
+    const response = await proxyUpstream(
+      proxyRequest({ method: "GET", sessionId: "null-body-session" }),
+      fakeEnv(),
+      actor,
+      routeInput("null-body-session"),
+      undefined,
+      (promise: Promise<unknown>) => waitUntilPromises.push(promise)
+    )
+
+    expect(response.status).toBe(204)
+    expect(await response.text()).toBe("")
+    await Promise.all(waitUntilPromises)
+
+    expect(events.map((event) => event.kind)).toEqual(["meta", "body"])
+    expect(events[1]?.input).toMatchObject({
+      direction: "upstream_to_client",
+      bytes: 0,
+      bodyBase64: "",
+      sha256: await sha256(""),
+      payload: { status: 204 },
+    })
+  })
+})
+
+interface TranscriptEvent {
+  readonly kind: "meta" | "body"
+  readonly input: Record<string, any>
+}
+
+const fakeEnv = (): Record<string, unknown> => ({
+  CODEX_UPSTREAM: "https://upstream.example/backend-api/codex",
+})
+
+const routeInput = (sessionId: string): Record<string, unknown> => ({
+  orgId: "org-test",
+  agentType: "codex",
+  sessionId,
+})
+
+const proxyRequest = (input: {
+  readonly method?: string
+  readonly body?: string
+  readonly sessionId: string
+}): Request =>
+  new Request("https://subrouter.example/v1/responses", {
+    method: input.method ?? "POST",
+    headers: {
+      Authorization: "Bearer tenant-key",
+      "Content-Type": "application/json",
+      "X-Subrouter-Session": input.sessionId,
+    },
+    ...(input.body === undefined ? {} : { body: input.body }),
+  })
+
+const fakeActor = (overrides: {
+  readonly recordTranscriptMeta?: (input: Record<string, any>) => Promise<{ ok: true }>
+  readonly recordTranscriptBody?: (input: Record<string, any>) => Promise<{ ok: true }>
+}): Record<string, unknown> => ({
+  async routeForProxy() {
+    return {
+      account: {
+        id: "acct-test",
+        kind: "codex_oauth",
+        label: "test@example.com",
+        hasCredentials: true,
+        hasTotp: false,
+        credentials: { accessToken: "upstream-token" },
+      },
+    }
+  },
+  recordTranscriptMeta:
+    overrides.recordTranscriptMeta ?? (async () => ({ ok: true })),
+  recordTranscriptBody:
+    overrides.recordTranscriptBody ?? (async () => ({ ok: true })),
+})
+
+type TestFetch = (
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1]
+) => Response | Promise<Response>
+
+const setFetch = (fetcher: TestFetch): void => {
+  globalThis.fetch = Object.assign(fetcher, { preconnect: () => {} }) as typeof fetch
+}
+
+const deferred = <T>(): {
+  readonly promise: Promise<T>
+  readonly resolve: (value: T | PromiseLike<T>) => void
+  readonly reject: (reason?: unknown) => void
+} => {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve
+    reject = innerReject
+  })
+  return { promise, resolve, reject }
+}
+
+const withTimeout = async <T>(promise: Promise<T>, label: string): Promise<T> => {
+  let timeout: Timer | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(`${label} timed out`)), 1_000)
+      }),
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
+
+const byteLength = (value: string): number => encoder.encode(value).byteLength
+
+const base64 = (value: string): string => Buffer.from(value).toString("base64")
+
+const sha256 = async (value: string): Promise<string> => {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(value))
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+}

--- a/cloudflare/packages/worker/test/worker-transcripts.test.ts
+++ b/cloudflare/packages/worker/test/worker-transcripts.test.ts
@@ -277,11 +277,7 @@ describe("subrouter Durable Object Worker transcripts", () => {
     expect(upstreamRequests[0]?.path).toBe("/backend-api/codex/responses")
     expect(upstreamRequests[0]?.auth).toBe("Bearer codex-access-token")
 
-    const list = await fetch(`${baseURL}/_subrouter/transcripts?tenant=${tenant.id}`, {
-      headers: { Authorization: `Bearer ${adminToken}` },
-    })
-    expect(list.status).toBe(200)
-    const summaries = (await list.json()) as Array<Record<string, any>>
+    const summaries = await waitForTranscriptEvents(baseURL, tenant.id, 3)
     expect(summaries).toHaveLength(1)
     expect(summaries[0]?.agent_type).toBe("codex")
     expect(summaries[0]?.session_id).toBe("session-1")


### PR DESCRIPTION
Fixes buffered proxying: the HTTP proxy path awaited a full `response.clone().arrayBuffer()` for transcript recording before returning, so every streamed completion reached the client only after upstream finished (measured: TTFB == total, 3.0s on a 400-token stream vs 1.0s TTFB direct; claude CLI ttft_ms 8684 of duration_ms 10171). Interactive CLIs through the DO saw a frozen terminal then an end-dump.

Now the upstream body is tee'd: the client branch returns immediately; the recording branch drains eagerly at tee time (client-independent speed) and transcript recording runs in `ctx.waitUntil` with order and fields unchanged (meta → client_to_upstream → upstream_to_client, same sha256/base64/payload.status). Rejection sidecars prevent stranded tee branches and unhandled rejections when a DO RPC rejects or the client aborts mid-upload; recording failures never affect the client response. Fallback without ctx preserves the old awaited semantics.

Two /fable judge rounds (round 1 REVISE caught the stranded-branch and unhandled-rejection modes; round 2 APPROVE). bun test 50 pass including new tests that discriminate both failure modes, tsc clean, wrangler dry-run green. Post-merge I'll deploy staging and re-run the 400-token TTFB probe to confirm first-token streaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785806648&installation_id=133855650&pr_number=58&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F58&signature=f7adde3dbee10bf6ed765213c03495643903771b827f8158b00342020879069a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams proxied HTTP responses directly to clients while recording transcripts off-path, fixing the buffered proxy that delayed first byte until the upstream finished. This restores first-token streaming and keeps transcript failures from affecting client responses.

- **Bug Fixes**
  - Tee the upstream response body: one branch to the client, one for transcript capture.
  - Record meta → request → response in order via `ctx.waitUntil`; fall back to awaited recording if no `ctx`.
  - Guard against DO RPC failures and client aborts to avoid stranded tees and unhandled rejections.
  - Added targeted tests for streaming, null-body responses, and failure modes.

<sup>Written for commit 77a96e55c14ae165edc95cbca8e9317ef9e788ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP proxy transcript capture now records both request and response bodies, including status details for empty responses.
  * Transcript processing can run in the background, improving responsiveness while preserving recording.

* **Bug Fixes**
  * Improved reliability of streamed proxy responses so client traffic continues even if transcript recording fails.
  * Better handling of streaming and empty-body responses to keep transcript data complete and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->