### PR TITLE
sr reset: --gto selection, credit counts/expiry, account numbering

### DIFF
--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -1648,6 +1648,45 @@ func displayUsageRowsGrid(out io.Writer, rows []srUsageRow, numbered bool, color
 	}
 }
 
+// printAccountCountSummary prints a one-line total across providers so the user
+// can see how many accounts are configured at a glance, e.g.
+// "Total: 23 Codex accounts, 2 Claude profiles (25 accounts)".
+func printAccountCountSummary(out io.Writer, rows []srUsageRow) {
+	if len(rows) <= 1 {
+		return
+	}
+	order := []accounts.Provider{}
+	counts := map[accounts.Provider]int{}
+	for _, row := range rows {
+		p := usageProvider(row)
+		if _, seen := counts[p]; !seen {
+			order = append(order, p)
+		}
+		counts[p]++
+	}
+	parts := make([]string, 0, len(order))
+	for _, p := range order {
+		parts = append(parts, fmt.Sprintf("%d %s", counts[p], providerCountNoun(p, counts[p])))
+	}
+	colored := colorEnabled(out)
+	summary := fmt.Sprintf("Total: %s (%d accounts)", strings.Join(parts, ", "), len(rows))
+	fmt.Fprintln(out, style(colored, ansiDim, summary))
+}
+
+func providerCountNoun(provider accounts.Provider, n int) string {
+	switch provider {
+	case accounts.ProviderCodex:
+		return "Codex"
+	case accounts.ProviderClaude:
+		if n == 1 {
+			return "Claude profile"
+		}
+		return "Claude profiles"
+	default:
+		return strings.Title(string(provider))
+	}
+}
+
 func usageRowErrorHint(row srUsageRow) string {
 	if row.err == nil || !authErrorNeedsReadd(row.err) {
 		return ""
@@ -1775,16 +1814,17 @@ func usageGridResetCell(row srUsageRow) usageGridCell {
 	if info.Eligible != nil && !*info.Eligible {
 		return usageGridCell{Text: "not elig", Style: ansiDim}
 	}
-	if info.Available {
-		return usageGridCell{Text: "avail", Style: ansiGreen}
-	}
-	if info.Consumed {
-		return usageGridCell{Text: "used", Style: ansiYellow}
-	}
+	// Prefer the concrete count over a bare "avail" so >1 credits are visible.
 	if info.Remaining != nil {
 		if *info.Remaining > 0 {
 			return usageGridCell{Text: fmt.Sprintf("%d left", *info.Remaining), Style: ansiGreen}
 		}
+		return usageGridCell{Text: "used", Style: ansiYellow}
+	}
+	if info.Available {
+		return usageGridCell{Text: "avail", Style: ansiGreen}
+	}
+	if info.Consumed {
 		return usageGridCell{Text: "used", Style: ansiYellow}
 	}
 	if strings.TrimSpace(info.Status) != "" {

--- a/cmd/subrouter/sr_reset.go
+++ b/cmd/subrouter/sr_reset.go
@@ -26,14 +26,19 @@ func (r srRunner) reset(ctx context.Context, args []string) error {
 	flags := flag.NewFlagSet("reset", flag.ContinueOnError)
 	flags.SetOutput(r.errOut)
 	flags.Usage = func() {
-		fmt.Fprintln(r.errOut, "usage: subrouter reset [email] [--all] [--dry-run]")
+		fmt.Fprintln(r.errOut, "usage: subrouter reset [email] [--all] [--gto [-n N]] [--dry-run]")
 		fmt.Fprintln(r.errOut, "  Redeem a ChatGPT Pro rate-limit reset credit.")
 		fmt.Fprintln(r.errOut, "  No args: reset the best cooked account with a credit available.")
 		fmt.Fprintln(r.errOut, "  <email>: reset a specific account.")
 		fmt.Fprintln(r.errOut, "  --all: reset every cooked account that has a credit.")
-		fmt.Fprintln(r.errOut, "  --dry-run: list eligible accounts without redeeming.")
+		fmt.Fprintln(r.errOut, "  --gto: reset the account(s) routing would most benefit from un-cooking,")
+		fmt.Fprintln(r.errOut, "         ranked by post-reset weekly headroom then downtime saved.")
+		fmt.Fprintln(r.errOut, "  -n N:  with --gto, redeem the top N ranked accounts (default 1).")
+		fmt.Fprintln(r.errOut, "  --dry-run: list candidates and value verdict without redeeming.")
 	}
 	all := flags.Bool("all", false, "reset every cooked account that has an available credit")
+	gto := flags.Bool("gto", false, "reset the game-theory-optimal account(s) to un-cook, by post-reset headroom then downtime saved")
+	count := flags.Int("n", 1, "with --gto, how many top-ranked accounts to redeem")
 	dryRun := flags.Bool("dry-run", false, "list eligible accounts without redeeming a credit")
 	if err := flags.Parse(args); err != nil {
 		if err == flag.ErrHelp {
@@ -49,10 +54,27 @@ func (r srRunner) reset(ctx context.Context, args []string) error {
 	if email != "" && *all {
 		return fmt.Errorf("pass either an email or --all, not both")
 	}
+	if *gto && (email != "" || *all) {
+		return fmt.Errorf("--gto selects candidates itself; do not combine it with an email or --all")
+	}
+	if !*gto && *count != 1 {
+		return fmt.Errorf("-n only applies with --gto")
+	}
+	if *gto && *count < 1 {
+		return fmt.Errorf("-n must be at least 1")
+	}
 
-	if server, ok, err := r.selectedRemoteServer(); err != nil {
+	server, ok, err := r.selectedRemoteServer()
+	if err != nil {
 		return err
-	} else if ok {
+	}
+	if *gto {
+		if ok {
+			return r.resetRemoteGTO(ctx, server, *count, *dryRun)
+		}
+		return r.resetLocalGTO(ctx, *count, *dryRun)
+	}
+	if ok {
 		return r.resetRemote(ctx, server, email, *all, *dryRun)
 	}
 	return r.resetLocal(ctx, email, *all, *dryRun)
@@ -84,7 +106,16 @@ func (r srRunner) resetRemote(ctx context.Context, server srServerConfig, email 
 	return r.resetRemoteSweep(ctx, server, target, all, dryRun)
 }
 
-func (r srRunner) resetRemoteSweep(ctx context.Context, server srServerConfig, email string, all, dryRun bool) error {
+// remoteResetPayload mirrors the server's /_subrouter/rate-limit-reset JSON.
+type remoteResetPayload struct {
+	Reset   int                 `json:"reset"`
+	DryRun  bool                `json:"dry_run"`
+	Results []remoteResetResult `json:"results"`
+}
+
+// resetRemoteRequest performs one reset call against the server and returns the
+// decoded payload without printing, so callers (sweep, GTO) can aggregate.
+func (r srRunner) resetRemoteRequest(ctx context.Context, server srServerConfig, email string, all, dryRun bool) (remoteResetPayload, error) {
 	u := server.URL + "/_subrouter/rate-limit-reset?"
 	q := url.Values{}
 	if all {
@@ -98,7 +129,7 @@ func (r srRunner) resetRemoteSweep(ctx context.Context, server srServerConfig, e
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u+q.Encode(), nil)
 	if err != nil {
-		return err
+		return remoteResetPayload{}, err
 	}
 	addServerAdminAuth(req, server)
 	client := r.client
@@ -107,23 +138,27 @@ func (r srRunner) resetRemoteSweep(ctx context.Context, server srServerConfig, e
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		return err
+		return remoteResetPayload{}, err
 	}
 	defer res.Body.Close()
 	body, _ := io.ReadAll(io.LimitReader(res.Body, 1<<20))
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		if len(body) == 0 {
-			return fmt.Errorf("rate-limit reset failed: %s", res.Status)
+			return remoteResetPayload{}, fmt.Errorf("rate-limit reset failed: %s", res.Status)
 		}
-		return fmt.Errorf("rate-limit reset failed: %s\n%s", res.Status, bytes.TrimSpace(body))
+		return remoteResetPayload{}, fmt.Errorf("rate-limit reset failed: %s\n%s", res.Status, bytes.TrimSpace(body))
 	}
-	var payload struct {
-		Reset   int                 `json:"reset"`
-		DryRun  bool                `json:"dry_run"`
-		Results []remoteResetResult `json:"results"`
-	}
+	var payload remoteResetPayload
 	if err := json.Unmarshal(body, &payload); err != nil {
-		return fmt.Errorf("decode reset response: %w", err)
+		return remoteResetPayload{}, fmt.Errorf("decode reset response: %w", err)
+	}
+	return payload, nil
+}
+
+func (r srRunner) resetRemoteSweep(ctx context.Context, server srServerConfig, email string, all, dryRun bool) error {
+	payload, err := r.resetRemoteRequest(ctx, server, email, all, dryRun)
+	if err != nil {
+		return err
 	}
 	printResetResults(r.out, payload.DryRun, payload.Reset, payload.Results)
 	return nil

--- a/cmd/subrouter/sr_reset.go
+++ b/cmd/subrouter/sr_reset.go
@@ -34,11 +34,13 @@ func (r srRunner) reset(ctx context.Context, args []string) error {
 		fmt.Fprintln(r.errOut, "  --gto: reset the account(s) routing would most benefit from un-cooking,")
 		fmt.Fprintln(r.errOut, "         ranked by post-reset weekly headroom then downtime saved.")
 		fmt.Fprintln(r.errOut, "  -n N:  with --gto, redeem the top N ranked accounts (default 1).")
+		fmt.Fprintln(r.errOut, "  --list: show every account's available reset credits with expiry (no redeem).")
 		fmt.Fprintln(r.errOut, "  --dry-run: list candidates and value verdict without redeeming.")
 	}
 	all := flags.Bool("all", false, "reset every cooked account that has an available credit")
 	gto := flags.Bool("gto", false, "reset the game-theory-optimal account(s) to un-cook, by post-reset headroom then downtime saved")
 	count := flags.Int("n", 1, "with --gto, how many top-ranked accounts to redeem")
+	list := flags.Bool("list", false, "list every account's available reset credits with expiry (no redeem)")
 	dryRun := flags.Bool("dry-run", false, "list eligible accounts without redeeming a credit")
 	if err := flags.Parse(args); err != nil {
 		if err == flag.ErrHelp {
@@ -54,6 +56,9 @@ func (r srRunner) reset(ctx context.Context, args []string) error {
 	if email != "" && *all {
 		return fmt.Errorf("pass either an email or --all, not both")
 	}
+	if *list && (email != "" || *all || *gto) {
+		return fmt.Errorf("--list only reports credits; do not combine it with an email, --all, or --gto")
+	}
 	if *gto && (email != "" || *all) {
 		return fmt.Errorf("--gto selects candidates itself; do not combine it with an email or --all")
 	}
@@ -67,6 +72,12 @@ func (r srRunner) reset(ctx context.Context, args []string) error {
 	server, ok, err := r.selectedRemoteServer()
 	if err != nil {
 		return err
+	}
+	if *list {
+		if ok {
+			return r.resetListRemote(ctx, server)
+		}
+		return r.resetListLocal(ctx)
 	}
 	if *gto {
 		if ok {

--- a/cmd/subrouter/sr_reset_gto.go
+++ b/cmd/subrouter/sr_reset_gto.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+// gtoResetLowValueSeconds is the natural-recovery threshold below which a reset
+// is judged low value: if every cooked account self-heals within this window,
+// redeeming a one-time credit only saves a few minutes.
+const gtoResetLowValueSeconds int64 = 20 * 60
+
+// gtoResetCandidate is one cooked account that still holds a reset credit,
+// scored for how worthwhile un-cooking it is right now.
+type gtoResetCandidate struct {
+	email string
+	// postResetHeadroom is the fraction of the tightest weekly window still
+	// free. A reset clears the short (5h) window, so this is what the account
+	// has left to spend once it comes back. Higher is a stronger routing pick.
+	postResetHeadroom float64
+	// downtimeSavedSeconds is how long until the account would self-heal without
+	// a reset (the latest reset among its currently-saturated windows). Higher
+	// means the credit buys more.
+	downtimeSavedSeconds int64
+	// weeklyExhausted is true when a weekly window is itself maxed, so a 5h
+	// reset may not fully un-cook the account.
+	weeklyExhausted  bool
+	creditsRemaining int
+}
+
+// gtoResetMetrics derives the reset-value signals from an account's windows.
+// postResetHeadroom looks only at weekly (long) windows because the reset
+// refreshes the short window; downtimeSaved is the latest reset across every
+// saturated non-Spark window (when the account naturally becomes usable again).
+func gtoResetMetrics(windows []accounts.UsageWindow) (postResetHeadroom float64, downtimeSaved int64, weeklyExhausted bool) {
+	postResetHeadroom = 1.0
+	for _, w := range windows {
+		if isSparkWindow(w) {
+			continue
+		}
+		used := clampUsagePercent(w.UsedPercent)
+		if isLongQuotaWindow(w) {
+			remaining := 1 - used/100
+			if remaining < postResetHeadroom {
+				postResetHeadroom = remaining
+			}
+			if used >= 100 {
+				weeklyExhausted = true
+			}
+		}
+		if used >= 100 && w.ResetAfterSeconds > downtimeSaved {
+			downtimeSaved = w.ResetAfterSeconds
+		}
+	}
+	return postResetHeadroom, downtimeSaved, weeklyExhausted
+}
+
+// complimentaryResetRemaining reports how many reset credits an account holds,
+// treating an available-but-uncounted credit as one.
+func complimentaryResetRemaining(info *accounts.ComplimentaryResetInfo) int {
+	if info == nil || !info.Available {
+		return 0
+	}
+	if info.Remaining != nil {
+		return *info.Remaining
+	}
+	return 1
+}
+
+// gtoResetCandidates ranks the cooked, credit-holding Codex accounts by how much
+// routing gains from un-cooking each one, and reports how many Codex accounts
+// are already usable (so the caller can judge whether any reset is warranted).
+func gtoResetCandidates(rows []srUsageRow) (usableNow int, candidates []gtoResetCandidate) {
+	for _, row := range rows {
+		if row.err != nil || usageProvider(row) != accounts.ProviderCodex || row.authMode != accounts.AuthModeOAuth {
+			continue
+		}
+		if !row.cooked && !row.tempCooked {
+			usableNow++
+			continue
+		}
+		credits := complimentaryResetRemaining(row.complimentaryReset)
+		if credits <= 0 {
+			continue
+		}
+		headroom, downtime, weeklyExhausted := gtoResetMetrics(row.windows)
+		candidates = append(candidates, gtoResetCandidate{
+			email:                row.email,
+			postResetHeadroom:    headroom,
+			downtimeSavedSeconds: downtime,
+			weeklyExhausted:      weeklyExhausted,
+			creditsRemaining:     credits,
+		})
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		a, b := candidates[i], candidates[j]
+		// A usable-after-reset account (weekly not maxed) beats one the reset
+		// might not fully un-cook.
+		if a.weeklyExhausted != b.weeklyExhausted {
+			return !a.weeklyExhausted
+		}
+		if a.postResetHeadroom != b.postResetHeadroom {
+			return a.postResetHeadroom > b.postResetHeadroom
+		}
+		if a.downtimeSavedSeconds != b.downtimeSavedSeconds {
+			return a.downtimeSavedSeconds > b.downtimeSavedSeconds
+		}
+		return a.email < b.email
+	})
+	return usableNow, candidates
+}
+
+// assessResetValue turns the live picture into a one-line verdict plus a boolean
+// worthwhile flag. It never blocks the reset (fast unblock is always allowed);
+// it just tells the user whether the credit is well spent.
+func assessResetValue(usableNow int, candidates []gtoResetCandidate) (verdict string, worthwhile bool) {
+	if usableNow > 0 {
+		return fmt.Sprintf("LOW VALUE: %d Codex account(s) already usable — no reset needed to unblock.", usableNow), false
+	}
+	if len(candidates) == 0 {
+		return "No cooked Codex account holds a reset credit.", false
+	}
+	soonest := candidates[0].downtimeSavedSeconds
+	for _, c := range candidates {
+		if c.downtimeSavedSeconds < soonest {
+			soonest = c.downtimeSavedSeconds
+		}
+	}
+	if soonest > 0 && soonest < gtoResetLowValueSeconds {
+		return fmt.Sprintf("LOW VALUE: every cooked account self-heals within %s — a reset saves little.", formatDuration(soonest)), false
+	}
+	if soonest <= 0 {
+		return "GOOD VALUE: all Codex accounts cooked with no near-term natural reset.", true
+	}
+	return fmt.Sprintf("GOOD VALUE: all Codex accounts cooked; soonest natural recovery in %s.", formatDuration(soonest)), true
+}
+
+func printGTOCandidates(out io.Writer, candidates []gtoResetCandidate, total int) {
+	fmt.Fprintf(out, "Top %d of %d reset candidate(s):\n", len(candidates), total)
+	for i, c := range candidates {
+		saved := "self-heals now"
+		if c.downtimeSavedSeconds > 0 {
+			saved = "saves " + formatDuration(c.downtimeSavedSeconds)
+		}
+		note := ""
+		if c.weeklyExhausted {
+			note = " (weekly maxed — reset may not fully un-cook)"
+		}
+		fmt.Fprintf(out, "  %d. %s: %d%% weekly headroom after reset, %s, %d credit(s) left%s\n",
+			i+1, c.email, int(c.postResetHeadroom*100+0.5), saved, c.creditsRemaining, note)
+	}
+}
+
+// resetRemoteGTO selects and redeems the game-theory-optimal reset target(s) via
+// the team server. It always prints the value verdict first, then either the
+// dry-run candidate list or the redeem results.
+func (r srRunner) resetRemoteGTO(ctx context.Context, server srServerConfig, n int, dryRun bool) error {
+	statuses, ok, err := r.fetchServerUsageStatuses(ctx, server)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("server %s does not expose usage-status; cannot compute --gto selection", server.Name)
+	}
+	rows := usageRowsFromServerUsageStatuses(statuses)
+	usableNow, candidates := gtoResetCandidates(rows)
+	verdict, _ := assessResetValue(usableNow, candidates)
+	fmt.Fprintln(r.out, verdict)
+	if len(candidates) == 0 {
+		if dryRun {
+			return nil
+		}
+		return fmt.Errorf("no cooked Codex account has a rate-limit reset credit available")
+	}
+	top := candidates
+	if len(top) > n {
+		top = top[:n]
+	}
+	if dryRun {
+		printGTOCandidates(r.out, top, len(candidates))
+		return nil
+	}
+	results := make([]remoteResetResult, 0, len(top))
+	reset := 0
+	for _, c := range top {
+		payload, err := r.resetRemoteRequest(ctx, server, c.email, false, false)
+		if err != nil {
+			results = append(results, remoteResetResult{Email: c.email, Error: err.Error()})
+			continue
+		}
+		results = append(results, payload.Results...)
+		reset += payload.Reset
+	}
+	printResetResults(r.out, false, reset, results)
+	return nil
+}
+
+// resetLocalGTO is the no-server path: it scores locally-stored accounts against
+// live usage and redeems the top N directly through the wham API.
+func (r srRunner) resetLocalGTO(ctx context.Context, n int, dryRun bool) error {
+	storedAccounts, err := r.store.ListStored()
+	if err != nil {
+		return err
+	}
+	rows := make([]srUsageRow, 0, len(storedAccounts))
+	accountByEmail := make(map[string]accounts.Account, len(storedAccounts))
+	for _, stored := range storedAccounts {
+		if stored.IsAPIKey() {
+			continue
+		}
+		account, ok := stored.Account(stored.SourcePath(r.store))
+		if !ok || account.Token == "" {
+			continue
+		}
+		details, err := accounts.FetchCodexUsageDetails(ctx, r.client, account)
+		if err != nil {
+			continue
+		}
+		row := srUsageRow{
+			email:              stored.Email,
+			authMode:           accounts.AuthModeOAuth,
+			provider:           accounts.ProviderCodex,
+			windows:            details.Windows,
+			complimentaryReset: details.ComplimentaryReset,
+			score:              scoreFromWindows(stored.Email, details.Windows),
+		}
+		row.cooked, row.cookedReason = cookedFromWindows(details.Windows)
+		row.tempCooked, row.tempCookedReason = tempCookedFromWindows(details.Windows)
+		rows = append(rows, row)
+		accountByEmail[stored.Email] = account
+	}
+	usableNow, candidates := gtoResetCandidates(rows)
+	verdict, _ := assessResetValue(usableNow, candidates)
+	fmt.Fprintln(r.out, verdict)
+	if len(candidates) == 0 {
+		if dryRun {
+			return nil
+		}
+		return fmt.Errorf("no cooked Codex account has a rate-limit reset credit available")
+	}
+	top := candidates
+	if len(top) > n {
+		top = top[:n]
+	}
+	if dryRun {
+		printGTOCandidates(r.out, top, len(candidates))
+		return nil
+	}
+	results := make([]remoteResetResult, 0, len(top))
+	reset := 0
+	for _, c := range top {
+		account := accountByEmail[c.email]
+		res := remoteResetResult{Email: c.email, Eligible: true}
+		if before, err := accounts.FetchCodexUsageDetails(ctx, r.client, account); err == nil {
+			res.WindowsBefore = before.Windows
+		}
+		credit, err := accounts.RedeemRateLimitReset(ctx, r.client, account)
+		if err != nil {
+			res.Error = err.Error()
+			results = append(results, res)
+			continue
+		}
+		res.Credit = &credit
+		res.Reset = true
+		if after, err := accounts.FetchCodexUsageDetails(ctx, r.client, account); err == nil {
+			res.WindowsAfter = after.Windows
+		}
+		results = append(results, res)
+		reset++
+	}
+	printResetResults(r.out, false, reset, results)
+	return nil
+}

--- a/cmd/subrouter/sr_reset_gto.go
+++ b/cmd/subrouter/sr_reset_gto.go
@@ -2,12 +2,143 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"sort"
+	"time"
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 )
+
+// resetCreditsAccount mirrors the server's /_subrouter/reset-credits entry.
+type resetCreditsAccount struct {
+	Email   string                          `json:"email"`
+	Count   int                             `json:"count"`
+	Credits []accounts.RateLimitResetCredit `json:"credits,omitempty"`
+	Error   string                          `json:"error,omitempty"`
+}
+
+// soonestCreditExpiry returns the earliest expiry across a set of credits.
+func soonestCreditExpiry(credits []accounts.RateLimitResetCredit) (time.Time, bool) {
+	var soonest time.Time
+	found := false
+	for _, c := range credits {
+		if c.ExpiresAt == "" {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, c.ExpiresAt)
+		if err != nil {
+			continue
+		}
+		if !found || t.Before(soonest) {
+			soonest = t
+			found = true
+		}
+	}
+	return soonest, found
+}
+
+// formatExpiryFromNow renders how long until expiry relative to now.
+func formatExpiryFromNow(expiry, now time.Time) string {
+	d := expiry.Sub(now)
+	if d <= 0 {
+		return "expired"
+	}
+	return "expires in " + formatDuration(int64(d/time.Second))
+}
+
+func printResetCredits(out io.Writer, now time.Time, entries []resetCreditsAccount) {
+	total := 0
+	withCredits := 0
+	for _, e := range entries {
+		total += e.Count
+		line := fmt.Sprintf("  %-28s %d credit(s)", e.Email, e.Count)
+		if e.Error != "" {
+			line = fmt.Sprintf("  %-28s error: %s", e.Email, e.Error)
+		} else if e.Count == 0 {
+			continue
+		} else {
+			withCredits++
+			if expiry, ok := soonestCreditExpiry(e.Credits); ok {
+				line += ", soonest " + formatExpiryFromNow(expiry, now)
+			} else {
+				line += ", no expiry reported"
+			}
+		}
+		fmt.Fprintln(out, line)
+	}
+	fmt.Fprintf(out, "%d reset credit(s) across %d account(s).\n", total, withCredits)
+}
+
+// resetListRemote fetches per-account reset-credit detail (count + expiry) from
+// the team server, which alone holds live tokens to query the upstream.
+func (r srRunner) resetListRemote(ctx context.Context, server srServerConfig) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/_subrouter/reset-credits", nil)
+	if err != nil {
+		return err
+	}
+	addServerAdminAuth(req, server)
+	client := r.client
+	if client == nil {
+		client = &http.Client{Timeout: 60 * time.Second}
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("server %s does not expose /_subrouter/reset-credits yet; redeploy it to use --list", server.Name)
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return fmt.Errorf("reset-credits failed: %s", res.Status)
+	}
+	var payload struct {
+		Accounts []resetCreditsAccount `json:"accounts"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		return fmt.Errorf("decode reset-credits response: %w", err)
+	}
+	sort.Slice(payload.Accounts, func(i, j int) bool { return payload.Accounts[i].Email < payload.Accounts[j].Email })
+	printResetCredits(r.out, time.Now(), payload.Accounts)
+	return nil
+}
+
+// resetListLocal lists reset credits using locally stored tokens (no server).
+func (r srRunner) resetListLocal(ctx context.Context) error {
+	storedAccounts, err := r.store.ListStored()
+	if err != nil {
+		return err
+	}
+	entries := make([]resetCreditsAccount, 0, len(storedAccounts))
+	for _, stored := range storedAccounts {
+		if stored.IsAPIKey() {
+			continue
+		}
+		account, ok := stored.Account(stored.SourcePath(r.store))
+		if !ok || account.Token == "" {
+			continue
+		}
+		entry := resetCreditsAccount{Email: stored.Email}
+		credits, err := accounts.ListRateLimitResetCredits(ctx, r.client, account)
+		if err != nil {
+			entry.Error = err.Error()
+		} else {
+			for _, c := range credits {
+				if c.Status == "" || c.Status == "available" {
+					entry.Credits = append(entry.Credits, c)
+				}
+			}
+			entry.Count = len(entry.Credits)
+		}
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Email < entries[j].Email })
+	printResetCredits(r.out, time.Now(), entries)
+	return nil
+}
 
 // gtoResetLowValueSeconds is the natural-recovery threshold below which a reset
 // is judged low value: if every cooked account self-heals within this window,

--- a/cmd/subrouter/sr_reset_gto_test.go
+++ b/cmd/subrouter/sr_reset_gto_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 )
@@ -109,5 +111,78 @@ func TestAssessResetValue(t *testing.T) {
 	// No candidates.
 	if _, ok := assessResetValue(0, nil); ok {
 		t.Fatal("no candidates should not be worthwhile")
+	}
+}
+
+func TestUsageGridResetCellShowsCount(t *testing.T) {
+	rem := 3
+	row := srUsageRow{
+		provider: accounts.ProviderCodex, authMode: accounts.AuthModeOAuth,
+		complimentaryReset: &accounts.ComplimentaryResetInfo{Known: true, Available: true, Remaining: &rem},
+	}
+	if got := usageGridResetCell(row).Text; got != "3 left" {
+		t.Fatalf("reset cell = %q, want %q (count must win over 'avail')", got, "3 left")
+	}
+	zero := 0
+	row.complimentaryReset = &accounts.ComplimentaryResetInfo{Known: true, Remaining: &zero}
+	if got := usageGridResetCell(row).Text; got != "used" {
+		t.Fatalf("zero-credit cell = %q, want used", got)
+	}
+}
+
+func TestPrintAccountCountSummary(t *testing.T) {
+	rows := []srUsageRow{
+		{email: "a@x.com", provider: accounts.ProviderCodex},
+		{email: "b@x.com", provider: accounts.ProviderCodex},
+		{email: "default", provider: accounts.ProviderClaude},
+	}
+	var out bytes.Buffer
+	printAccountCountSummary(&out, rows)
+	got := out.String()
+	if !strings.Contains(got, "2 Codex") || !strings.Contains(got, "1 Claude profile") || !strings.Contains(got, "(3 accounts)") {
+		t.Fatalf("summary = %q, want counts + total", got)
+	}
+}
+
+func TestSoonestCreditExpiryAndFormat(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	credits := []accounts.RateLimitResetCredit{
+		{ExpiresAt: now.Add(72 * time.Hour).Format(time.RFC3339)},
+		{ExpiresAt: now.Add(24 * time.Hour).Format(time.RFC3339)},
+		{ExpiresAt: ""}, // no expiry, ignored
+	}
+	exp, ok := soonestCreditExpiry(credits)
+	if !ok {
+		t.Fatal("expected an expiry")
+	}
+	if got := formatExpiryFromNow(exp, now); !strings.Contains(got, "expires in 1d") {
+		t.Fatalf("format = %q, want soonest (1d)", got)
+	}
+	if _, ok := soonestCreditExpiry([]accounts.RateLimitResetCredit{{ExpiresAt: ""}}); ok {
+		t.Fatal("no parseable expiry should report none")
+	}
+}
+
+func TestPrintResetCredits(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	entries := []resetCreditsAccount{
+		{Email: "a@x.com", Count: 2, Credits: []accounts.RateLimitResetCredit{{ExpiresAt: now.Add(48 * time.Hour).Format(time.RFC3339)}}},
+		{Email: "b@x.com", Count: 0},
+		{Email: "c@x.com", Error: "token expired"},
+	}
+	var out bytes.Buffer
+	printResetCredits(&out, now, entries)
+	got := out.String()
+	if !strings.Contains(got, "a@x.com") || !strings.Contains(got, "expires in 2d") {
+		t.Fatalf("missing account/expiry: %q", got)
+	}
+	if strings.Contains(got, "b@x.com") {
+		t.Fatalf("zero-credit account should be omitted: %q", got)
+	}
+	if !strings.Contains(got, "token expired") {
+		t.Fatalf("error account should be shown: %q", got)
+	}
+	if !strings.Contains(got, "2 reset credit(s) across 1 account(s)") {
+		t.Fatalf("totals wrong: %q", got)
 	}
 }

--- a/cmd/subrouter/sr_reset_gto_test.go
+++ b/cmd/subrouter/sr_reset_gto_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+func win(name string, used float64, limit, reset int64) accounts.UsageWindow {
+	return accounts.UsageWindow{Name: name, UsedPercent: used, LimitWindowSeconds: limit, ResetAfterSeconds: reset}
+}
+
+func credit(remaining int) *accounts.ComplimentaryResetInfo {
+	return &accounts.ComplimentaryResetInfo{Known: true, Available: true, Remaining: &remaining}
+}
+
+// tempWindows: only the 5h window is maxed, weekly token healthy. A reset yields
+// a fully usable account.
+func tempWindows(fiveHourReset int64) []accounts.UsageWindow {
+	return []accounts.UsageWindow{
+		win("primary", 100, 18000, fiveHourReset),
+		win("secondary", 20, 604800, 586000),
+	}
+}
+
+// cookedWindows: the weekly request-count window is maxed too, so a 5h reset may
+// not fully un-cook the account.
+func cookedWindows(requestLimitReset int64) []accounts.UsageWindow {
+	return []accounts.UsageWindow{
+		win("primary", 100, 18000, 180),
+		win("request-limit", 100, 604800, requestLimitReset),
+		win("secondary", 20, 604800, 586000),
+	}
+}
+
+func TestGTOResetMetricsTempVsCooked(t *testing.T) {
+	hr, downtime, weekly := gtoResetMetrics(tempWindows(360))
+	if weekly {
+		t.Fatal("temp account should not be weekly exhausted")
+	}
+	if downtime != 360 {
+		t.Fatalf("temp downtime = %d, want 360", downtime)
+	}
+	if hr < 0.79 || hr > 0.81 {
+		t.Fatalf("temp post-reset headroom = %f, want ~0.80", hr)
+	}
+
+	hr, downtime, weekly = gtoResetMetrics(cookedWindows(540))
+	if !weekly {
+		t.Fatal("cooked account should be weekly exhausted (request-limit maxed)")
+	}
+	if downtime != 540 {
+		t.Fatalf("cooked downtime = %d, want 540 (latest saturated reset)", downtime)
+	}
+	if hr != 0 {
+		t.Fatalf("cooked post-reset headroom = %f, want 0 (weekly maxed)", hr)
+	}
+}
+
+func TestGTOResetCandidatesRankingAndUsableCount(t *testing.T) {
+	rows := []srUsageRow{
+		{email: "usable@x.com", authMode: accounts.AuthModeOAuth, provider: accounts.ProviderCodex},
+		{
+			email: "cooked@x.com", authMode: accounts.AuthModeOAuth, provider: accounts.ProviderCodex,
+			windows: cookedWindows(540), cooked: true, complimentaryReset: credit(2),
+		},
+		{
+			email: "temp-more-headroom@x.com", authMode: accounts.AuthModeOAuth, provider: accounts.ProviderCodex,
+			windows: tempWindows(360), tempCooked: true, complimentaryReset: credit(3),
+		},
+		{
+			email: "no-credit@x.com", authMode: accounts.AuthModeOAuth, provider: accounts.ProviderCodex,
+			windows: tempWindows(360), tempCooked: true, complimentaryReset: &accounts.ComplimentaryResetInfo{Known: true, Available: false},
+		},
+	}
+
+	usable, cands := gtoResetCandidates(rows)
+	if usable != 1 {
+		t.Fatalf("usableNow = %d, want 1", usable)
+	}
+	if len(cands) != 2 {
+		t.Fatalf("candidates = %d, want 2 (no-credit excluded)", len(cands))
+	}
+	// Temp (not weekly-exhausted, high headroom) must rank above the cooked one.
+	if cands[0].email != "temp-more-headroom@x.com" {
+		t.Fatalf("first candidate = %s, want temp-more-headroom@x.com", cands[0].email)
+	}
+	if cands[1].email != "cooked@x.com" {
+		t.Fatalf("second candidate = %s, want cooked@x.com", cands[1].email)
+	}
+}
+
+func TestAssessResetValue(t *testing.T) {
+	// Anyone usable -> low value.
+	if _, ok := assessResetValue(2, []gtoResetCandidate{{email: "a", downtimeSavedSeconds: 100000}}); ok {
+		t.Fatal("usable accounts present should read low value")
+	}
+	// Everyone self-heals soon -> low value.
+	v, ok := assessResetValue(0, []gtoResetCandidate{{email: "a", downtimeSavedSeconds: 360}})
+	if ok || !strings.Contains(v, "LOW VALUE") {
+		t.Fatalf("near-term recovery should be low value, got ok=%v verdict=%q", ok, v)
+	}
+	// All cooked, far-out recovery -> good value.
+	v, ok = assessResetValue(0, []gtoResetCandidate{{email: "a", downtimeSavedSeconds: 3 * 60 * 60}})
+	if !ok || !strings.Contains(v, "GOOD VALUE") {
+		t.Fatalf("far recovery should be good value, got ok=%v verdict=%q", ok, v)
+	}
+	// No candidates.
+	if _, ok := assessResetValue(0, nil); ok {
+		t.Fatal("no candidates should not be worthwhile")
+	}
+}

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -522,7 +522,8 @@ func (r srRunner) serverStatus(ctx context.Context, store srServerStore, name st
 	if available {
 		rows := usageRowsFromServerUsageStatuses(usage)
 		fmt.Fprintf(r.out, "Server: %s (%s)\n", server.Name, server.URL)
-		displayUsageRows(r.out, rows, false)
+		displayUsageRows(r.out, rows, true)
+		printAccountCountSummary(r.out, rows)
 		r.printBedrockStatus(ctx, server)
 		return nil
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -908,6 +908,7 @@ func (s Server) Handler() http.Handler {
 	mux.HandleFunc("/_subrouter/account-status", s.requireAdmin(s.handleAccountStatus))
 	mux.HandleFunc("/_subrouter/usage-status", s.requireAdmin(s.handleUsageStatus))
 	mux.HandleFunc("/_subrouter/rate-limit-reset", s.requireAdmin(s.handleRateLimitReset))
+	mux.HandleFunc("/_subrouter/reset-credits", s.requireAdmin(s.handleResetCredits))
 	mux.HandleFunc("/_subrouter/reload-accounts", s.requireAdmin(s.handleReloadAccounts))
 	mux.HandleFunc("/_subrouter/sessions", s.requireAdmin(s.handleSessions))
 	mux.HandleFunc("/_subrouter/dashboard", s.requireAdmin(s.handleDashboard))
@@ -1239,6 +1240,73 @@ func (s Server) handleRateLimitReset(w http.ResponseWriter, r *http.Request) {
 		"dry_run": dryRun,
 		"results": results,
 	})
+}
+
+// ResetCreditsAccount is one account's redeemable rate-limit reset credits,
+// including each credit's expiry so callers can see when they lapse.
+type ResetCreditsAccount struct {
+	Email   string                          `json:"email"`
+	Count   int                             `json:"count"`
+	Credits []accounts.RateLimitResetCredit `json:"credits,omitempty"`
+	Error   string                          `json:"error,omitempty"`
+}
+
+// handleResetCredits lists every stored OAuth account's available reset credits
+// with granted/expiry timestamps. This is read-only (a GET) but still admin
+// gated because it makes an authenticated call per account against the upstream.
+func (s Server) handleResetCredits(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.AccountRef == nil {
+		http.Error(w, "account store not configured", http.StatusInternalServerError)
+		return
+	}
+	ctx := r.Context()
+	storedAccounts, err := s.AccountRef.store.ListStored()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	sem := make(chan struct{}, 4)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	out := make([]ResetCreditsAccount, 0, len(storedAccounts))
+	for i := range storedAccounts {
+		stored := storedAccounts[i]
+		if stored.IsAPIKey() {
+			continue
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			account, ok := stored.Account(stored.SourcePath(s.AccountRef.store))
+			if !ok || account.Token == "" {
+				return
+			}
+			entry := ResetCreditsAccount{Email: account.Email}
+			credits, err := accounts.ListRateLimitResetCredits(ctx, s.AccountRef.client, account)
+			if err != nil {
+				entry.Error = err.Error()
+			} else {
+				for _, c := range credits {
+					if c.Status == "" || c.Status == "available" {
+						entry.Credits = append(entry.Credits, c)
+					}
+				}
+				entry.Count = len(entry.Credits)
+			}
+			mu.Lock()
+			out = append(out, entry)
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	sort.Slice(out, func(i, j int) bool { return out[i].Email < out[j].Email })
+	writeJSON(w, map[string]any{"ok": true, "accounts": out})
 }
 
 // rateLimitResetOne resolves a single account by email and redeems a credit if


### PR DESCRIPTION
Reset-credit visibility and smarter reset selection for `sr`.

## 1. `sr reset --gto` — game-theory-optimal reset selection

The no-arg `sr reset` picks the cooked account with the longest natural 7d reset. When every account's weekly window resets at roughly the same time (the common case), that tiebreak is arbitrary and unrelated to what routing would use next, and it can spend a scarce one-time credit on an account whose only maxed window self-heals in minutes.

```
sr reset --gto              # redeem the single best account to un-cook
sr reset --gto -n 3         # redeem the top 3
sr reset --gto --dry-run    # rank candidates + value verdict, spend nothing
```

Ranking of cooked accounts that hold a credit: (1) not weekly-exhausted first (a 5h reset only un-cooks an account whose weekly windows have room), (2) post-reset weekly headroom, (3) downtime saved. Every run prints a verdict first: `LOW VALUE` when accounts are already usable or all self-heal within 20m, `GOOD VALUE` when all cooked with a far-out reset. The verdict never blocks the redeem (fast unblock always allowed).

## 2. Reset-credit counts in the `sr` table

The `1x reset` column showed a bare `avail` because the cell checked `Available` before `Remaining`. It now shows the concrete count, so accounts with more than one credit are visible:

```
17   aziz@manaflow.ai   ...  1x reset: 4 left
14   aifirehose@...     ...  1x reset: 3 left
```

## 3. Account numbering + total

The bare `sr` status view now numbers every account across providers and prints a total footer:

```
Total: 23 Codex, 2 Claude profiles, 1 Kimi, 1 Zai (27 accounts)
```

## 4. `sr reset --list` — credits with expiry

```
sr reset --list
  aziz@manaflow.ai    4 credit(s), soonest expires in 5d 3h
  ...
  34 reset credit(s) across 11 account(s).
```

Per-credit `expires_at` is only readable by the live server (it holds the refreshed OAuth tokens; on-disk copies are stale), so this is a read-only, admin-gated `GET /_subrouter/reset-credits` that queries the upstream per account. The CLI renders count + soonest expiry and degrades gracefully when no expiry is reported.

**Deploy note:** items 1–3 are pure CLI and work as soon as the `sr` binary is rebuilt. Item 4's `--list` needs the mini server redeployed (new endpoint); the expiry values will be verified live post-deploy.

## Tests

`cmd/subrouter/sr_reset_gto_test.go` covers GTO metrics/ranking/verdict, the count cell, the total summary, expiry parsing/formatting, and the reset-credits printer. Full `cmd/subrouter` and `internal/proxy` suites pass.