### PR TITLE
Log, contain, and cleanly surface Bedrock mid-stream errors on the fable path

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -8,7 +8,9 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -180,12 +182,41 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 	}
 
 	if stream && resp.StatusCode == http.StatusOK {
+		first, peeked, err := peekBedrockStream(resp.Body)
+		if err != nil || strings.EqualFold(first.messageType, "exception") {
+			if s.Logger != nil {
+				attrs := []any{"bedrock_source", sourceName, "region", region, "saw_message_stop", false}
+				if first.exceptionType != "" {
+					attrs = append(attrs, "exception_type", first.exceptionType, "message", bedrockLogPreview(first.payload))
+				}
+				if err != nil {
+					attrs = append(attrs, "read_err", err)
+				}
+				s.Logger.Warn("claude-fable bedrock stream failed before first event", attrs...)
+			}
+			_ = resp.Body.Close()
+			body := first.payload
+			if len(body) == 0 {
+				body = []byte(`{"type":"error","error":{"type":"api_error","message":"Bedrock stream failed before first event"}}`)
+			}
+			s.recordClaudeFableBedrockCost(started, region, http.StatusServiceUnavailable, bedrockUsage{}, false)
+			return &http.Response{
+				Status:        "503 Service Unavailable",
+				StatusCode:    http.StatusServiceUnavailable,
+				Proto:         "HTTP/1.1",
+				ProtoMajor:    1,
+				ProtoMinor:    1,
+				Header:        http.Header{"Content-Type": {"application/json"}},
+				Body:          io.NopCloser(bytes.NewReader(body)),
+				ContentLength: int64(len(body)),
+			}, nil
+		}
 		pr, pw := io.Pipe()
 		go func() {
-			usage, haveUsage := transcodeBedrockToSSE(pw, resp.Body)
+			result := transcodeBedrockToSSE(pw, io.MultiReader(bytes.NewReader(peeked), resp.Body), s.Logger, sourceName, region)
 			_ = resp.Body.Close()
 			_ = pw.Close()
-			s.recordClaudeFableBedrockCost(started, region, http.StatusOK, usage, haveUsage)
+			s.recordClaudeFableBedrockCost(started, region, http.StatusOK, result.Usage, result.HaveUsage)
 		}()
 		return &http.Response{
 			Status:        "200 OK",
@@ -401,18 +432,75 @@ func (cfg *BedrockConfig) onThrottle(sourceName, region, model string) {
 	}
 }
 
+type bedrockStreamResult struct {
+	Usage          bedrockUsage
+	HaveUsage      bool
+	SawMessageStop bool
+	ExceptionType  string
+	ReadErr        error
+}
+
+type bedrockFrame struct {
+	payload       []byte
+	messageType   string
+	eventType     string
+	exceptionType string
+}
+
+var errBedrockStreamEmpty = errors.New("bedrock stream ended before first event")
+
 // transcodeBedrockToSSE converts a Bedrock invoke-with-response-stream body (AWS
 // event-stream framing wrapping Anthropic event JSON) into Anthropic Messages
 // SSE, which is what a Claude client on the OAuth path expects. It also extracts
-// token usage for cost tracking. w may be an http.ResponseWriter (flushed per
-// event) or a plain writer like an io.Pipe (each Write hands the event to the
-// reader directly).
-func transcodeBedrockToSSE(w io.Writer, src io.Reader) (bedrockUsage, bool) {
+// token usage for cost tracking and reports stream anomalies. w may be an
+// http.ResponseWriter (flushed per event) or a plain writer like an io.Pipe
+// (each Write hands the event to the reader directly).
+func transcodeBedrockToSSE(w io.Writer, src io.Reader, logger *slog.Logger, bedrockSource, region string) bedrockStreamResult {
 	flusher, _ := w.(http.Flusher)
 	var scanner bedrockFrameScanner
-	var usage bedrockUsage
-	var got bool
-	emit := func(inner []byte) {
+	var result bedrockStreamResult
+	exceptionHandled := false
+	finalize := func() bedrockStreamResult {
+		result.HaveUsage = result.HaveUsage && !result.Usage.empty()
+		return result
+	}
+	writeErrorEvent := func(errorType, message string) {
+		payload, _ := json.Marshal(map[string]any{
+			"type": "error",
+			"error": map[string]string{
+				"type":    errorType,
+				"message": message,
+			},
+		})
+		_, _ = w.Write([]byte("event: error\ndata: "))
+		_, _ = w.Write(payload)
+		_, _ = w.Write([]byte("\n\n"))
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+	emit := func(frame bedrockFrame) {
+		if exceptionHandled {
+			return
+		}
+		if strings.EqualFold(frame.messageType, "exception") {
+			result.ExceptionType = frame.exceptionType
+			exceptionHandled = true
+			if logger != nil {
+				logger.Warn("claude-fable bedrock mid-stream exception", "exception_type", frame.exceptionType, "message", bedrockLogPreview(frame.payload), "bedrock_source", bedrockSource, "region", region, "saw_message_stop", result.SawMessageStop)
+			}
+			if strings.Contains(strings.ToLower(frame.exceptionType), "throttl") {
+				writeErrorEvent("overloaded_error", "Bedrock throttled mid-stream")
+			} else {
+				message := "Bedrock stream error"
+				if frame.exceptionType != "" {
+					message += ": " + frame.exceptionType
+				}
+				writeErrorEvent("api_error", message)
+			}
+			return
+		}
+		inner := frame.payload
 		var ev struct {
 			Type    string `json:"type"`
 			Message struct {
@@ -423,14 +511,20 @@ func transcodeBedrockToSSE(w io.Writer, src io.Reader) (bedrockUsage, bool) {
 		_ = json.Unmarshal(inner, &ev)
 		switch ev.Type {
 		case "message_start":
-			usage.InputTokens = ev.Message.Usage.InputTokens
-			usage.CacheReadTokens = ev.Message.Usage.CacheReadTokens
-			usage.CacheWriteTokens = ev.Message.Usage.CacheWriteTokens
-			got = true
+			result.Usage.InputTokens = ev.Message.Usage.InputTokens
+			result.Usage.CacheReadTokens = ev.Message.Usage.CacheReadTokens
+			result.Usage.CacheWriteTokens = ev.Message.Usage.CacheWriteTokens
+			result.HaveUsage = true
 		case "message_delta":
 			if ev.Usage.OutputTokens > 0 {
-				usage.OutputTokens = ev.Usage.OutputTokens
-				got = true
+				result.Usage.OutputTokens = ev.Usage.OutputTokens
+				result.HaveUsage = true
+			}
+		case "message_stop":
+			result.SawMessageStop = true
+		case "error":
+			if logger != nil {
+				logger.Warn("claude-fable bedrock in-band error", "exception_type", "", "message", bedrockLogPreview(inner), "bedrock_source", bedrockSource, "region", region, "saw_message_stop", result.SawMessageStop)
 			}
 		}
 		eventType := ev.Type
@@ -449,19 +543,33 @@ func transcodeBedrockToSSE(w io.Writer, src io.Reader) (bedrockUsage, bool) {
 		n, readErr := src.Read(buf)
 		if n > 0 {
 			scanner.feed(buf[:n], emit)
+			if exceptionHandled {
+				return finalize()
+			}
 		}
 		if readErr != nil {
+			if !result.SawMessageStop && !exceptionHandled {
+				result.ReadErr = readErr
+				if logger != nil {
+					logger.Error("claude-fable bedrock stream truncated", "bedrock_source", bedrockSource, "region", region, "read_err", readErr, "saw_message_stop", result.SawMessageStop, "exception_type", "", "message", "")
+				}
+				writeErrorEvent("api_error", "Bedrock stream interrupted")
+			} else if readErr != io.EOF {
+				result.ReadErr = readErr
+			}
 			break
 		}
 	}
-	return usage, got && !usage.empty()
+	return finalize()
 }
 
 // bedrockFrameScanner parses AWS event-stream frames incrementally and yields
-// each frame's decoded inner payload (the Anthropic event JSON).
+// each frame's decoded inner payload (the Anthropic event JSON) with AWS
+// event-stream metadata. Exception frames carry a raw JSON error payload instead
+// of a {"bytes": "..."} wrapper.
 type bedrockFrameScanner struct{ buf []byte }
 
-func (s *bedrockFrameScanner) feed(data []byte, emit func([]byte)) {
+func (s *bedrockFrameScanner) feed(data []byte, emit func(bedrockFrame)) {
 	s.buf = append(s.buf, data...)
 	for {
 		if len(s.buf) < 12 {
@@ -478,18 +586,137 @@ func (s *bedrockFrameScanner) feed(data []byte, emit func([]byte)) {
 		}
 		payloadStart := 12 + headersLen
 		payloadEnd := total - 4
+		headers := map[string]string(nil)
+		if headersLen >= 0 && 12+headersLen <= payloadEnd {
+			headers, _ = parseBedrockEventHeaders(s.buf[12 : 12+headersLen])
+		} else {
+			payloadStart = 12
+		}
 		if payloadStart <= payloadEnd && payloadEnd <= len(s.buf) {
+			frame := bedrockFrame{
+				messageType:   headers[":message-type"],
+				eventType:     headers[":event-type"],
+				exceptionType: headers[":exception-type"],
+			}
+			payload := s.buf[payloadStart:payloadEnd]
+			if strings.EqualFold(frame.messageType, "exception") {
+				frame.payload = append([]byte(nil), payload...)
+				emit(frame)
+				s.buf = s.buf[total:]
+				continue
+			}
 			var wrap struct {
 				Bytes string `json:"bytes"`
 			}
-			if json.Unmarshal(s.buf[payloadStart:payloadEnd], &wrap) == nil && wrap.Bytes != "" {
+			if json.Unmarshal(payload, &wrap) == nil && wrap.Bytes != "" {
 				if decoded, err := base64.StdEncoding.DecodeString(wrap.Bytes); err == nil {
-					emit(decoded)
+					frame.payload = decoded
+					emit(frame)
 				}
 			}
 		}
 		s.buf = s.buf[total:]
 	}
+}
+
+func parseBedrockEventHeaders(headers []byte) (map[string]string, bool) {
+	out := make(map[string]string)
+	for len(headers) > 0 {
+		if len(headers) < 2 {
+			return nil, false
+		}
+		nameLen := int(headers[0])
+		headers = headers[1:]
+		if len(headers) < nameLen+1 {
+			return nil, false
+		}
+		name := string(headers[:nameLen])
+		headers = headers[nameLen:]
+		valueType := headers[0]
+		headers = headers[1:]
+		switch valueType {
+		case 0, 1:
+		case 2:
+			if len(headers) < 1 {
+				return nil, false
+			}
+			headers = headers[1:]
+		case 3:
+			if len(headers) < 2 {
+				return nil, false
+			}
+			headers = headers[2:]
+		case 4:
+			if len(headers) < 4 {
+				return nil, false
+			}
+			headers = headers[4:]
+		case 5, 8:
+			if len(headers) < 8 {
+				return nil, false
+			}
+			headers = headers[8:]
+		case 6, 7:
+			if len(headers) < 2 {
+				return nil, false
+			}
+			valueLen := int(binary.BigEndian.Uint16(headers[:2]))
+			headers = headers[2:]
+			if len(headers) < valueLen {
+				return nil, false
+			}
+			if valueType == 7 {
+				out[name] = string(headers[:valueLen])
+			}
+			headers = headers[valueLen:]
+		case 9:
+			if len(headers) < 16 {
+				return nil, false
+			}
+			headers = headers[16:]
+		default:
+			return nil, false
+		}
+	}
+	return out, true
+}
+
+func peekBedrockStream(src io.Reader) (bedrockFrame, []byte, error) {
+	var scanner bedrockFrameScanner
+	var first bedrockFrame
+	var got bool
+	var peeked bytes.Buffer
+	emit := func(frame bedrockFrame) {
+		if !got {
+			first = frame
+			got = true
+		}
+	}
+	buf := make([]byte, 32*1024)
+	for !got {
+		n, readErr := src.Read(buf)
+		if n > 0 {
+			peeked.Write(buf[:n])
+			scanner.feed(buf[:n], emit)
+		}
+		if got {
+			break
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				return bedrockFrame{}, peeked.Bytes(), errBedrockStreamEmpty
+			}
+			return bedrockFrame{}, peeked.Bytes(), readErr
+		}
+	}
+	return first, peeked.Bytes(), nil
+}
+
+func bedrockLogPreview(payload []byte) string {
+	if len(payload) > 256 {
+		payload = payload[:256]
+	}
+	return string(payload)
 }
 
 func (s Server) handleBedrockCost(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/bedrock_cost_test.go
+++ b/internal/proxy/bedrock_cost_test.go
@@ -107,7 +107,7 @@ func TestTranscodeBedrockToSSE(t *testing.T) {
 	stream := append(append(append([]byte{}, start...), delta...), stop...)
 
 	rec := httptest.NewRecorder()
-	usage, ok := transcodeBedrockToSSE(rec, bytes.NewReader(stream))
+	result := transcodeBedrockToSSE(rec, bytes.NewReader(stream), nil, "", "")
 	out := rec.Body.String()
 	if !strings.Contains(out, "event: message_start\ndata: {") {
 		t.Fatalf("missing message_start SSE frame:\n%s", out)
@@ -115,7 +115,7 @@ func TestTranscodeBedrockToSSE(t *testing.T) {
 	if !strings.Contains(out, "event: message_stop\ndata: {") {
 		t.Fatalf("missing message_stop SSE frame:\n%s", out)
 	}
-	if !ok || usage.InputTokens != 10 || usage.OutputTokens != 7 {
-		t.Fatalf("usage = %+v ok=%v, want in=10 out=7", usage, ok)
+	if !result.HaveUsage || result.Usage.InputTokens != 10 || result.Usage.OutputTokens != 7 {
+		t.Fatalf("usage = %+v ok=%v, want in=10 out=7", result.Usage, result.HaveUsage)
 	}
 }

--- a/internal/proxy/bedrock_stream_test.go
+++ b/internal/proxy/bedrock_stream_test.go
@@ -1,0 +1,236 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type bedrockHeaderKV struct {
+	name  string
+	value string
+}
+
+func buildEventStreamFrameWithHeaders(t *testing.T, headers []bedrockHeaderKV, payload []byte) []byte {
+	t.Helper()
+	var headerBlock bytes.Buffer
+	for _, h := range headers {
+		if len(h.name) > 255 {
+			t.Fatalf("header name too long: %s", h.name)
+		}
+		headerBlock.WriteByte(byte(len(h.name)))
+		headerBlock.WriteString(h.name)
+		headerBlock.WriteByte(7)
+		if len(h.value) > 65535 {
+			t.Fatalf("header value too long: %s", h.name)
+		}
+		var lenBuf [2]byte
+		binary.BigEndian.PutUint16(lenBuf[:], uint16(len(h.value)))
+		headerBlock.Write(lenBuf[:])
+		headerBlock.WriteString(h.value)
+	}
+	headersBytes := headerBlock.Bytes()
+	total := 16 + len(headersBytes) + len(payload)
+	frame := make([]byte, total)
+	binary.BigEndian.PutUint32(frame[0:4], uint32(total))
+	binary.BigEndian.PutUint32(frame[4:8], uint32(len(headersBytes)))
+	copy(frame[12:12+len(headersBytes)], headersBytes)
+	copy(frame[12+len(headersBytes):12+len(headersBytes)+len(payload)], payload)
+	return frame
+}
+
+func buildBedrockExceptionFrame(t *testing.T, exceptionType, body string) []byte {
+	t.Helper()
+	return buildEventStreamFrameWithHeaders(t, []bedrockHeaderKV{
+		{name: ":message-type", value: "exception"},
+		{name: ":exception-type", value: exceptionType},
+		{name: ":event-type", value: exceptionType},
+	}, []byte(body))
+}
+
+func buildMalformedHeaderEventFrame(t *testing.T, eventJSON string) []byte {
+	t.Helper()
+	payload, err := json.Marshal(map[string]string{"bytes": base64.StdEncoding.EncodeToString([]byte(eventJSON))})
+	if err != nil {
+		t.Fatal(err)
+	}
+	headers := []byte{5, 'x', 'y'}
+	total := 16 + len(headers) + len(payload)
+	frame := make([]byte, total)
+	binary.BigEndian.PutUint32(frame[0:4], uint32(total))
+	binary.BigEndian.PutUint32(frame[4:8], uint32(len(headers)))
+	copy(frame[12:12+len(headers)], headers)
+	copy(frame[12+len(headers):12+len(headers)+len(payload)], payload)
+	return frame
+}
+
+func TestTranscodeBedrockToSSEHappyPathByteIdentical(t *testing.T) {
+	startJSON := `{"type":"message_start","message":{"usage":{"input_tokens":10}}}`
+	deltaJSON := `{"type":"message_delta","usage":{"output_tokens":7}}`
+	stopJSON := `{"type":"message_stop"}`
+	stream := append(append(append([]byte{}, buildEventStreamFrame(t, startJSON)...), buildEventStreamFrame(t, deltaJSON)...), buildEventStreamFrame(t, stopJSON)...)
+
+	var logBuf bytes.Buffer
+	rec := httptest.NewRecorder()
+	result := transcodeBedrockToSSE(rec, bytes.NewReader(stream), slog.New(slog.NewTextHandler(&logBuf, nil)), "aw0", "us-east-1")
+
+	want := "event: message_start\ndata: " + startJSON + "\n\n" +
+		"event: message_delta\ndata: " + deltaJSON + "\n\n" +
+		"event: message_stop\ndata: " + stopJSON + "\n\n"
+	if rec.Body.String() != want {
+		t.Fatalf("SSE output changed:\ngot  %q\nwant %q", rec.Body.String(), want)
+	}
+	if logBuf.Len() != 0 {
+		t.Fatalf("clean stream logged unexpectedly:\n%s", logBuf.String())
+	}
+	if !result.HaveUsage || result.Usage.InputTokens != 10 || result.Usage.OutputTokens != 7 || !result.SawMessageStop || result.ReadErr != nil || result.ExceptionType != "" {
+		t.Fatalf("result = %+v, want clean usage result", result)
+	}
+}
+
+func TestTranscodeBedrockToSSEMidstreamException(t *testing.T) {
+	stream := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":3}}}`),
+		buildBedrockExceptionFrame(t, "throttlingException", `{"message":"Rate exceeded"}`)...,
+	)
+	var logBuf bytes.Buffer
+	rec := httptest.NewRecorder()
+	result := transcodeBedrockToSSE(rec, bytes.NewReader(stream), slog.New(slog.NewTextHandler(&logBuf, nil)), "aw0", "us-west-2")
+
+	out := rec.Body.String()
+	if !strings.Contains(out, "event: message_start") {
+		t.Fatalf("missing forwarded first event:\n%s", out)
+	}
+	if !strings.Contains(out, "event: error") || !strings.Contains(out, `"type":"overloaded_error"`) || !strings.Contains(out, "Bedrock throttled mid-stream") {
+		t.Fatalf("missing throttling SSE error:\n%s", out)
+	}
+	if result.ExceptionType != "throttlingException" {
+		t.Fatalf("exception type = %q, want throttlingException", result.ExceptionType)
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, "claude-fable bedrock mid-stream exception") ||
+		!strings.Contains(logs, "exception_type=throttlingException") ||
+		!strings.Contains(logs, "bedrock_source=aw0") ||
+		!strings.Contains(logs, "region=us-west-2") ||
+		!strings.Contains(logs, "Rate exceeded") {
+		t.Fatalf("missing diagnostic exception log:\n%s", logs)
+	}
+}
+
+func TestTranscodeBedrockToSSETruncatedStream(t *testing.T) {
+	stream := buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":3}}}`)
+	var logBuf bytes.Buffer
+	rec := httptest.NewRecorder()
+	result := transcodeBedrockToSSE(rec, bytes.NewReader(stream), slog.New(slog.NewTextHandler(&logBuf, nil)), "aw0", "us-east-1")
+
+	if result.ReadErr != io.EOF || result.SawMessageStop {
+		t.Fatalf("result = %+v, want EOF without message_stop", result)
+	}
+	out := rec.Body.String()
+	if !strings.Contains(out, "event: error") || !strings.Contains(out, `"type":"api_error"`) || !strings.Contains(out, "Bedrock stream interrupted") {
+		t.Fatalf("missing synthetic interruption error:\n%s", out)
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, "level=ERROR") ||
+		!strings.Contains(logs, "claude-fable bedrock stream truncated") ||
+		!strings.Contains(logs, "bedrock_source=aw0") ||
+		!strings.Contains(logs, "region=us-east-1") ||
+		!strings.Contains(logs, "saw_message_stop=false") {
+		t.Fatalf("missing truncation log:\n%s", logs)
+	}
+}
+
+func TestTranscodeBedrockToSSEMalformedHeadersDoNotBreakPayloadExtraction(t *testing.T) {
+	stopJSON := `{"type":"message_stop"}`
+	stream := buildMalformedHeaderEventFrame(t, stopJSON)
+	rec := httptest.NewRecorder()
+	result := transcodeBedrockToSSE(rec, bytes.NewReader(stream), nil, "", "")
+	if !result.SawMessageStop {
+		t.Fatalf("result = %+v, want message_stop despite malformed headers", result)
+	}
+	if got := rec.Body.String(); got != "event: message_stop\ndata: "+stopJSON+"\n\n" {
+		t.Fatalf("output = %q, want decoded message_stop", got)
+	}
+
+	garbageHeaderLen := buildEventStreamFrame(t, stopJSON)
+	binary.BigEndian.PutUint32(garbageHeaderLen[4:8], 999)
+	rec = httptest.NewRecorder()
+	result = transcodeBedrockToSSE(rec, bytes.NewReader(garbageHeaderLen), nil, "", "")
+	if !result.SawMessageStop {
+		t.Fatalf("result = %+v, want message_stop despite garbage headersLen", result)
+	}
+}
+
+func TestServeClaudeFableBedrockPrimaryFallsThroughOnExceptionFirstStream(t *testing.T) {
+	bodyStr := `{"model":"claude-fable-5","stream":true,"max_tokens":8,"messages":[]}`
+	var logBuf bytes.Buffer
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(buildBedrockExceptionFrame(t, "modelStreamErrorException", `{"message":"boom"}`))),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := Server{
+		MaxBodyBytes:        1 << 20,
+		FableBedrockPrimary: true,
+		Logger:              slog.New(slog.NewTextHandler(&logBuf, nil)),
+		Bedrock:             &BedrockConfig{Regions: []string{"us-east-1"}, Credentials: staticBedrockCreds(), Transport: rt},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(bodyStr))
+	rec := httptest.NewRecorder()
+	if s.serveClaudeFableBedrockPrimary(rec, req) {
+		t.Fatal("expected exception-first stream to fall through")
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("recorder body = %q, want untouched", rec.Body.String())
+	}
+	restored, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(restored) != bodyStr {
+		t.Fatalf("restored body = %q, want %q", string(restored), bodyStr)
+	}
+	if logs := logBuf.String(); !strings.Contains(logs, "claude-fable bedrock stream failed before first event") || !strings.Contains(logs, "exception_type=modelStreamErrorException") {
+		t.Fatalf("missing first-event failure log:\n%s", logs)
+	}
+}
+
+func TestServeClaudeFableBedrockPrimaryFallsThroughOnEmptyStream(t *testing.T) {
+	bodyStr := `{"model":"claude-fable-5","stream":true,"max_tokens":8,"messages":[]}`
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := Server{
+		MaxBodyBytes:        1 << 20,
+		FableBedrockPrimary: true,
+		Bedrock:             &BedrockConfig{Regions: []string{"us-east-1"}, Credentials: staticBedrockCreds(), Transport: rt},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(bodyStr))
+	rec := httptest.NewRecorder()
+	if s.serveClaudeFableBedrockPrimary(rec, req) {
+		t.Fatal("expected empty stream to fall through")
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("recorder body = %q, want untouched", rec.Body.String())
+	}
+	restored, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(restored) != bodyStr {
+		t.Fatalf("restored body = %q, want %q", string(restored), bodyStr)
+	}
+}


### PR DESCRIPTION
A cfable (Claude Code via cmux-mac-mini subrouter, fable-bedrock-primary) session surfaced `API Error: Server error mid-response` while the daemon logged nothing. Root cause: `transcodeBedrockToSSE` silently dropped AWS event-stream exception frames (their payload is raw JSON, not `{"bytes":...}`-wrapped), swallowed mid-stream read errors, and logged nothing after the 200 was committed. The incident window shows zero trace among 4781 otherwise-successful fable streams that day.

Changes, all in `internal/proxy/bedrock.go`:

- The frame scanner now parses AWS event-stream headers (`:message-type`, `:exception-type`, `:event-type`) with full bounds checking; malformed header blocks degrade to the old headerless payload extraction and cannot panic.
- `transcodeBedrockToSSE` takes a logger plus source/region, logs every mid-stream exception, in-band error event, and truncation, and returns a stream summary. Clean streams produce byte-identical SSE and no new log lines (asserted by test).
- Exceptions become well-formed Anthropic SSE `error` events: throttling maps to `overloaded_error` so client backoff engages, everything else to `api_error`. A stream ending without `message_stop` gets a synthetic `api_error` event instead of a silent truncation.
- `claudeFableBedrockResponse` now peeks the first decoded frame before returning the streaming 200. Exception-first or empty streams become a synthetic 503, so `serveClaudeFableBedrockPrimary` takes its existing non-2xx path: body restored, pool serves the request, client never sees the failure. No timers; the peek is a synchronous read bound to the request context.
- The `/bedrock/*` gateway path is untouched (its consumers transcode themselves).

New `internal/proxy/bedrock_stream_test.go` covers: happy-path byte identity, mid-stream throttle exception (log + `overloaded_error` SSE), truncation (ERROR log + synthetic error event), malformed/garbage headers, exception-first fall-through (nothing written to client, body restored), and empty-stream fall-through.

Verified: `go build ./...`, `go vet ./internal/proxy/`, `go test ./...` all green.

Judge notes (non-blocking, follow-up candidates): post-first-event non-throttle exception mapping is implemented but only the throttle variant is tested; exception-first fall-through records a 503 cost row though Bedrock answered 200 (zero usage, totals unaffected); the first-frame peek buffer is unbounded against a pathological garbage 200 stream (authenticated TLS upstream, theoretical).

Companion (already live, out of repo): the cmux-mac-mini `subrouter-verify.sh` watchdog now ALERTs on the new `claude-fable bedrock mid-stream exception` / `stream truncated` log lines and on daemon panics, and exports bedrock counters in `status.json`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786129809&installation_id=133855650&pr_number=68&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F68&signature=c3bda9640fce5073cadba86a0efeec9ef03798986253669e50f86d216ddee0ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent Bedrock mid-stream failures on the fable path by parsing AWS event-stream headers, surfacing clean Anthropic SSE errors, and logging/handling truncations so clients can retry and the pool can recover.

- **Bug Fixes**
  - Parse AWS event-stream headers and handle `exception` frames instead of dropping them.
  - Don’t swallow mid-stream read errors; emit a synthetic SSE `error` on truncation.
  - Peek the first Bedrock frame before sending 200; exception-first or empty streams return 503 so `serveClaudeFableBedrockPrimary` falls through to the pool.
  - Clean streams stay byte-identical and log-silent; `/bedrock/*` is unchanged.

- **New Features**
  - Log exceptions, in-band errors, and truncations with `bedrock_source` and `region`.
  - Map Bedrock exceptions to Anthropic SSE `error` events (`throttling` -> `overloaded_error`, else `api_error`); synthesize `api_error` if no `message_stop`.
  - Return a stream summary (usage, saw_message_stop, exception_type) for accurate cost tracking.

<sup>Written for commit ca58b69e30926041ae2d8190cf240a26bfd0e0a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

