### PR TITLE
deploy/macos: run the team Subrouter on a Mac with full GCP parity

### DIFF
--- a/deploy/macos/README.md
+++ b/deploy/macos/README.md
@@ -1,0 +1,99 @@
+# macOS Subrouter Deployment
+
+Runs the shared "team" Subrouter on a macOS host (a Mac mini) with full parity
+to the GCP deployment in `../gcp`. Use this when you want the router on an
+office Mac instead of a cloud VM.
+
+Defaults:
+
+- Label: `ai.manaflow.subrouter-team` (system LaunchDaemon)
+- Service user: `_subrouter` (dedicated, hidden role account)
+- Listen: `0.0.0.0:31415`, restricted to the tailnet + loopback by pf
+- State: `/var/lib/subrouter` (mirrors the GCP `/var/lib/subrouter` layout)
+- Binary: `/usr/local/bin/subrouter` (public release, auto-updated)
+
+## Why a dedicated user + LaunchDaemon (not `sr install-daemon`)
+
+`sr install-daemon` installs a per-user LaunchAgent bound to loopback, which is
+right for a personal `sr`/`cx` daemon but wrong for a shared server: it dies on
+logout, only serves loopback, and (running as your login user) can't be
+egress-isolated with pf on a machine that runs other things. The team router
+instead runs as its own `_subrouter` user under a system LaunchDaemon, which is
+what makes the pf `user`-scoped egress block possible without touching other
+workloads on the host (e.g. a co-hosted cmux-feed).
+
+## Parity with GCP
+
+| Concern | GCP (systemd) | macOS (launchd) |
+| --- | --- | --- |
+| Service | `subrouter.service` + `subrouter.socket` | `ai.manaflow.subrouter-team` LaunchDaemon |
+| Auto-update (2 min) | `subrouter-autoupdate.timer` | `ai.manaflow.subrouter-autoupdate` (`StartInterval`) |
+| Self-verify (5 min) | `subrouter-verify.timer` | `ai.manaflow.subrouter-verify` (`StartInterval`) |
+| Egress isolation | iptables block to tailnet on `tailscale0` | pf anchor scoped to `user _subrouter` |
+| Zero-downtime restart | systemd socket handoff | none — a restart drops in-flight requests briefly |
+
+The one thing macOS can't match is systemd socket activation, so auto-update
+restarts cause a short blip. `subrouter` drains on SIGTERM and
+`launchctl kickstart -k` gives a clean stop/start.
+
+pf note: Tailscale MagicDNS (`100.100.100.100`) is inside `100.64.0.0/10`, so the
+anchor explicitly allows `_subrouter -> 100.100.100.100:53`; without it the
+router loses DNS and can't reach the upstream APIs.
+
+## Install
+
+```bash
+# from a checkout on the host, or scp just this directory:
+sudo ./install-macos.sh
+```
+
+Override the bind or version with env, e.g. `SUBROUTER_ADDR=0.0.0.0:31415`,
+`SUBROUTER_VERSION=v0.1.33`. The installer creates the user, installs the
+binary + scripts + pf anchor, writes the LaunchDaemons, and waits for health.
+It does **not** install account state.
+
+Verify:
+
+```bash
+curl -fsS http://127.0.0.1:31415/_subrouter/health         # {"ok":true}
+sudo launchctl print system/ai.manaflow.subrouter-team | grep state
+sudo pfctl -a ai.manaflow.subrouter -sr                     # anchor rules
+```
+
+## Migrating account state from the GCP router
+
+Account OAuth refresh tokens **rotate on use**, so only one live router may own
+them at a time. Migrate during a short window, do not run both against the same
+accounts:
+
+```bash
+# 1. stop the GCP router so its token chains freeze
+gcloud compute ssh subrouter-team --zone <zone> --command 'sudo systemctl stop subrouter'
+
+# 2. archive + copy /var/lib/subrouter to the mac
+gcloud compute ssh subrouter-team --zone <zone> --command 'sudo tar -C /var/lib -czf /tmp/sr.tgz subrouter'
+gcloud compute scp subrouter-team:/tmp/sr.tgz /tmp/sr.tgz --zone <zone>
+scp /tmp/sr.tgz <mac>:/tmp/sr.tgz
+
+# 3. on the mac: extract into place, fix ownership, reload accounts
+ssh <mac> 'sudo tar -C /var/lib -xzf /tmp/sr.tgz \
+  && sudo chown -R _subrouter:_subrouter /var/lib/subrouter \
+  && sudo launchctl kickstart -k system/ai.manaflow.subrouter-team \
+  && curl -fsS -X POST http://127.0.0.1:31415/_subrouter/reload-accounts'
+
+# 4. confirm all accounts are present and the verifier is clean
+ssh <mac> 'curl -fsS http://127.0.0.1:31415/_subrouter/usage-status | python3 -c "import sys,json;d=json.load(sys.stdin);print(len(d if isinstance(d,list) else d[\"accounts\"]))"'
+```
+
+Then repoint clients' `team` server URL at the mac and keep the GCP VM stopped
+(not deleted) as instant rollback. To roll back, reverse step 2-3 (mac -> GCP)
+and restart `subrouter` on the VM.
+
+## Uninstall
+
+```bash
+for l in verify autoupdate team pf; do sudo launchctl bootout system/ai.manaflow.subrouter-$l 2>/dev/null; done
+sudo rm -f /Library/LaunchDaemons/ai.manaflow.subrouter-*.plist
+sudo pfctl -a ai.manaflow.subrouter -F rules
+# state in /var/lib/subrouter and the _subrouter user are left in place on purpose
+```

