### PR TITLE
sr: restart account numbering per provider group

### DIFF
--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -1602,13 +1602,26 @@ func displayUsageRows(out io.Writer, rows []srUsageRow, numbered bool) {
 		return
 	}
 	colored := colorEnabled(out)
-	displayUsageRowsGrid(out, rows, numbered, colored)
+	displayUsageRowsGrid(out, rows, numbered, false, colored)
 }
 
-func displayUsageRowsGrid(out io.Writer, rows []srUsageRow, numbered bool, colored bool) {
+// displayUsageRowsPerGroup renders the table with numbering that restarts at 1
+// for each provider group. Use for the informational status view; the switch
+// picker keeps global numbering because it selects an account by that index.
+func displayUsageRowsPerGroup(out io.Writer, rows []srUsageRow) {
+	if len(rows) == 0 {
+		fmt.Fprintln(out, "No accounts configured. Run 'subrouter add' to add one.")
+		return
+	}
+	colored := colorEnabled(out)
+	displayUsageRowsGrid(out, rows, true, true, colored)
+}
+
+func displayUsageRowsGrid(out io.Writer, rows []srUsageRow, numbered, perGroupNumbers bool, colored bool) {
 	fmt.Fprintln(out)
 	currentGroup := ""
 	accountRowIndex := 0
+	groupRowIndex := 0
 	for i, row := range rows {
 		group := usageProviderLabel(row)
 		columns := usageGridColumns(out, numbered, usageProvider(row))
@@ -1622,16 +1635,22 @@ func displayUsageRowsGrid(out io.Writer, rows []srUsageRow, numbered bool, color
 			}, colored, "")
 			printUsageGridSeparator(out, columns, colored)
 			currentGroup = group
+			groupRowIndex = 0
 		}
 		rowIndex := ""
 		if numbered {
-			rowIndex = strconv.Itoa(i + 1)
+			if perGroupNumbers {
+				rowIndex = strconv.Itoa(groupRowIndex + 1)
+			} else {
+				rowIndex = strconv.Itoa(i + 1)
+			}
 		}
 		values := usageGridValues(row, rowIndex)
 		printUsageGridLine(out, columns, func(col usageGridColumn) usageGridCell {
 			return values[col.Key]
 		}, colored, usageGridRowStyle(accountRowIndex))
 		accountRowIndex++
+		groupRowIndex++
 	}
 	fmt.Fprintln(out)
 	if usageRowsHaveErrors(rows) {

--- a/cmd/subrouter/sr_reset_gto_test.go
+++ b/cmd/subrouter/sr_reset_gto_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -184,5 +185,35 @@ func TestPrintResetCredits(t *testing.T) {
 	}
 	if !strings.Contains(got, "2 reset credit(s) across 1 account(s)") {
 		t.Fatalf("totals wrong: %q", got)
+	}
+}
+
+func TestDisplayUsageRowsPerGroupRestartsNumbering(t *testing.T) {
+	rem := 1
+	rows := []srUsageRow{
+		{email: "codexone@x.com", provider: accounts.ProviderCodex, authMode: accounts.AuthModeOAuth, complimentaryReset: &accounts.ComplimentaryResetInfo{Known: true, Remaining: &rem}},
+		{email: "codextwo@x.com", provider: accounts.ProviderCodex, authMode: accounts.AuthModeOAuth},
+		{email: "claudeprof", provider: accounts.ProviderClaude},
+	}
+	var out bytes.Buffer
+	displayUsageRowsPerGroup(&out, rows)
+	ansi := regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	nums := map[string]string{}
+	for _, line := range strings.Split(ansi.ReplaceAllString(out.String(), ""), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		for _, e := range []string{"codexone@x.com", "codextwo@x.com", "claudeprof"} {
+			if strings.Contains(line, e) {
+				nums[e] = fields[0]
+			}
+		}
+	}
+	if nums["codexone@x.com"] != "1" || nums["codextwo@x.com"] != "2" {
+		t.Fatalf("codex numbering = %v, want 1,2", nums)
+	}
+	if nums["claudeprof"] != "1" {
+		t.Fatalf("claude numbering = %q, want restart at 1", nums["claudeprof"])
 	}
 }

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -522,7 +522,7 @@ func (r srRunner) serverStatus(ctx context.Context, store srServerStore, name st
 	if available {
 		rows := usageRowsFromServerUsageStatuses(usage)
 		fmt.Fprintf(r.out, "Server: %s (%s)\n", server.Name, server.URL)
-		displayUsageRows(r.out, rows, true)
+		displayUsageRowsPerGroup(r.out, rows)
 		printAccountCountSummary(r.out, rows)
 		r.printBedrockStatus(ctx, server)
 		return nil


### PR DESCRIPTION
The bare `sr` status view numbered accounts continuously across providers (1..27). This restarts numbering at 1 for each provider group so each category's count is obvious:

```
Codex accounts
1   aw3@manaflow.com   ...
...
23  lc+3@cmux.com      ...
Claude profiles
1   default            ...
2   lawrence@manaflow.ai ...
Kimi accounts
1   kimi:main          ...
```

The interactive `Switch to (#):` picker keeps global numbering because it selects an account by that index; per-group numbering is a display-only mode used by the status view. Test added; full `cmd/subrouter` + `internal/proxy` suites pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786245534&installation_id=133855650&pr_number=70&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F70&signature=f0349121be1aee49b407c1e04ddcddecf8b36207b392ad84e3a67c9d02c4a16e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restart account numbering at 1 for each provider group in the `sr` status view. This makes category counts obvious while the interactive “Switch to (#)” picker still uses global indices.

- New Features
  - Added per-group numbering mode for the status view.
  - Updated server status to use per-group numbering; the switch picker keeps global numbering.
  - Added test to verify numbering resets within each provider group.

<sup>Written for commit cc6b12d1eb1c3b916547441dc167b030b0e84565. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server status usage tables now restart account numbering for each provider group, making grouped information easier to read.
  * Preserved continuous numbering and alternating row styling in views where global numbering is expected.

* **Tests**
  * Added coverage to verify numbering resets correctly when the provider changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->