### PR TITLE
fix(claude): stop macOS Keychain corrupting OAuth credentials on refresh

### DIFF
--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -592,6 +592,7 @@ func readCredentialFile(instancePath string) (*CredentialInfo, bool) {
 }
 
 func parseCredentialPayload(body []byte) (*CredentialInfo, error) {
+	body = healHexEncodedCredential(body)
 	var raw struct {
 		ClaudeAIOAuth *CredentialInfo `json:"claudeAiOauth"`
 	}
@@ -601,14 +602,48 @@ func parseCredentialPayload(body []byte) (*CredentialInfo, error) {
 	return raw.ClaudeAIOAuth, nil
 }
 
+// healHexEncodedCredential recovers credentials that macOS `security
+// find-generic-password -w` returned hex-encoded. `security` hex-encodes a
+// generic-password value on read whenever it contains a newline, so a
+// credential previously written with indented (multi-line) JSON round-trips as
+// a hex string like "7b0a2020..." that fails to JSON-parse. Detect that shape
+// (credential JSON always starts with '{' or '['; its hex form starts with the
+// ASCII "7b" or "5b") and decode it back. credentialPayload now writes compact
+// JSON so new writes avoid this, but this keeps already-written blobs readable.
+//
+// hex.DecodeString plus the subsequent json.Unmarshal are the real gate: a body
+// that only coincidentally starts with "7b"/"5b" but isn't valid hex-of-JSON
+// fails to decode (or decodes to non-JSON) and is returned unchanged, so this
+// is a no-op on ordinary JSON.
+func healHexEncodedCredential(body []byte) []byte {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) < 2 || len(trimmed)%2 != 0 {
+		return body
+	}
+	// `security` emits lowercase hex; hex.DecodeString accepts either case, so
+	// match either and let the decode be the real gate.
+	prefix := bytes.ToLower(trimmed[:2])
+	if !bytes.Equal(prefix, []byte("7b")) && !bytes.Equal(prefix, []byte("5b")) {
+		return body
+	}
+	decoded, err := hex.DecodeString(string(trimmed))
+	if err != nil {
+		return body
+	}
+	return decoded
+}
+
 func credentialPayload(credential CredentialInfo) ([]byte, error) {
-	body, err := json.MarshalIndent(map[string]CredentialInfo{
+	// Compact (single-line) JSON: macOS `security` hex-encodes multi-line
+	// keychain values on read, which breaks parseCredentialPayload. json.Marshal
+	// escapes any in-string newline to \n, so the output is always single-line.
+	// See healHexEncodedCredential.
+	body, err := json.Marshal(map[string]CredentialInfo{
 		"claudeAiOauth": credential,
-	}, "", "  ")
+	})
 	if err != nil {
 		return nil, err
 	}
-	body = append(body, '\n')
 	return body, nil
 }
 