--- a/deploy/macos/ai.manaflow.subrouter-autoupdate.plist
+++ b/deploy/macos/ai.manaflow.subrouter-autoupdate.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Polls for new Subrouter releases every 2 min and auto-updates
+     (launchd analog of the GCP subrouter-autoupdate.timer). Runs as root. -->
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>ai.manaflow.subrouter-autoupdate</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/bin/subrouter-autoupdate.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StartInterval</key>
+	<integer>120</integer>
+	<key>Nice</key>
+	<integer>10</integer>
+	<key>StandardOutPath</key>
+	<string>/var/log/subrouter-autoupdate.log</string>
+	<key>StandardErrorPath</key>
+	<string>/var/log/subrouter-autoupdate.log</string>
+</dict>
+</plist>

--- a/deploy/macos/ai.manaflow.subrouter-pf.plist
+++ b/deploy/macos/ai.manaflow.subrouter-pf.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Loads the Subrouter pf anchor at boot (parity with the GCP iptables
+     tailnet-egress-block oneshot). Re-asserts every 10 min so the anchor
+     survives another tool flushing pf. -->
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>ai.manaflow.subrouter-pf</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/bin/subrouter-pf.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StartInterval</key>
+	<integer>600</integer>
+	<key>StandardOutPath</key>
+	<string>/var/log/subrouter-pf.log</string>
+	<key>StandardErrorPath</key>
+	<string>/var/log/subrouter-pf.log</string>
+</dict>
+</plist>

--- a/deploy/macos/ai.manaflow.subrouter-team.plist
+++ b/deploy/macos/ai.manaflow.subrouter-team.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  System LaunchDaemon for the shared "team" Subrouter on a macOS host.
+  install-macos.sh substitutes __ADDR__ (default 0.0.0.0:31415). Runs as the
+  dedicated _subrouter service user so pf can scope egress isolation to it
+  (see pf-subrouter.conf) without affecting anything else on a shared host.
+  State lives in /var/lib/subrouter (mirrors the GCP layout for a 1:1 copy).
+-->
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>ai.manaflow.subrouter-team</string>
+	<key>UserName</key>
+	<string>_subrouter</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/var/lib/subrouter</string>
+		<key>SUBROUTER_STATE_DIR</key>
+		<string>/var/lib/subrouter</string>
+		<key>PATH</key>
+		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+	</dict>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/bin/subrouter</string>
+		<string>serve</string>
+		<string>--addr</string>
+		<string>__ADDR__</string>
+		<string>--sr-switch-interval</string>
+		<string>10m</string>
+	</array>
+	<key>KeepAlive</key>
+	<true/>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>ThrottleInterval</key>
+	<integer>10</integer>
+	<key>WorkingDirectory</key>
+	<string>/var/lib/subrouter</string>
+	<key>StandardOutPath</key>
+	<string>/var/log/subrouter.log</string>
+	<key>StandardErrorPath</key>
+	<string>/var/log/subrouter.err.log</string>
+	<key>ProcessType</key>
+	<string>Interactive</string>
+</dict>
+</plist>

--- a/deploy/macos/ai.manaflow.subrouter-verify.plist
+++ b/deploy/macos/ai.manaflow.subrouter-verify.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Runs the Claude rate-limit reroute self-verifier every 5 min
+     (launchd analog of the GCP subrouter-verify.timer). Runs as root. -->
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>ai.manaflow.subrouter-verify</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/bin/subrouter-verify.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StartInterval</key>
+	<integer>300</integer>
+	<key>Nice</key>
+	<integer>10</integer>
+	<key>StandardOutPath</key>
+	<string>/var/log/subrouter-verify.log</string>
+	<key>StandardErrorPath</key>
+	<string>/var/log/subrouter-verify.log</string>
+</dict>
+</plist>

