### PR TITLE
deploy/macos: Bedrock (Fable) gateway support + runbook

### DIFF
--- a/deploy/macos/BEDROCK.md
+++ b/deploy/macos/BEDROCK.md
@@ -1,0 +1,125 @@
+# Serving Claude Fable from AWS Bedrock
+
+The team subrouter can serve Claude Fable (`claude-fable-5`) from AWS Bedrock so
+Fable never hard-fails when the Claude subscription pool is rate-limited. The
+subrouter signs each request with AWS SigV4 and forwards it to
+`bedrock-runtime.<region>.amazonaws.com`; clients never hold AWS credentials.
+
+Fable routing order is subscription pool first, then Bedrock, then a dedicated
+Anthropic API key. Set `--fable-bedrock-primary` to send Fable to Bedrock first
+instead (see below).
+
+## Use a SigV4 IAM key, not a Bedrock API key
+
+AWS Bedrock API keys (`ABSK...`, sent as a bearer/`x-api-key` to the Mantle
+endpoint) are bound to your organization's `default` project, whose data
+retention mode is `default`. Fable rejects that with:
+
+```
+data retention mode 'default' is not available for this model
+```
+
+Fixing it requires setting the project to `provider_data_share`, but the API
+returns `cannot update the default project`, and a new project's key cannot be
+minted through the public API. A plain SigV4 IAM key sidesteps the project
+entirely and invokes Fable directly, so the subrouter uses SigV4. Do not use a
+Bedrock API key here.
+
+## 1. Create a scoped IAM key
+
+With admin credentials for the Bedrock account:
+
+```bash
+aws iam create-user --user-name subrouter-bedrock-fable
+aws iam put-user-policy --user-name subrouter-bedrock-fable \
+  --policy-name invoke-fable --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
+      "Resource": [
+        "arn:aws:bedrock:*::foundation-model/anthropic.claude-fable-5*",
+        "arn:aws:bedrock:*:<ACCOUNT_ID>:inference-profile/us.anthropic.claude-fable-5*"
+      ]
+    }]
+  }'
+aws iam create-access-key --user-name subrouter-bedrock-fable
+```
+
+Confirm the key works before installing (allow a few seconds for IAM to
+propagate):
+
+```bash
+curl -sS -X POST \
+  "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-fable-5/invoke" \
+  --aws-sigv4 "aws:amz:us-east-1:bedrock" --user "$AKID:$SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"anthropic_version":"bedrock-2023-05-31","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
+# -> 200 with a claude-fable-5 message
+```
+
+## 2. Install with Bedrock enabled
+
+Pass the key to `install-macos.sh` through the environment. Pick a random
+gateway token; clients must present it to the external `/bedrock/*` route (the
+internal Fable fallback does not need it).
+
+```bash
+sudo SUBROUTER_ENABLE_BEDROCK=1 \
+  SUBROUTER_BEDROCK_AWS_ACCESS_KEY_ID=AKIA... \
+  SUBROUTER_BEDROCK_AWS_SECRET_ACCESS_KEY=... \
+  SUBROUTER_BEDROCK_REGION=us-east-1 \
+  SUBROUTER_BEDROCK_GATEWAY_TOKEN="$(openssl rand -hex 16)" \
+  SUBROUTER_FABLE_BEDROCK_PRIMARY=1 \
+  ./install-macos.sh
+```
+
+This writes the AWS profile to `/var/lib/subrouter/.aws` (owned by `_subrouter`,
+`0600`), adds the `--bedrock` flags to the team LaunchDaemon, and restarts it.
+Drop `SUBROUTER_FABLE_BEDROCK_PRIMARY=1` to keep Bedrock as a fallback instead of
+the primary Fable route.
+
+Env vars:
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `SUBROUTER_ENABLE_BEDROCK` | `0` | `1` turns on the Bedrock gateway. |
+| `SUBROUTER_BEDROCK_AWS_ACCESS_KEY_ID` | — | SigV4 access key id (required). |
+| `SUBROUTER_BEDROCK_AWS_SECRET_ACCESS_KEY` | — | SigV4 secret (required). |
+| `SUBROUTER_BEDROCK_REGION` | `us-east-1` | Bedrock region for Fable. |
+| `SUBROUTER_BEDROCK_PROFILE` | `aw1` | AWS profile name written under `.aws`. |
+| `SUBROUTER_BEDROCK_GATEWAY_TOKEN` | — | Bearer token for the external `/bedrock/*` route. |
+| `SUBROUTER_FABLE_BEDROCK_PRIMARY` | `0` | `1` routes Fable to Bedrock before the pool. |
+
+## 3. Verify
+
+```bash
+# gateway enabled on startup
+sudo grep "bedrock gateway enabled" /var/log/subrouter.err.log | tail -1
+
+# direct invoke through the gateway (needs the token)
+curl -sS -X POST http://127.0.0.1:31415/bedrock/model/us.anthropic.claude-fable-5/invoke \
+  -H "Authorization: Bearer $SUBROUTER_BEDROCK_GATEWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"anthropic_version":"bedrock-2023-05-31","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
+# -> 200; without the token -> 401
+
+# Fable through the proxy (id is msg_bdrk_... when served by Bedrock)
+curl -sS -X POST http://127.0.0.1:31415/v1/messages \
+  -H "X-Subrouter-Agent: claude" -H "anthropic-version: 2023-06-01" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"claude-fable-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
+
+# tracked spend
+curl -sS http://127.0.0.1:31415/_subrouter/bedrock-cost
+```
+
+## Notes
+
+- Bedrock Fable is paid; the pool-first default drains free subscription quota
+  before paying. `--fable-bedrock-primary` pays Bedrock for every Fable token.
+- The config survives daemon restart, reboot, and auto-update. Re-running
+  `install-macos.sh` re-applies it only if the `SUBROUTER_ENABLE_BEDROCK` env is
+  set again.
+- Rotate the IAM key with `aws iam create-access-key` / `delete-access-key` and
+  re-run the install with the new value.

