### PR TITLE
worker: redact query values in transcript upstream URLs

### DIFF
--- a/cloudflare/packages/worker/src/contract.ts
+++ b/cloudflare/packages/worker/src/contract.ts
@@ -764,6 +764,14 @@ export const upstreamURLForRequest = (
   return output
 }
 
+export const redactedUpstreamURL = (url: URL | string): string => {
+  const input = new URL(url.toString())
+  const query = [...input.searchParams]
+    .map(([key]) => `${encodeURIComponent(key)}=[redacted]`)
+    .join("&")
+  return `${input.origin}${input.pathname}${query ? `?${query}` : ""}`
+}
+
 const upstreamPath = (
   requestPath: string,
   account: StoredAccountContract,

--- a/cloudflare/packages/worker/src/index.ts
+++ b/cloudflare/packages/worker/src/index.ts
@@ -14,6 +14,7 @@ import {
   normalizeAgentType,
   parseProxyRouteInput,
   providerForAccount,
+  redactedUpstreamURL,
   refreshFailureFromError,
   refreshOAuthCredentials,
   safeGoAccount,
@@ -2718,11 +2719,8 @@ const proxyUpstream = async (
       { status: 503 }
     )
   }
-  const upstreamURL = upstreamURLForRequest(
-    request.url,
-    account,
-    defaultUpstreamForAccount(env, account)
-  )
+  const defaultUpstream = defaultUpstreamForAccount(env, account)
+  const upstreamURL = upstreamURLForRequest(request.url, account, defaultUpstream)
   const headers = setUpstreamAuthHeaders(request.headers, account)
   const agentType = routeInput.agentType ?? "codex"
   const transcriptMetaInput = {
@@ -2736,7 +2734,7 @@ const proxyUpstream = async (
       account: account.id,
       method: request.method,
       path: new URL(request.url).pathname,
-      upstream: upstreamURL.toString(),
+      upstream: redactedUpstreamURL(upstreamURL),
       headers: redactedHeaders(stripSubrouterHeaders(request.headers)),
     },
   } satisfies TranscriptEventInput
@@ -2814,11 +2812,8 @@ const proxyUpstreamWebSocket = async (
       { status: 503 }
     )
   }
-  const upstreamURL = upstreamURLForRequest(
-    request.url,
-    account,
-    defaultUpstreamForAccount(env, account)
-  )
+  const defaultUpstream = defaultUpstreamForAccount(env, account)
+  const upstreamURL = upstreamURLForRequest(request.url, account, defaultUpstream)
   const headers = setUpstreamAuthHeaders(request.headers, account)
   headers.set("Upgrade", "websocket")
   await actor.recordTranscriptMeta({
@@ -2832,8 +2827,8 @@ const proxyUpstreamWebSocket = async (
       account: account.id,
       method: request.method,
       path: new URL(request.url).pathname,
-      upstream: defaultUpstreamForAccount(env, account),
-      upstream_url: upstreamURL.toString(),
+      upstream: redactedUpstreamURL(defaultUpstream),
+      upstream_url: redactedUpstreamURL(upstreamURL),
       headers: redactedHeaders(headers),
     },
   })

--- a/cloudflare/packages/worker/test/contract.test.ts
+++ b/cloudflare/packages/worker/test/contract.test.ts
@@ -5,6 +5,7 @@ import {
   fetchProviderUsage,
   refreshOAuthCredentials,
   parseProxyRouteInput,
+  redactedUpstreamURL,
   safeGoAccount,
   scopedSessionKey,
   setUpstreamAuthHeaders,
@@ -136,6 +137,16 @@ describe("subrouter Durable Object contract", () => {
         "https://api.openai.com/v1"
       ).toString()
     ).toBe("https://api.openai.com/v1/responses")
+  })
+
+  test("redacted upstream URLs keep parameter names without values", () => {
+    expect(
+      redactedUpstreamURL(
+        "https://api.openai.com/v1/chat/completions?key=sk-secret123&empty=&key=second#ignored"
+      )
+    ).toBe(
+      "https://api.openai.com/v1/chat/completions?key=[redacted]&empty=[redacted]&key=[redacted]"
+    )
   })
 
   test("codex oauth refresh rotates access, refresh, and id tokens", async () => {

--- a/cloudflare/packages/worker/test/proxy-streaming.test.ts
+++ b/cloudflare/packages/worker/test/proxy-streaming.test.ts
@@ -131,6 +131,52 @@ describe("HTTP proxy streaming transcripts", () => {
     })
   })
 