--- a/deploy/macos/install-macos.sh
+++ b/deploy/macos/install-macos.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Install the shared "team" Subrouter on a macOS host, with full parity to the
+# GCP deployment: a dedicated _subrouter service user, a system LaunchDaemon,
+# pf egress isolation, auto-update, and the Claude-reroute self-verifier.
+#
+# Self-contained: scp just this directory (deploy/macos/) to the host and run
+#   sudo ./install-macos.sh
+# Idempotent: safe to re-run to upgrade the binary or refresh units.
+#
+# It does NOT touch account state. Seed /var/lib/subrouter/codex/accounts
+# separately (migration copies it from the current live router). By default the
+# daemon comes up with no accounts (a healthy but empty standby).
+set -euo pipefail
+
+REPO="${SUBROUTER_REPO:-manaflow-ai/subrouter}"
+LABEL="${SUBROUTER_LABEL:-ai.manaflow.subrouter-team}"
+ADDR="${SUBROUTER_ADDR:-0.0.0.0:31415}"
+STATE_DIR="${SUBROUTER_STATE_DIR:-/var/lib/subrouter}"
+SVC_USER="${SUBROUTER_USER:-_subrouter}"
+BIN="${SUBROUTER_BIN:-/usr/local/bin/subrouter}"
+VERSION="${SUBROUTER_VERSION:-latest}"
+VERSION_FILE="/etc/subrouter-version"
+ANCHOR="ai.manaflow.subrouter"
+ANCHOR_DST="/etc/pf.anchors/${ANCHOR}"
+LAUNCHD_DIR="/Library/LaunchDaemons"
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+log() { echo "install-macos: $*"; }
+
+if [ "$(id -u)" != "0" ]; then
+  echo "install-macos.sh must run as root; use sudo" >&2
+  exit 1
+fi
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "install-macos.sh is macOS-only" >&2
+  exit 1
+fi
+
+case "$(uname -m)" in
+  arm64|aarch64) arch="arm64" ;;
+  x86_64|amd64) arch="amd64" ;;
+  *) echo "unsupported arch $(uname -m)" >&2; exit 1 ;;
+esac
+
+# --- 1. dedicated service user + group -------------------------------------
+find_free_id() {
+  local id=440
+  local used
+  used="$(dscl . -list /Users UniqueID | awk '{print $2}'; dscl . -list /Groups PrimaryGroupID | awk '{print $2}')"
+  while grep -qx "$id" <<<"$used"; do id=$((id + 1)); done
+  echo "$id"
+}
+if ! dscl . -read "/Users/${SVC_USER}" >/dev/null 2>&1; then
+  uid="$(find_free_id)"
+  log "creating service user ${SVC_USER} (uid=${uid})"
+  dscl . -create "/Groups/${SVC_USER}"
+  dscl . -create "/Groups/${SVC_USER}" PrimaryGroupID "${uid}"
+  dscl . -create "/Groups/${SVC_USER}" RealName "Subrouter Service"
+  dscl . -create "/Users/${SVC_USER}"
+  dscl . -create "/Users/${SVC_USER}" RealName "Subrouter Service"
+  dscl . -create "/Users/${SVC_USER}" UniqueID "${uid}"
+  dscl . -create "/Users/${SVC_USER}" PrimaryGroupID "${uid}"
+  dscl . -create "/Users/${SVC_USER}" UserShell /usr/bin/false
+  dscl . -create "/Users/${SVC_USER}" NFSHomeDirectory "${STATE_DIR}"
+  dscl . -create "/Users/${SVC_USER}" IsHidden 1
+else
+  log "service user ${SVC_USER} already exists"
+fi
+gid="$(dscl . -read "/Users/${SVC_USER}" PrimaryGroupID | awk '{print $2}')"
+
+# --- 2. state + log dirs ----------------------------------------------------
+install -d -m 0750 -o "${SVC_USER}" -g "${gid}" "${STATE_DIR}"
+install -d -m 0750 -o "${SVC_USER}" -g "${gid}" "${STATE_DIR}/codex" "${STATE_DIR}/codex/accounts"
+install -d -m 0750 -o root -g wheel /var/lib/subrouter-verify
+for f in /var/log/subrouter.log /var/log/subrouter.err.log; do
+  touch "$f"; chown "${SVC_USER}:${gid}" "$f"; chmod 0640 "$f"
+done
+
+# --- 3. binary --------------------------------------------------------------
+fetch_binary() {
+  local ver="$1"
+  if [ "$ver" = "latest" ]; then
+    ver="$(curl -fsSL -H 'Accept: application/vnd.github+json' \
+      "https://api.github.com/repos/${REPO}/releases/latest" \
+      | python3 -c 'import json,sys;print(json.load(sys.stdin)["tag_name"])')"
+  fi
+  [ -n "$ver" ] || { echo "could not resolve version" >&2; exit 1; }
+  local v="${ver#v}"
+  local asset="subrouter_${v}_darwin_${arch}"
+  local base="https://github.com/${REPO}/releases/download/${ver}"
+  local tmp; tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' RETURN
+  log "downloading ${asset}"
+  curl -fsSL -o "${tmp}/${asset}" "${base}/${asset}"
+  curl -fsSL -o "${tmp}/SHA256SUMS" "${base}/SHA256SUMS"
+  ( cd "$tmp" && grep " ${asset}\$" SHA256SUMS | shasum -a 256 -c - >/dev/null )
+  install -m 0755 "${tmp}/${asset}" "${BIN}"
+  ln -sf "${BIN}" /usr/local/bin/sr
+  ln -sf "${BIN}" /usr/local/bin/cx
+  echo "${ver}" > "${VERSION_FILE}"
+  log "installed subrouter ${ver} to ${BIN}"
+}
+fetch_binary "${VERSION}"
+
+# --- 4. helper scripts + pf anchor ------------------------------------------
+install -m 0755 "${here}/subrouter-autoupdate.sh" /usr/local/bin/subrouter-autoupdate.sh
+install -m 0755 "${here}/subrouter-verify.sh"     /usr/local/bin/subrouter-verify.sh
+install -m 0755 "${here}/subrouter-pf.sh"         /usr/local/bin/subrouter-pf.sh
+install -d -m 0755 /etc/pf.anchors
+install -m 0644 "${here}/pf-subrouter.conf" "${ANCHOR_DST}"
+
+# --- 5. LaunchDaemons -------------------------------------------------------
+render_team_plist() {
+  sed "s|__ADDR__|${ADDR}|g" "${here}/ai.manaflow.subrouter-team.plist" \
+    > "${LAUNCHD_DIR}/ai.manaflow.subrouter-team.plist"
+}
+render_team_plist
+install -m 0644 "${here}/ai.manaflow.subrouter-pf.plist"         "${LAUNCHD_DIR}/"
+install -m 0644 "${here}/ai.manaflow.subrouter-autoupdate.plist" "${LAUNCHD_DIR}/"
+install -m 0644 "${here}/ai.manaflow.subrouter-verify.plist"     "${LAUNCHD_DIR}/"
+chown root:wheel "${LAUNCHD_DIR}/ai.manaflow.subrouter-"*.plist
+chmod 0644 "${LAUNCHD_DIR}/ai.manaflow.subrouter-"*.plist
+
+boot() { # label plist
+  local label="$1" plist="$2"
+  launchctl bootout "system/${label}" 2>/dev/null || true
+  launchctl bootstrap system "${plist}"
+  launchctl enable "system/${label}" 2>/dev/null || true
+}
+boot ai.manaflow.subrouter-pf         "${LAUNCHD_DIR}/ai.manaflow.subrouter-pf.plist"
+boot ai.manaflow.subrouter-team       "${LAUNCHD_DIR}/ai.manaflow.subrouter-team.plist"
+boot ai.manaflow.subrouter-autoupdate "${LAUNCHD_DIR}/ai.manaflow.subrouter-autoupdate.plist"
+boot ai.manaflow.subrouter-verify     "${LAUNCHD_DIR}/ai.manaflow.subrouter-verify.plist"
+
+# --- 6. health --------------------------------------------------------------
+log "waiting for health on 127.0.0.1:31415"
+i=0
+until curl -fsS http://127.0.0.1:31415/_subrouter/health >/dev/null 2>&1; do
+  i=$((i + 1))
+  if [ "$i" -ge 30 ]; then
+    echo "install-macos: health check failed; see /var/log/subrouter.err.log" >&2
+    exit 1
+  fi
+  sleep 1
+done
+log "healthy. daemon ${LABEL} listening on ${ADDR}"
+log "accounts dir: ${STATE_DIR}/codex/accounts (seed via migration)"

