### PR TITLE
Scope Claude exhaustion marks per model pool; drain Fable weekly quota first

### DIFF
--- a/internal/proxy/claude_failover_test.go
+++ b/internal/proxy/claude_failover_test.go
@@ -307,7 +307,7 @@ func TestCaptureResponseBodyClaude401MarksExhausted(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"authentication_error"}}`)),
 		Header:     http.Header{},
 	}
-	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "/v1/messages")
+	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "", "/v1/messages")
 	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
 		t.Fatal("claude 401 should mark the account exhausted via passive inspection")
 	}
@@ -341,7 +341,7 @@ func TestCaptureResponseBodyClaude429MarksExhausted(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error"}}`)),
 		Header:     h,
 	}
-	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "/v1/messages")
+	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "", "/v1/messages")
 	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
 		t.Fatal("claude rejected-header 429 should mark the account exhausted via passive inspection")
 	}
@@ -357,7 +357,7 @@ func TestCaptureResponseBodyClaudeBare429DoesNotPoison(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}`)),
 		Header:     http.Header{},
 	}
-	server.captureResponseBody(response, "claude", "session-1", "healthy@example.com", accounts.ProviderClaude, "/v1/messages")
+	server.captureResponseBody(response, "claude", "session-1", "healthy@example.com", accounts.ProviderClaude, "", "/v1/messages")
 	if server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "healthy@example.com") {
 		t.Fatal("a bare (headerless) 429 must NOT mark a healthy account exhausted")
 	}

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -117,8 +117,12 @@ func TestClaude429FailoverEndToEndAndCaptured(t *testing.T) {
 	if freshHits != 1 {
 		t.Fatalf("fresh upstream hits = %d, want 1 (served after failover)", freshHits)
 	}
-	if !schedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
-		t.Fatal("cooked account should be marked exhausted by the 429")
+	scheduler := schedulerRef.Get()
+	if !scheduler.ForModel(agentclaude.OpusFeature).Exhausted(accounts.ProviderClaude, "cooked@example.com") {
+		t.Fatal("cooked account should be marked exhausted for the Opus pool by the 429")
+	}
+	if scheduler.Exhausted(accounts.ProviderClaude, "cooked@example.com") {
+		t.Fatal("Opus 429 should not mark the base account exhausted")
 	}
 	assignment, ok := store.Get("claude", "session-rl")
 	if !ok || assignment.AccountID != "fresh@example.com" {
@@ -595,6 +599,83 @@ func TestClaudeTransient429FailsOverWithoutPoisoningScore(t *testing.T) {
 	}
 }
 
+func TestClaudeBareRejectedFableMarksOnlyFablePool(t *testing.T) {
+	const (
+		fableAccount = "a@example.com"
+		otherAccount = "z@example.com"
+	)
+	fableKey := selectacct.ModelKey(agentclaude.FableFeature)
+	opusKey := selectacct.ModelKey(agentclaude.OpusFeature)
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: fableAccount, Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-a"},
+			{ID: otherAccount, Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-z"},
+		},
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+			{
+				AccountID: fableAccount, Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1,
+				ModelScores: map[string]selectacct.Score{
+					fableKey: {AccountID: fableAccount, Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+					opusKey:  {AccountID: fableAccount, Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+				},
+			},
+			{
+				AccountID: otherAccount, Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1,
+				ModelScores: map[string]selectacct.Score{
+					fableKey: {AccountID: otherAccount, Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+					opusKey:  {AccountID: otherAccount, Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+				},
+			},
+		})),
+	}
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		h := http.Header{}
+		h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Header:     h,
+			Body:       io.NopCloser(strings.NewReader(realisticAnthropic429Body)),
+		}
+	}}
+	transport := usageLimitRetryTransport{
+		base: stub, server: &server, provider: accounts.ProviderClaude,
+		agent: "claude", session: "session-fable", account: fableAccount,
+		method: http.MethodPost, path: "/v1/messages", maxAttempts: 1,
+		poolModel: agentclaude.FableFeature,
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader([]byte(`{"model":"claude-fable-5"}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok-a")
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status=%d, want original fable rejection", response.StatusCode)
+	}
+
+	scheduler := server.SchedulerRef.Get()
+	if !scheduler.ForModel(agentclaude.FableFeature).Exhausted(accounts.ProviderClaude, fableAccount) {
+		t.Fatal("bare rejected fable response should mark only the fable pool")
+	}
+	if scheduler.Exhausted(accounts.ProviderClaude, fableAccount) {
+		t.Fatal("bare rejected fable response must not mark the base account exhausted")
+	}
+	if scheduler.ForModel(agentclaude.OpusFeature).Exhausted(accounts.ProviderClaude, fableAccount) {
+		t.Fatal("bare rejected fable response must not mark opus exhausted")
+	}
+	picked, err := scheduler.ForModel(agentclaude.OpusFeature).Pick(server.Accounts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if picked.ID != fableAccount {
+		t.Fatalf("opus pick after fable rejection = %q, want same account %q", picked.ID, fableAccount)
+	}
+}
+
 // TestClaudeFailoverExhaustionIsLogged guards the monitoring contract: when
 // every failover attempt is rate-limited and the client ends up with a 429, the
 // single authoritative failure signal must be logged even though no
