### PR TITLE
worker: quota-aware tenant health and reframed credit-exhaustion errors

### DIFF
--- a/cloudflare/packages/worker/src/index.ts
+++ b/cloudflare/packages/worker/src/index.ts
@@ -106,10 +106,17 @@ interface TenantAccountOutput {
   readonly created_at: string
   readonly email?: string
   readonly validation?: "ok" | "failed"
+  readonly health: AccountHealthOutput
 }
 
 type UpstreamProvider = "claude" | "codex"
 type WaitUntil = (promise: Promise<unknown>) => void
+
+interface AccountHealthOutput {
+  readonly ok: boolean
+  readonly lastQuotaErrorAt?: string
+  readonly message?: string
+}
 
 const anthropicBootstrapModelQuotas: AccountModelQuotas = {
   opus: { remainingPercent: 100 },
@@ -136,6 +143,9 @@ interface StoredAccount extends Account {
   readonly createdAt: number
   readonly updatedAt: number
   readonly source?: string
+  readonly lastQuotaErrorAt?: number
+  readonly lastQuotaErrorCode?: string
+  readonly consecutiveQuotaErrors?: number
 }
 
 interface RouteOutput {
@@ -185,6 +195,14 @@ interface AccountRow {
   readonly totp_algorithm: string | null
   readonly created_at: number
   readonly updated_at: number
+  readonly last_quota_error_at: number | null
+  readonly last_quota_error_code: string | null
+  readonly consecutive_quota_errors: number | null
+}
+
+interface TableInfoRow {
+  readonly [key: string]: SqlStorageValue
+  readonly name: string
 }
 
 interface OAuthRefreshStatus {
@@ -593,6 +611,16 @@ const safeTenantAccount = (
     created_at: new Date(account.createdAt).toISOString(),
     ...(safe.email ? { email: safe.email } : {}),
     ...(validation ? { validation } : {}),
+    health: accountHealth(account),
+  }
+}
+
+const accountHealth = (account: StoredAccount): AccountHealthOutput => {
+  if (!account.lastQuotaErrorAt) return { ok: true }
+  return {
+    ok: false,
+    lastQuotaErrorAt: new Date(account.lastQuotaErrorAt).toISOString(),
+    message: "Upstream reported quota exhaustion for this shared tenant account.",
   }
 }
 
@@ -808,6 +836,15 @@ const rowToAccount = (row: AccountRow): StoredAccount => ({
   createdAt: row.created_at,
   updatedAt: row.updated_at,
   source: "durable-object",
+  ...(row.last_quota_error_at !== null
+    ? { lastQuotaErrorAt: row.last_quota_error_at }
+    : {}),
+  ...(row.last_quota_error_code !== null
+    ? { lastQuotaErrorCode: row.last_quota_error_code }
+    : {}),
+  ...(row.consecutive_quota_errors !== null
+    ? { consecutiveQuotaErrors: row.consecutive_quota_errors }
+    : {}),
 })
 
 const quotaRowsToRecord = (
@@ -1444,6 +1481,7 @@ export class SubrouterDurableObject extends DurableObject<Env> {
       INSERT OR IGNORE INTO subrouter_status(id) VALUES (1);
       INSERT OR IGNORE INTO lifecycle(id, started_at) VALUES (1, ${Date.now()});
     `)
+    this.ensureAccountHealthColumns()
 
     this.ctx.blockConcurrencyWhile(async () => {
       await this.scheduleNextRefreshAlarm()
@@ -1678,9 +1716,13 @@ export class SubrouterDurableObject extends DurableObject<Env> {
     }
   }
 
-  async ready(): Promise<{ ok: boolean; draining: boolean }> {
+  async ready(): Promise<{ ok: boolean; draining: boolean; accountsDegraded: number }> {
     const draining = this.isDraining()
-    return { ok: !draining, draining }
+    return {
+      ok: !draining,
+      draining,
+      accountsDegraded: this.accountsDegradedCount(this.ctx.storage.sql),
+    }
   }
 
   async drain(): Promise<{ ok: true; draining: true }> {
@@ -1917,6 +1959,52 @@ export class SubrouterDurableObject extends DurableObject<Env> {
     }
   }
 
+  async recordAccountQuotaError(input: {
+    readonly orgId?: string
+    readonly accountId: string
+    readonly code: string
+  }): Promise<{ ok: true }> {
+    const orgId = this.resolveOrgId(input.orgId)
+    const accountId = this.requireNonEmpty(input.accountId, "accountId")
+    const code = this.requireNonEmpty(input.code, "code")
+    const now = Date.now()
+    this.ctx.storage.sql.exec(
+      `UPDATE accounts
+       SET last_quota_error_at = ?,
+           last_quota_error_code = ?,
+           consecutive_quota_errors = COALESCE(consecutive_quota_errors, 0) + 1,
+           updated_at = ?
+       WHERE id = ? AND org_id = ?`,
+      now,
+      code,
+      now,
+      accountId,
+      orgId
+    )
+    return { ok: true }
+  }
+
+  async clearAccountQuotaError(input: {
+    readonly orgId?: string
+    readonly accountId: string
+  }): Promise<{ ok: true }> {
+    const orgId = this.resolveOrgId(input.orgId)
+    const accountId = this.requireNonEmpty(input.accountId, "accountId")
+    const now = Date.now()
+    this.ctx.storage.sql.exec(
+      `UPDATE accounts
+       SET last_quota_error_at = NULL,
+           last_quota_error_code = NULL,
+           consecutive_quota_errors = 0,
+           updated_at = ?
+       WHERE id = ? AND org_id = ? AND last_quota_error_at IS NOT NULL`,
+      now,
+      accountId,
+      orgId
+    )
+    return { ok: true }
+  }
+
   async recordTranscriptMeta(input: TranscriptEventInput): Promise<{ ok: true }> {
     const agentType = normalizeAgentType(input.agentType) || "codex"
     const sessionId = this.requireNonEmpty(input.sessionId, "sessionId")
@@ -2056,6 +2144,34 @@ export class SubrouterDurableObject extends DurableObject<Env> {
 
   private statusRow(sql: SqlStorage): StatusRow {
     return sql.exec<StatusRow>("SELECT * FROM subrouter_status WHERE id = 1").one()
+  }
+
+  private ensureAccountHealthColumns(): void {
+    const existing = new Set(
+      this.ctx.storage.sql
+        .exec<TableInfoRow>("PRAGMA table_info(accounts)")
+        .toArray()
+        .map((row) => row.name)
+    )
+    if (!existing.has("last_quota_error_at")) {
+      this.ctx.storage.sql.exec("ALTER TABLE accounts ADD COLUMN last_quota_error_at INTEGER")
+    }
+    if (!existing.has("last_quota_error_code")) {
+      this.ctx.storage.sql.exec("ALTER TABLE accounts ADD COLUMN last_quota_error_code TEXT")
+    }
+    if (!existing.has("consecutive_quota_errors")) {
+      this.ctx.storage.sql.exec(
+        "ALTER TABLE accounts ADD COLUMN consecutive_quota_errors INTEGER DEFAULT 0"
+      )
+    }
+  }
+
+  private accountsDegradedCount(sql: SqlStorage): number {
+    return sql
+      .exec<CountRow>(
+        "SELECT COUNT(*) AS count FROM accounts WHERE last_quota_error_at IS NOT NULL"
+      )
+      .one().count
   }
 
   private listEligibleAccounts(
@@ -2699,6 +2815,143 @@ const recordTelemetryAccount = (
   telemetry.upstreamProvider = providerForAccount(account.kind)
 }
 
+interface QuotaObservation {
+  readonly code: string
+  readonly response?: Response
+}
+
+const quotaResponseForNon2xx = async (
+  response: Response,
+  account: StoredAccountContract
+): Promise<QuotaObservation | null> => {
+  if (response.status < 400) return null
+  const bodyText = await response.clone().text()
+  const parsed = parseJsonOrText(bodyText)
+  const message = providerErrorMessage(parsed)
+  const creditExhausted = isAnthropicCreditExhaustion(parsed, bodyText)
+  // Only credit-class exhaustion counts: a plain 429 is transient rate
+  // limiting on an account that still has quota, and telling users to
+  // "top up" for it would be wrong advice.
+  if (!creditExhausted) return null
+
+  const code = providerErrorCode(parsed) ?? "anthropic_credit_exhausted"
+  const reframedBody = reframeQuotaJsonBody(parsed, account.label, message)
+  if (!reframedBody) return { code }
+
+  const headers = new Headers(response.headers)
+  headers.delete("content-length")
+  if (!headers.has("content-type")) {
+    headers.set("content-type", "application/json; charset=utf-8")
+  }
+  return {
+    code,
+    response: new Response(JSON.stringify(reframedBody), {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    }),
+  }
+}
+
+const providerErrorMessage = (body: unknown): string | undefined => {
+  if (!body || typeof body !== "object") {
+    return typeof body === "string" && body.trim() ? body : undefined
+  }
+  const record = body as Record<string, unknown>
+  const error = record["error"]
+  if (error && typeof error === "object" && !Array.isArray(error)) {
+    const nestedMessage = (error as Record<string, unknown>)["message"]
+    if (typeof nestedMessage === "string" && nestedMessage.trim()) {
+      return nestedMessage
+    }
+  }
+  if (typeof error === "string" && error.trim()) return error
+  const message = record["message"]
+  return typeof message === "string" && message.trim() ? message : undefined
+}
+
+const providerErrorCode = (body: unknown): string | undefined => {
+  if (!body || typeof body !== "object") return undefined
+  const record = body as Record<string, unknown>
+  const error = record["error"]
+  if (error && typeof error === "object" && !Array.isArray(error)) {
+    const nested = error as Record<string, unknown>
+    for (const key of ["code", "type"]) {
+      const value = nested[key]
+      if (typeof value === "string" && value.trim()) return value
+    }
+  }
+  for (const key of ["code", "type"]) {
+    const value = record[key]
+    if (typeof value === "string" && value.trim()) return value
+  }
+  return undefined
+}
+
+const isAnthropicCreditExhaustion = (parsed: unknown, rawBody: string): boolean => {
+  const haystack = `${providerErrorCode(parsed) ?? ""}\n${providerErrorMessage(parsed) ?? ""}\n${rawBody}`.toLowerCase()
+  return (
+    haystack.includes("out of extra usage") ||
+    haystack.includes("claude.ai/settings/usage") ||
+    haystack.includes("credit_balance_too_low") ||
+    haystack.includes("out of credits")
+  )
+}
+
+const reframeQuotaJsonBody = (
+  body: unknown,
+  accountLabel: string,
+  providerMessage: string | undefined
+): unknown | null => {
+  if (!providerMessage) return null
+  const message = quotaReframeMessage(accountLabel, providerMessage)
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null
+  const record = body as Record<string, unknown>
+  const error = record["error"]
+  if (error && typeof error === "object" && !Array.isArray(error)) {
+    return {
+      ...record,
+      error: {
+        ...(error as Record<string, unknown>),
+        message,
+      },
+    }
+  }
+  if (typeof error === "string") {
+    return { ...record, error: message }
+  }
+  if (typeof record["message"] === "string") {
+    return { ...record, message }
+  }
+  return null
+}
+
+const quotaReframeMessage = (
+  accountLabel: string,
+  providerMessage: string
+): string =>
+  `[cmux subrouter] shared tenant account '${sanitizeQuotaMessage(accountLabel)}' is out of quota - ask the tenant owner to top up or add another account (run: cmux-subrouter status). Provider says: ${sanitizeQuotaMessage(providerMessage)}`
+
+const sanitizeQuotaMessage = (value: string): string =>
+  value
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
+    .replace(/sk-[A-Za-z0-9_-]+/g, "[redacted]")
+    .replace(/srt_[0-9a-f]+/gi, "[redacted]")
+    .replace(/[\r\n\t]+/g, " ")
+    .slice(0, 500)
+
+const scheduleAccountHealthWrite = (
+  waitUntil: WaitUntil | undefined,
+  promise: Promise<unknown>
+): void => {
+  const guarded = promise.catch(() => {})
+  if (waitUntil) {
+    waitUntil(guarded)
+    return
+  }
+  void guarded
+}
+
 const proxyUpstream = async (
   request: Request,
   env: Env,
@@ -2752,8 +3005,33 @@ const proxyUpstream = async (
   const upstreamRequest = new Request(upstreamURL, init)
   const response = await fetch(upstreamRequest)
   if (telemetry) telemetry.upstreamStatus = response.status
-  const [clientBody, transcriptBody] = response.body
-    ? response.body.tee()
+  let clientResponse = response
+  if (response.status >= 200 && response.status < 300) {
+    if ((account as StoredAccountContract & { readonly lastQuotaErrorAt?: number }).lastQuotaErrorAt) {
+      scheduleAccountHealthWrite(
+        waitUntil,
+        actor.clearAccountQuotaError({
+          orgId: routeInput.orgId,
+          accountId: account.id,
+        })
+      )
+    }
+  } else {
+    const quota = await quotaResponseForNon2xx(response, account)
+    if (quota) {
+      scheduleAccountHealthWrite(
+        waitUntil,
+        actor.recordAccountQuotaError({
+          orgId: routeInput.orgId,
+          accountId: account.id,
+          code: quota.code,
+        })
+      )
+      clientResponse = quota.response ?? response
+    }
+  }
+  const [clientBody, transcriptBody] = clientResponse.body
+    ? clientResponse.body.tee()
     : [null, null]
   const transcriptBodyBuffer = transcriptBody
     ? new Response(transcriptBody).arrayBuffer()
@@ -2778,7 +3056,7 @@ const proxyUpstream = async (
       eventType: "http_body",
       direction: "upstream_to_client",
       body: await transcriptBodyBuffer,
-      payload: { status: response.status },
+      payload: { status: clientResponse.status },
     })
   }
   if (waitUntil) {
@@ -2787,9 +3065,9 @@ const proxyUpstream = async (
     await recordTranscripts()
   }
   return new Response(clientBody, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: response.headers,
+    status: clientResponse.status,
+    statusText: clientResponse.statusText,
+    headers: clientResponse.headers,
   })
 }
 

--- a/cloudflare/packages/worker/test/account-upload.test.ts
+++ b/cloudflare/packages/worker/test/account-upload.test.ts
@@ -14,6 +14,107 @@ afterEach(async () => {
 })
 
 describe("tenant account upload API", () => {
+  test("surfaces quota health and clears it after a successful proxy response", async () => {
+    let mode: "quota" | "ok" = "quota"
+    const providerMessage = "You're out of extra usage. Add more at claude.ai/settings/usage"
+    const upstream = Bun.serve({
+      port: 0,
+      async fetch() {
+        if (mode === "quota") {
+          return Response.json(
+            {
+              type: "error",
+              error: {
+                type: "rate_limit_error",
+                message: providerMessage,
+              },
+            },
+            { status: 429 }
+          )
+        }
+        return Response.json({ ok: true })
+      },
+    })
+    servers.push(upstream)
+
+    const worker = await startWorker({ claudeUpstream: upstream.url.origin })
+    const tenant = await createTenant(worker.baseURL, "Quota Health Tenant")
+    const account = await uploadAccount(worker.baseURL, tenant.key, {
+      provider: "anthropic-apikey",
+      label: "shared claude",
+      apiKey: "sk-ant-quota-health-secret",
+    }, ["sk-ant-quota-health-secret"])
+    expect(account.health).toEqual({ ok: true })
+
+    const quota = await fetch(`${worker.baseURL}/v1/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${tenant.key}`,
+        "Content-Type": "application/json",
+        "X-Subrouter-Account-ID": account.id,
+        "X-Subrouter-Session": "quota-health-session",
+      },
+      body: JSON.stringify({ model: "claude-3-5-sonnet-latest", messages: [] }),
+    })
+    expect(quota.status).toBe(429)
+    const quotaBody = (await quota.json()) as Record<string, any>
+    expect(quotaBody.error.message).toContain("shared claude")
+    expect(quotaBody.error.message).toContain("cmux-subrouter status")
+    expect(quotaBody.error.message).toContain(providerMessage)
+
+    const degradedAccounts = await waitForTenantAccounts(
+      worker.baseURL,
+      tenant.key,
+      (accounts) => accounts[0]?.health?.ok === false
+    )
+    expect(degradedAccounts[0]?.health).toMatchObject({
+      ok: false,
+      message: "Upstream reported quota exhaustion for this shared tenant account.",
+    })
+    expect(degradedAccounts[0]?.health?.lastQuotaErrorAt).toEqual(expect.any(String))
+    const degradedText = JSON.stringify(degradedAccounts)
+    expect(degradedText).not.toContain("sk-ant-quota-health-secret")
+
+    const ready = await fetch(`${worker.baseURL}/_subrouter/ready?tenant=${tenant.id}`)
+    expect(ready.status).toBe(200)
+    const readyBody = (await ready.json()) as Record<string, unknown>
+    expect(readyBody).toEqual({
+      ok: true,
+      draining: false,
+      accountsDegraded: 1,
+    })
+
+    mode = "ok"
+    const ok = await fetch(`${worker.baseURL}/v1/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${tenant.key}`,
+        "Content-Type": "application/json",
+        "X-Subrouter-Account-ID": account.id,
+        "X-Subrouter-Session": "quota-health-clear-session",
+      },
+      body: JSON.stringify({ model: "claude-3-5-sonnet-latest", messages: [] }),
+    })
+    expect(ok.status).toBe(200)
+    const okBody = (await ok.json()) as Record<string, unknown>
+    expect(okBody).toEqual({ ok: true })
+
+    const healthyAccounts = await waitForTenantAccounts(
+      worker.baseURL,
+      tenant.key,
+      (accounts) => accounts[0]?.health?.ok === true
+    )
+    expect(healthyAccounts[0]?.health).toEqual({ ok: true })
+
+    const readyAfterClear = await fetch(`${worker.baseURL}/_subrouter/ready?tenant=${tenant.id}`)
+    const readyAfterClearBody = (await readyAfterClear.json()) as Record<string, unknown>
+    expect(readyAfterClearBody).toEqual({
+      ok: true,
+      draining: false,
+      accountsDegraded: 0,
+    })
+  }, 60_000)
+
   test("times out validation fetches without storing the account", async () => {
     const hangingUsage = Bun.serve({
       port: 0,
@@ -244,4 +345,24 @@ const uploadAccount = async (
   const text = await response.text()
   for (const secret of secrets) expect(text).not.toContain(secret)
   return JSON.parse(text) as Record<string, any>
+}
+
+const waitForTenantAccounts = async (
+  baseURL: string,
+  tenantKey: string,
+  predicate: (accounts: Array<Record<string, any>>) => boolean
+): Promise<Array<Record<string, any>>> => {
+  const deadline = Date.now() + 10_000
+  let lastAccounts: Array<Record<string, any>> = []
+  while (Date.now() < deadline) {
+    const response = await fetch(`${baseURL}/tenant/accounts`, {
+      headers: { Authorization: `Bearer ${tenantKey}` },
+    })
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { accounts: Array<Record<string, any>> }
+    lastAccounts = body.accounts
+    if (predicate(lastAccounts)) return lastAccounts
+    await Bun.sleep(100)
+  }
+  throw new Error(`tenant accounts did not reach expected health: ${JSON.stringify(lastAccounts)}`)
 }

--- a/cloudflare/packages/worker/test/proxy-streaming.test.ts
+++ b/cloudflare/packages/worker/test/proxy-streaming.test.ts
@@ -131,6 +131,134 @@ describe("HTTP proxy streaming transcripts", () => {
     })
   })
 
+  test("reframes tenant quota errors and records account health off the response path", async () => {
+    const waitUntilPromises: Promise<unknown>[] = []
+    const quotaWrites: Record<string, any>[] = []
+    const providerMessage = "You're out of extra usage. Add more at claude.ai/settings/usage"
+    const actor = fakeActor({
+      account: {
+        id: "claude-shared",
+        kind: "anthropic_oauth",
+        label: "team claude",
+        hasCredentials: true,
+        hasTotp: false,
+        credentials: { accessToken: "upstream-token" },
+      },
+      async recordAccountQuotaError(input) {
+        quotaWrites.push(input)
+        return { ok: true }
+      },
+    })
+
+    setFetch(
+      async () =>
+        Response.json(
+          {
+            type: "error",
+            error: {
+              type: "rate_limit_error",
+              message: providerMessage,
+            },
+          },
+          { status: 429 }
+        )
+    )
+    const response = await proxyUpstream(
+      proxyRequest({ body: "client-body", sessionId: "quota-session" }),
+      fakeEnv(),
+      actor,
+      { ...routeInput("quota-session"), agentType: "claude" },
+      undefined,
+      (promise: Promise<unknown>) => waitUntilPromises.push(promise)
+    )
+
+    expect(response.status).toBe(429)
+    const body = (await response.json()) as Record<string, any>
+    expect(body.type).toBe("error")
+    expect(body.error.type).toBe("rate_limit_error")
+    expect(body.error.message).toContain("[cmux subrouter]")
+    expect(body.error.message).toContain("team claude")
+    expect(body.error.message).toContain("cmux-subrouter status")
+    expect(body.error.message).toContain(providerMessage)
+    await Promise.all(waitUntilPromises)
+    expect(quotaWrites).toEqual([
+      {
+        orgId: "org-test",
+        accountId: "claude-shared",
+        code: "rate_limit_error",
+      },
+    ])
+  })
+
+  test("passes ordinary non-quota errors through unchanged", async () => {
+    const waitUntilPromises: Promise<unknown>[] = []
+    const quotaWrites: Record<string, any>[] = []
+    const errorBody = {
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message: "model is required",
+      },
+    }
+    const actor = fakeActor({
+      async recordAccountQuotaError(input) {
+        quotaWrites.push(input)
+        return { ok: true }
+      },
+    })
+
+    setFetch(async () => Response.json(errorBody, { status: 400 }))
+    const response = await proxyUpstream(
+      proxyRequest({ body: "client-body", sessionId: "validation-session" }),
+      fakeEnv(),
+      actor,
+      routeInput("validation-session"),
+      undefined,
+      (promise: Promise<unknown>) => waitUntilPromises.push(promise)
+    )
+
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as Record<string, unknown>
+    expect(body).toEqual(errorBody)
+    await Promise.all(waitUntilPromises)
+    expect(quotaWrites).toEqual([])
+  })
+
+  test("clears account quota health after a subsequent 2xx", async () => {
+    const waitUntilPromises: Promise<unknown>[] = []
+    const clears: Record<string, any>[] = []
+    const actor = fakeActor({
+      account: {
+        id: "acct-test",
+        kind: "codex_oauth",
+        label: "test@example.com",
+        hasCredentials: true,
+        hasTotp: false,
+        credentials: { accessToken: "upstream-token" },
+        lastQuotaErrorAt: Date.now(),
+      },
+      async clearAccountQuotaError(input) {
+        clears.push(input)
+        return { ok: true }
+      },
+    })
+
+    setFetch(async () => new Response("ok", { status: 200 }))
+    const response = await proxyUpstream(
+      proxyRequest({ body: "client-body", sessionId: "clear-session" }),
+      fakeEnv(),
+      actor,
+      routeInput("clear-session"),
+      undefined,
+      (promise: Promise<unknown>) => waitUntilPromises.push(promise)
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe("ok")
+    await Promise.all(waitUntilPromises)
+    expect(clears).toEqual([{ orgId: "org-test", accountId: "acct-test" }])
+  })
+
   test("redacts upstream query values in transcript meta without changing the upstream request", async () => {
     const events: TranscriptEvent[] = []
     const waitUntilPromises: Promise<unknown>[] = []
@@ -357,12 +485,15 @@ const proxyRequest = (input: {
   })
 
 const fakeActor = (overrides: {
+  readonly account?: Record<string, any>
   readonly recordTranscriptMeta?: (input: Record<string, any>) => Promise<{ ok: true }>
   readonly recordTranscriptBody?: (input: Record<string, any>) => Promise<{ ok: true }>
+  readonly recordAccountQuotaError?: (input: Record<string, any>) => Promise<{ ok: true }>
+  readonly clearAccountQuotaError?: (input: Record<string, any>) => Promise<{ ok: true }>
 }): Record<string, unknown> => ({
   async routeForProxy() {
     return {
-      account: {
+      account: overrides.account ?? {
         id: "acct-test",
         kind: "codex_oauth",
         label: "test@example.com",
@@ -376,6 +507,10 @@ const fakeActor = (overrides: {
     overrides.recordTranscriptMeta ?? (async () => ({ ok: true })),
   recordTranscriptBody:
     overrides.recordTranscriptBody ?? (async () => ({ ok: true })),
+  recordAccountQuotaError:
+    overrides.recordAccountQuotaError ?? (async () => ({ ok: true })),
+  clearAccountQuotaError:
+    overrides.clearAccountQuotaError ?? (async () => ({ ok: true })),
 })
 
 type TestFetch = (

--- a/cloudflare/packages/worker/test/worker-transcripts.test.ts
+++ b/cloudflare/packages/worker/test/worker-transcripts.test.ts
@@ -192,10 +192,18 @@ describe("subrouter Durable Object Worker transcripts", () => {
     )
     expect(tenantAReadyBeforeDrain.status).toBe(200)
     const tenantAReadyBeforeDrainBody = await tenantAReadyBeforeDrain.json() as Record<string, unknown>
-    expect(tenantAReadyBeforeDrainBody).toEqual({ ok: true, draining: false })
+    expect(tenantAReadyBeforeDrainBody).toEqual({
+      ok: true,
+      draining: false,
+      accountsDegraded: 0,
+    })
     expect(tenantBReadyBeforeDrain.status).toBe(200)
     const tenantBReadyBeforeDrainBody = await tenantBReadyBeforeDrain.json() as Record<string, unknown>
-    expect(tenantBReadyBeforeDrainBody).toEqual({ ok: true, draining: false })
+    expect(tenantBReadyBeforeDrainBody).toEqual({
+      ok: true,
+      draining: false,
+      accountsDegraded: 0,
+    })
     expect((await fetch(`${baseURL}/_subrouter/ready?tenant=Bad Tenant`)).status).toBe(400)
 
     const drainA = await fetch(`${baseURL}/_subrouter/drain?tenant=${tenantA.id}`, {
@@ -215,10 +223,18 @@ describe("subrouter Durable Object Worker transcripts", () => {
     )
     expect(tenantAReadyAfterDrain.status).toBe(503)
     const tenantAReadyAfterDrainBody = await tenantAReadyAfterDrain.json() as Record<string, unknown>
-    expect(tenantAReadyAfterDrainBody).toEqual({ ok: false, draining: true })
+    expect(tenantAReadyAfterDrainBody).toEqual({
+      ok: false,
+      draining: true,
+      accountsDegraded: 0,
+    })
     expect(tenantBReadyAfterDrain.status).toBe(200)
     const tenantBReadyAfterDrainBody = await tenantBReadyAfterDrain.json() as Record<string, unknown>
-    expect(tenantBReadyAfterDrainBody).toEqual({ ok: true, draining: false })
+    expect(tenantBReadyAfterDrainBody).toEqual({
+      ok: true,
+      draining: false,
+      accountsDegraded: 0,
+    })
 
     const drainStatusA = await adminJSON<Record<string, any>>(
       baseURL,


### PR DESCRIPTION
From the agent-trial findings: `cmux-subrouter status` reported `ok:true` while every proxied Claude call failed on quota, and the raw upstream "out of extra usage — add more at claude.ai/settings/usage" message misdirected teammates to their personal billing when the exhausted account was the shared tenant's.

Credit-class exhaustion (narrow classifier: out-of-extra-usage / claude.ai-settings-usage / credit_balance_too_low / out-of-credits; plain 429 rate limits deliberately excluded) now records per-account health in DO storage via waitUntil (lastQuotaErrorAt/code/consecutive, cleared on next 2xx with no steady-state writes), surfaces as sanitized `health` on `/tenant/accounts` and `accountsDegraded` on the ready endpoint, and the client-facing error keeps the provider's status + JSON shape while the message names the shared account label, points at `cmux-subrouter status`, and appends the original provider text. The 2xx streaming path gains zero awaits and zero body reads before the tee; ordinary non-quota errors pass through byte-identical.

/fable loop: judge APPROVE round 1 (56 tests traced: streaming safety, classifier narrowness, JSON-shape preservation for Anthropic/OpenAI/string shapes, sanitization, no GTO/#60 or transcript-redaction touchpoints); the judge's rate-limit-mislabeling note was applied before landing. bun test 56 pass, tsc clean, wrangler dry-run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785900789&installation_id=133855650&pr_number=62&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F62&signature=79c19c593074605a08191e131aeeb7e99453ccf85a0be729adc9d0aeed6952ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds quota-aware account health and clearer credit-exhaustion errors in the worker. Teams now see which shared tenant account is out of quota and how many accounts are degraded.

- **New Features**
  - Record per-account quota exhaustion (last time/code/consecutive) in Durable Object storage via `waitUntil`; clear on next 2xx.
  - Expose `health` on `/tenant/accounts` and `accountsDegraded` on `/_subrouter/ready`.
  - Reframe credit-exhaustion responses: keep provider status and JSON shape, name the shared account label, suggest `cmux-subrouter status`, append the original provider text, and redact secrets.

- **Bug Fixes**
  - Stop misdirecting users to personal billing by replacing Anthropic’s raw “out of extra usage” text with tenant-aware guidance.
  - Only classify credit exhaustion (`out of extra usage`, `claude.ai/settings/usage`, `credit_balance_too_low`, `out of credits`); plain 429 rate limits pass through unchanged.

<sup>Written for commit 7b8caf2376c200c075416baf005fabfc8b63c62a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant account health tracking for quota-related failures, including degraded status and recovery reporting.
  * Improved readiness reporting to show how many accounts are currently degraded.
  * Updated proxy handling to surface clearer quota-exhaustion errors and preserve the final response sent to clients.

* **Bug Fixes**
  * Tenant account health now recovers after a successful request following a quota error.
  * Existing tenant account records are automatically kept compatible with the new health tracking fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->