--- a/deploy/macos/pf-subrouter.conf
+++ b/deploy/macos/pf-subrouter.conf
@@ -1,0 +1,29 @@
+#
+# pf anchor for the shared macOS Subrouter host (loaded into anchor
+# "ai.manaflow.subrouter" by subrouter-pf.sh). Mirrors the GCP firewall intent
+# on a shared box, scoped to the dedicated _subrouter user so cmux-feed and
+# interactive use are untouched.
+#
+# 1. Inbound: only the tailnet and loopback may reach the router port. The
+#    daemon binds 0.0.0.0:31415, so without this the office LAN could reach it.
+# 2. Outbound: the _subrouter user may not open NEW connections to tailnet peers
+#    (a routing proxy must not be able to pivot into the tailnet). Replies to
+#    inbound connections are stateful and bypass this via the inbound pass state.
+#    Tailscale MagicDNS (100.100.100.100:53) is exempted or the router loses DNS.
+#
+# Tables/macros are expanded by subrouter-pf.sh before loading.
+
+# --- inbound to the router port (31415) ---
+block in quick proto tcp to any port 31415
+pass  in quick proto tcp from 127.0.0.0/8      to any port 31415 keep state
+pass  in quick proto tcp from ::1              to any port 31415 keep state
+pass  in quick proto tcp from 100.64.0.0/10    to any port 31415 keep state
+pass  in quick proto tcp from fd7a:115c:a1e0::/48 to any port 31415 keep state
+
+# --- outbound egress isolation for the router user ---
+# Allow MagicDNS first (100.100.100.100 is inside 100.64.0.0/10) so the router
+# can still resolve upstream API hostnames.
+pass  out quick proto { tcp udp } from any to 100.100.100.100 port 53 user _subrouter keep state
+# Block any other NEW connection from the router user into tailnet address space.
+block out quick proto tcp from any to 100.64.0.0/10       user _subrouter
+block out quick proto tcp from any to fd7a:115c:a1e0::/48 user _subrouter

--- a/deploy/macos/pf-subrouter.conf
+++ b/deploy/macos/pf-subrouter.conf
@@ -14,11 +14,13 @@
 # Tables/macros are expanded by subrouter-pf.sh before loading.
 
 # --- inbound to the router port (31415) ---