+  test("redacts upstream query values in transcript meta without changing the upstream request", async () => {
+    const events: TranscriptEvent[] = []
+    const waitUntilPromises: Promise<unknown>[] = []
+    let fetchedURL = ""
+    const actor = fakeActor({
+      async recordTranscriptMeta(input) {
+        events.push({ kind: "meta", input })
+        return { ok: true }
+      },
+      async recordTranscriptBody(input) {
+        events.push({ kind: "body", input })
+        return { ok: true }
+      },
+    })
+
+    setFetch(async (input) => {
+      fetchedURL = new Request(input).url
+      return new Response("ok", { status: 200 })
+    })
+    const response = await proxyUpstream(
+      proxyRequest({
+        body: "client-body",
+        sessionId: "redacted-query-session",
+        query: "?api_key=sk-secret123&debug=true",
+      }),
+      fakeEnv(),
+      actor,
+      routeInput("redacted-query-session"),
+      undefined,
+      (promise: Promise<unknown>) => waitUntilPromises.push(promise)
+    )
+
+    expect(response.status).toBe(200)
+    await response.text()
+    await Promise.all(waitUntilPromises)
+
+    expect(fetchedURL).toBe(
+      "https://upstream.example/backend-api/codex/responses?api_key=sk-secret123&debug=true"
+    )
+    expect(events[0]?.input.payload.upstream).toBe(
+      "https://upstream.example/backend-api/codex/responses?api_key=[redacted]&debug=[redacted]"
+    )
+    expect(JSON.stringify(events[0]?.input.payload)).toContain("api_key")
+    expect(JSON.stringify(events[0]?.input.payload)).not.toContain("sk-secret123")
+  })
+
   test("isolates deferred transcript RPC failures from the client response", async () => {
     const waitUntilPromises: Promise<unknown>[] = []
     const actor = fakeActor({
@@ -298,8 +344,9 @@ const proxyRequest = (input: {
   readonly method?: string
   readonly body?: string
   readonly sessionId: string
+  readonly query?: string
 }): Request =>
-  new Request("https://subrouter.example/v1/responses", {
+  new Request(`https://subrouter.example/v1/responses${input.query ?? ""}`, {
     method: input.method ?? "POST",
     headers: {
       Authorization: "Bearer tenant-key",


### PR DESCRIPTION
Security-audit fix: transcript metadata stored the full upstream URL including the client's query string, so providers that accept credentials in query params (?key=...) would have secrets persisted into DO transcript storage (admin-gated, but defense-in-depth). `redactedUpstreamURL` keeps origin + pathname + query key names and replaces every value with `[redacted]`, applied to the HTTP proxy's `payload.upstream` and the WebSocket path's `payload.upstream`/`payload.upstream_url`. The actual upstream fetch URL is untouched. Tests cover key-name preservation, value redaction, and pass-through of the original query to the real upstream request.

bun test 52 pass across the worker suite, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785896315&installation_id=133855650&pr_number=59&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F59&signature=a17ebb178798bdee9b8468fdd5a8051de4bc433e733c7781f728e3f00564f0ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts query parameter values from upstream URLs in transcript metadata to prevent leaking secrets. Applies to HTTP and WebSocket proxy meta; upstream requests still use the original URLs.

- **Bug Fixes**
  - Added `redactedUpstreamURL` to keep origin, path, and query keys while replacing all values with `[redacted]`.
  - Applied to `payload.upstream` and `payload.upstream_url` across proxies; headers continue using existing redaction.
  - Tests cover key-name preservation, value redaction, and unchanged upstream request URLs.

<sup>Written for commit 57ab9f84ad5ac81110596f2407bd9bc2a48614f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transcript details now hide query parameter values in upstream URLs while keeping parameter names and paths visible.
  * HTTP and WebSocket proxy metadata now consistently use redacted upstream URLs.

* **Bug Fixes**
  * Improved handling of upstream URL logging so sensitive query strings are no longer exposed in recorded transcripts.
  * Preserved the original upstream request behavior while changing only the displayed metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->