@@ -652,7 +733,7 @@ func TestClaudeFailoverSkipsMarkedExhaustedAlternates(t *testing.T) {
 	if _, err := store.Put("claude", "session-exhausted-alt", "cooked@example.com", ""); err != nil {
 		t.Fatal(err)
 	}
-	server.SchedulerRef.MarkExhaustedUntil(accounts.ProviderClaude, "fresh@example.com", time.Now().Add(time.Hour))
+	server.SchedulerRef.MarkExhaustedUntil(accounts.ProviderClaude, "fresh@example.com", "", time.Now().Add(time.Hour))
 
 	var calls int
 	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
@@ -1010,7 +1091,7 @@ func TestClaudeUpstreamServerErrorLoggedNotExhausted(t *testing.T) {
 		Header:     http.Header{},
 		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"overloaded_error"}}`)),
 	}
-	server.captureResponseBody(response, "claude", "session-1", "acct@example.com", accounts.ProviderClaude, "/v1/messages")
+	server.captureResponseBody(response, "claude", "session-1", "acct@example.com", accounts.ProviderClaude, "", "/v1/messages")
 	logs := logBuf.String()
 	if !strings.Contains(logs, "claude upstream server error") || !strings.Contains(logs, "status=529") {
 		t.Fatalf("expected a 529 upstream-server-error log; logs=\n%s", logs)
@@ -1315,7 +1396,7 @@ func TestClaudeFailoverTriesRecoveredAccount(t *testing.T) {
 	}
 	ref := selectacct.NewSchedulerRef(selectacct.NewScheduler(nil))
 	// recovered@ was marked exhausted while cooked, but its window has reset.
-	ref.MarkExhaustedUntil(accounts.ProviderClaude, "recovered@example.com", time.Now().Add(-time.Second))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "recovered@example.com", "", time.Now().Add(-time.Second))
 	server := Server{
 		Accounts: []accounts.Account{
 			{ID: "cooked@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-cooked"},
@@ -1363,34 +1444,34 @@ func TestMarkTTLSelection(t *testing.T) {
 	h.Set("Anthropic-Ratelimit-Unified-Reset", strconv.FormatInt(resetEpoch, 10))
 
 	// Rate-limit mark: expiry = upstream reset.
-	server.markAccountExhaustedFromResponse(accounts.ProviderClaude, "rl@example.com", http.StatusTooManyRequests, h)
-	until, ok := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "rl@example.com")
+	server.markAccountExhaustedFromResponse(accounts.ProviderClaude, "rl@example.com", "", http.StatusTooManyRequests, h)
+	until, ok := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "rl@example.com", "")
 	if !ok || !until.Equal(time.Unix(resetEpoch, 0)) {
 		t.Fatalf("rate-limit mark until=%v ok=%v, want upstream reset %v", until, ok, time.Unix(resetEpoch, 0))
 	}
 	// Re-marking with the same headers (the passive body-inspect path) must not
 	// shorten the expiry to the default TTL.
-	server.markAccountExhaustedFromResponse(accounts.ProviderClaude, "rl@example.com", http.StatusTooManyRequests, h)
-	until2, _ := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "rl@example.com")
+	server.markAccountExhaustedFromResponse(accounts.ProviderClaude, "rl@example.com", "", http.StatusTooManyRequests, h)
+	until2, _ := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "rl@example.com", "")
 	if !until2.Equal(time.Unix(resetEpoch, 0)) {
 		t.Fatalf("re-mark shortened expiry to %v, want %v", until2, time.Unix(resetEpoch, 0))
 	}
 
 	// 401 dead credential: long credential TTL, not the 10m default.
-	server.markAccountExhaustedFromResponse(accounts.ProviderClaude, "dead@example.com", http.StatusUnauthorized, http.Header{})
-	deadUntil, ok := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "dead@example.com")
+	server.markAccountExhaustedFromResponse(accounts.ProviderClaude, "dead@example.com", "", http.StatusUnauthorized, http.Header{})
+	deadUntil, ok := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "dead@example.com", "")
 	if !ok || time.Until(deadUntil) < 50*time.Minute {
 		t.Fatalf("401 mark until=%v (in %v), want ~1h credential TTL", deadUntil, time.Until(deadUntil))
 	}
 
 	// Terminal refresh failure: credential TTL; transient: short default.
-	server.markAccountExhaustedRefreshFailure(accounts.ProviderClaude, "invalid@example.com", fmt.Errorf("400 Bad Request: invalid_grant"))
-	invUntil, _ := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "invalid@example.com")
+	server.markAccountExhaustedRefreshFailure(accounts.ProviderClaude, "invalid@example.com", "", fmt.Errorf("400 Bad Request: invalid_grant"))
+	invUntil, _ := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "invalid@example.com", "")
 	if time.Until(invUntil) < 50*time.Minute {
 		t.Fatalf("terminal refresh mark in %v, want ~1h", time.Until(invUntil))
 	}
-	server.markAccountExhaustedRefreshFailure(accounts.ProviderClaude, "blip@example.com", fmt.Errorf("dial tcp: connection refused"))
-	blipUntil, _ := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "blip@example.com")
+	server.markAccountExhaustedRefreshFailure(accounts.ProviderClaude, "blip@example.com", "", fmt.Errorf("dial tcp: connection refused"))
+	blipUntil, _ := server.SchedulerRef.ExhaustedUntilFor(accounts.ProviderClaude, "blip@example.com", "")
 	if time.Until(blipUntil) > 15*time.Minute {
 		t.Fatalf("transient refresh mark in %v, want ~10m default", time.Until(blipUntil))
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1084,7 +1084,7 @@ func (s Server) withRequestTimeExhaustionWindows(statuses []AccountUsageStatus) 
 		if status.AuthMode != accounts.AuthModeOAuth {
 			continue
 		}
-		until, ok := s.SchedulerRef.ExhaustedUntilFor(status.Provider, status.ID)
+		until, ok := s.SchedulerRef.ExhaustedUntilFor(status.Provider, status.ID, "")
 		if !ok || !until.After(now) {
 			continue
 		}
@@ -1690,7 +1690,7 @@ func (s Server) proxyHandler() http.Handler {
 			return
 		}
 		if websocket.IsWebSocketUpgrade(r) {
-			s.proxyWebSocket(w, r, account, sessionAgentType, sessionID, userEmail, upstream)
+			s.proxyWebSocket(w, r, account, sessionAgentType, sessionID, userEmail, requestPoolModel, upstream)
 			return
 		}
 		proxyRequest := r.Clone(r.Context())
@@ -1777,7 +1777,7 @@ func (s Server) proxyHandler() http.Handler {
 		}
 		rp.Transport = transport
 		rp.ModifyResponse = func(response *http.Response) error {
-			s.captureResponseBody(response, sessionAgentType, sessionID, account.ID, account.Provider, proxyRequest.URL.Path)
+			s.captureResponseBody(response, sessionAgentType, sessionID, account.ID, account.Provider, requestPoolModel, proxyRequest.URL.Path)
 			return nil
 		}
 		if s.Logger != nil {
@@ -1839,7 +1839,7 @@ func baseURLProbeRequest(r *http.Request) bool {
 	return r.Method == http.MethodHead && (r.URL.Path == "" || r.URL.Path == "/")
 }
 
-func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account accounts.Account, agentType, sessionID, userEmail string, upstream *url.URL) {
+func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account accounts.Account, agentType, sessionID, userEmail, poolModel string, upstream *url.URL) {
 	upstreamURL := cloneURL(r.URL)
 	upstreamURL.Scheme = websocketScheme(upstream.Scheme)
 	upstreamURL.Host = upstream.Host
@@ -1885,12 +1885,12 @@ func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account a
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		s.copyWebSocketMessages(agentType, sessionID, account.ID, "client_to_upstream", clientConn, upstreamConn)
+		s.copyWebSocketMessages(agentType, sessionID, account.ID, poolModel, "client_to_upstream", clientConn, upstreamConn)
 		_ = upstreamConn.Close()
 	}()
 	go func() {
 		defer wg.Done()
-		s.copyWebSocketMessages(agentType, sessionID, account.ID, "upstream_to_client", upstreamConn, clientConn)
+		s.copyWebSocketMessages(agentType, sessionID, account.ID, poolModel, "upstream_to_client", upstreamConn, clientConn)
 		_ = clientConn.Close()
 	}()
 	wg.Wait()
@@ -1925,7 +1925,7 @@ func cloneWebSocketResponseHeaders(headers http.Header) http.Header {
 	return out
 }
 
-func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, direction string, src, dst *websocket.Conn) {
+func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, poolModel, direction string, src, dst *websocket.Conn) {
 	for {
 		messageType, body, err := src.ReadMessage()
 		if err != nil {
@@ -1937,7 +1937,7 @@ func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, direction
 			})
 		}
 		if direction == "upstream_to_client" && messageType == websocket.TextMessage && usageLimitJSON(body) {
-			s.markAccountExhausted(providerForRequest(agentType, ""), accountID)
+			s.markAccountExhausted(providerForRequest(agentType, ""), accountID, poolModel)
 		}
 		if err := dst.WriteMessage(messageType, body); err != nil {
 			return
@@ -1945,9 +1945,9 @@ func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, direction
 	}
 }
 
-func (s Server) markAccountExhausted(provider accounts.Provider, accountID string) {
+func (s Server) markAccountExhausted(provider accounts.Provider, accountID, poolKey string) {
 	if s.SchedulerRef != nil {
-		s.SchedulerRef.MarkExhausted(provider, accountID)
+		s.SchedulerRef.MarkExhausted(provider, accountID, poolKey)
 	}
 }
 
@@ -1958,7 +1958,7 @@ func (s Server) markAccountExhausted(provider accounts.Provider, accountID strin
 // cleared on a successful usage refresh, which the loaded usage endpoint kept
 // failing; failover then burned its attempts on genuinely-cooked accounts and
 // never reached the recovered one.
-func (s Server) markAccountExhaustedFromResponse(provider accounts.Provider, accountID string, status int, header http.Header) {
+func (s Server) markAccountExhaustedFromResponse(provider accounts.Provider, accountID, poolKey string, status int, header http.Header) {
 	if s.SchedulerRef == nil {
 		return
 	}
@@ -1968,10 +1968,10 @@ func (s Server) markAccountExhaustedFromResponse(provider accounts.Provider, acc
 		// self-heals on a schedule. A longer TTL avoids probing every few
 		// minutes while still picking the account back up within the hour
 		// after a re-auth or an org re-enable.
-		s.markAccountExhaustedCredential(provider, accountID)
+		s.markAccountExhaustedCredential(provider, accountID, "")
 		return
 	}
-	s.SchedulerRef.MarkExhaustedUntil(provider, accountID, claudeExhaustionExpiry(header, time.Now()))
+	s.SchedulerRef.MarkExhaustedUntil(provider, accountID, poolKey, claudeExhaustionExpiry(header, time.Now()))
 }
 
 // credentialExhaustionTTL is how long an account with a dead credential
@@ -1981,22 +1981,22 @@ func (s Server) markAccountExhaustedFromResponse(provider accounts.Provider, acc
 // successful usage refresh.
 const credentialExhaustionTTL = time.Hour
 
-func (s Server) markAccountExhaustedCredential(provider accounts.Provider, accountID string) {
+func (s Server) markAccountExhaustedCredential(provider accounts.Provider, accountID, poolKey string) {
 	if s.SchedulerRef == nil {
 		return
 	}
-	s.SchedulerRef.MarkExhaustedUntil(provider, accountID, time.Now().Add(credentialExhaustionTTL))
+	s.SchedulerRef.MarkExhaustedUntil(provider, accountID, "", time.Now().Add(credentialExhaustionTTL))
 }
 
 // markAccountExhaustedRefreshFailure picks the mark TTL by failure class: a
 // terminal credential error gets the long credential TTL, anything transient
 // gets the short default so the account rejoins quickly.
-func (s Server) markAccountExhaustedRefreshFailure(provider accounts.Provider, accountID string, err error) {
+func (s Server) markAccountExhaustedRefreshFailure(provider accounts.Provider, accountID, poolKey string, err error) {
 	if isTerminalCredentialError(err) {
-		s.markAccountExhaustedCredential(provider, accountID)
+		s.markAccountExhaustedCredential(provider, accountID, "")
 		return
 	}
-	s.markAccountExhausted(provider, accountID)
+	s.markAccountExhausted(provider, accountID, "")
 }
 
 // claudeExhaustionExpiry picks when an exhaustion mark should lapse:
@@ -2181,7 +2181,7 @@ func (s Server) recordReplayableRequestBody(r *http.Request, agentType, sessionI
 	s.Transcripts.RecordPayloadSummary(agentType, sessionID, "http_body", "client_to_upstream", streamID, bytesRead, hex.EncodeToString(hasher.Sum(nil)), chunks, nil)
 }
 
-func (s Server) captureResponseBody(response *http.Response, agentType, sessionID, accountID string, provider accounts.Provider, path string) {
+func (s Server) captureResponseBody(response *http.Response, agentType, sessionID, accountID string, provider accounts.Provider, poolModel, path string) {
 	// Anthropic signals subscription exhaustion with a plain 429 and a dead or
 	// expired OAuth token with a plain 401, neither with a codex-style
 	// usage-limit body to inspect. Both mean this account can't serve the
@@ -2198,7 +2198,7 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 		// the rejected header). A transient "allowed"/"allowed_warning" 429 still
 		// fails over for this request but must not mark a healthy account exhausted.
 		if claudeAccountExhaustedByResponse(response.StatusCode, response.Header) {
-			s.markAccountExhaustedFromResponse(provider, accountID, response.StatusCode, response.Header)
+			s.markAccountExhaustedFromResponse(provider, accountID, poolModel, response.StatusCode, response.Header)
 		}
 		// Surface the genuine upstream rate-limit signal (headers now, body
 		// prefix below). Anthropic conveys subscription exhaustion only via the
@@ -2244,7 +2244,7 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 				// Use the response's headers so a header-derived reset expiry set
 				// above is recomputed identically, not overwritten with the short
 				// default TTL.
-				s.markAccountExhaustedFromResponse(provider, accountID, response.StatusCode, response.Header)
+				s.markAccountExhaustedFromResponse(provider, accountID, poolModel, response.StatusCode, response.Header)
 			}
 			// Only log the body for the original hard rate-limit statuses
 			// (429/401), whose body is a known rate-limit/auth error envelope. A
@@ -2916,7 +2916,7 @@ func (s Server) refreshSelectedAccount(ctx context.Context, provider accounts.Pr
 		s.Logger.Warn("selected Claude account refresh failed, trying another account", "account", account.ID, "error", err)
 	}
 	tried := map[string]struct{}{account.ID: {}}
-	s.markAccountExhaustedRefreshFailure(provider, account.ID, err)
+	s.markAccountExhaustedRefreshFailure(provider, account.ID, "", err)
 	lastErr := err
 	for {
 		next, pickErr := s.retryAccount(ctx, provider, agentType, sessionID, userEmail, tried)
@@ -2929,7 +2929,7 @@ func (s Server) refreshSelectedAccount(ctx context.Context, provider accounts.Pr
 			return refreshed, nil
 		}
 		lastErr = err
-		s.markAccountExhaustedRefreshFailure(provider, next.ID, err)
+		s.markAccountExhaustedRefreshFailure(provider, next.ID, "", err)
 		if s.Logger != nil {
 			s.Logger.Warn("retry Claude account refresh failed", "account", next.ID, "error", err)
 		}
@@ -3397,7 +3397,7 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			// Use the response's own reset time so the mark self-expires when the
 			// window recovers (codex responses lack these headers and fall back
 			// to the default TTL inside claudeExhaustionExpiry).
-			t.server.markAccountExhaustedFromResponse(t.provider, accountID, response.StatusCode, response.Header)
+			t.server.markAccountExhaustedFromResponse(t.provider, accountID, selectacct.ModelKey(t.poolModel), response.StatusCode, response.Header)
 		}
 		if attempt == maxAttempts || t.server == nil {
 			reason := "max_attempts"
@@ -3630,7 +3630,7 @@ func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provide
 			if terminal {
 				// Credential TTL, not the short default: a dead token only heals
 				// via human re-auth, so frequent probes are pure overhead.
-				s.markAccountExhaustedCredential(provider, account.ID)
+				s.markAccountExhaustedCredential(provider, account.ID, "")
 			}
 			if s.Logger != nil {
 				s.Logger.Warn("usage-limit retry skipping OAuth account with failed refresh",

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -1071,7 +1071,7 @@ func TestUsageStatusEndpointFetchesUsageWithoutForcingFreshRefresh(t *testing.T)
 
 func TestUsageStatusEndpointIncludesClaudeRequestTimeExhaustion(t *testing.T) {
 	ref := selectacct.NewSchedulerRef(selectacct.NewScheduler(nil))
-	ref.MarkExhaustedUntil(accounts.ProviderClaude, "claude@example.com", time.Now().Add(2*time.Hour))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "claude@example.com", "", time.Now().Add(2*time.Hour))
 	handler := Server{
 		Accounts: []accounts.Account{{
 			ID:       "claude@example.com",
@@ -2732,7 +2732,7 @@ func TestHandlerReroutesActiveStickySessionWhenAssignedAccountExhausted(t *testi
 		t.Fatal("timed out waiting for first request to become active")
 	}
 
-	schedulerRef.MarkExhausted(accounts.ProviderCodex, "empty@example.com")
+	schedulerRef.MarkExhausted(accounts.ProviderCodex, "empty@example.com", "")
 
 	secondReq, err := http.NewRequest(http.MethodGet, subrouter.URL+"/backend-api/codex/analytics-events/events", nil)
 	if err != nil {

--- a/internal/selectacct/limits.go
+++ b/internal/selectacct/limits.go
@@ -21,13 +21,13 @@ type LimitWindow struct {
 // This is fully general: any additional rate limit the upstream reports becomes
 // its own pool, keyed by the limit name, with no per-model special cases.
 func ScoreFromLimitWindows(accountID string, sessions int, windows []LimitWindow) Score {
-	base := scoreFromLimitWindows(accountID, sessions, filterWindowsByModelKey(windows, ""))
+	base := scoreFromLimitWindows(accountID, sessions, filterWindowsByModelKey(windows, ""), "")
 	var modelScores map[string]Score
 	for _, key := range distinctModelKeys(windows) {
 		if modelScores == nil {
 			modelScores = make(map[string]Score)
 		}
-		modelScores[key] = scoreFromLimitWindows(accountID, sessions, filterWindowsByModelKey(windows, key))
+		modelScores[key] = scoreFromLimitWindows(accountID, sessions, filterWindowsByModelKey(windows, key), key)
 	}
 	base.ModelScores = modelScores
 	return base
@@ -86,10 +86,11 @@ func filterWindowsByModelKey(windows []LimitWindow, key string) []LimitWindow {
 	return filtered
 }
 
-func scoreFromLimitWindows(accountID string, sessions int, windows []LimitWindow) Score {
+func scoreFromLimitWindows(accountID string, sessions int, windows []LimitWindow, modelKey string) Score {
 	headroom := 1.0
 	shortHeadroom := 1.0
 	shortResetAfterSeconds := int64(0)
+	weeklyPressure := 0.0
 	hasShortWindow := false
 	for _, window := range windows {
 		remaining := 1 - clampPercent(window.UsedPercent)/100
@@ -103,16 +104,25 @@ func scoreFromLimitWindows(accountID string, sessions int, windows []LimitWindow
 				shortResetAfterSeconds = window.ResetAfterSeconds
 			}
 		}
+		if fableDrainPressureModelKey(modelKey) && isNonShortResettingWindow(window) {
+			if pressure := expiryPressure(remaining, window.ResetAfterSeconds); pressure > weeklyPressure {
+				weeklyPressure = pressure
+			}
+		}
 	}
 	if !hasShortWindow {
 		shortHeadroom = headroom
+	}
+	pressure := expiryPressure(headroom, shortResetAfterSeconds)
+	if fableDrainPressureModelKey(modelKey) {
+		pressure += weeklyPressure
 	}
 	return Score{
 		AccountID:              accountID,
 		Headroom:               headroom,
 		ShortHeadroom:          shortHeadroom,
 		ShortResetAfterSeconds: shortResetAfterSeconds,
-		ExpiryPressure:         expiryPressure(headroom, shortResetAfterSeconds),
+		ExpiryPressure:         pressure,
 		Sessions:               sessions,
 	}
 }
@@ -122,6 +132,17 @@ func isShortWindow(window LimitWindow) bool {
 		return window.LimitWindowSeconds <= 6*60*60
 	}
 	return false
+}
+
+func isNonShortResettingWindow(window LimitWindow) bool {
+	if window.LimitWindowSeconds <= 6*60*60 {
+		return false
+	}
+	return window.ResetAfterSeconds > 0
+}
+
+func fableDrainPressureModelKey(key string) bool {
+	return key == "claudefable"
 }
 
 func expiryPressure(headroom float64, resetAfterSeconds int64) float64 {

--- a/internal/selectacct/scheduler_ref.go
+++ b/internal/selectacct/scheduler_ref.go
@@ -1,6 +1,7 @@
 package selectacct
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -33,14 +34,16 @@ func NewSchedulerRef(scheduler Scheduler) *SchedulerRef {
 }
 
 func (r *SchedulerRef) Get() Scheduler {
-	r.pruneExpired(time.Now())
+	now := time.Now()
+	r.pruneExpired(now)
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.scheduler
+	return applyExhaustionMarks(r.scheduler, r.exhaustedUntil, now)
 }
 
-// pruneExpired drops exhaustion marks whose window has reset, restoring the
-// account to the optimistic default score so routing can try it again.
+// pruneExpired drops exhaustion marks whose window has reset. The base snapshot
+// is not mutated; once the overlay mark is gone, routing reads the snapshot (or
+// optimistic default) normally.
 //
 // Deliberate tradeoff: a lapsed mark cannot distinguish "recovered" from "fresh
 // usage re-confirmed exhausted" (refreshes seed zero scores forward, so the two
@@ -67,25 +70,21 @@ func (r *SchedulerRef) pruneExpired(now time.Time) {
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	next := Scheduler{scores: make(map[string]Score, len(r.scheduler.scores)), sessionCounts: r.scheduler.sessionCounts}
-	for key, score := range r.scheduler.scores {
-		next.scores[key] = score
-	}
 	for key, until := range r.exhaustedUntil {
 		if until.After(now) {
 			continue
 		}
 		delete(r.exhaustedUntil, key)
-		delete(next.scores, key)
 	}
-	r.scheduler = next
 }
 
 func (r *SchedulerRef) Set(scheduler Scheduler) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	base := r.scheduler
 	r.scheduler = scheduler
 	r.retainExhaustedExpiriesLocked()
+	r.scheduler = stripCarriedForwardExhaustionOverlays(r.scheduler, base, r.exhaustedUntil)
 	r.updatedAt = time.Now()
 }
 
@@ -105,7 +104,17 @@ func (r *SchedulerRef) Set(scheduler Scheduler) {
 func (r *SchedulerRef) retainExhaustedExpiriesLocked() {
 	now := time.Now()
 	for key := range r.exhaustedUntil {
-		score, ok := r.scheduler.scores[key]
+		scoreKey, _, poolKey, ok := exhaustionKeyParts(key)
+		if !ok {
+			delete(r.exhaustedUntil, key)
+			continue
+		}
+		score, ok := r.scheduler.scores[scoreKey]
+		if ok && poolKey != "" {
+			if modelScore, modelOK := score.ModelScores[poolKey]; modelOK {
+				score = modelScore
+			}
+		}
 		switch {
 		case !ok || !score.exhausted():
 			delete(r.exhaustedUntil, key)
@@ -132,40 +141,208 @@ func (r *SchedulerRef) retainExhaustedExpiriesLocked() {
 // real quota.
 const DefaultExhaustedTTL = 10 * time.Minute
 
-func (r *SchedulerRef) MarkExhausted(provider accounts.Provider, accountID string) {
-	r.MarkExhaustedUntil(provider, accountID, time.Now().Add(DefaultExhaustedTTL))
+func (r *SchedulerRef) MarkExhausted(provider accounts.Provider, accountID, poolKey string) {
+	r.MarkExhaustedUntil(provider, accountID, poolKey, time.Now().Add(DefaultExhaustedTTL))
 }
 
-// MarkExhaustedUntil zero-scores the account until the given time, after which
-// the mark expires and the account returns to the optimistic default so routing
-// tries it again. Callers pass the upstream's own reset time
+// MarkExhaustedUntil records an exhaustion overlay until the given time, after
+// which routing reads the base snapshot again. An empty poolKey marks the whole
+// account; a non-empty poolKey marks only that model pool. Callers pass the
+// upstream's own reset time
 // (anthropic-ratelimit-unified-reset / Retry-After) when available.
-func (r *SchedulerRef) MarkExhaustedUntil(provider accounts.Provider, accountID string, until time.Time) {
+func (r *SchedulerRef) MarkExhaustedUntil(provider accounts.Provider, accountID, poolKey string, until time.Time) {
 	if accountID == "" {
 		return
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.scheduler = r.scheduler.WithScore(Score{
-		AccountID:     accountID,
-		Provider:      provider,
-		Headroom:      0,
-		ShortHeadroom: 0,
-	})
 	if r.exhaustedUntil == nil {
 		r.exhaustedUntil = make(map[string]time.Time)
 	}
-	r.exhaustedUntil[ScoreKey(provider, accountID)] = until
+	r.exhaustedUntil[poolScopedExhaustionKey(provider, accountID, poolKey)] = until
 	r.updatedAt = time.Now()
 }
 
 // ExhaustedUntilFor reports the expiry recorded for an account's exhaustion
 // mark, if any. Used by tests and diagnostics to verify TTL selection.
-func (r *SchedulerRef) ExhaustedUntilFor(provider accounts.Provider, accountID string) (time.Time, bool) {
+func (r *SchedulerRef) ExhaustedUntilFor(provider accounts.Provider, accountID, poolKey string) (time.Time, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	until, ok := r.exhaustedUntil[ScoreKey(provider, accountID)]
+	until, ok := r.exhaustedUntil[poolScopedExhaustionKey(provider, accountID, poolKey)]
 	return until, ok
+}
+
+func poolScopedExhaustionKey(provider accounts.Provider, accountID, poolKey string) string {
+	return ScoreKey(provider, accountID) + "\x00" + ModelKey(poolKey)
+}
+
+func exhaustionKeyParts(key string) (scoreKey string, provider accounts.Provider, poolKey string, ok bool) {
+	parts := strings.SplitN(key, "\x00", 3)
+	if len(parts) != 3 {
+		return "", "", "", false
+	}
+	provider = accounts.Provider(parts[0])
+	return ScoreKey(provider, parts[1]), provider, parts[2], true
+}
+
+func applyExhaustionMarks(base Scheduler, exhaustedUntil map[string]time.Time, now time.Time) Scheduler {
+	if len(exhaustedUntil) == 0 {
+		return base
+	}
+	next := Scheduler{
+		scores:        make(map[string]Score, len(base.scores)),
+		sessionCounts: base.sessionCounts,
+		liveDebits:    base.liveDebits,
+	}
+	for key, score := range base.scores {
+		next.scores[key] = copyScore(score)
+	}
+	introducedPools := make(map[string]bool)
+	for key, until := range exhaustedUntil {
+		if !until.After(now) {
+			continue
+		}
+		_, _, poolKey, ok := exhaustionKeyParts(key)
+		if ok && poolKey != "" && !base.hasModelScore(poolKey) {
+			introducedPools[poolKey] = true
+		}
+	}
+	for poolKey := range introducedPools {
+		for scoreKey, score := range next.scores {
+			if _, ok := score.ModelScores[poolKey]; ok {
+				continue
+			}
+			score.ModelScores = copyModelScores(score.ModelScores)
+			if score.ModelScores == nil {
+				score.ModelScores = make(map[string]Score, 1)
+			}
+			poolScore := score
+			poolScore.ModelScores = nil
+			score.ModelScores[poolKey] = poolScore
+			next.scores[scoreKey] = score
+		}
+	}
+	accountWide := make(map[string]bool)
+	for key, until := range exhaustedUntil {
+		if !until.After(now) {
+			continue
+		}
+		scoreKey, provider, poolKey, ok := exhaustionKeyParts(key)
+		if !ok || poolKey != "" {
+			continue
+		}
+		score := next.scores[scoreKey]
+		if score.AccountID == "" {
+			_, accountID, _ := strings.Cut(scoreKey, "\x00")
+			score.AccountID = accountID
+		}
+		score.Provider = provider
+		score.Headroom = 0
+		score.ShortHeadroom = 0
+		score.ModelScores = nil
+		next.scores[scoreKey] = score
+		accountWide[scoreKey] = true
+	}
+	for key, until := range exhaustedUntil {
+		if !until.After(now) {
+			continue
+		}
+		scoreKey, provider, poolKey, ok := exhaustionKeyParts(key)
+		if !ok || poolKey == "" || accountWide[scoreKey] {
+			continue
+		}
+		score := next.scores[scoreKey]
+		if score.AccountID == "" {
+			_, accountID, _ := strings.Cut(scoreKey, "\x00")
+			score = Score{AccountID: accountID, Provider: provider, Headroom: 1, ShortHeadroom: 1}
+		}
+		score.Provider = provider
+		score.ModelScores = copyModelScores(score.ModelScores)
+		if score.ModelScores == nil {
+			score.ModelScores = make(map[string]Score, 1)
+		}
+		score.ModelScores[poolKey] = Score{AccountID: score.AccountID, Provider: provider, Headroom: 0, ShortHeadroom: 0}
+		next.scores[scoreKey] = score
+	}
+	return next
+}
+
+func copyScore(score Score) Score {
+	score.ModelScores = copyModelScores(score.ModelScores)
+	return score
+}
+
+func copyModelScores(modelScores map[string]Score) map[string]Score {
+	if len(modelScores) == 0 {
+		return nil
+	}
+	out := make(map[string]Score, len(modelScores))
+	for key, score := range modelScores {
+		out[key] = score
+	}
+	return out
+}
+
+func stripCarriedForwardExhaustionOverlays(current, base Scheduler, exhaustedUntil map[string]time.Time) Scheduler {
+	if len(exhaustedUntil) == 0 {
+		return current
+	}
+	next := Scheduler{
+		scores:        make(map[string]Score, len(current.scores)),
+		sessionCounts: current.sessionCounts,
+		liveDebits:    current.liveDebits,
+	}
+	for key, score := range current.scores {
+		next.scores[key] = copyScore(score)
+	}
+	for key := range exhaustedUntil {
+		scoreKey, _, poolKey, ok := exhaustionKeyParts(key)
+		if !ok {
+			continue
+		}
+		if poolKey != "" && !base.hasModelScore(poolKey) {
+			for candidateKey, candidate := range next.scores {
+				modelScore, modelOK := candidate.ModelScores[poolKey]
+				if !modelOK || modelScore.Fresh {
+					continue
+				}
+				candidate.ModelScores = copyModelScores(candidate.ModelScores)
+				delete(candidate.ModelScores, poolKey)
+				next.scores[candidateKey] = candidate
+			}
+		}
+		score, ok := next.scores[scoreKey]
+		if !ok {
+			continue
+		}
+		if poolKey == "" {
+			if !score.exhausted() || score.Fresh {
+				continue
+			}
+			if baseScore, baseOK := base.scores[scoreKey]; baseOK {
+				next.scores[scoreKey] = copyScore(baseScore)
+			} else {
+				delete(next.scores, scoreKey)
+			}
+			continue
+		}
+		modelScore, modelOK := score.ModelScores[poolKey]
+		if !modelOK || !modelScore.exhausted() || modelScore.Fresh {
+			continue
+		}
+		score.ModelScores = copyModelScores(score.ModelScores)
+		if baseScore, baseOK := base.scores[scoreKey]; baseOK {
+			if baseModelScore, baseModelOK := baseScore.ModelScores[poolKey]; baseModelOK {
+				score.ModelScores[poolKey] = baseModelScore
+			} else {
+				delete(score.ModelScores, poolKey)
+			}
+		} else {
+			delete(score.ModelScores, poolKey)
+		}
+		next.scores[scoreKey] = score
+	}
+	return next
 }
 
 func (r *SchedulerRef) Stale(ttl time.Duration) bool {
@@ -194,8 +371,10 @@ func (r *SchedulerRef) FinishRefresh(scheduler Scheduler, update bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if update {
+		base := r.scheduler
 		r.scheduler = scheduler
 		r.retainExhaustedExpiriesLocked()
+		r.scheduler = stripCarriedForwardExhaustionOverlays(r.scheduler, base, r.exhaustedUntil)
 		// Fresh scores supersede the live debits accumulated against the old
 		// snapshot. A failed refresh (update=false) keeps them: the snapshot
 		// is still the old one, so its debits still apply.

--- a/internal/selectacct/scheduler_ref_test.go
+++ b/internal/selectacct/scheduler_ref_test.go
@@ -47,8 +47,8 @@ func TestSchedulerRefRetryAfterSkippedRefreshWaitsForTTL(t *testing.T) {
 // account. A future mark holds.
 func TestMarkExhaustedUntilExpires(t *testing.T) {
 	ref := NewSchedulerRef(NewScheduler(nil))
-	ref.MarkExhaustedUntil(accounts.ProviderClaude, "recovered@example.com", time.Now().Add(-time.Second))
-	ref.MarkExhaustedUntil(accounts.ProviderClaude, "cooked@example.com", time.Now().Add(time.Hour))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "recovered@example.com", "", time.Now().Add(-time.Second))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "cooked@example.com", "", time.Now().Add(time.Hour))
 	s := ref.Get()
 	if s.Exhausted(accounts.ProviderClaude, "recovered@example.com") {
 		t.Fatal("expired mark must lapse: recovered account still exhausted")
@@ -58,11 +58,75 @@ func TestMarkExhaustedUntilExpires(t *testing.T) {
 	}
 }
 
+func TestMarkExhaustedUntilPoolScoped(t *testing.T) {
+	const (
+		fable = "claudefable"
+		opus  = "claudeopus"
+	)
+	ref := NewSchedulerRef(NewScheduler([]Score{{
+		AccountID:     "a@example.com",
+		Provider:      accounts.ProviderClaude,
+		Headroom:      1,
+		ShortHeadroom: 1,
+		ModelScores: map[string]Score{
+			fable: {AccountID: "a@example.com", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+			opus:  {AccountID: "a@example.com", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+		},
+	}}))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "a@example.com", fable, time.Now().Add(time.Hour))
+
+	s := ref.Get()
+	if !s.ForModel(fable).Exhausted(accounts.ProviderClaude, "a@example.com") {
+		t.Fatal("fable pool mark should exhaust fable")
+	}
+	if s.ForModel(opus).Exhausted(accounts.ProviderClaude, "a@example.com") {
+		t.Fatal("fable pool mark should not exhaust opus")
+	}
+	if s.Exhausted(accounts.ProviderClaude, "a@example.com") {
+		t.Fatal("fable pool mark should not exhaust the base account score")
+	}
+}
+
+func TestMarkExhaustedUntilAccountWideStillExhaustsEveryPool(t *testing.T) {
+	const fable = "claudefable"
+	ref := NewSchedulerRef(NewScheduler([]Score{{
+		AccountID:     "a@example.com",
+		Provider:      accounts.ProviderClaude,
+		Headroom:      1,
+		ShortHeadroom: 1,
+		ModelScores: map[string]Score{
+			fable: {AccountID: "a@example.com", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+		},
+	}}))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "a@example.com", "", time.Now().Add(time.Hour))
+
+	s := ref.Get()
+	if !s.Exhausted(accounts.ProviderClaude, "a@example.com") {
+		t.Fatal("account-wide mark should exhaust the base score")
+	}
+	if !s.ForModel(fable).Exhausted(accounts.ProviderClaude, "a@example.com") {
+		t.Fatal("account-wide mark should exhaust model pools")
+	}
+}
+
+func TestMarkExhaustedUntilPoolMarkExpires(t *testing.T) {
+	const fable = "claudefable"
+	ref := NewSchedulerRef(NewScheduler(nil))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "a@example.com", fable, time.Now().Add(-time.Second))
+
+	if ref.Get().ForModel(fable).Exhausted(accounts.ProviderClaude, "a@example.com") {
+		t.Fatal("expired pool mark should allow an optimistic retry")
+	}
+	if _, ok := ref.ExhaustedUntilFor(accounts.ProviderClaude, "a@example.com", fable); ok {
+		t.Fatal("expired pool mark should be pruned")
+	}
+}
+
 // TestSetClearsExhaustedUntil: a full refresh supersedes request-time marks; a
 // later prune must not delete refreshed scores.
 func TestSetClearsExhaustedUntil(t *testing.T) {
 	ref := NewSchedulerRef(NewScheduler(nil))
-	ref.MarkExhaustedUntil(accounts.ProviderClaude, "a@example.com", time.Now().Add(-time.Second))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "a@example.com", "", time.Now().Add(-time.Second))
 	ref.Set(NewScheduler([]Score{{AccountID: "a@example.com", Provider: accounts.ProviderClaude, Headroom: 0.02, ShortHeadroom: 0.02}}))
 	s := ref.Get()
 	if got := s.ScoreFor(accounts.ProviderClaude, "a@example.com").Headroom; got != 0.02 {
@@ -76,7 +140,7 @@ func TestSetClearsExhaustedUntil(t *testing.T) {
 // and the recovered account stays unroutable.
 func TestPartialRefreshKeepsMarkExpiry(t *testing.T) {
 	ref := NewSchedulerRef(NewScheduler(nil))
-	ref.MarkExhaustedUntil(accounts.ProviderClaude, "recovered@example.com", time.Now().Add(-time.Second))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "recovered@example.com", "", time.Now().Add(-time.Second))
 	// Partial refresh: another account got fresh data, but recovered@'s zero
 	// score is seeded/carried forward unchanged.
 	ref.FinishRefresh(NewScheduler([]Score{
@@ -87,7 +151,7 @@ func TestPartialRefreshKeepsMarkExpiry(t *testing.T) {
 		t.Fatal("carried-forward zero score must keep its expiry; recovered account still exhausted after lapse")
 	}
 	// But a refresh that genuinely supersedes the mark (headroom) drops the expiry.
-	ref.MarkExhaustedUntil(accounts.ProviderClaude, "busy@example.com", time.Now().Add(-time.Second))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "busy@example.com", "", time.Now().Add(-time.Second))
 	ref.FinishRefresh(NewScheduler([]Score{
 		{AccountID: "busy@example.com", Provider: accounts.ProviderClaude, Headroom: 0.05, ShortHeadroom: 0.05},
 	}), true)
@@ -102,12 +166,12 @@ func TestPartialRefreshKeepsMarkExpiry(t *testing.T) {
 // the cost of guessing wrong is bounded at one attempt per expiry window.
 func TestLapsedMarkRemarksOnNextReject(t *testing.T) {
 	ref := NewSchedulerRef(NewScheduler(nil))
-	ref.MarkExhaustedUntil(accounts.ProviderClaude, "cooked@example.com", time.Now().Add(-time.Second))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "cooked@example.com", "", time.Now().Add(-time.Second))
 	if ref.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
 		t.Fatal("lapsed mark should allow one optimistic probe")
 	}
 	// The probe's rejected response re-marks with the new upstream reset.
-	ref.MarkExhaustedUntil(accounts.ProviderClaude, "cooked@example.com", time.Now().Add(2*time.Hour))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "cooked@example.com", "", time.Now().Add(2*time.Hour))
 	if !ref.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
 		t.Fatal("re-mark after the probe's reject must hold until the new reset")
 	}
@@ -120,12 +184,12 @@ func TestLapsedMarkRemarksOnNextReject(t *testing.T) {
 func TestFreshZeroReanchorsExpiry(t *testing.T) {
 	ref := NewSchedulerRef(NewScheduler(nil))
 	// Old request-time mark about to lapse.
-	ref.MarkExhaustedUntil(accounts.ProviderClaude, "confirmed@example.com", time.Now().Add(time.Millisecond))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "confirmed@example.com", "", time.Now().Add(time.Millisecond))
 	// Fresh refresh re-confirms exhaustion with a 2h window reset.
 	ref.FinishRefresh(NewScheduler([]Score{
 		{AccountID: "confirmed@example.com", Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0, ShortResetAfterSeconds: 7200, Fresh: true},
 	}), true)
-	until, ok := ref.ExhaustedUntilFor(accounts.ProviderClaude, "confirmed@example.com")
+	until, ok := ref.ExhaustedUntilFor(accounts.ProviderClaude, "confirmed@example.com", "")
 	if !ok || time.Until(until) < 90*time.Minute {
 		t.Fatalf("fresh zero should re-anchor expiry to its reset (~2h), got %v (in %v)", until, time.Until(until))
 	}
@@ -136,12 +200,90 @@ func TestFreshZeroReanchorsExpiry(t *testing.T) {
 	// A fresh zero must never SHORTEN a longer authoritative expiry.
 	ref2 := NewSchedulerRef(NewScheduler(nil))
 	long := time.Now().Add(72 * time.Hour)
-	ref2.MarkExhaustedUntil(accounts.ProviderClaude, "weekly@example.com", long)
+	ref2.MarkExhaustedUntil(accounts.ProviderClaude, "weekly@example.com", "", long)
 	ref2.FinishRefresh(NewScheduler([]Score{
 		{AccountID: "weekly@example.com", Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0, ShortResetAfterSeconds: 3600, Fresh: true},
 	}), true)
-	got, _ := ref2.ExhaustedUntilFor(accounts.ProviderClaude, "weekly@example.com")
+	got, _ := ref2.ExhaustedUntilFor(accounts.ProviderClaude, "weekly@example.com", "")
 	if !got.Equal(long) {
 		t.Fatalf("fresh zero shortened authoritative expiry: got %v want %v", got, long)
+	}
+}
+
+func TestPoolScopedFreshZeroReanchorsExpiry(t *testing.T) {
+	const fable = "claudefable"
+	ref := NewSchedulerRef(NewScheduler(nil))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "confirmed@example.com", fable, time.Now().Add(time.Millisecond))
+	ref.FinishRefresh(NewScheduler([]Score{{
+		AccountID:     "confirmed@example.com",
+		Provider:      accounts.ProviderClaude,
+		Headroom:      1,
+		ShortHeadroom: 1,
+		ModelScores: map[string]Score{
+			fable: {
+				AccountID:              "confirmed@example.com",
+				Provider:               accounts.ProviderClaude,
+				Headroom:               0,
+				ShortHeadroom:          0,
+				ShortResetAfterSeconds: 7200,
+				Fresh:                  true,
+			},
+		},
+	}}), true)
+
+	until, ok := ref.ExhaustedUntilFor(accounts.ProviderClaude, "confirmed@example.com", fable)
+	if !ok || time.Until(until) < 90*time.Minute {
+		t.Fatalf("fresh pool zero should re-anchor expiry to its reset (~2h), got %v (in %v)", until, time.Until(until))
+	}
+	if !ref.Get().ForModel(fable).Exhausted(accounts.ProviderClaude, "confirmed@example.com") {
+		t.Fatal("freshly-confirmed exhausted pool must stay exhausted")
+	}
+}
+
+func TestPoolScopedRecoveredRefreshDropsExpiry(t *testing.T) {
+	const fable = "claudefable"
+	ref := NewSchedulerRef(NewScheduler(nil))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "recovered@example.com", fable, time.Now().Add(time.Hour))
+	ref.FinishRefresh(NewScheduler([]Score{{
+		AccountID:     "recovered@example.com",
+		Provider:      accounts.ProviderClaude,
+		Headroom:      1,
+		ShortHeadroom: 1,
+		ModelScores: map[string]Score{
+			fable: {AccountID: "recovered@example.com", Provider: accounts.ProviderClaude, Headroom: 0.8, ShortHeadroom: 0.8, Fresh: true},
+		},
+	}}), true)
+
+	if _, ok := ref.ExhaustedUntilFor(accounts.ProviderClaude, "recovered@example.com", fable); ok {
+		t.Fatal("fresh recovered pool score should drop the pool mark")
+	}
+	if ref.Get().ForModel(fable).Exhausted(accounts.ProviderClaude, "recovered@example.com") {
+		t.Fatal("fresh recovered pool score should be routable")
+	}
+}
+
+func TestPoolScopedRetainLeavesOtherPoolMark(t *testing.T) {
+	const (
+		fable = "claudefable"
+		opus  = "claudeopus"
+	)
+	ref := NewSchedulerRef(NewScheduler(nil))
+	ref.MarkExhaustedUntil(accounts.ProviderClaude, "a@example.com", opus, time.Now().Add(time.Hour))
+	ref.FinishRefresh(NewScheduler([]Score{{
+		AccountID:     "a@example.com",
+		Provider:      accounts.ProviderClaude,
+		Headroom:      1,
+		ShortHeadroom: 1,
+		ModelScores: map[string]Score{
+			fable: {AccountID: "a@example.com", Provider: accounts.ProviderClaude, Headroom: 0.8, ShortHeadroom: 0.8, Fresh: true},
+			opus:  {AccountID: "a@example.com", Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0},
+		},
+	}}), true)
+
+	if _, ok := ref.ExhaustedUntilFor(accounts.ProviderClaude, "a@example.com", opus); !ok {
+		t.Fatal("fable refresh should not clear a carried-forward opus mark")
+	}
+	if !ref.Get().ForModel(opus).Exhausted(accounts.ProviderClaude, "a@example.com") {
+		t.Fatal("opus mark should still apply after fable refresh")
 	}
 }

--- a/internal/selectacct/scheduler_test.go
+++ b/internal/selectacct/scheduler_test.go
@@ -287,6 +287,56 @@ func TestLiveDebitsSurviveForModelAndSessionCounts(t *testing.T) {
 	}
 }
 
+func TestFablePickPrefersSoonerWeeklyReset(t *testing.T) {
+	const fable = "claudefable"
+	soon := ScoreFromLimitWindows("soon@example.com", 0, []LimitWindow{
+		{Name: "5h", Feature: fable, UsedPercent: 10, LimitWindowSeconds: 5 * 60 * 60, ResetAfterSeconds: 5 * 60 * 60},
+		{Name: "oauth-apps-weekly", Feature: fable, UsedPercent: 10, LimitWindowSeconds: 7 * 24 * 60 * 60, ResetAfterSeconds: 2 * 60 * 60},
+	})
+	soon.Provider = accounts.ProviderClaude
+	later := ScoreFromLimitWindows("later@example.com", 0, []LimitWindow{
+		{Name: "5h", Feature: fable, UsedPercent: 10, LimitWindowSeconds: 5 * 60 * 60, ResetAfterSeconds: 5 * 60 * 60},
+		{Name: "oauth-apps-weekly", Feature: fable, UsedPercent: 10, LimitWindowSeconds: 7 * 24 * 60 * 60, ResetAfterSeconds: 5 * 24 * 60 * 60},
+	})
+	later.Provider = accounts.ProviderClaude
+	scheduler := NewScheduler([]Score{later, soon}).ForModel(fable)
+	picked, err := scheduler.Pick([]accounts.Account{
+		{ID: "later@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "x"},
+		{ID: "soon@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "x"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if picked.ID != "soon@example.com" {
+		t.Fatalf("picked %q, want sooner-resetting fable account", picked.ID)
+	}
+}
+
+func TestOpusPickIgnoresWeeklyDrainPressure(t *testing.T) {
+	const opus = "claudeopus"
+	soon := ScoreFromLimitWindows("soon@example.com", 0, []LimitWindow{
+		{Name: "5h", Feature: opus, UsedPercent: 10, LimitWindowSeconds: 5 * 60 * 60, ResetAfterSeconds: 5 * 60 * 60},
+		{Name: "opus-weekly", Feature: opus, UsedPercent: 10, LimitWindowSeconds: 7 * 24 * 60 * 60, ResetAfterSeconds: 2 * 60 * 60},
+	})
+	soon.Provider = accounts.ProviderClaude
+	later := ScoreFromLimitWindows("later@example.com", 0, []LimitWindow{
+		{Name: "5h", Feature: opus, UsedPercent: 10, LimitWindowSeconds: 5 * 60 * 60, ResetAfterSeconds: 5 * 60 * 60},
+		{Name: "opus-weekly", Feature: opus, UsedPercent: 10, LimitWindowSeconds: 7 * 24 * 60 * 60, ResetAfterSeconds: 5 * 24 * 60 * 60},
+	})
+	later.Provider = accounts.ProviderClaude
+	scheduler := NewScheduler([]Score{later, soon}).ForModel(opus)
+	picked, err := scheduler.Pick([]accounts.Account{
+		{ID: "later@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "x"},
+		{ID: "soon@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "x"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if picked.ID != "later@example.com" {
+		t.Fatalf("picked %q, want ordinary headroom/tie ordering unchanged for opus", picked.ID)
+	}
+}
+
 func TestSchedulerRefLiveDebitLifecycle(t *testing.T) {
 	ref := NewSchedulerRef(NewScheduler(nil))
 	ref.NoteRouted(accounts.ProviderClaude, "a")


### PR DESCRIPTION
## Problem
"Subrouter out of subs → not routing to Bedrock" was really a per-pool routing defect. Fable **is** falling back to Bedrock (live `bedrock-cost.jsonl`), but Bedrock is throttling hard, and separately, an account whose **Fable** quota is exhausted was being skipped for **Opus/Sonnet** even though its Opus/Sonnet weekly quota was intact.

Root cause: request-time exhaustion marks were **account-wide**. `SchedulerRef.MarkExhaustedUntil` zeroed the whole `Score` (wiping `ModelScores`), keyed by account only. A Fable 429/rejection — including a bare `anthropic-ratelimit-unified-status: rejected` with no per-window headers, and websocket/body usage-limit signals — cooked the entire account. The usage-**refresh** scoring was already per-pool; the mark was the sole account-wide chokepoint.

## Change
**Part 1 — pool-scoped exhaustion marks (overlay-applied).**
- `exhaustedUntil` keyed by `(account, pool)`; `MarkExhausted[Until]` take a `poolKey`.
- Marks applied as a read-time overlay in `Get()` (`applyExhaustionMarks`) so the base snapshot is never mutated and the careful expiry/refresh reconciliation survives. Pool marks zero only that pool's `ModelScore` (introducing the pool across accounts when absent so `ForModel` narrows); account-wide marks (`poolKey==""`) zero the whole account as before.
- `pruneExpired` just drops lapsed marks; `retain`/`strip` reconcile against a refresh by evidence class (fresh zero re-anchors, recovered drops, carried-forward zero restores from base), per pool.
- Threaded the request pool into the response / retry-transport / websocket / body markers. **Credential (401/403) and refresh-failure marks stay account-wide** (a dead credential kills every pool).

**Part 2 — drain Fable subscription before paid Bedrock.**
- The `claudefable` pool's `ExpiryPressure` now also reflects its **weekly** (non-short) window's reset urgency, so `Pick` prefers Fable-pool accounts whose weekly quota resets soonest (use-it-or-lose-it). Base/Opus/Sonnet scoring and the tuned velocity constants (`LiveDebitPerRequest`, `VelocityProjectionMinutes`) are unchanged.

## Tests
New behavior-level tests, all green (`go test ./...`), incl. the exact user scenario:
- `TestClaudeBareRejectedFableMarksOnlyFablePool` — a bare Fable 429 marks only the fable pool; the account is still `Pick`-able for Opus.
- `TestMarkExhaustedUntilPoolScoped`, `…AccountWideStillExhaustsEveryPool`, `…PoolMarkExpires`.
- `TestPoolScopedFreshZeroReanchorsExpiry`, `…RecoveredRefreshDropsExpiry`, `…RetainLeavesOtherPoolMark` (refresh reconciliation safety: genuinely-cooked accounts stay out, recovered ones return).
- `TestFablePickPrefersSoonerWeeklyReset`, `TestOpusPickIgnoresWeeklyDrainPressure`.

## Not included
Bedrock/model routing is untouched — Fable-only-on-Bedrock stays; Opus never falls back to Bedrock (out of Opus quota → 503, by design). Deploying to `subrouter-team` is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785896318&installation_id=133855650&pr_number=60&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F60&signature=1eca27fd8ff6fa4be5c4c34a680f93a244735005ba8a35bc11e58c79f391d9e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope Claude exhaustion to model pools so a Fable 429 no longer blocks Opus/Sonnet, and prioritize draining Fable’s weekly quota before falling back to paid Bedrock.

- **Bug Fixes**
  - Exhaustion marks are now keyed by `(account, pool)` and applied as a read-time overlay in `SchedulerRef.Get()`.
  - Only the marked pool is zeroed; empty pool marks still zero the whole account. Credential/auth and refresh-failure marks remain account-wide.
  - Threaded the pool key through HTTP retries, WebSocket, and body-inspect paths.

- **New Features**
  - The `claudefable` pool’s `ExpiryPressure` now includes weekly window reset urgency.
  - `Pick` prefers Fable accounts that reset sooner; other pools’ scoring is unchanged.

<sup>Written for commit da3e554e26cada9be4fb9679430ddef2315a1c40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