-block in quick proto tcp to any port 31415
-pass  in quick proto tcp from 127.0.0.0/8      to any port 31415 keep state
-pass  in quick proto tcp from ::1              to any port 31415 keep state
-pass  in quick proto tcp from 100.64.0.0/10    to any port 31415 keep state
+# pf `quick` = first match wins, so the allow rules MUST precede the catch-all
+# block; otherwise the block swallows every source, loopback included.
+pass  in quick proto tcp from 127.0.0.0/8        to any port 31415 keep state
+pass  in quick proto tcp from ::1                to any port 31415 keep state
+pass  in quick proto tcp from 100.64.0.0/10      to any port 31415 keep state
 pass  in quick proto tcp from fd7a:115c:a1e0::/48 to any port 31415 keep state
+block in quick proto tcp to any port 31415
 
 # --- outbound egress isolation for the router user ---
 # Allow MagicDNS first (100.100.100.100 is inside 100.64.0.0/10) so the router

--- a/deploy/macos/subrouter-autoupdate.sh
+++ b/deploy/macos/subrouter-autoupdate.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Pull-based auto-updater for a macOS Subrouter host (parity with the GCP
+# updater in ../gcp/subrouter-autoupdate.sh).
+#
+# Polls the latest published GitHub release and, when it differs from the
+# installed version, downloads the matching darwin binary, verifies its
+# checksum, swaps it in atomically, and restarts the LaunchDaemon. launchd has
+# no systemd-socket handoff, so a restart briefly drops in-flight requests; the
+# process handles SIGTERM and `launchctl kickstart -k` gives a clean stop/start.
+# A release only exists after CI ran `go test`, so this never deploys untested
+# code. Runs as root from a LaunchDaemon (writes /usr/local/bin and /etc).
+set -euo pipefail
+
+REPO="${SUBROUTER_REPO:-manaflow-ai/subrouter}"
+BIN="${SUBROUTER_BIN:-/usr/local/bin/subrouter}"
+VERSION_FILE="${SUBROUTER_VERSION_FILE:-/etc/subrouter-version}"
+LABEL="${SUBROUTER_LABEL:-ai.manaflow.subrouter-team}"
+HEALTH_URL="${SUBROUTER_HEALTH_URL:-http://127.0.0.1:31415/_subrouter/health}"
+
+log() { echo "subrouter-autoupdate: $*"; }
+
+case "$(uname -m)" in
+  x86_64|amd64) arch="amd64" ;;
+  arm64|aarch64) arch="arm64" ;;
+  *) log "unsupported arch $(uname -m)"; exit 1 ;;
+esac
+
+latest_tag="$(curl -fsSL -H 'Accept: application/vnd.github+json' \
+  "https://api.github.com/repos/${REPO}/releases/latest" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])')"
+if [ -z "${latest_tag}" ]; then
+  log "could not resolve latest release tag"; exit 1
+fi
+
+installed=""
+[ -f "${VERSION_FILE}" ] && installed="$(cat "${VERSION_FILE}" 2>/dev/null || true)"
+
+if [ "${latest_tag}" = "${installed}" ]; then
+  exit 0
+fi
+
+version="${latest_tag#v}"
+asset="subrouter_${version}_darwin_${arch}"
+base="https://github.com/${REPO}/releases/download/${latest_tag}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+log "updating ${installed:-none} -> ${latest_tag} (${asset})"
+curl -fsSL -o "${tmp}/${asset}" "${base}/${asset}"
+curl -fsSL -o "${tmp}/SHA256SUMS" "${base}/SHA256SUMS"
+( cd "${tmp}" && grep " ${asset}\$" SHA256SUMS | shasum -a 256 -c - )
+
+chmod 0755 "${tmp}/${asset}"
+cp -p "${BIN}" "${BIN}.bak-$(date +%Y%m%d-%H%M%S)" 2>/dev/null || true
+# Atomic replace: install to a temp path on the same filesystem, then rename.
+install -m 0755 "${tmp}/${asset}" "${BIN}.new"
+mv -f "${BIN}.new" "${BIN}"
+launchctl kickstart -k "system/${LABEL}"
+
+i=0
+until curl -fsS "${HEALTH_URL}" >/dev/null 2>&1; do
+  i=$((i + 1))
+  if [ "${i}" -ge 30 ]; then
+    log "health check failed after restart; leaving new binary in place"
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "${latest_tag}" > "${VERSION_FILE}"
+log "updated to ${latest_tag} and healthy"