--- a/internal/agents/claude/store_test.go
+++ b/internal/agents/claude/store_test.go
@@ -1,7 +1,9 @@
 package claude
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -88,6 +90,67 @@ func TestClaudeConfigDirFallsBackWhenAliasMissing(t *testing.T) {
 
 	if got := store.ClaudeConfigDir("work"); got != filepath.Clean(instancePath) {
 		t.Fatalf("ClaudeConfigDir = %q, want %q", got, filepath.Clean(instancePath))
+	}
+}
+
+func TestCredentialPayloadIsSingleLine(t *testing.T) {
+	// macOS `security find-generic-password -w` hex-encodes any keychain value
+	// containing a newline on read, so the persisted payload must be one line.
+	body, err := credentialPayload(CredentialInfo{AccessToken: "tok", RefreshToken: "refresh", SubscriptionType: "pro"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.ContainsRune(body, '\n') {
+		t.Fatalf("credentialPayload must be single-line (no newline); got %q", body)
+	}
+	cred, err := parseCredentialPayload(body)
+	if err != nil || cred == nil {
+		t.Fatalf("round-trip parse: cred=%v err=%v", cred, err)
+	}
+	if cred.AccessToken != "tok" || cred.RefreshToken != "refresh" {
+		t.Fatalf("round-trip credential = %+v, want accessToken=tok refreshToken=refresh", cred)
+	}
+}
+
+func TestParseCredentialPayloadHealsHexEncoded(t *testing.T) {
+	// A credential written by an older build (indented JSON) that macOS
+	// `security -w` returned hex-encoded on read must still be readable.
+	indented := []byte("{\n  \"claudeAiOauth\": {\n    \"accessToken\": \"tok\",\n    \"refreshToken\": \"refresh\"\n  }\n}")
+	hexed := []byte(hex.EncodeToString(indented))
+	cred, err := parseCredentialPayload(hexed)
+	if err != nil {
+		t.Fatalf("heal+parse hex-encoded credential: %v", err)
+	}
+	if cred == nil || cred.AccessToken != "tok" || cred.RefreshToken != "refresh" {
+		t.Fatalf("healed credential = %+v, want accessToken=tok refreshToken=refresh", cred)
+	}
+}
+
+func TestHealHexEncodedCredentialNoOpOnPlainJSON(t *testing.T) {
+	// Real credential JSON starts with the byte '{' (not the ASCII "7b"), so the
+	// heal must never mutate it.
+	for name, in := range map[string][]byte{
+		"compact":       []byte(`{"claudeAiOauth":{"accessToken":"tok"}}`),
+		"indented":      []byte("{\n  \"claudeAiOauth\": {}\n}"),
+		"leading-space": []byte(`  {"claudeAiOauth":{}}`),
+	} {
+		if got := healHexEncodedCredential(in); !bytes.Equal(got, in) {
+			t.Fatalf("%s: heal mutated plain JSON: %q -> %q", name, in, got)
+		}
+	}
+}
+
+func TestHealHexEncodedCredentialGuardsMalformed(t *testing.T) {
+	// Inputs that pass the "7b"/"5b" prefix filter but are not valid hex must be
+	// returned unchanged (fail-closed; downstream json.Unmarshal reports it).
+	for _, in := range [][]byte{
+		[]byte("7"),    // too short
+		[]byte("7b0"),  // odd length
+		[]byte("7bzz"), // non-hex body
+	} {
+		if got := healHexEncodedCredential(in); !bytes.Equal(got, in) {
+			t.Fatalf("guard: %q was mutated to %q", in, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

On macOS, Claude accounts break after ~an hour of use: `sr claude list` shows

```
Error: invalid character 'b' after top-level value
```

and the daemon logs `Claude profile credential unreadable, skipping` +
`usage fetch failed: 401 Unauthorized`, scores every account `headroom=0`, and
routing returns **`no non-exhausted claude accounts available`**. It works right
after `sr claude add`, then breaks once the OAuth access token first refreshes.

## Root cause

Claude credentials are persisted to the login Keychain in `store.WriteCredential`:

```go
body, _ := credentialPayload(credential)   // json.MarshalIndent -> multi-line
exec.Command("security", "add-generic-password", "-U", "-s", service, "-a", user, "-w", string(body))
```

`credentialPayload` used `json.MarshalIndent` (pretty, multi-line). macOS
`security find-generic-password -w` **hex-encodes any generic-password value
that contains a newline** on read, so the credential comes back as an ASCII hex
string like `7b0a2020...` (`{`=`0x7b`, then `\n`=`0x0a`). `parseCredentialPayload`
feeds that to `json.Unmarshal`, which parses the leading `7` as a number and
then fails on `b` -> `invalid character 'b' after top-level value`.

The daemon rewrites the credential after every token refresh
(`RefreshCredentialIfExpired` -> `WriteCredential`), so each account
self-corrupts within its access-token lifetime.

Repro on any Mac:
```sh
security add-generic-password -U -s demo -a "$USER" -w "$(printf '{\n  "a": 1\n}')"
security find-generic-password -s demo -w   # prints hex "7b0a...", not the JSON
```

## Fix

- **`credentialPayload` now writes compact `json.Marshal`** (single line).
  `json.Marshal` escapes any in-string newline to `\n`, so the stored value can
  never contain a raw newline and `security` returns it as text. This prevents
  new corruption.
- **`parseCredentialPayload` heals already-hex-encoded blobs on read** via
  `healHexEncodedCredential`, so existing corrupted Keychain entries recover
  without a re-login. It only triggers on the `"7b"`/`"5b"` ASCII-hex prefix;
  `hex.DecodeString` + the subsequent `json.Unmarshal` are the real gate, so it
  is a **no-op on ordinary JSON** (which starts with the byte `{`, i.e. `0x7b`,
  not the two ASCII characters `7b`). Malformed input is returned unchanged
  (fail-closed).

No new dependencies (`bytes`/`encoding/hex` already imported). Linux/`.credentials.json`
persistence is unaffected (that path never round-trips through `security`).

## Tests

Adds to `internal/agents/claude/store_test.go`:
- `TestCredentialPayloadIsSingleLine` — the persisted payload contains no newline and round-trips.
- `TestParseCredentialPayloadHealsHexEncoded` — a hex-encoded (old multi-line) credential is read back correctly.
- `TestHealHexEncodedCredentialNoOpOnPlainJSON` — compact/indented/leading-space JSON is never mutated.
- `TestHealHexEncodedCredentialGuardsMalformed` — short/odd-length/non-hex input is returned unchanged.

`go test ./internal/agents/claude/` and `go vet` pass; `gofmt` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786370339&installation_id=133855650&pr_number=73&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F73&signature=b5045b47b0e80b3c225244615ca946ea4417958bd2d63e73d70863198338b114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS Keychain newline/hex issue that corrupted Claude OAuth credentials after refresh. Writes single-line JSON and auto-heals previously hex-encoded entries so accounts keep working.

- **Bug Fixes**
  - `credentialPayload` now uses `encoding/json` (`json.Marshal`) to write compact JSON, avoiding newlines that make `security find-generic-password -w` hex-encode values.
  - `parseCredentialPayload` runs `healHexEncodedCredential` to decode ASCII-hex payloads (prefix `7b`/`5b`) via `encoding/hex`; it’s a no-op for normal JSON and fail-closed on malformed input.

<sup>Written for commit 7b05740d925f89ac60160e61c8245bfd3712fad7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential handling on macOS by recovering keychain data returned as hex-encoded JSON.
  * Preserved compatibility with previously stored credential data.
  * Credential data is now stored in a more compact, single-line format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->