### PR TITLE
sr status: show AWS Bedrock spend and rate limits

### DIFF
--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -523,6 +523,7 @@ func (r srRunner) serverStatus(ctx context.Context, store srServerStore, name st
 		rows := usageRowsFromServerUsageStatuses(usage)
 		fmt.Fprintf(r.out, "Server: %s (%s)\n", server.Name, server.URL)
 		displayUsageRows(r.out, rows, false)
+		r.printBedrockStatus(ctx, server)
 		return nil
 	}
 	res, err := r.fetchServerAccountsResponse(ctx, server)

--- a/cmd/subrouter/sr_server_test.go
+++ b/cmd/subrouter/sr_server_test.go
@@ -94,11 +94,18 @@ func TestSRServerStatusSendsAdminToken(t *testing.T) {
 		out:    &out,
 		errOut: &out,
 		client: &http.Client{Transport: srRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-			if req.URL.Path != "/_subrouter/usage-status" {
-				t.Fatalf("path = %s, want /_subrouter/usage-status", req.URL.Path)
-			}
 			if got := req.Header.Get("Authorization"); got != "Bearer secret-token" {
 				t.Fatalf("Authorization = %q", got)
+			}
+			if req.URL.Path == "/_subrouter/bedrock-cost" {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(bytes.NewReader([]byte(`{"requests":0,"throttled":0}`))),
+				}, nil
+			}
+			if req.URL.Path != "/_subrouter/usage-status" {
+				t.Fatalf("path = %s, want /_subrouter/usage-status", req.URL.Path)
 			}
 			body, _ := json.Marshal([]remoteServerUsageStatus{{
 				ID:                 "acct@example.com",
@@ -305,6 +312,15 @@ func TestSRDefaultOutputUsesDefaultRemoteServerStatus(t *testing.T) {
 		out:     &out,
 		errOut:  &out,
 		client: &http.Client{Transport: srRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			// status also queries bedrock-cost for the spend/rate-limit block;
+			// return an empty summary so it stays silent here.
+			if req.URL.Path == "/_subrouter/bedrock-cost" {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(bytes.NewReader([]byte(`{"requests":0,"throttled":0}`))),
+				}, nil
+			}
 			if req.URL.Path != "/_subrouter/usage-status" {
 				t.Fatalf("path = %s, want /_subrouter/usage-status", req.URL.Path)
 			}

--- a/cmd/subrouter/sr_spend.go
+++ b/cmd/subrouter/sr_spend.go
@@ -31,6 +31,54 @@ type bedrockCostSummaryView struct {
 	ByModel          map[string]bedrockModelAggView `json:"by_model"`
 }
 
+// fetchBedrockSummary pulls the server's AWS Bedrock cost/throttle summary.
+func (r srRunner) fetchBedrockSummary(ctx context.Context, server srServerConfig) (bedrockCostSummaryView, error) {
+	var summary bedrockCostSummaryView
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/_subrouter/bedrock-cost", nil)
+	if err != nil {
+		return summary, err
+	}
+	addServerAdminAuth(req, server)
+	client := r.client
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return summary, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return summary, fmt.Errorf("bedrock cost fetch failed: %s", res.Status)
+	}
+	if err := json.NewDecoder(res.Body).Decode(&summary); err != nil {
+		return summary, err
+	}
+	return summary, nil
+}
+
+// printBedrockStatus appends a compact AWS Bedrock spend + rate-limit block to
+// `sr` status. It stays silent on servers with no Bedrock activity (or old
+// servers missing the endpoint) so it never clutters non-Bedrock status output.
+func (r srRunner) printBedrockStatus(ctx context.Context, server srServerConfig) {
+	summary, err := r.fetchBedrockSummary(ctx, server)
+	if err != nil {
+		return
+	}
+	if summary.Requests == 0 && summary.Throttled == 0 {
+		return
+	}
+	fmt.Fprintln(r.out)
+	fmt.Fprintf(r.out, "AWS Bedrock spend     today $%s · 7d $%s · 30d $%s · all-time $%s (%d req)\n",
+		fmtUSD4(summary.TodayUSD), fmtUSD4(summary.Week7dUSD), fmtUSD4(summary.Month30dUSD),
+		fmtUSD4(summary.TotalUSD), summary.Requests)
+	limits := fmt.Sprintf("throttled(429) %d", summary.Throttled)
+	if summary.Throttled > 0 && summary.LastThrottle != "" {
+		limits += " · last " + summary.LastThrottle
+	}
+	fmt.Fprintf(r.out, "AWS Bedrock limits    %s\n", limits)
+}
+
 // spend reports AWS Bedrock spend tracked by the default Subrouter server.
 func (r srRunner) spend(ctx context.Context) error {
 	server, ok, err := r.defaultRemoteServer()
@@ -40,25 +88,8 @@ func (r srRunner) spend(ctx context.Context) error {
 	if !ok {
 		return fmt.Errorf("sr spend needs a default Subrouter server; run '%s server use <name>'", r.programOrSubrouter())
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/_subrouter/bedrock-cost", nil)
+	summary, err := r.fetchBedrockSummary(ctx, server)
 	if err != nil {
-		return err
-	}
-	addServerAdminAuth(req, server)
-	client := r.client
-	if client == nil {
-		client = &http.Client{Timeout: 15 * time.Second}
-	}
-	res, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		return fmt.Errorf("bedrock cost fetch failed: %s", res.Status)
-	}
-	var summary bedrockCostSummaryView
-	if err := json.NewDecoder(res.Body).Decode(&summary); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Appends a compact AWS Bedrock block to `sr` status for a remote server:

```
AWS Bedrock spend     today $X · 7d $X · 30d $X · all-time $X (N req)
AWS Bedrock limits    throttled(429) N
```

Extracts the bedrock-cost fetch from `sr_spend.go` into `fetchBedrockSummary` and reuses it; stays silent on servers with no Bedrock activity. Verified live against the mac-mini server.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786073523&installation_id=133855650&pr_number=67&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F67&signature=c88a9f66120a156a77ba55d88de015306b4547d3dffdd0e458b5ad4ec9df049d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show AWS Bedrock spend and rate-limit info in `sr status` for remote servers. Adds a compact block with today/7d/30d/all-time spend, request count, and 429 throttles; stays silent if no Bedrock activity.

- **New Features**
  - `sr status` prints Bedrock spend and limits under server usage.
  - Shows last throttle time when available; hides block if the endpoint is missing or activity is zero.

- **Refactors**
  - Extracted Bedrock cost fetch into `fetchBedrockSummary` and reused in `sr spend`.
  - Tests updated to stub `/_subrouter/bedrock-cost`.

<sup>Written for commit ddb0ded61589a269fcaccc92db78454121dfa054. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server status now includes a compact Bedrock usage and throttling summary when available.
  * Spend reporting continues to show detailed usage totals, with improved backend status handling.

* **Bug Fixes**
  * Updated status responses to avoid errors when the Bedrock cost endpoint is queried.
  * Improved handling for default remote status output so it remains stable with the extra backend check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->