--- a/deploy/macos/subrouter-pf.sh
+++ b/deploy/macos/subrouter-pf.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Load the Subrouter pf anchor on a shared macOS host.
+#
+# Enables pf and evaluates the "ai.manaflow.subrouter" anchor by reloading the
+# system ruleset (/etc/pf.conf) with an appended anchor reference, so we never
+# permanently edit /etc/pf.conf (which macOS updates reset). Best-effort: a pf
+# failure must never take down the host, so this always exits 0.
+set -u
+
+ANCHOR="ai.manaflow.subrouter"
+ANCHOR_FILE="/etc/pf.anchors/${ANCHOR}"
+
+log() { echo "subrouter-pf: $*"; }
+
+if [ ! -f "${ANCHOR_FILE}" ]; then
+  log "anchor file missing: ${ANCHOR_FILE} (nothing to load)"
+  exit 0
+fi
+
+# Enable pf if it is not already on. -E bumps a reference count and is safe to
+# call when pf is already enabled by something else.
+pfctl -E >/dev/null 2>&1 || pfctl -e >/dev/null 2>&1 || true
+
+tmp="$(mktemp /tmp/subrouter-pf.XXXXXX)" || { log "mktemp failed"; exit 0; }
+# Preserve the system ruleset (Apple anchors, any local includes) and append
+# our filter anchor + its rules.
+if [ -f /etc/pf.conf ]; then
+  cat /etc/pf.conf >"${tmp}" 2>/dev/null || true
+fi
+printf '\nanchor "%s"\nload anchor "%s" from "%s"\n' \
+  "${ANCHOR}" "${ANCHOR}" "${ANCHOR_FILE}" >>"${tmp}"
+
+if pfctl -f "${tmp}" >/dev/null 2>&1; then
+  log "loaded anchor ${ANCHOR}"
+else
+  log "pfctl reload failed (non-fatal); leaving existing ruleset in place"
+fi
+rm -f "${tmp}"
+exit 0