--- a/deploy/macos/README.md
+++ b/deploy/macos/README.md
@@ -89,6 +89,12 @@ Then repoint clients' `team` server URL at the mac and keep the GCP VM stopped
 (not deleted) as instant rollback. To roll back, reverse step 2-3 (mac -> GCP)
 and restart `subrouter` on the VM.
 
+## Bedrock (Claude Fable)
+
+To serve Claude Fable from AWS Bedrock, follow [BEDROCK.md](./BEDROCK.md). In
+short, pass a SigV4 IAM key and `SUBROUTER_ENABLE_BEDROCK=1` (optionally
+`SUBROUTER_FABLE_BEDROCK_PRIMARY=1`) to `install-macos.sh`.
+
 ## Uninstall
 
 ```bash

--- a/deploy/macos/ai.manaflow.subrouter-team.plist
+++ b/deploy/macos/ai.manaflow.subrouter-team.plist
@@ -2,7 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--
   System LaunchDaemon for the shared "team" Subrouter on a macOS host.
-  install-macos.sh substitutes __ADDR__ (default 0.0.0.0:31415). Runs as the
+  install-macos.sh substitutes the listen address and injects any extra serve
+  flags (e.g. the Bedrock gateway; empty by default; see BEDROCK.md). Runs as
+  the
   dedicated _subrouter service user so pf can scope egress isolation to it
   (see pf-subrouter.conf) without affecting anything else on a shared host.
   State lives in /var/lib/subrouter (mirrors the GCP layout for a 1:1 copy).
@@ -30,6 +32,7 @@
 		<string>__ADDR__</string>
 		<string>--sr-switch-interval</string>
 		<string>10m</string>
+__EXTRA_ARGS__
 	</array>
 	<key>KeepAlive</key>
 	<true/>

--- a/deploy/macos/install-macos.sh
+++ b/deploy/macos/install-macos.sh
@@ -20,6 +20,19 @@ SVC_USER="${SUBROUTER_USER:-_subrouter}"
 BIN="${SUBROUTER_BIN:-/usr/local/bin/subrouter}"
 VERSION="${SUBROUTER_VERSION:-latest}"
 VERSION_FILE="/etc/subrouter-version"
+
+# --- Bedrock (Fable) gateway, opt-in --------------------------------------
+# Set SUBROUTER_ENABLE_BEDROCK=1 to serve Claude Fable from AWS Bedrock. Supply
+# an IAM access key scoped to bedrock:InvokeModel on claude-fable-5 (SigV4; the
+# API-key/Mantle path is blocked by the default project's data-retention mode,
+# so SigV4 is required). See BEDROCK.md.
+ENABLE_BEDROCK="${SUBROUTER_ENABLE_BEDROCK:-0}"
+BEDROCK_REGION="${SUBROUTER_BEDROCK_REGION:-us-east-1}"
+BEDROCK_PROFILE="${SUBROUTER_BEDROCK_PROFILE:-aw1}"
+BEDROCK_GATEWAY_TOKEN="${SUBROUTER_BEDROCK_GATEWAY_TOKEN:-}"
+FABLE_BEDROCK_PRIMARY="${SUBROUTER_FABLE_BEDROCK_PRIMARY:-0}"
+BEDROCK_AWS_ACCESS_KEY_ID="${SUBROUTER_BEDROCK_AWS_ACCESS_KEY_ID:-}"
+BEDROCK_AWS_SECRET_ACCESS_KEY="${SUBROUTER_BEDROCK_AWS_SECRET_ACCESS_KEY:-}"
 ANCHOR="ai.manaflow.subrouter"
 ANCHOR_DST="/etc/pf.anchors/${ANCHOR}"
 LAUNCHD_DIR="/Library/LaunchDaemons"
@@ -108,10 +121,60 @@ install -m 0755 "${here}/subrouter-pf.sh"         /usr/local/bin/subrouter-pf.sh
 install -d -m 0755 /etc/pf.anchors
 install -m 0644 "${here}/pf-subrouter.conf" "${ANCHOR_DST}"
 
+# --- 4b. Bedrock AWS credentials + serve flags ------------------------------
+# Extra <string> lines injected into the team plist ProgramArguments.
+EXTRA_ARGS_XML=""
+if [ "${ENABLE_BEDROCK}" = "1" ]; then
+  if [ -z "${BEDROCK_AWS_ACCESS_KEY_ID}" ] || [ -z "${BEDROCK_AWS_SECRET_ACCESS_KEY}" ]; then
+    echo "install-macos: SUBROUTER_ENABLE_BEDROCK=1 requires SUBROUTER_BEDROCK_AWS_ACCESS_KEY_ID and SUBROUTER_BEDROCK_AWS_SECRET_ACCESS_KEY" >&2
+    exit 1
+  fi
+  log "installing Bedrock AWS profile '${BEDROCK_PROFILE}' for ${SVC_USER}"
+  install -d -m 0700 -o "${SVC_USER}" -g "${gid}" "${STATE_DIR}/.aws"
+  umask 077
+  printf '[%s]\naws_access_key_id = %s\naws_secret_access_key = %s\n' \
+    "${BEDROCK_PROFILE}" "${BEDROCK_AWS_ACCESS_KEY_ID}" "${BEDROCK_AWS_SECRET_ACCESS_KEY}" \
+    > "${STATE_DIR}/.aws/credentials"
+  printf '[profile %s]\nregion = %s\n' "${BEDROCK_PROFILE}" "${BEDROCK_REGION}" \
+    > "${STATE_DIR}/.aws/config"
+  chown "${SVC_USER}:${gid}" "${STATE_DIR}/.aws/credentials" "${STATE_DIR}/.aws/config"
+  chmod 0600 "${STATE_DIR}/.aws/credentials" "${STATE_DIR}/.aws/config"
+
+  add_arg() { EXTRA_ARGS_XML="${EXTRA_ARGS_XML}		<string>$1</string>"$'\n'; }
+  add_arg "--bedrock"
+  add_arg "--bedrock-region"; add_arg "${BEDROCK_REGION}"
+  add_arg "--bedrock-profiles"; add_arg "${BEDROCK_PROFILE}"
+  if [ -n "${BEDROCK_GATEWAY_TOKEN}" ]; then
+    add_arg "--bedrock-gateway-token"; add_arg "${BEDROCK_GATEWAY_TOKEN}"
+  fi
+  if [ "${FABLE_BEDROCK_PRIMARY}" = "1" ]; then
+    add_arg "--fable-bedrock-primary"
+  fi
+  # strip trailing newline
+  EXTRA_ARGS_XML="${EXTRA_ARGS_XML%$'\n'}"
+fi
+
 # --- 5. LaunchDaemons -------------------------------------------------------
 render_team_plist() {
-  sed "s|__ADDR__|${ADDR}|g" "${here}/ai.manaflow.subrouter-team.plist" \
-    > "${LAUNCHD_DIR}/ai.manaflow.subrouter-team.plist"
+  ADDR="${ADDR}" EXTRA_ARGS_XML="${EXTRA_ARGS_XML}" python3 - \
+    "${here}/ai.manaflow.subrouter-team.plist" \
+    "${LAUNCHD_DIR}/ai.manaflow.subrouter-team.plist" <<'PY'
+import os, sys
+src, dst = sys.argv[1], sys.argv[2]
+text = open(src).read().replace("__ADDR__", os.environ["ADDR"])
+extra = os.environ.get("EXTRA_ARGS_XML", "")
+# Replace only the standalone __EXTRA_ARGS__ line (never a substring), so args
+# containing "--" never leak into the XML comment above.
+out = []
+for line in text.splitlines():
+    if line.strip() == "__EXTRA_ARGS__":
+        if extra:
+            out.append(extra)
+        # else: drop the line
+    else:
+        out.append(line)
+open(dst, "w").write("\n".join(out) + "\n")
+PY
 }
 render_team_plist
 install -m 0644 "${here}/ai.manaflow.subrouter-pf.plist"         "${LAUNCHD_DIR}/"


### PR DESCRIPTION
Makes the Bedrock Fable gateway a first-class, durable install option for the macOS team subrouter.

- `install-macos.sh`: `SUBROUTER_ENABLE_BEDROCK=1` + SigV4 IAM key env writes `/var/lib/subrouter/.aws` and injects `--bedrock`/`--bedrock-region`/`--bedrock-profiles`/`--bedrock-gateway-token` and optional `--fable-bedrock-primary` into the team plist (new `__EXTRA_ARGS__` placeholder). Re-install no longer wipes Bedrock config.
- `BEDROCK.md`: runbook — why SigV4 not the Bedrock API key (default project stuck on `data retention mode 'default'`), scoped IAM policy, install env, verification.
- Placeholder replacement is line-exact so args containing `--` never leak into the XML comment; both rendered plists pass `plutil -lint`.

Base is `feat-macos-mini-deploy` since deploy/macos/ lives there. This is the reproducible setup path for Aziz's subrouter.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786056189&installation_id=133855650&pr_number=66&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F66&signature=42b9e6da61c178901109b17807d8c57821dd358fec20054147c87242c12c3f7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class AWS Bedrock (Claude Fable) gateway support to the macOS team subrouter and a runbook for setup, making Fable resilient when the subscription pool is rate-limited.

- **New Features**
  - `install-macos.sh`: enable Bedrock with `SUBROUTER_ENABLE_BEDROCK=1`; write SigV4 creds to `/var/lib/subrouter/.aws`; inject `--bedrock`/`--bedrock-region`/`--bedrock-profiles` and optional `--bedrock-gateway-token`/`--fable-bedrock-primary` via a new `__EXTRA_ARGS__` in `ai.manaflow.subrouter-team.plist`; survives re-install.
  - `BEDROCK.md` runbook covering SigV4 vs Bedrock API key, scoped IAM policy, install env, and verification; `README.md` links to it.
  - Safe plist rendering with line-exact `__EXTRA_ARGS__` replacement; plists pass `plutil -lint`.

- **Migration**
  - Use a scoped SigV4 IAM key (not a Bedrock API key), then run `install-macos.sh` with `SUBROUTER_ENABLE_BEDROCK=1` and the required Bedrock env; see `deploy/macos/BEDROCK.md` for steps.

<sup>Written for commit 3f0edb1096f15aca00fc06f00806f6a23c5aa671. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

