### PR TITLE
Route opted-in Claude accounts through extra usage (overage) before the Fable fallback chain

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -182,6 +182,7 @@ func serve(args []string) error {
 	bedrockGatewayToken := flags.String("bedrock-gateway-token", "", "optional bearer token clients must present to the Bedrock gateway; defaults to SUBROUTER_BEDROCK_GATEWAY_TOKEN")
 	bedrockProfiles := flags.String("bedrock-profiles", "", "comma-separated AWS profiles for the Bedrock gateway; defaults to SUBROUTER_BEDROCK_PROFILES or discovered awN profiles")
 	bedrockAutoBump := flags.Bool("bedrock-autobump", false, "request a Service Quotas increase (2x, deduped) when Bedrock throttles Fable/Opus")
+	claudeOverageCostLog := flags.String("claude-overage-cost-log", "", "append Claude extra-usage token records to this JSONL file; empty disables")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -316,7 +317,11 @@ func serve(args []string) error {
 		MaxBodyBytes:      *maxBodyBytes,
 		Bedrock:           bedrockConfig,
 		ClaudeFableAPIKey: strings.TrimSpace(os.Getenv("SUBROUTER_CLAUDE_FABLE_API_KEY")),
-		Transcripts:       transcript.NewRecorder(*transcriptDir),
+		// SUBROUTER_CLAUDE_OVERAGE_ACCOUNTS is a comma-separated list of Claude
+		// profile names (often emails) allowed to serve via Anthropic extra usage.
+		ClaudeOverageAccounts:    proxy.NormalizeClaudeOverageAccounts(os.Getenv("SUBROUTER_CLAUDE_OVERAGE_ACCOUNTS")),
+		ClaudeOverageCostLogPath: strings.TrimSpace(*claudeOverageCostLog),
+		Transcripts:              transcript.NewRecorder(*transcriptDir),
 	}
 	transcriptGCSSyncer := transcript.NewGCSSyncer(transcript.GCSSyncerConfig{
 		SourceDir:      *transcriptDir,
@@ -848,7 +853,7 @@ Usage:
   %[1]s spend              Show AWS Bedrock spend tracked by the server
   %[1]s gemini             Manage Gemini profiles
 
-  %[1]s serve [--addr 127.0.0.1:31415] [--fetch-usage=true] [--codex-upstream URL] [--claude-upstream URL] [--kimi-upstream URL] [--zai-upstream URL] [--transcripts DIR] [--transcript-gcs-uri gs://bucket/prefix] [--transcript-gcs-sync-timeout 30m] [--transcript-local-retention 24h] [--transcript-max-local-bytes 2GiB]
+  %[1]s serve [--addr 127.0.0.1:31415] [--fetch-usage=true] [--codex-upstream URL] [--claude-upstream URL] [--kimi-upstream URL] [--zai-upstream URL] [--transcripts DIR] [--transcript-gcs-uri gs://bucket/prefix] [--transcript-gcs-sync-timeout 30m] [--transcript-local-retention 24h] [--transcript-max-local-bytes 2GiB] [--claude-overage-cost-log FILE]
   %[1]s accounts
   %[1]s codex [codex args...]
   %[1]s install-daemon [--start=true]       macOS LaunchAgent
@@ -861,6 +866,7 @@ Session stickiness:
   Send X-Subrouter-Account-ID to force a specific account, including an API-key account.
   Subrouter switches the active sr account every 10m by default; set --sr-switch-interval=0 to disable.
   For %[1]s codex, set SUBROUTER_CODEX_USER_EMAIL and/or SUBROUTER_CODEX_ACCOUNT_ID instead.
+  For Claude extra usage, set SUBROUTER_CLAUDE_OVERAGE_ACCOUNTS to comma-separated Claude profile names.
   The proxy also checks common session headers, query params, and small JSON bodies.
 `, program)
 }

--- a/internal/proxy/claude_overage.go
+++ b/internal/proxy/claude_overage.go
@@ -1,0 +1,310 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/internal/selectacct"
+)
+
+const (
+	claudeOverageAccountHeader = "X-Subrouter-Overage-Account"
+	claudeOverageFloorHeadroom = 0.01
+)
+
+type claudeOverageUsage struct {
+	InputTokens              int
+	OutputTokens             int
+	CacheCreationInputTokens int
+	CacheReadInputTokens     int
+}
+
+func (u claudeOverageUsage) empty() bool {
+	return u.InputTokens == 0 && u.OutputTokens == 0 &&
+		u.CacheCreationInputTokens == 0 && u.CacheReadInputTokens == 0
+}
+
+type claudeOverageCostRecord struct {
+	Timestamp                string `json:"ts"`
+	Account                  string `json:"account"`
+	Model                    string `json:"model,omitempty"`
+	Status                   int    `json:"status"`
+	InputTokens              *int   `json:"input_tokens,omitempty"`
+	OutputTokens             *int   `json:"output_tokens,omitempty"`
+	CacheCreationInputTokens *int   `json:"cache_creation_input_tokens,omitempty"`
+	CacheReadInputTokens     *int   `json:"cache_read_input_tokens,omitempty"`
+}
+
+var claudeOverageCostMu sync.Mutex
+
+func NormalizeClaudeOverageAccounts(raw string) map[string]bool {
+	out := map[string]bool{}
+	for _, part := range strings.Split(raw, ",") {
+		id := normalizeClaudeOverageAccountID(part)
+		if id == "" {
+			continue
+		}
+		out[id] = true
+	}
+	return out
+}
+
+func normalizeClaudeOverageAccountID(accountID string) string {
+	return strings.ToLower(strings.TrimSpace(accountID))
+}
+
+func (s Server) claudeOverageOptIn(accountID string) bool {
+	if len(s.ClaudeOverageAccounts) == 0 {
+		return false
+	}
+	return s.ClaudeOverageAccounts[normalizeClaudeOverageAccountID(accountID)]
+}
+
+func claudeOverageServed(status int, header http.Header) bool {
+	return status >= 200 && status < 300 && claudeResponseRejected(header)
+}
+
+func stripClaudeOverageHeaders(header http.Header) {
+	if header == nil {
+		return
+	}
+	for key := range header {
+		lower := strings.ToLower(key)
+		if lower == "retry-after" || strings.HasPrefix(lower, "anthropic-ratelimit-unified-") {
+			header.Del(key)
+		}
+	}
+	header.Del(claudeOverageAccountHeader)
+}
+
+func (s Server) markClaudeOverageResponse(resp *http.Response, accountID string) {
+	if resp == nil {
+		return
+	}
+	stripClaudeOverageHeaders(resp.Header)
+	if resp.Header == nil {
+		resp.Header = http.Header{}
+	}
+	// This marker is consumed and removed by captureResponseBody before
+	// ReverseProxy copies headers. Overage applies only to POST /v1/messages, so
+	// the GET cache path should never see it; captureResponseBody still strips it
+	// before cacheRecorder can store headers.
+	resp.Header.Set(claudeOverageAccountHeader, accountID)
+}
+
+func applyClaudeOverageFloor(score selectacct.Score, windows []accounts.UsageWindow) selectacct.Score {
+	if !claudeExtraUsageAvailable(windows) {
+		return score
+	}
+	if score.Headroom < claudeOverageFloorHeadroom {
+		score.Headroom = claudeOverageFloorHeadroom
+	}
+	if score.ShortHeadroom < claudeOverageFloorHeadroom {
+		score.ShortHeadroom = claudeOverageFloorHeadroom
+	}
+	if len(score.ModelScores) > 0 {
+		modelScores := make(map[string]selectacct.Score, len(score.ModelScores))
+		for key, modelScore := range score.ModelScores {
+			if modelScore.Headroom < claudeOverageFloorHeadroom {
+				modelScore.Headroom = claudeOverageFloorHeadroom
+			}
+			if modelScore.ShortHeadroom < claudeOverageFloorHeadroom {
+				modelScore.ShortHeadroom = claudeOverageFloorHeadroom
+			}
+			modelScores[key] = modelScore
+		}
+		score.ModelScores = modelScores
+	}
+	return score
+}
+
+func claudeExtraUsageAvailable(windows []accounts.UsageWindow) bool {
+	for _, window := range windows {
+		if strings.EqualFold(strings.TrimSpace(window.Name), "extra") && window.UsedPercent < 100 {
+			return true
+		}
+	}
+	return false
+}
+
+func (s Server) logClaudeOverageServed(accountID, model string, status int) {
+	if s.Logger != nil {
+		s.Logger.Info("claude overage served", "account", accountID, "model", model, "status", status)
+	}
+}
+
+func (s Server) appendClaudeOverageCostRecord(accountID, model string, status int, usage claudeOverageUsage, usageOK bool) {
+	if strings.TrimSpace(s.ClaudeOverageCostLogPath) == "" {
+		return
+	}
+	record := claudeOverageCostRecord{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Account:   accountID,
+		Model:     model,
+		Status:    status,
+	}
+	if usageOK {
+		record.InputTokens = intPtr(usage.InputTokens)
+		record.OutputTokens = intPtr(usage.OutputTokens)
+		record.CacheCreationInputTokens = intPtr(usage.CacheCreationInputTokens)
+		record.CacheReadInputTokens = intPtr(usage.CacheReadInputTokens)
+	}
+	appendClaudeOverageCostRecord(s.ClaudeOverageCostLogPath, record)
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func appendClaudeOverageCostRecord(path string, record claudeOverageCostRecord) {
+	if strings.TrimSpace(path) == "" {
+		return
+	}
+	line, err := json.Marshal(record)
+	if err != nil {
+		return
+	}
+	claudeOverageCostMu.Lock()
+	defer claudeOverageCostMu.Unlock()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, _ = f.Write(append(line, '\n'))
+}
+
+func parseClaudeOverageUsage(body []byte) (model string, usage claudeOverageUsage, ok bool) {
+	if len(body) == 0 {
+		return "", claudeOverageUsage{}, false
+	}
+	if model, usage, ok = parseClaudeOverageJSONUsage(body); ok {
+		return model, usage, true
+	}
+	return parseClaudeOverageSSEUsage(body)
+}
+
+func parseClaudeOverageJSONUsage(body []byte) (string, claudeOverageUsage, bool) {
+	var payload struct {
+		Model string `json:"model"`
+		Usage struct {
+			InputTokens              int `json:"input_tokens"`
+			OutputTokens             int `json:"output_tokens"`
+			CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+			CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", claudeOverageUsage{}, false
+	}
+	usage := claudeOverageUsage{
+		InputTokens:              payload.Usage.InputTokens,
+		OutputTokens:             payload.Usage.OutputTokens,
+		CacheCreationInputTokens: payload.Usage.CacheCreationInputTokens,
+		CacheReadInputTokens:     payload.Usage.CacheReadInputTokens,
+	}
+	if usage.empty() {
+		return payload.Model, usage, false
+	}
+	return payload.Model, usage, true
+}
+
+func parseClaudeOverageSSEUsage(body []byte) (string, claudeOverageUsage, bool) {
+	var model string
+	var usage claudeOverageUsage
+	var got bool
+	for _, data := range sseDataPayloads(string(body)) {
+		var event struct {
+			Type    string `json:"type"`
+			Message struct {
+				Model string `json:"model"`
+				Usage struct {
+					InputTokens              int `json:"input_tokens"`
+					OutputTokens             int `json:"output_tokens"`
+					CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+					CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+				} `json:"usage"`
+			} `json:"message"`
+			Usage struct {
+				InputTokens              int `json:"input_tokens"`
+				OutputTokens             int `json:"output_tokens"`
+				CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+				CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+			} `json:"usage"`
+		}
+		if err := json.Unmarshal([]byte(data), &event); err != nil {
+			continue
+		}
+		if event.Message.Model != "" {
+			model = event.Message.Model
+		}
+		messageUsage := claudeOverageUsage{
+			InputTokens:              event.Message.Usage.InputTokens,
+			OutputTokens:             event.Message.Usage.OutputTokens,
+			CacheCreationInputTokens: event.Message.Usage.CacheCreationInputTokens,
+			CacheReadInputTokens:     event.Message.Usage.CacheReadInputTokens,
+		}
+		deltaUsage := claudeOverageUsage{
+			InputTokens:              event.Usage.InputTokens,
+			OutputTokens:             event.Usage.OutputTokens,
+			CacheCreationInputTokens: event.Usage.CacheCreationInputTokens,
+			CacheReadInputTokens:     event.Usage.CacheReadInputTokens,
+		}
+		if !messageUsage.empty() {
+			mergeClaudeOverageUsage(&usage, messageUsage)
+			got = true
+		}
+		if !deltaUsage.empty() {
+			mergeClaudeOverageUsage(&usage, deltaUsage)
+			got = true
+		}
+	}
+	return model, usage, got
+}
+
+func sseDataPayloads(body string) []string {
+	var payloads []string
+	var data []string
+	flush := func() {
+		if len(data) == 0 {
+			return
+		}
+		payloads = append(payloads, strings.Join(data, "\n"))
+		data = nil
+	}
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			flush()
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			value := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if value != "[DONE]" {
+				data = append(data, value)
+			}
+		}
+	}
+	flush()
+	return payloads
+}
+
+func mergeClaudeOverageUsage(dst *claudeOverageUsage, src claudeOverageUsage) {
+	if src.InputTokens != 0 {
+		dst.InputTokens = src.InputTokens
+	}
+	if src.OutputTokens != 0 {
+		dst.OutputTokens = src.OutputTokens
+	}
+	if src.CacheCreationInputTokens != 0 {
+		dst.CacheCreationInputTokens = src.CacheCreationInputTokens
+	}
+	if src.CacheReadInputTokens != 0 {
+		dst.CacheReadInputTokens = src.CacheReadInputTokens
+	}
+}

--- a/internal/proxy/claude_overage_test.go
+++ b/internal/proxy/claude_overage_test.go
@@ -1,0 +1,461 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
+	"github.com/manaflow-ai/subrouter/internal/selectacct"
+	"github.com/manaflow-ai/subrouter/internal/session"
+)
+
+func TestNormalizeClaudeOverageAccounts(t *testing.T) {
+	accounts := NormalizeClaudeOverageAccounts(" Lawrence@Manaflow.AI , other-profile ,,LAWRENCE@MANAFLOW.AI ")
+	if !accounts["lawrence@manaflow.ai"] {
+		t.Fatalf("missing normalized opt-in account: %+v", accounts)
+	}
+	if !accounts["other-profile"] {
+		t.Fatalf("missing second opt-in account: %+v", accounts)
+	}
+	if len(accounts) != 2 {
+		t.Fatalf("accounts = %+v, want two deduped entries", accounts)
+	}
+
+	t.Setenv("SUBROUTER_CLAUDE_OVERAGE_ACCOUNTS", " Lawrence@Manaflow.AI ")
+	server := Server{ClaudeOverageAccounts: NormalizeClaudeOverageAccounts(os.Getenv("SUBROUTER_CLAUDE_OVERAGE_ACCOUNTS"))}
+	if !server.ClaudeOverageAccounts["lawrence@manaflow.ai"] || !server.claudeOverageOptIn(" LAWRENCE@MANAFLOW.AI ") {
+		t.Fatalf("env-derived Server.ClaudeOverageAccounts = %+v", server.ClaudeOverageAccounts)
+	}
+}
+
+func TestClaudeOverageOptInPassesThroughAndLogsCost(t *testing.T) {
+	var cookedHits, freshHits int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		auth := r.Header.Get("Authorization")
+		switch {
+		case strings.Contains(auth, "tok-cooked"):
+			cookedHits++
+			w.Header().Set("Retry-After", "3600")
+			w.Header().Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+			w.Header().Set("Anthropic-Ratelimit-Unified-5h-Status", "rejected")
+			w.Header().Set("Anthropic-Ratelimit-Unified-7d-Status", "allowed")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"msg_overage","type":"message","model":"claude-fable-5","usage":{"input_tokens":11,"output_tokens":22,"cache_creation_input_tokens":3,"cache_read_input_tokens":4}}`))
+		case strings.Contains(auth, "tok-fresh"):
+			freshHits++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"unexpected_failover"}`))
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer upstream.Close()
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("claude", "session-overage", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+		{AccountID: "cooked@example.com", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+		{AccountID: "fresh@example.com", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+	}))
+	var logBuf bytes.Buffer
+	costLog := filepath.Join(t.TempDir(), "claude-overage.jsonl")
+	handler := Server{
+		ClaudeUpstream: upstreamURL,
+		Accounts: []accounts.Account{
+			{ID: "cooked@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-cooked"},
+			{ID: "fresh@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-fresh"},
+		},
+		Sessions:                 store,
+		SchedulerRef:             schedulerRef,
+		UsageScoreTTL:            0,
+		MaxBodyBytes:             1 << 20,
+		Logger:                   slog.New(slog.NewTextHandler(&logBuf, nil)),
+		ClaudeOverageAccounts:    NormalizeClaudeOverageAccounts(" cooked@example.com "),
+		ClaudeOverageCostLogPath: costLog,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	req, err := http.NewRequest(http.MethodPost, subrouter.URL+"/v1/messages", strings.NewReader(`{"model":"claude-fable-5","messages":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Subrouter-Agent", "claude")
+	req.Header.Set("X-Subrouter-Session", "session-overage")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(response.Body)
+	_ = response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want overage 200", response.StatusCode, body)
+	}
+	if cookedHits != 1 || freshHits != 0 {
+		t.Fatalf("upstream hits cooked=%d fresh=%d, want 1/0", cookedHits, freshHits)
+	}
+	for _, header := range []string{
+		"Retry-After",
+		"Anthropic-Ratelimit-Unified-Status",
+		"Anthropic-Ratelimit-Unified-5h-Status",
+		"Anthropic-Ratelimit-Unified-7d-Status",
+		claudeOverageAccountHeader,
+	} {
+		if got := response.Header.Get(header); got != "" {
+			t.Fatalf("client header %s = %q, want stripped", header, got)
+		}
+	}
+	if schedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
+		t.Fatal("overage-served opt-in account should remain routable")
+	}
+	if !strings.Contains(logBuf.String(), "claude overage served") {
+		t.Fatalf("missing overage served log; logs=\n%s", logBuf.String())
+	}
+	data, err := os.ReadFile(costLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(data), &record); err != nil {
+		t.Fatalf("cost log JSON = %q: %v", data, err)
+	}
+	if record["account"] != "cooked@example.com" || record["status"].(float64) != 200 {
+		t.Fatalf("cost record account/status = %+v", record)
+	}
+	if record["input_tokens"].(float64) != 11 || record["output_tokens"].(float64) != 22 ||
+		record["cache_creation_input_tokens"].(float64) != 3 || record["cache_read_input_tokens"].(float64) != 4 {
+		t.Fatalf("cost record tokens = %+v", record)
+	}
+}
+
+func TestClaudeOverageFailoverUsesServingAccountIdentity(t *testing.T) {
+	server, store := claudeFailoverServer(t)
+	server.ClaudeOverageAccounts = NormalizeClaudeOverageAccounts("fresh@example.com")
+	if _, err := store.Put("claude", "session-overage-failover", "cooked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	var cookedCalls, freshCalls int
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		switch req.Header.Get("Authorization") {
+		case "Bearer tok-cooked":
+			cookedCalls++
+			h := http.Header{}
+			h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+			return &http.Response{StatusCode: http.StatusTooManyRequests, Header: h, Body: io.NopCloser(strings.NewReader(realisticAnthropic429Body))}
+		case "Bearer tok-fresh":
+			freshCalls++
+			h := http.Header{}
+			h.Set("Retry-After", "3600")
+			h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+			h.Set("Anthropic-Ratelimit-Unified-5h-Status", "rejected")
+			return &http.Response{StatusCode: http.StatusOK, Header: h, Body: io.NopCloser(strings.NewReader(`{"id":"msg_overage"}`))}
+		default:
+			return &http.Response{StatusCode: http.StatusBadRequest, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(`bad auth`))}
+		}
+	}}
+	body := []byte(`{"model":"claude-opus-4-8","messages":[]}`)
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(body)), nil }
+	req.Header.Set("Authorization", "Bearer tok-cooked")
+	transport := usageLimitRetryTransport{
+		base:        stub,
+		server:      &server,
+		provider:    accounts.ProviderClaude,
+		agent:       "claude",
+		session:     "session-overage-failover",
+		account:     "cooked@example.com",
+		method:      http.MethodPost,
+		path:        "/v1/messages",
+		maxAttempts: 4,
+	}
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want opt-in overage 200", response.StatusCode)
+	}
+	if cookedCalls != 1 || freshCalls != 1 {
+		t.Fatalf("calls cooked=%d fresh=%d, want 1/1", cookedCalls, freshCalls)
+	}
+	if got := response.Header.Get("Anthropic-Ratelimit-Unified-Status"); got != "" {
+		t.Fatalf("unified status leaked from active overage path: %q", got)
+	}
+	if got := response.Header.Get(claudeOverageAccountHeader); got != "fresh@example.com" {
+		t.Fatalf("marker account = %q, want fresh@example.com", got)
+	}
+	if server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "fresh@example.com") {
+		t.Fatal("serving opt-in account should not be exhausted")
+	}
+}
+
+func TestClaudeOverageOptIn429FallsThroughToFableFallback(t *testing.T) {
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: "overage@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-overage"},
+		},
+		Sessions:              store,
+		SchedulerRef:          selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{{AccountID: "overage@example.com", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1}})),
+		ClaudeOverageAccounts: NormalizeClaudeOverageAccounts("overage@example.com"),
+	}
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		h := http.Header{}
+		h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		return &http.Response{StatusCode: http.StatusTooManyRequests, Header: h, Body: io.NopCloser(strings.NewReader(realisticAnthropic429Body))}
+	}}
+	body := []byte(`{"model":"claude-fable-5","messages":[]}`)
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(body)), nil }
+	req.Header.Set("Authorization", "Bearer tok-overage")
+	fallbackCalled := false
+	transport := usageLimitRetryTransport{
+		base:        stub,
+		server:      &server,
+		provider:    accounts.ProviderClaude,
+		agent:       "claude",
+		session:     "session-fable-overage",
+		account:     "overage@example.com",
+		method:      http.MethodPost,
+		path:        "/v1/messages",
+		maxAttempts: 4,
+		poolModel:   agentclaude.FableFeature,
+		fableFallback: func() (*http.Response, bool) {
+			fallbackCalled = true
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(`{"type":"message","source":"fallback"}`))}, true
+		},
+	}
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK || !fallbackCalled {
+		t.Fatalf("status=%d fallbackCalled=%v, want fable fallback 200", response.StatusCode, fallbackCalled)
+	}
+	if !server.SchedulerRef.Get().ForModel(agentclaude.FableFeature).Exhausted(accounts.ProviderClaude, "overage@example.com") {
+		t.Fatal("429 rejected should still mark the account exhausted for the request pool")
+	}
+}
+
+func TestClaudeOverageNonReplayableRequestStillStripsAndReturns(t *testing.T) {
+	server := Server{ClaudeOverageAccounts: NormalizeClaudeOverageAccounts("overage@example.com")}
+	stub := &stubRoundTripper{responses: func(req *http.Request) *http.Response {
+		h := http.Header{}
+		h.Set("Retry-After", "3600")
+		h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		return &http.Response{StatusCode: http.StatusOK, Header: h, Body: io.NopCloser(strings.NewReader(`{"id":"msg_overage"}`))}
+	}}
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", io.NopCloser(strings.NewReader(`{}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.GetBody = nil
+	transport := usageLimitRetryTransport{
+		base:     stub,
+		server:   &server,
+		provider: accounts.ProviderClaude,
+		account:  "overage@example.com",
+	}
+	response, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if stub.calls != 1 || response.StatusCode != http.StatusOK {
+		t.Fatalf("calls=%d status=%d, want one accepted overage response", stub.calls, response.StatusCode)
+	}
+	if got := response.Header.Get("Retry-After"); got != "" {
+		t.Fatalf("Retry-After = %q, want stripped", got)
+	}
+	if got := response.Header.Get(claudeOverageAccountHeader); got != "overage@example.com" {
+		t.Fatalf("marker = %q, want overage account", got)
+	}
+}
+
+func TestClaudeOverageFloorKeepsOptInScoresEligible(t *testing.T) {
+	windows := []accounts.UsageWindow{
+		{Name: "5h", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
+		{Name: "7d", UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
+		{Name: agentclaude.FableWindowName, Feature: agentclaude.FableFeature, UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
+		{Name: "extra", UsedPercent: 25},
+	}
+	base := scoreFromUsageWindows(accounts.ProviderClaude, "acct@example.com", windows)
+	if !selectacct.NewScheduler([]selectacct.Score{base}).Exhausted(accounts.ProviderClaude, "acct@example.com") {
+		t.Fatal("non-opt-in base score should stay exhausted")
+	}
+	optIn := applyClaudeOverageFloor(base, windows)
+	if optIn.Headroom < claudeOverageFloorHeadroom || optIn.ShortHeadroom < claudeOverageFloorHeadroom {
+		t.Fatalf("base floor not applied: %+v", optIn)
+	}
+	fableScore, ok := optIn.ModelScores[selectacct.ModelKey(agentclaude.FableFeature)]
+	if !ok {
+		t.Fatalf("missing fable score: %+v", optIn.ModelScores)
+	}
+	if fableScore.Headroom < claudeOverageFloorHeadroom || fableScore.ShortHeadroom < claudeOverageFloorHeadroom {
+		t.Fatalf("model floor not applied: %+v", fableScore)
+	}
+	if selectacct.NewScheduler([]selectacct.Score{optIn}).ForModel(agentclaude.FableFeature).Exhausted(accounts.ProviderClaude, "acct@example.com") {
+		t.Fatal("opt-in score with extra usage headroom should not be exhausted")
+	}
+
+	usedExtra := append([]accounts.UsageWindow(nil), windows...)
+	usedExtra[len(usedExtra)-1].UsedPercent = 100
+	cooked := applyClaudeOverageFloor(scoreFromUsageWindows(accounts.ProviderClaude, "acct@example.com", usedExtra), usedExtra)
+	if !selectacct.NewScheduler([]selectacct.Score{cooked}).ForModel(agentclaude.FableFeature).Exhausted(accounts.ProviderClaude, "acct@example.com") {
+		t.Fatal("extra usage at 100% should not get the floor")
+	}
+}
+
+func TestServerAppliesClaudeOverageFloorOnlyForOptInRoutingScores(t *testing.T) {
+	windows := []accounts.UsageWindow{
+		{Name: "5h", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
+		{Name: "7d", UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
+		{Name: agentclaude.FableWindowName, Feature: agentclaude.FableFeature, UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
+		{Name: "extra", UsedPercent: 10},
+	}
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: "optin@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth},
+			{ID: "plain@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth},
+		},
+		SchedulerRef:          selectacct.NewSchedulerRef(selectacct.NewScheduler(nil)),
+		ClaudeOverageAccounts: NormalizeClaudeOverageAccounts(" optin@example.com "),
+	}
+	server.updateSchedulerFromUsageStatuses([]AccountUsageStatus{
+		{
+			AccountStatus: AccountStatus{ID: "optin@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth},
+			UsageFresh:    true,
+			Windows:       windows,
+		},
+		{
+			AccountStatus: AccountStatus{ID: "plain@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth},
+			UsageFresh:    true,
+			Windows:       windows,
+		},
+	})
+	scheduler := server.SchedulerRef.Get()
+	if scheduler.ForModel(agentclaude.FableFeature).Exhausted(accounts.ProviderClaude, "optin@example.com") {
+		t.Fatal("opt-in routing score should receive the overage floor")
+	}
+	if !scheduler.ForModel(agentclaude.FableFeature).Exhausted(accounts.ProviderClaude, "plain@example.com") {
+		t.Fatal("non-opt-in routing score should remain exhausted")
+	}
+}
+
+func TestParseClaudeOverageSSEUsage(t *testing.T) {
+	body := "" +
+		"event: message_start\n" +
+		"data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-opus-4-8\",\"usage\":{\"input_tokens\":7,\"cache_read_input_tokens\":2}}}\n\n" +
+		"event: message_delta\n" +
+		"data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":9}}\n\n"
+	model, usage, ok := parseClaudeOverageUsage([]byte(body))
+	if !ok {
+		t.Fatal("expected SSE usage")
+	}
+	if model != "claude-opus-4-8" || usage.InputTokens != 7 || usage.OutputTokens != 9 || usage.CacheReadInputTokens != 2 {
+		t.Fatalf("model=%q usage=%+v", model, usage)
+	}
+}
+
+func TestCaptureResponseBodyPassiveClaudeOverageStripsAndSkipsExhaustion(t *testing.T) {
+	server, _ := claudeFailoverServer(t)
+	server.ClaudeOverageAccounts = NormalizeClaudeOverageAccounts("cooked@example.com")
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Anthropic-Ratelimit-Unified-Status": []string{"rejected"},
+			"Retry-After":                        []string{"3600"},
+		},
+		Body: io.NopCloser(strings.NewReader(`{"id":"msg_overage"}`)),
+	}
+	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "", "/v1/messages")
+	_, _ = io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
+	if got := response.Header.Get("Anthropic-Ratelimit-Unified-Status"); got != "" {
+		t.Fatalf("unified status = %q, want stripped", got)
+	}
+	if server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
+		t.Fatal("passive overage handling should not exhaust opted-in account")
+	}
+}
+
+func TestClaudeOverageCostLogWithoutUsageStillAppends(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "claude-overage.jsonl")
+	server := Server{ClaudeOverageCostLogPath: path}
+	server.appendClaudeOverageCostRecord("acct@example.com", "claude-opus", http.StatusOK, claudeOverageUsage{}, false)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"account":"acct@example.com"`) || strings.Contains(string(data), "input_tokens") {
+		t.Fatalf("unexpected cost log line: %s", data)
+	}
+}
+
+func TestScoreAccountsAppliesClaudeOverageFloorForOptInFreshUsage(t *testing.T) {
+	account := accounts.Account{ID: "optin@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok"}
+	ref := &AccountRef{
+		accounts: []accounts.Account{account},
+		client:   &http.Client{Transport: &countingTransport{responses: claudeUsageOK}},
+		usageWindows: map[string]usageWindowsEntry{
+			account.ID + "\x00" + string(account.Provider): {
+				windows: []accounts.UsageWindow{
+					{Name: "5h", UsedPercent: 100, LimitWindowSeconds: 5 * 60 * 60},
+					{Name: "7d", UsedPercent: 100, LimitWindowSeconds: 7 * 24 * 60 * 60},
+					{Name: "extra", UsedPercent: 1},
+				},
+				at: time.Now(),
+			},
+		},
+	}
+	server := Server{
+		AccountRef:            ref,
+		SchedulerRef:          selectacct.NewSchedulerRef(selectacct.NewScheduler(nil)),
+		ClaudeOverageAccounts: NormalizeClaudeOverageAccounts("optin@example.com"),
+		RefreshAccountFn: func(ctx context.Context, account accounts.Account) (accounts.Account, error) {
+			return account, nil
+		},
+	}
+	scores, scored := server.scoreAccounts(context.Background(), []accounts.Account{account})
+	if scored != 1 || len(scores) != 1 {
+		t.Fatalf("scored=%d scores=%d", scored, len(scores))
+	}
+	if selectacct.NewScheduler(scores).Exhausted(accounts.ProviderClaude, "optin@example.com") {
+		t.Fatalf("opt-in score should not be exhausted: %+v", scores[0])
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -65,6 +65,10 @@ type Server struct {
 	// ONLY to Fable; Opus/Sonnet/etc. continue to use the OAuth pool and never
 	// touch this key.
 	ClaudeFableAPIKey string
+	// ClaudeOverageAccounts holds normalized Claude OAuth account IDs that may
+	// accept Anthropic extra-usage responses instead of failing over.
+	ClaudeOverageAccounts    map[string]bool
+	ClaudeOverageCostLogPath string
 }
 
 type ActiveSessions struct {
@@ -1058,6 +1062,9 @@ func (s Server) updateSchedulerFromUsageStatuses(statuses []AccountUsageStatus) 
 		}
 		if idx, ok := scoreByID[selectacct.ScoreKey(status.Provider, status.ID)]; ok {
 			next := scoreFromUsageWindows(status.Provider, status.ID, status.Windows)
+			if status.Provider == accounts.ProviderClaude && s.claudeOverageOptIn(status.ID) {
+				next = applyClaudeOverageFloor(next, status.Windows)
+			}
 			next.Fresh = true
 			scores[idx] = next
 			scored++
@@ -1454,6 +1461,9 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 		}
 		if idx, ok := scoreByID[selectacct.ScoreKey(account.Provider, account.ID)]; ok {
 			next := scoreFromUsageWindows(account.Provider, account.ID, windows)
+			if account.Provider == accounts.ProviderClaude && s.claudeOverageOptIn(account.ID) {
+				next = applyClaudeOverageFloor(next, windows)
+			}
 			next.Fresh = true
 			scores[idx] = next
 			scored++
@@ -2182,6 +2192,26 @@ func (s Server) recordReplayableRequestBody(r *http.Request, agentType, sessionI
 }
 
 func (s Server) captureResponseBody(response *http.Response, agentType, sessionID, accountID string, provider accounts.Provider, poolModel, path string) {
+	overageAccount := ""
+	if response != nil {
+		// A marker naming a non-opted-in account can only be a forgery (requests
+		// that bypass the retry transport reach here with upstream headers
+		// intact); ignore it but still remove the header so it never leaks.
+		if marker := strings.TrimSpace(response.Header.Get(claudeOverageAccountHeader)); marker != "" && !s.claudeOverageOptIn(marker) {
+			response.Header.Del(claudeOverageAccountHeader)
+		}
+		if marker := strings.TrimSpace(response.Header.Get(claudeOverageAccountHeader)); marker != "" {
+			overageAccount = marker
+			stripClaudeOverageHeaders(response.Header)
+		} else if provider == accounts.ProviderClaude && accountID != "" &&
+			claudeOverageServed(response.StatusCode, response.Header) && s.claudeOverageOptIn(accountID) {
+			overageAccount = accountID
+			stripClaudeOverageHeaders(response.Header)
+		}
+	}
+	if overageAccount != "" {
+		s.logClaudeOverageServed(overageAccount, poolModel, response.StatusCode)
+	}
 	// Anthropic signals subscription exhaustion with a plain 429 and a dead or
 	// expired OAuth token with a plain 401, neither with a codex-style
 	// usage-limit body to inspect. Both mean this account can't serve the
@@ -2190,7 +2220,7 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 	// anthropic-ratelimit-unified-status=rejected is also unusable, because the
 	// account is depleted (served via overage) and Claude Code hard-blocks the
 	// user on that header even though the request "succeeded".
-	claudeUnusable := provider == accounts.ProviderClaude && accountID != "" &&
+	claudeUnusable := overageAccount == "" && provider == accounts.ProviderClaude && accountID != "" &&
 		(claudeAccountUnusableStatus(response.StatusCode) || claudeResponseRejected(response.Header))
 	if claudeUnusable {
 		// Only poison the routing score when the account is genuinely out of
@@ -2232,12 +2262,19 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 			}, claudeRateLimitHeaderFields(response.Header)...)...)
 	}
 	inspectUsageLimit := s.SchedulerRef != nil && accountID != "" && responseStatusCanExhaust(response.StatusCode)
-	if response.Body == nil || (s.Transcripts == nil && s.Logger == nil && !inspectUsageLimit && !claudeUnusable) {
+	logOverageCost := overageAccount != "" && strings.TrimSpace(s.ClaudeOverageCostLogPath) != ""
+	if response.Body == nil {
+		if logOverageCost {
+			s.appendClaudeOverageCostRecord(overageAccount, poolModel, response.StatusCode, claudeOverageUsage{}, false)
+		}
+		return
+	}
+	if s.Transcripts == nil && s.Logger == nil && !inspectUsageLimit && !claudeUnusable && !logOverageCost {
 		return
 	}
 	payload := map[string]any{"status": response.StatusCode}
 	var inspect func([]byte)
-	if inspectUsageLimit || claudeUnusable {
+	if inspectUsageLimit || claudeUnusable || logOverageCost {
 		loggedBody := false
 		inspect = func(body []byte) {
 			if inspectUsageLimit && usageLimitJSON(body) {
@@ -2259,6 +2296,13 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 					"path", path,
 					"status", response.StatusCode,
 					"body", string(body))
+			}
+			if logOverageCost {
+				model, usage, usageOK := parseClaudeOverageUsage(body)
+				if poolModel != "" {
+					model = poolModel
+				}
+				s.appendClaudeOverageCostRecord(overageAccount, model, response.StatusCode, usage, usageOK)
 			}
 		}
 	}
@@ -3327,8 +3371,19 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 	overloadRetries := 0
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		response, err := base.RoundTrip(attemptReq)
-		if err != nil || req.GetBody == nil || req.Context().Err() != nil {
+		if err != nil || req.Context().Err() != nil {
 			return response, err
+		}
+		// The overage marker is subrouter-internal: only markClaudeOverageResponse
+		// below may set it, so an upstream-injected copy is dropped unread.
+		response.Header.Del(claudeOverageAccountHeader)
+		if t.provider == accounts.ProviderClaude && t.server != nil &&
+			claudeOverageServed(response.StatusCode, response.Header) && t.server.claudeOverageOptIn(accountID) {
+			t.server.markClaudeOverageResponse(response, accountID)
+			return response, nil
+		}
+		if req.GetBody == nil {
+			return response, nil
 		}
 		// Anthropic overload (529/5xx): retry the SAME account after a bounded
 		// backoff. Overload is API-wide, not account-specific, so no failover, no


### PR DESCRIPTION
Anthropic serves a depleted account via paid extra usage with HTTP 200 + `anthropic-ratelimit-unified-status: rejected`, and Claude Code hard-blocks on that header, so subrouter treated every overage-served 200 as unusable and pushed all Fable overflow to Bedrock and the standalone API key. Extra usage is discounted relative to the API key, so this adds per-account opt-in overage routing.

**Behavior**
- `SUBROUTER_CLAUDE_OVERAGE_ACCOUNTS` (comma-separated profile names, e.g. `lawrence@manaflow.ai`) opts accounts in.
- Opt-in account + 2xx-with-`rejected` header: served to the client with all `anthropic-ratelimit-unified-*` and `Retry-After` headers stripped, no failover, no exhaustion mark. The serving account's identity is tracked across mid-request failover via an internal `X-Subrouter-Overage-Account` marker that is dropped if upstream-injected, validated against the opt-in set, and removed before the client sees it.
- 429-rejected (overage disabled / out of credits / cap hit) keeps existing behavior: exhaustion mark + failover, falling through to the Bedrock → API-key chain.
- Scoring: opt-in accounts with maxed 5h/7d/fable windows but extra-usage headroom keep a 0.01 headroom floor in base and model-pool scores, so ordering is healthy subscription accounts → overage accounts → Bedrock → API key. The floor disappears at 100% extra-usage utilization.
- Observability: `claude overage served` Info log per request; `--claude-overage-cost-log` appends JSONL `{ts, account, model, status, token counts}` with tokens best-effort parsed from JSON or SSE bodies. No dollar math, no secrets.

**Non-opt-in accounts are byte-for-byte unchanged**; websocket path untouched. 11 new tests cover env parsing, passthrough/no-failover, serving-account identity after failover, non-replayable requests, 429 fall-through, the scoring floor, passive stripping, SSE usage parsing, and cost-log append. `go build ./... && go vet ./... && go test ./...` green; overage tests race-clean at `-count=3 -race`.

Deploy note: after merge, add `SUBROUTER_CLAUDE_OVERAGE_ACCOUNTS=lawrence@manaflow.ai` to `/etc/subrouter-fable.env` on subrouter-team (and optionally `--claude-overage-cost-log /var/lib/subrouter/claude-overage-cost.jsonl` to `SUBROUTER_EXTRA_ARGS`), then restart the service. Extra usage must be enabled and funded on the account in the Anthropic Console for the 200-rejected path to occur at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785904212&installation_id=133855650&pr_number=64&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F64&signature=8128d2ccc979bffe34374384dc24a73bd4f3fa89ecbf88d4f0453cb410998cae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opted-in Claude OAuth accounts now use Anthropic extra usage before the Fable fallback. 2xx responses with `anthropic-ratelimit-unified-status: rejected` are treated as successful, reducing Bedrock/API-key spillover and cost.

- **New Features**
  - Opt-in via `SUBROUTER_CLAUDE_OVERAGE_ACCOUNTS` (comma-separated Claude profile names).
  - For opted-in accounts, 2xx + `rejected` is served to clients; `Anthropic-Ratelimit-Unified-*` and `Retry-After` headers are stripped. No failover or exhaustion mark. An internal `X-Subrouter-Overage-Account` tracks the serving account across retries and is removed before client response.
  - 429 `rejected` still marks the account exhausted and fails over as before (Bedrock → API key).
  - Routing scores for opted-in accounts get a 0.01 headroom floor when extra-usage has headroom; the floor disappears at 100% extra-usage. This keeps order: healthy subscription accounts → overage accounts → Bedrock → API key.
  - Observability: logs “claude overage served”. Optional JSONL cost log via `--claude-overage-cost-log`, with best-effort token counts parsed from JSON/SSE. Non‑opt‑in behavior is unchanged.

- **Migration**
  - Set `SUBROUTER_CLAUDE_OVERAGE_ACCOUNTS` (e.g., `lawrence@manaflow.ai`) on the server.
  - Optionally enable cost logging: `--claude-overage-cost-log /path/to/claude-overage.jsonl`.
  - Ensure Anthropic extra usage is enabled and funded for opted-in accounts, then restart the service.

<sup>Written for commit e304164a10cb352258a383fed6bb7c3b65619b0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