--- a/deploy/macos/subrouter-verify.sh
+++ b/deploy/macos/subrouter-verify.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# subrouter-verify (macOS): durable self-verification of the Claude rate-limit
+# reroute. macOS port of ../gcp/subrouter-verify.sh.
+#
+# Two substitutions vs the systemd version:
+#   - `journalctl -u ... --cursor-file`  -> byte-offset cursors over the daemon
+#     log files (/var/log/subrouter.log + .err.log), advanced each run.
+#   - `systemctl is-active`              -> LaunchDaemon state + health endpoint.
+# All other checks are identical: the failed-reroute invariant, contract drift
+# (Claude 429s / unknown unified-status), health/version, and an hourly canary
+# that pins one tiny request to a cooked account and asserts it is not rejected.
+#
+# Output: ALERT/INFO/OK lines to this job's log and to
+# /var/lib/subrouter-verify/alerts.log; a summary to status.json.
+set -uo pipefail
+
+LABEL="${SUBROUTER_LABEL:-ai.manaflow.subrouter-team}"
+HEALTH="${SUBROUTER_HEALTH_URL:-http://127.0.0.1:31415/_subrouter/health}"
+USAGE="${SUBROUTER_USAGE_URL:-http://127.0.0.1:31415/_subrouter/usage-status}"
+PROXY="${SUBROUTER_PROXY_URL:-http://127.0.0.1:31415/v1/messages}"
+LOGS=("/var/log/subrouter.err.log" "/var/log/subrouter.log")
+STATE=/var/lib/subrouter-verify
+CANARY_STAMP="$STATE/canary.last"
+ALERTS="$STATE/alerts.log"
+STATUS="$STATE/status.json"
+mkdir -p "$STATE"
+
+now_epoch=$(date -u +%s)
+now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+alerts=0
+
+emit() { # level msg...
+  local level="$1"; shift
+  local line="$now_iso [$level] $*"
+  echo "SUBROUTER-VERIFY $line"
+  echo "$line" >> "$ALERTS"
+  [ "$level" = "ALERT" ] && alerts=$((alerts + 1))
+  return 0
+}
+
+# Read new bytes appended to a log file since the last run, advancing a
+# per-file byte cursor. Seeds to the current size on first run so we never
+# alert on historical log lines. Handles truncation/rotation (pos > size).
+read_new_log() {
+  local f="$1"
+  local cf
+  cf="$STATE/pos.$(echo "$f" | tr '/.' '__')"
+  [ -f "$f" ] || return 0
+  local size pos
+  size=$(stat -f %z "$f" 2>/dev/null || echo 0)
+  if [ ! -f "$cf" ]; then echo "$size" >"$cf"; return 0; fi
+  pos=$(cat "$cf" 2>/dev/null || echo 0)
+  case "$pos" in ''|*[!0-9]*) pos=0 ;; esac
+  [ "$pos" -gt "$size" ] && pos=0
+  if [ "$size" -gt "$pos" ]; then
+    tail -c "+$((pos + 1))" "$f" 2>/dev/null
+  fi
+  echo "$size" >"$cf"
+}
+
+# --- healthy Claude account count from usage-status (for the invariant) ---
+counts=$(curl -fsS "$USAGE" 2>/dev/null | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print("0 0"); sys.exit()
+rows = d if isinstance(d, list) else d.get("accounts", [])
+cl = [x for x in rows if x.get("provider") == "claude"]
+def healthy(x):
+    ws = x.get("windows") or []
+    mx = max([w.get("UsedPercent", 0) for w in ws], default=0)
+    return bool(x.get("auth_valid")) and not x.get("error") and mx < 95
+print(sum(1 for x in cl if healthy(x)), len(cl))
+' 2>/dev/null || echo "0 0")
+healthy_claude=$(awk '{print $1}' <<<"$counts"); : "${healthy_claude:=0}"
+total_claude=$(awk '{print $2}' <<<"$counts"); : "${total_claude:=0}"
+
+# --- 1. health + version (detect a down service or silent rollback) ---
+state_line=$(launchctl print "system/${LABEL}" 2>/dev/null | awk -F'= ' '/[^a-z]state = /{print $2; exit}')
+if [ "${state_line:-}" != "running" ]; then
+  # launchctl phrasing varies by macOS; fall back to the health probe.
+  if ! curl -fsS "$HEALTH" >/dev/null 2>&1; then
+    emit ALERT "subrouter LaunchDaemon ${LABEL} not running (state=${state_line:-unknown})"
+  fi
+fi
+if ! curl -fsS "$HEALTH" >/dev/null 2>&1; then
+  emit ALERT "subrouter health endpoint not responding"
+fi
+ver=$(cat /etc/subrouter-version 2>/dev/null || echo unknown)
+
+# --- read new log lines since last run (byte cursors advance themselves) ---
+lines=""
+for f in "${LOGS[@]}"; do
+  lines+=$'\n'"$(read_new_log "$f")"
+done
+
+drift_429=0
+overload_5xx=0
+while IFS= read -r l; do
+  [ -z "$l" ] && continue
+  # 2. Failed-reroute invariant: a rate-limit reached the client after failover
+  #    gave up. Real bug only if healthy accounts existed and not all were tried.
+  case "$l" in
+    *"claude rate-limit returned to client after failover exhausted"*)
+      reason=$(sed -n 's/.*reason=\([^ ]*\).*/\1/p' <<<"$l")
+      tried=$(sed -n 's/.*tried_accounts=\([0-9]*\).*/\1/p' <<<"$l"); : "${tried:=0}"
+      if [ "$healthy_claude" -gt 0 ] && [ "$tried" -lt "$total_claude" ]; then
+        emit ALERT "failed reroute while healthy accounts existed: reason=$reason tried=$tried total_claude=$total_claude healthy=$healthy_claude :: $l"
+      else
+        emit INFO "failover exhausted, pool genuinely constrained: reason=$reason tried=$tried healthy=$healthy_claude"
+      fi
+      ;;
+  esac
+  # 3. Contract drift: Claude HTTP 429 reappearing (we handle it, but note it).
+  case "$l" in
+    *"claude account unusable upstream response"*"status=429"*)
+      drift_429=$((drift_429 + 1)) ;;
+  esac
+  # 3b. Anthropic overload (529/5xx): not a subrouter bug, but track it.
+  case "$l" in
+    *"claude upstream server error"*)
+      overload_5xx=$((overload_5xx + 1)) ;;
+  esac
+  # 4. Contract drift: an anthropic-ratelimit-unified-status value we do not know.
+  case "$l" in
+    *"claude account unusable upstream response"*" anthropic-ratelimit-unified-status="*)
+      st=$(sed -n 's/.* anthropic-ratelimit-unified-status=\([a-z_]*\).*/\1/p' <<<"$l")
+      case "$st" in
+        allowed|allowed_warning|rejected|"") : ;;
+        *) emit ALERT "unknown anthropic-ratelimit-unified-status=$st (possible contract drift): $l" ;;
+      esac
+      ;;
+  esac
+done <<<"$lines"
+[ "$drift_429" -gt 0 ] && emit INFO "claude HTTP 429s observed this window (handled): $drift_429"
+if [ "$overload_5xx" -gt 0 ]; then
+  if [ "$overload_5xx" -ge 20 ]; then
+    emit ALERT "anthropic overload: $overload_5xx upstream 5xx/529 this window (clients likely force-failing)"
+  else
+    emit INFO "anthropic overload: $overload_5xx upstream 5xx/529 this window"
+  fi
+fi
+
+# --- 5. Canary (hourly, only when a cooked Claude account exists) ---
+last_canary=$(cat "$CANARY_STAMP" 2>/dev/null || echo 0)
+case "$last_canary" in ''|*[!0-9]*) last_canary=0 ;; esac
+if [ $((now_epoch - last_canary)) -ge 3600 ]; then
+  cooked=$(curl -fsS "$USAGE" 2>/dev/null | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit()
+rows = d if isinstance(d, list) else d.get("accounts", [])
+for x in rows:
+    if x.get("provider") != "claude" or x.get("error"):
+        continue
+    ws = x.get("windows") or []
+    if any(w.get("Name") == "7d" and w.get("UsedPercent", 0) >= 100 for w in ws):
+        print(x.get("id")); break
+' 2>/dev/null)
+  if [ -n "$cooked" ]; then
+    echo "$now_epoch" >"$CANARY_STAMP"
+    st=$(curl -sS -D - -o /dev/null --max-time 30 -X POST "$PROXY" \
+      -H 'X-Subrouter-Agent: claude' -H "X-Subrouter-Account-ID: $cooked" \
+      -H "X-Subrouter-Session: verify-canary-$now_epoch" \
+      -H 'anthropic-version: 2023-06-01' -H 'content-type: application/json' \
+      -d '{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}' 2>/dev/null \
+      | grep -i '^anthropic-ratelimit-unified-status:' | head -1 | tr -d '\r' | awk '{print tolower($2)}')
+    case "$st" in
+      allowed|allowed_warning)
+        emit OK "canary: pinned cooked $cooked -> client got $st (not blocked)" ;;
+      rejected)
+        emit ALERT "canary: pinned cooked $cooked -> client got REJECTED (reroute BROKEN)" ;;
+      *)
+        emit INFO "canary: pinned cooked $cooked -> unified-status=${st:-none} (inconclusive)" ;;
+    esac
+  fi
+fi
+
+printf '{"ts":"%s","version":"%s","healthy_claude":%s,"total_claude":%s,"overload_5xx":%s,"claude_429s":%s,"alerts_this_run":%s}\n' \
+  "$now_iso" "$ver" "$healthy_claude" "$total_claude" "$overload_5xx" "$drift_429" "$alerts" >"$STATUS"
+[ "$alerts" -eq 0 ] && emit OK "checks passed (version=$ver healthy_claude=$healthy_claude/$total_claude)"
+exit 0


