### PR TITLE
Bedrock: rotate InvokeModel across multiple regions to raise Fable TPM

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -178,7 +178,7 @@ func serve(args []string) error {
 	maxBodyBytes := flags.Int64("max-body-bytes", 1<<20, "max JSON request body bytes to inspect for session IDs")
 	fetchUsage := flags.Bool("fetch-usage", true, "fetch Codex usage on startup for account selection")
 	bedrockEnable := flags.Bool("bedrock", false, "enable the /bedrock/* AWS SigV4 signing gateway for Claude Code Bedrock mode")
-	bedrockRegion := flags.String("bedrock-region", "us-east-1", "AWS region for the Bedrock signing gateway")
+	bedrockRegion := flags.String("bedrock-region", "us-east-1", "comma-separated AWS regions for the Bedrock signing gateway")
 	bedrockGatewayToken := flags.String("bedrock-gateway-token", "", "optional bearer token clients must present to the Bedrock gateway; defaults to SUBROUTER_BEDROCK_GATEWAY_TOKEN")
 	bedrockProfiles := flags.String("bedrock-profiles", "", "comma-separated AWS profiles for the Bedrock gateway; defaults to SUBROUTER_BEDROCK_PROFILES or discovered awN profiles")
 	bedrockAutoBump := flags.Bool("bedrock-autobump", false, "request a Service Quotas increase (2x, deduped) when Bedrock throttles Fable/Opus")
@@ -265,8 +265,12 @@ func serve(args []string) error {
 		if token == "" {
 			token = strings.TrimSpace(os.Getenv("SUBROUTER_BEDROCK_GATEWAY_TOKEN"))
 		}
+		regions := parseBedrockRegions(*bedrockRegion)
+		if len(regions) == 0 {
+			return errors.New("bedrock: no AWS regions configured")
+		}
 		profileNames := bedrockAWSProfileNames(*bedrockProfiles)
-		awsCfg, sources, err := loadBedrockAWSSources(context.Background(), *bedrockRegion, profileNames, *bedrockAutoBump)
+		awsCfg, sources, err := loadBedrockAWSSources(context.Background(), regions[0], profileNames, *bedrockAutoBump)
 		if err != nil {
 			return fmt.Errorf("bedrock: load AWS config: %w", err)
 		}
@@ -274,7 +278,7 @@ func serve(args []string) error {
 			return errors.New("bedrock: no AWS credentials available")
 		}
 		bedrockConfig = &proxy.BedrockConfig{
-			Region:       *bedrockRegion,
+			Regions:      regions,
 			Sources:      sources,
 			GatewayToken: token,
 			Transport:    outboundTransport,
@@ -283,7 +287,7 @@ func serve(args []string) error {
 		if *bedrockAutoBump {
 			bedrockConfig.Bumper = proxy.NewBedrockQuotaBumper(awsCfg, slog.Default())
 		}
-		slog.Info("bedrock gateway enabled", "region", *bedrockRegion, "auth", token != "", "autobump", *bedrockAutoBump, "profiles", strings.Join(bedrockSourceNames(sources), ","))
+		slog.Info("bedrock gateway enabled", "regions", strings.Join(regions, ","), "auth", token != "", "autobump", *bedrockAutoBump, "profiles", strings.Join(bedrockSourceNames(sources), ","))
 	}
 
 	initialAccounts := append([]accounts.Account(nil), codexAccounts...)
@@ -412,6 +416,20 @@ func bedrockAWSProfileNames(flagValue string) []string {
 		return profiles
 	}
 	return discoverBedrockAWSProfiles(awsSharedConfigPaths())
+}
+
+func parseBedrockRegions(raw string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, part := range strings.Split(raw, ",") {
+		region := strings.TrimSpace(part)
+		if region == "" || seen[region] {
+			continue
+		}
+		seen[region] = true
+		out = append(out, region)
+	}
+	return out
 }
 
 func splitProfileList(raw string) []string {

--- a/cmd/subrouter/sr_claude_aws_test.go
+++ b/cmd/subrouter/sr_claude_aws_test.go
@@ -71,3 +71,12 @@ func TestBedrockAWSProfileNames(t *testing.T) {
 		t.Fatalf("explicit profiles = %q, want aw2,aw1", got)
 	}
 }
+
+func TestParseBedrockRegions(t *testing.T) {
+	if got := strings.Join(parseBedrockRegions(" us-east-1,us-west-2,, us-east-1,us-east-2 "), ","); got != "us-east-1,us-west-2,us-east-2" {
+		t.Fatalf("regions = %q, want us-east-1,us-west-2,us-east-2", got)
+	}
+	if got := parseBedrockRegions(" , "); len(got) != 0 {
+		t.Fatalf("empty regions = %v, want none", got)
+	}
+}

--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -24,7 +24,10 @@ import (
 // forwarded to bedrock-runtime, so clients (e.g. Claude Code in Bedrock gateway
 // mode with CLAUDE_CODE_SKIP_BEDROCK_AUTH=1) never need AWS credentials.
 type BedrockConfig struct {
-	Region      string
+	// Regions is the ordered set of Bedrock runtime regions to try. List only
+	// regions where the target inference profile has model access and TPM quota;
+	// Bedrock 4xx model-access failures are terminal and are not retried.
+	Regions     []string
 	Credentials aws.CredentialsProvider
 	Sources     []BedrockCredentialSource
 	// GatewayToken, when non-empty, must be presented by clients via the
@@ -37,8 +40,8 @@ type BedrockConfig struct {
 	CostLogPath string
 	// Bumper, when set, requests a Service Quotas increase when Bedrock throttles
 	// (HTTP 429), deduped per quota with a cooldown.
-	Bumper     *bedrockQuotaBumper
-	nextSource atomic.Uint64
+	Bumper      *bedrockQuotaBumper
+	nextAttempt atomic.Uint64
 }
 
 type BedrockCredentialSource struct {
@@ -48,6 +51,11 @@ type BedrockCredentialSource struct {
 }
 
 const bedrockService = "bedrock"
+
+type bedrockAttempt struct {
+	Region string
+	Source BedrockCredentialSource
+}
 
 func (s Server) bedrockHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -79,7 +87,7 @@ func (s Server) bedrockHandler() http.Handler {
 		headers := http.Header{}
 		copyBedrockRequestHeaders(headers, r.Header)
 		started := time.Now()
-		resp, sourceName, err := s.signAndForwardBedrockWithHeaders(r.Context(), r.Method, upstreamPath, r.URL.RawQuery, headers, body)
+		resp, sourceName, region, err := s.signAndForwardBedrockWithHeaders(r.Context(), r.Method, upstreamPath, r.URL.RawQuery, headers, body)
 		if err != nil {
 			if s.Logger != nil {
 				s.Logger.Error("bedrock upstream request failed", "path", upstreamPath, "remote_addr", clientRemoteIP(r), "user_agent", r.UserAgent(), "error", err)
@@ -102,15 +110,16 @@ func (s Server) bedrockHandler() http.Handler {
 		model := bedrockModelFromPath(upstreamPath)
 		if resp.StatusCode == http.StatusTooManyRequests {
 			if s.Logger != nil {
-				s.Logger.Warn("bedrock throttled", "model", model, "path", upstreamPath, "remote_addr", clientRemoteIP(r), "user_agent", r.UserAgent(), "bedrock_source", sourceName)
+				s.Logger.Warn("bedrock throttled", "model", model, "path", upstreamPath, "remote_addr", clientRemoteIP(r), "user_agent", r.UserAgent(), "bedrock_source", sourceName, "region", region)
 			}
-			cfg.onThrottle(sourceName, model)
+			cfg.onThrottle(sourceName, region, model)
 		}
 		usage, haveUsage := s.streamBedrockResponse(w, resp)
 		if cfg.CostLogPath != "" && model != "" {
 			record := bedrockCostRecord{
 				Timestamp:  started.UTC().Format(time.RFC3339),
 				Model:      model,
+				Region:     region,
 				Status:     resp.StatusCode,
 				DurationMs: time.Since(started).Milliseconds(),
 			}
@@ -159,15 +168,15 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 	}
 	path := "/model/" + bedrockFableModelID + "/" + endpoint
 	started := time.Now()
-	resp, sourceName, err := s.signAndForwardBedrock(ctx, http.MethodPost, path, newBody)
+	resp, sourceName, region, err := s.signAndForwardBedrock(ctx, http.MethodPost, path, newBody)
 	if err != nil {
 		return nil, err
 	}
 	if resp.StatusCode == http.StatusTooManyRequests {
 		if s.Logger != nil {
-			s.Logger.Warn("bedrock throttled", "model", bedrockFableModelID, "path", path, "bedrock_source", sourceName)
+			s.Logger.Warn("bedrock throttled", "model", bedrockFableModelID, "path", path, "bedrock_source", sourceName, "region", region)
 		}
-		cfg.onThrottle(sourceName, bedrockFableModelID)
+		cfg.onThrottle(sourceName, region, bedrockFableModelID)
 	}
 
 	if stream && resp.StatusCode == http.StatusOK {
@@ -176,7 +185,7 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 			usage, haveUsage := transcodeBedrockToSSE(pw, resp.Body)
 			_ = resp.Body.Close()
 			_ = pw.Close()
-			s.recordClaudeFableBedrockCost(started, http.StatusOK, usage, haveUsage)
+			s.recordClaudeFableBedrockCost(started, region, http.StatusOK, usage, haveUsage)
 		}()
 		return &http.Response{
 			Status:        "200 OK",
@@ -200,10 +209,10 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 		if len(preview) > 512 {
 			preview = preview[:512]
 		}
-		s.Logger.Warn("claude-fable bedrock error response", "status", resp.StatusCode, "bedrock_source", sourceName, "body", string(preview))
+		s.Logger.Warn("claude-fable bedrock error response", "status", resp.StatusCode, "bedrock_source", sourceName, "region", region, "body", string(preview))
 	}
 	usage, haveUsage := parseBedrockInvokeUsage(respBody)
-	s.recordClaudeFableBedrockCost(started, resp.StatusCode, usage, haveUsage)
+	s.recordClaudeFableBedrockCost(started, region, resp.StatusCode, usage, haveUsage)
 	return &http.Response{
 		Status:        resp.Status,
 		StatusCode:    resp.StatusCode,
@@ -216,7 +225,7 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 	}, nil
 }
 
-func (s Server) recordClaudeFableBedrockCost(started time.Time, status int, usage bedrockUsage, haveUsage bool) {
+func (s Server) recordClaudeFableBedrockCost(started time.Time, region string, status int, usage bedrockUsage, haveUsage bool) {
 	cfg := s.Bedrock
 	if cfg == nil || cfg.CostLogPath == "" {
 		return
@@ -224,6 +233,7 @@ func (s Server) recordClaudeFableBedrockCost(started time.Time, status int, usag
 	record := bedrockCostRecord{
 		Timestamp:  started.UTC().Format(time.RFC3339),
 		Model:      bedrockFableModelID,
+		Region:     region,
 		Status:     status,
 		DurationMs: time.Since(started).Milliseconds(),
 	}
@@ -236,23 +246,23 @@ func (s Server) recordClaudeFableBedrockCost(started time.Time, status int, usag
 
 // signAndForwardBedrock SigV4-signs a JSON body to bedrock-runtime and returns
 // the raw response plus the Bedrock source name that handled it.
-func (s Server) signAndForwardBedrock(ctx context.Context, method, upstreamPath string, body []byte) (*http.Response, string, error) {
+func (s Server) signAndForwardBedrock(ctx context.Context, method, upstreamPath string, body []byte) (*http.Response, string, string, error) {
 	headers := http.Header{"Content-Type": []string{"application/json"}}
 	return s.signAndForwardBedrockWithHeaders(ctx, method, upstreamPath, "", headers, body)
 }
 
-func (s Server) signAndForwardBedrockWithHeaders(ctx context.Context, method, upstreamPath, rawQuery string, headers http.Header, body []byte) (*http.Response, string, error) {
+func (s Server) signAndForwardBedrockWithHeaders(ctx context.Context, method, upstreamPath, rawQuery string, headers http.Header, body []byte) (*http.Response, string, string, error) {
 	cfg := s.Bedrock
-	sources := cfg.orderedSources()
+	attempts := cfg.orderedAttempts()
 	var firstErr error
-	for i, source := range sources {
-		resp, err := s.signAndForwardBedrockWithSource(ctx, source, method, upstreamPath, rawQuery, headers, body)
+	for i, attempt := range attempts {
+		resp, err := s.signAndForwardBedrockWithSource(ctx, attempt.Source, attempt.Region, method, upstreamPath, rawQuery, headers, body)
 		if err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
 			if s.Logger != nil {
-				s.Logger.Warn("bedrock source failed", "bedrock_source", source.Name, "path", upstreamPath, "error", err)
+				s.Logger.Warn("bedrock source failed", "bedrock_source", attempt.Source.Name, "region", attempt.Region, "path", upstreamPath, "error", err)
 			}
 			continue
 		}
@@ -260,27 +270,27 @@ func (s Server) signAndForwardBedrockWithHeaders(ctx context.Context, method, up
 		// TPM) or a Bedrock-side 5xx (e.g. 503 "Bedrock is unable to process
 		// your request"): both are specific to this source's account/endpoint
 		// and another source may serve the request fine.
-		if (resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500) && i+1 < len(sources) {
+		if (resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500) && i+1 < len(attempts) {
 			if s.Logger != nil {
-				s.Logger.Warn("bedrock source unusable, retrying next source", "bedrock_source", source.Name, "path", upstreamPath, "status", resp.StatusCode)
+				s.Logger.Warn("bedrock source unusable, retrying next source", "bedrock_source", attempt.Source.Name, "region", attempt.Region, "path", upstreamPath, "status", resp.StatusCode)
 			}
 			if resp.StatusCode == http.StatusTooManyRequests {
-				cfg.onThrottle(source.Name, bedrockModelFromPath(upstreamPath))
+				cfg.onThrottle(attempt.Source.Name, attempt.Region, bedrockModelFromPath(upstreamPath))
 			}
 			resp.Body.Close()
 			continue
 		}
-		return resp, source.Name, nil
+		return resp, attempt.Source.Name, attempt.Region, nil
 	}
 	if firstErr != nil {
-		return nil, "", firstErr
+		return nil, "", "", firstErr
 	}
-	return nil, "", io.ErrUnexpectedEOF
+	return nil, "", "", io.ErrUnexpectedEOF
 }
 
-func (s Server) signAndForwardBedrockWithSource(ctx context.Context, source BedrockCredentialSource, method, upstreamPath, rawQuery string, headers http.Header, body []byte) (*http.Response, error) {
+func (s Server) signAndForwardBedrockWithSource(ctx context.Context, source BedrockCredentialSource, region, method, upstreamPath, rawQuery string, headers http.Header, body []byte) (*http.Response, error) {
 	cfg := s.Bedrock
-	host := "bedrock-runtime." + cfg.Region + ".amazonaws.com"
+	host := "bedrock-runtime." + region + ".amazonaws.com"
 	target := &url.URL{Scheme: "https", Host: host, Path: upstreamPath, RawQuery: rawQuery}
 	outReq, err := http.NewRequestWithContext(ctx, method, target.String(), bytes.NewReader(body))
 	if err != nil {
@@ -300,7 +310,7 @@ func (s Server) signAndForwardBedrockWithSource(ctx context.Context, source Bedr
 	if err != nil {
 		return nil, err
 	}
-	if err := v4.NewSigner().SignHTTP(ctx, creds, outReq, sha256Hex(body), bedrockService, cfg.Region, time.Now()); err != nil {
+	if err := v4.NewSigner().SignHTTP(ctx, creds, outReq, sha256Hex(body), bedrockService, region, time.Now()); err != nil {
 		return nil, err
 	}
 	transport := cfg.Transport
@@ -314,7 +324,26 @@ func (s Server) signAndForwardBedrockWithSource(ctx context.Context, source Bedr
 }
 
 func (cfg *BedrockConfig) configured() bool {
-	return strings.TrimSpace(cfg.Region) != "" && len(cfg.sources()) > 0
+	return len(cfg.regions()) > 0 && len(cfg.sources()) > 0
+}
+
+func (cfg *BedrockConfig) primaryRegion() string {
+	if len(cfg.Regions) == 0 {
+		return ""
+	}
+	return cfg.Regions[0]
+}
+
+func (cfg *BedrockConfig) regions() []string {
+	var out []string
+	for _, region := range cfg.Regions {
+		region = strings.TrimSpace(region)
+		if region == "" {
+			continue
+		}
+		out = append(out, region)
+	}
+	return out
 }
 
 func (cfg *BedrockConfig) sources() []BedrockCredentialSource {
@@ -335,30 +364,40 @@ func (cfg *BedrockConfig) sources() []BedrockCredentialSource {
 	return out
 }
 
-func (cfg *BedrockConfig) orderedSources() []BedrockCredentialSource {
+func (cfg *BedrockConfig) orderedAttempts() []bedrockAttempt {
+	regions := cfg.regions()
 	sources := cfg.sources()
-	if len(sources) <= 1 {
-		return sources
+	if len(regions) == 0 || len(sources) == 0 {
+		return nil
 	}
-	start := int(cfg.nextSource.Add(1)-1) % len(sources)
-	ordered := make([]BedrockCredentialSource, 0, len(sources))
-	ordered = append(ordered, sources[start:]...)
-	ordered = append(ordered, sources[:start]...)
+	attempts := make([]bedrockAttempt, 0, len(regions)*len(sources))
+	for _, region := range regions {
+		for _, source := range sources {
+			attempts = append(attempts, bedrockAttempt{Region: region, Source: source})
+		}
+	}
+	if len(attempts) <= 1 {
+		return attempts
+	}
+	start := int(cfg.nextAttempt.Add(1)-1) % len(attempts)
+	ordered := make([]bedrockAttempt, 0, len(attempts))
+	ordered = append(ordered, attempts[start:]...)
+	ordered = append(ordered, attempts[:start]...)
 	return ordered
 }
 
-func (cfg *BedrockConfig) onThrottle(sourceName, model string) {
+func (cfg *BedrockConfig) onThrottle(sourceName, region, model string) {
 	if model == "" {
 		return
 	}
 	for _, source := range cfg.Sources {
 		if source.Name == sourceName && source.Bumper != nil {
-			go source.Bumper.onThrottle(model)
+			go source.Bumper.onThrottle(region, model)
 			return
 		}
 	}
 	if cfg.Bumper != nil {
-		go cfg.Bumper.onThrottle(model)
+		go cfg.Bumper.onThrottle(region, model)
 	}
 }
 

--- a/internal/proxy/bedrock_autobump.go
+++ b/internal/proxy/bedrock_autobump.go
@@ -18,7 +18,8 @@ type serviceQuotasAPI interface {
 }
 
 // bedrockTPMQuotaByModel maps a model substring to its adjustable per-minute
-// token quota code for the us. cross-region inference profiles (us-east-1).
+// token quota code for the us. cross-region inference profiles. These Service
+// Quotas codes are the same in every region.
 var bedrockTPMQuotaByModel = map[string]string{
 	"fable": "L-9B258944", // Cross-region model inference tokens per minute for Claude Fable 5
 	"opus":  "L-DB99DCDB", // Cross-region model inference tokens per minute for Claude Opus 4.8
@@ -29,6 +30,8 @@ var bedrockTPMQuotaByModel = map[string]string{
 // cooldown so sustained throttling never spams AWS with requests.
 type bedrockQuotaBumper struct {
 	client   serviceQuotasAPI
+	cfg      aws.Config
+	clients  map[string]serviceQuotasAPI
 	logger   *slog.Logger
 	cooldown time.Duration
 	maxValue float64
@@ -40,7 +43,8 @@ type bedrockQuotaBumper struct {
 // NewBedrockQuotaBumper builds a quota bumper that reacts to Bedrock throttling.
 func NewBedrockQuotaBumper(cfg aws.Config, logger *slog.Logger) *bedrockQuotaBumper {
 	return &bedrockQuotaBumper{
-		client:   servicequotas.NewFromConfig(cfg),
+		cfg:      cfg,
+		clients:  map[string]serviceQuotasAPI{},
 		logger:   logger,
 		cooldown: 6 * time.Hour,
 		maxValue: 20_000_000, // don't auto-request beyond 20M TPM
@@ -60,33 +64,46 @@ func bedrockQuotaCodeForModel(model string) (string, bool) {
 
 // onThrottle is invoked (in a goroutine) when Bedrock returns a throttling
 // response. It requests a quota increase for the model's TPM quota, subject to
-// the per-quota cooldown.
-func (b *bedrockQuotaBumper) onThrottle(model string) {
-	if b == nil || b.client == nil {
+// the per-region, per-quota cooldown.
+func (b *bedrockQuotaBumper) onThrottle(region, model string) {
+	if b == nil {
+		return
+	}
+	region = strings.TrimSpace(region)
+	if region == "" {
 		return
 	}
 	code, ok := bedrockQuotaCodeForModel(model)
 	if !ok {
 		return
 	}
+	cooldownKey := region + "\x00" + code
 	b.mu.Lock()
-	if last, seen := b.last[code]; seen && time.Since(last) < b.cooldown {
+	if b.last == nil {
+		b.last = map[string]time.Time{}
+	}
+	if last, seen := b.last[cooldownKey]; seen && time.Since(last) < b.cooldown {
 		b.mu.Unlock()
 		return
 	}
-	b.last[code] = time.Now()
+	b.last[cooldownKey] = time.Now()
 	b.mu.Unlock()
+
+	client := b.clientForRegion(region)
+	if client == nil {
+		return
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	cur, err := b.client.GetServiceQuota(ctx, &servicequotas.GetServiceQuotaInput{
+	cur, err := client.GetServiceQuota(ctx, &servicequotas.GetServiceQuotaInput{
 		ServiceCode: aws.String("bedrock"),
 		QuotaCode:   aws.String(code),
 	})
 	if err != nil || cur.Quota == nil || cur.Quota.Value == nil {
 		if b.logger != nil {
-			b.logger.Warn("bedrock autobump: get quota failed", "model", model, "quota", code, "error", err)
+			b.logger.Warn("bedrock autobump: get quota failed", "model", model, "region", region, "quota", code, "error", err)
 		}
 		return
 	}
@@ -97,18 +114,18 @@ func (b *bedrockQuotaBumper) onThrottle(model string) {
 	}
 	if desired <= current {
 		if b.logger != nil {
-			b.logger.Warn("bedrock autobump: already at cap, not requesting", "model", model, "quota", code, "current", current, "cap", b.maxValue)
+			b.logger.Warn("bedrock autobump: already at cap, not requesting", "model", model, "region", region, "quota", code, "current", current, "cap", b.maxValue)
 		}
 		return
 	}
-	out, err := b.client.RequestServiceQuotaIncrease(ctx, &servicequotas.RequestServiceQuotaIncreaseInput{
+	out, err := client.RequestServiceQuotaIncrease(ctx, &servicequotas.RequestServiceQuotaIncreaseInput{
 		ServiceCode:  aws.String("bedrock"),
 		QuotaCode:    aws.String(code),
 		DesiredValue: aws.Float64(desired),
 	})
 	if err != nil {
 		if b.logger != nil {
-			b.logger.Warn("bedrock autobump: request increase failed", "model", model, "quota", code, "current", current, "desired", desired, "error", err)
+			b.logger.Warn("bedrock autobump: request increase failed", "model", model, "region", region, "quota", code, "current", current, "desired", desired, "error", err)
 		}
 		return
 	}
@@ -118,6 +135,25 @@ func (b *bedrockQuotaBumper) onThrottle(model string) {
 			id = *out.RequestedQuota.Id
 		}
 		b.logger.Warn("bedrock autobump: requested quota increase after throttle",
-			"model", model, "quota", code, "current", current, "desired", desired, "request_id", id)
+			"model", model, "region", region, "quota", code, "current", current, "desired", desired, "request_id", id)
 	}
+}
+
+func (b *bedrockQuotaBumper) clientForRegion(region string) serviceQuotasAPI {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.client != nil {
+		return b.client
+	}
+	if b.clients == nil {
+		b.clients = map[string]serviceQuotasAPI{}
+	}
+	if client := b.clients[region]; client != nil {
+		return client
+	}
+	client := servicequotas.NewFromConfig(b.cfg, func(o *servicequotas.Options) {
+		o.Region = region
+	})
+	b.clients[region] = client
+	return client
 }

--- a/internal/proxy/bedrock_autobump_test.go
+++ b/internal/proxy/bedrock_autobump_test.go
@@ -38,7 +38,7 @@ func TestBumperDoublesAndDedupes(t *testing.T) {
 	mock := &mockServiceQuotas{current: 200_000}
 	b := newTestBumper(mock)
 
-	b.onThrottle("us.anthropic.claude-fable-5")
+	b.onThrottle("us-east-1", "us.anthropic.claude-fable-5")
 	if len(mock.requests) != 1 {
 		t.Fatalf("expected 1 request, got %d", len(mock.requests))
 	}
@@ -50,7 +50,7 @@ func TestBumperDoublesAndDedupes(t *testing.T) {
 	}
 
 	// Second throttle within cooldown must not re-request.
-	b.onThrottle("us.anthropic.claude-fable-5")
+	b.onThrottle("us-east-1", "us.anthropic.claude-fable-5")
 	if len(mock.requests) != 1 {
 		t.Fatalf("cooldown breached: %d requests", len(mock.requests))
 	}
@@ -59,7 +59,7 @@ func TestBumperDoublesAndDedupes(t *testing.T) {
 func TestBumperCapsAtMax(t *testing.T) {
 	mock := &mockServiceQuotas{current: 15_000_000}
 	b := newTestBumper(mock)
-	b.onThrottle("opus")
+	b.onThrottle("us-east-1", "opus")
 	if len(mock.requests) != 1 || mock.requests[0] != 20_000_000 {
 		t.Fatalf("expected capped request 20000000, got %v", mock.requests)
 	}
@@ -68,8 +68,40 @@ func TestBumperCapsAtMax(t *testing.T) {
 func TestBumperIgnoresUnknownModel(t *testing.T) {
 	mock := &mockServiceQuotas{current: 200_000}
 	b := newTestBumper(mock)
-	b.onThrottle("us.anthropic.claude-sonnet-5")
+	b.onThrottle("us-east-1", "us.anthropic.claude-sonnet-5")
 	if len(mock.requests) != 0 {
 		t.Fatalf("unknown model should not request; got %v", mock.requests)
+	}
+}
+
+func TestBumperUsesRegionClientAndDedupesPerRegion(t *testing.T) {
+	east := &mockServiceQuotas{current: 200_000}
+	west := &mockServiceQuotas{current: 300_000}
+	b := &bedrockQuotaBumper{
+		clients: map[string]serviceQuotasAPI{
+			"us-east-1": east,
+			"us-west-2": west,
+		},
+		cooldown: time.Hour,
+		maxValue: 20_000_000,
+		last:     map[string]time.Time{},
+	}
+
+	b.onThrottle("us-west-2", "us.anthropic.claude-fable-5")
+	if len(west.requests) != 1 || west.requests[0] != 600_000 {
+		t.Fatalf("west requests = %v, want one 600000 request", west.requests)
+	}
+	if len(east.requests) != 0 {
+		t.Fatalf("east should not be used for west throttle; got %v", east.requests)
+	}
+
+	b.onThrottle("us-west-2", "us.anthropic.claude-fable-5")
+	if len(west.requests) != 1 {
+		t.Fatalf("west cooldown breached: %d requests", len(west.requests))
+	}
+
+	b.onThrottle("us-east-1", "us.anthropic.claude-fable-5")
+	if len(east.requests) != 1 || east.requests[0] != 400_000 {
+		t.Fatalf("east requests = %v, want one 400000 request", east.requests)
 	}
 }

--- a/internal/proxy/bedrock_cost.go
+++ b/internal/proxy/bedrock_cost.go
@@ -62,6 +62,7 @@ func (u bedrockUsage) costUSD(model string) float64 {
 type bedrockCostRecord struct {
 	Timestamp  string       `json:"timestamp"`
 	Model      string       `json:"model"`
+	Region     string       `json:"region,omitempty"`
 	Status     int          `json:"status"`
 	Usage      bedrockUsage `json:"usage"`
 	CostUSD    float64      `json:"cost_usd_estimate"`

--- a/internal/proxy/bedrock_test.go
+++ b/internal/proxy/bedrock_test.go
@@ -42,7 +42,7 @@ func TestBedrockHandlerSignsAndForwards(t *testing.T) {
 			Header:     http.Header{"Content-Type": []string{"application/json"}},
 		}, nil
 	})
-	s := Server{Bedrock: &BedrockConfig{Region: "us-east-1", Credentials: staticBedrockCreds(), Transport: rt}}
+	s := Server{Bedrock: &BedrockConfig{Regions: []string{"us-east-1"}, Credentials: staticBedrockCreds(), Transport: rt}}
 	h := s.bedrockHandler()
 
 	req := httptest.NewRequest(http.MethodPost, "/bedrock/model/us.anthropic.claude-fable-5/invoke", strings.NewReader(`{"anthropic_version":"bedrock-2023-05-31"}`))
@@ -87,7 +87,7 @@ func TestBedrockHandlerRequiresGatewayToken(t *testing.T) {
 		forwarded = true
 		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader("ok"))}, nil
 	})
-	s := Server{Bedrock: &BedrockConfig{Region: "us-east-1", Credentials: staticBedrockCreds(), Transport: rt, GatewayToken: "secret-token"}}
+	s := Server{Bedrock: &BedrockConfig{Regions: []string{"us-east-1"}, Credentials: staticBedrockCreds(), Transport: rt, GatewayToken: "secret-token"}}
 	h := s.bedrockHandler()
 
 	// Missing token -> 401, never forwarded.
@@ -136,7 +136,7 @@ func TestBedrockHandlerRetriesNextSourceOnThrottle(t *testing.T) {
 		}
 	})
 	s := Server{Bedrock: &BedrockConfig{
-		Region: "us-east-1",
+		Regions: []string{"us-east-1"},
 		Sources: []BedrockCredentialSource{
 			{Name: "aw0", Credentials: namedBedrockCreds("AKIAONE")},
 			{Name: "aw1", Credentials: namedBedrockCreds("AKIATWO")},
@@ -159,6 +159,120 @@ func TestBedrockHandlerRetriesNextSourceOnThrottle(t *testing.T) {
 	}
 }
 
+func TestBedrockHandlerRetriesNextRegionOnThrottle(t *testing.T) {
+	var attempts []*http.Request
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts = append(attempts, req)
+		switch req.Host {
+		case "bedrock-runtime.us-east-1.amazonaws.com":
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"throttled"}`)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case "bedrock-runtime.us-west-2.amazonaws.com":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected host: %s", req.Host)
+			return nil, nil
+		}
+	})
+	s := Server{Bedrock: &BedrockConfig{
+		Regions:   []string{"us-east-1", "us-west-2"},
+		Sources:   []BedrockCredentialSource{{Name: "aw0", Credentials: staticBedrockCreds()}},
+		Transport: rt,
+	}}
+
+	req := httptest.NewRequest(http.MethodPost, "/bedrock/model/us.anthropic.claude-fable-5/invoke", strings.NewReader(`{"anthropic_version":"bedrock-2023-05-31"}`))
+	rec := httptest.NewRecorder()
+	s.bedrockHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+	if len(attempts) != 2 {
+		t.Fatalf("attempts = %d, want 2", len(attempts))
+	}
+	second := attempts[1]
+	if second.Host != "bedrock-runtime.us-west-2.amazonaws.com" {
+		t.Fatalf("second Host = %q, want us-west-2 Bedrock runtime", second.Host)
+	}
+	if got := second.URL.String(); got != "https://bedrock-runtime.us-west-2.amazonaws.com/model/us.anthropic.claude-fable-5/invoke" {
+		t.Fatalf("second URL = %q", got)
+	}
+	if auth := second.Header.Get("Authorization"); !strings.Contains(auth, "/us-west-2/bedrock/aws4_request") {
+		t.Fatalf("Authorization scope missing bedrock/us-west-2: %q", auth)
+	}
+}
+
+func TestBedrockHandlerRoundRobinStartsAcrossRegionSourcePairs(t *testing.T) {
+	var starts []string
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		auth := req.Header.Get("Authorization")
+		accessKey := ""
+		switch {
+		case strings.Contains(auth, "Credential=AKIAONE/"):
+			accessKey = "AKIAONE"
+		case strings.Contains(auth, "Credential=AKIATWO/"):
+			accessKey = "AKIATWO"
+		default:
+			t.Fatalf("unexpected Authorization header: %q", auth)
+		}
+		starts = append(starts, req.Host+"/"+accessKey)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+	s := Server{Bedrock: &BedrockConfig{
+		Regions: []string{"us-east-1", "us-west-2"},
+		Sources: []BedrockCredentialSource{
+			{Name: "aw0", Credentials: namedBedrockCreds("AKIAONE")},
+			{Name: "aw1", Credentials: namedBedrockCreds("AKIATWO")},
+		},
+		Transport: rt,
+	}}
+
+	for i := 0; i < 4; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/bedrock/model/us.anthropic.claude-fable-5/invoke", strings.NewReader(`{"anthropic_version":"bedrock-2023-05-31"}`))
+		rec := httptest.NewRecorder()
+		s.bedrockHandler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d status = %d, want 200 (body %q)", i, rec.Code, rec.Body.String())
+		}
+	}
+
+	want := strings.Join([]string{
+		"bedrock-runtime.us-east-1.amazonaws.com/AKIAONE",
+		"bedrock-runtime.us-east-1.amazonaws.com/AKIATWO",
+		"bedrock-runtime.us-west-2.amazonaws.com/AKIAONE",
+		"bedrock-runtime.us-west-2.amazonaws.com/AKIATWO",
+	}, ",")
+	if got := strings.Join(starts, ","); got != want {
+		t.Fatalf("start order = %s, want %s", got, want)
+	}
+}
+
+func TestBedrockConfigConfiguredRequiresRegionsAndSources(t *testing.T) {
+	if !(&BedrockConfig{Regions: []string{"us-east-1"}, Credentials: staticBedrockCreds()}).configured() {
+		t.Fatal("expected config with region and credentials to be configured")
+	}
+	if (&BedrockConfig{Credentials: staticBedrockCreds()}).configured() {
+		t.Fatal("config without regions should not be configured")
+	}
+	if (&BedrockConfig{Regions: []string{"us-east-1"}}).configured() {
+		t.Fatal("config without sources should not be configured")
+	}
+	if got := (&BedrockConfig{Regions: []string{"us-west-2"}, Credentials: staticBedrockCreds()}).primaryRegion(); got != "us-west-2" {
+		t.Fatalf("primaryRegion = %q, want us-west-2", got)
+	}
+}
+
 func TestBedrockHandlerLogsClientAttributionOnThrottle(t *testing.T) {
 	var logBuf bytes.Buffer
 	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -171,7 +285,7 @@ func TestBedrockHandlerLogsClientAttributionOnThrottle(t *testing.T) {
 	s := Server{
 		Logger: slog.New(slog.NewTextHandler(&logBuf, nil)),
 		Bedrock: &BedrockConfig{
-			Region:    "us-east-1",
+			Regions:   []string{"us-east-1"},
 			Sources:   []BedrockCredentialSource{{Name: "aw0", Credentials: namedBedrockCreds("AKIAONE")}},
 			Transport: rt,
 		},
@@ -225,7 +339,7 @@ func TestBedrockHandlerRetriesNextSourceOn5xx(t *testing.T) {
 		}
 	})
 	s := Server{Bedrock: &BedrockConfig{
-		Region: "us-east-1",
+		Regions: []string{"us-east-1"},
 		Sources: []BedrockCredentialSource{
 			{Name: "aw0", Credentials: namedBedrockCreds("AKIAONE")},
 			{Name: "aw1", Credentials: namedBedrockCreds("AKIATWO")},

--- a/internal/proxy/claude_fable_test.go
+++ b/internal/proxy/claude_fable_test.go
@@ -117,7 +117,7 @@ func TestClaudeFableFallbackPrefersBedrockOverAPIKey(t *testing.T) {
 		ClaudeFableAPIKey: "sk-ant-fable-key",
 		Transport:         apiRT,
 		Bedrock: &BedrockConfig{
-			Region:    "us-east-1",
+			Regions:   []string{"us-east-1"},
 			Sources:   []BedrockCredentialSource{{Name: "aw0", Credentials: staticBedrockCreds()}},
 			Transport: bedrockRT,
 		},
@@ -161,7 +161,7 @@ func TestClaudeFableFallbackBedrockUnusableFallsToAPIKey(t *testing.T) {
 			ClaudeFableAPIKey: "sk-ant-fable-key",
 			Transport:         apiRT,
 			Bedrock: &BedrockConfig{
-				Region:    "us-east-1",
+				Regions:   []string{"us-east-1"},
 				Sources:   []BedrockCredentialSource{{Name: "aw0", Credentials: staticBedrockCreds()}},
 				Transport: bedrockRT,
 			},
@@ -196,7 +196,7 @@ func TestClaudeFableFallbackBedrockTransportErrorFallsToAPIKey(t *testing.T) {
 		ClaudeFableAPIKey: "sk-ant-fable-key",
 		Transport:         apiRT,
 		Bedrock: &BedrockConfig{
-			Region:    "us-east-1",
+			Regions:   []string{"us-east-1"},
 			Sources:   []BedrockCredentialSource{{Name: "aw0", Credentials: staticBedrockCreds()}},
 			Transport: bedrockRT,
 		},
@@ -222,7 +222,7 @@ func TestClaudeFableFallbackBedrock429WithoutAPIKeyReturnsBedrockResponse(t *tes
 	})
 	s := Server{
 		Bedrock: &BedrockConfig{
-			Region:    "us-east-1",
+			Regions:   []string{"us-east-1"},
 			Sources:   []BedrockCredentialSource{{Name: "aw0", Credentials: staticBedrockCreds()}},
 			Transport: bedrockRT,
 		},
@@ -247,7 +247,7 @@ func TestServeClaudeFableFallbackUsesBedrockSources(t *testing.T) {
 		}, nil
 	})
 	s := Server{Bedrock: &BedrockConfig{
-		Region:    "us-east-1",
+		Regions:   []string{"us-east-1"},
 		Sources:   []BedrockCredentialSource{{Name: "aw0", Credentials: staticBedrockCreds()}},
 		Transport: rt,
 	}}
@@ -278,7 +278,7 @@ func TestClaudeFableBedrockResponseStreamsSSE(t *testing.T) {
 		}, nil
 	})
 	s := Server{Bedrock: &BedrockConfig{
-		Region:    "us-east-1",
+		Regions:   []string{"us-east-1"},
 		Sources:   []BedrockCredentialSource{{Name: "aw0", Credentials: staticBedrockCreds()}},
 		Transport: rt,
 	}}
@@ -323,7 +323,7 @@ func TestUsageLimitRetryTransportClaudeFableFallsBackAfterPoolExhausted(t *testi
 		}, nil
 	})
 	server.Bedrock = &BedrockConfig{
-		Region:    "us-east-1",
+		Regions:   []string{"us-east-1"},
 		Sources:   []BedrockCredentialSource{{Name: "aw0", Credentials: staticBedrockCreds()}},
 		Transport: bedrockRT,
 	}
@@ -387,7 +387,7 @@ func TestUsageLimitRetryTransportClaudeFableFallbackSuppressesExhaustedLog(t *te
 		}, nil
 	})
 	server.Bedrock = &BedrockConfig{
-		Region:    "us-east-1",
+		Regions:   []string{"us-east-1"},
 		Sources:   []BedrockCredentialSource{{Name: "aw0", Credentials: staticBedrockCreds()}},
 		Transport: bedrockRT,
 	}
@@ -520,7 +520,7 @@ func TestClaudeFableBedrockStripsUnsupportedFields(t *testing.T) {
 		}, nil
 	})
 	s := Server{Bedrock: &BedrockConfig{
-		Region:    "us-east-1",
+		Regions:   []string{"us-east-1"},
 		Sources:   []BedrockCredentialSource{{Name: "aw0", Credentials: staticBedrockCreds()}},
 		Transport: rt,
 	}}


### PR DESCRIPTION
## Why
"Subrouter out of subs → not routing to Bedrock properly" is a Bedrock **throughput** problem, not a routing bug. The Fable fallback signs every request to a single region (`--bedrock-region`, default `us-east-1`), so aggregate InvokeModel throughput is capped at one region's per-account TPM. Live: the last ~200 Bedrock calls were **~86% 429**. Throttled requests spill to the dedicated Anthropic API key (whose org is currently out of credits → "Credit balance too low"). Autobump only requests increases in `us-east-1` (6h cooldown) and AWS grants lag demand.

`us.anthropic.*` cross-region inference profiles are invokable from `us-east-1`/`us-east-2`/`us-west-2`, each a **separate per-region TPM bucket** — usable immediately, no new AWS accounts, no waiting on Service Quotas grants.

## What
- `--bedrock-region` accepts a **comma-separated list** (trim/dedupe). `BedrockConfig.Region` → `Regions []string` with `primaryRegion()`/`regions()`.
- Rotation walks the `regions × sources` cross-product (`orderedAttempts`) with a round-robin start, retrying **only on 429/5xx** (unchanged trigger). Each attempt signs to **its own region** — endpoint host and SigV4 scope both use the attempt's region, so there's no cross-region scope mismatch.
- Throttle/error logs and `bedrock-cost.jsonl` carry the region (optional field).
- Autobump is region-aware: `onThrottle(region, model)` caches a Service Quotas client per region and dedupes the cooldown by `(region, quotaCode)`.

**Default is unchanged.** `--bedrock-region` still defaults to `us-east-1`; a single region collapses to one attempt = byte-identical to today. Multi-region is opt-in.

## Tests (all green; `go test ./...`)
- `TestBedrockHandlerRetriesNextRegionOnThrottle` — first region 429 → second attempt hits `bedrock-runtime.us-west-2.amazonaws.com` and its `Authorization` scope is `/us-west-2/bedrock/aws4_request` (proves per-region SigV4 signing).
- `TestBedrockHandlerRoundRobinStartsAcrossRegionSourcePairs`, single-region back-compat, `configured()`, region parsing, and region-aware autobump (`onThrottle("us-west-2", …)` targets the us-west-2 quota client, deduped per `(region, code)`).

## Operator action to enable after merge/deploy
Set e.g. `--bedrock-region us-east-1,us-east-2,us-west-2` **and** enable Claude model access + TPM quota in each added region (a region lacking access returns a terminal 4xx that is not retried, so list only enabled regions).

## Not included
Adding AWS accounts (`--bedrock-profiles`), refilling the API-key credits, and PR #60 (per-pool exhaustion). Model selection / fable-only-on-Bedrock / Opus routing unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785898465&installation_id=133855650&pr_number=61&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F61&signature=619a4bfa0fc46272004ec23e3dd0aa3a59dbf982f15ad8f4d89b0bfefec74015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add multi-region rotation for Bedrock InvokeModel to raise effective TPM and cut 429s. Default remains single-region `us-east-1`; multi-region is opt-in.

- **New Features**
  - `--bedrock-region` now accepts a comma-separated list (whitespace-trimmed, deduped).
  - Requests rotate across the `regions × sources` pairs with a round‑robin start.
  - Retries move to the next pair only on 429/5xx; each attempt signs to its own region (host and SigV4 scope).
  - Throttle/error logs and cost records include the region.
  - Autobump is region-aware: per‑region Service Quotas client and cooldown keyed by `(region, quota)`.

- **Migration**
  - To enable: set `--bedrock-region us-east-1,us-east-2,us-west-2`.
  - Ensure Claude model access and TPM quota in every listed region.
  - Regions without access return a terminal 4xx and are not retried.

<sup>Written for commit 148d5ab42baa4fbe131a5c235ba92a4bb8f013ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