### PR DESCRIPTION
Adds `deploy/macos/` so the shared "team" Subrouter can run on a macOS host (a Mac mini) with full parity to `deploy/gcp`. Motivation: move the router off the GCP VM onto office hardware.

Design: a dedicated `_subrouter` service user under a system LaunchDaemon (`ai.manaflow.subrouter-team`), state in `/var/lib/subrouter` (1:1 with GCP), binary `/usr/local/bin/subrouter`. The dedicated user is what lets pf scope the tailnet-egress block to the router alone, so it can co-host other workloads (e.g. cmux-feed) without collateral.

Parity:
- Auto-update every 2m (`ai.manaflow.subrouter-autoupdate`, launchd `StartInterval`) — darwin/arm64 asset, checksum-verified, atomic swap, `launchctl kickstart -k`, health-gated.
- Claude-reroute self-verifier every 5m (`ai.manaflow.subrouter-verify`) — ported from `journalctl` to log-file byte cursors; same invariant/drift/canary logic.
- pf anchor `ai.manaflow.subrouter`: inbound `:31415` restricted to tailnet + loopback; new outbound to tailnet blocked for `user _subrouter`. MagicDNS `100.100.100.100:53` is exempted (it lives inside `100.64.0.0/10`, so blocking it would kill the router's DNS).
- The one gap vs systemd: no socket handoff, so auto-update restarts drop in-flight requests briefly (documented).

`install-macos.sh` is self-contained and idempotent; it creates the user, installs binary + scripts + pf anchor + LaunchDaemons, and waits for health. It does **not** touch account state — migration copies `/var/lib/subrouter` from the live router during a short window (README).

No Go changes; the running release binary is unaffected. `go build ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785903932&installation_id=133855650&pr_number=63&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F63&signature=da332278ea9ce8a78dc479148f487942a0ebc5578a1258ad8223574b86f87d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the shared team Subrouter on a macOS host with full parity to the GCP deployment so we can move the service off the GCP VM to a Mac mini. Uses a dedicated `_subrouter` user, system LaunchDaemons, and pf for safe co-hosting; includes a pf rule order fix so `:31415` stays reachable.

- **New Features**
  - Added `deploy/macos/` with `install-macos.sh` to set up `_subrouter`, LaunchDaemon `ai.manaflow.subrouter-team`, and health checks.
  - Auto-update every 2m and self-verifier every 5m via launchd (`ai.manaflow.subrouter-autoupdate`, `ai.manaflow.subrouter-verify`); darwin asset is checksum-verified and health-gated.
  - pf anchor `ai.manaflow.subrouter`: inbound `:31415` restricted to tailnet + loopback (fixed rule order to allow before block); block new outbound to tailnet for user `_subrouter`; allow MagicDNS `100.100.100.100:53`; anchor re-asserted every 10m (`ai.manaflow.subrouter-pf`).
  - Mirrors GCP paths: state in `/var/lib/subrouter`, binary `/usr/local/bin/subrouter`, logs in `/var/log`; install is idempotent.
  - Known gap vs systemd: no socket handoff, so auto-update restarts briefly drop in-flight requests. No Go changes.

- **Migration**
  - Stop the GCP router, copy `/var/lib/subrouter` to the Mac, fix ownership, restart, and POST `/_subrouter/reload-accounts`.
  - Repoint clients to the Mac host; keep the GCP VM stopped for quick rollback.

<sup>Written for commit 9d928ce2715886ec36c93751e93c9c641a5ee1ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS deployment support for the shared Subrouter, including installation, service setup, update automation, and health verification.
  * Added network isolation rules and launch daemons to run the service reliably in the background.
  * Added a detailed macOS deployment guide with install, migration, rollback, and uninstall steps.

* **Bug Fixes**
  * Improved service resilience with automatic checks, restart handling, and safer update application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->