### PR TITLE
Preserve connections across Subrouter upgrades

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -874,7 +874,7 @@ Usage:
   %[1]s gemini             Manage Gemini profiles
 
   %[1]s serve [--addr 127.0.0.1:31415] [--fetch-usage=true] [--codex-upstream URL] [--claude-upstream URL] [--kimi-upstream URL] [--zai-upstream URL] [--transcripts DIR] [--transcript-gcs-uri gs://bucket/prefix] [--transcript-gcs-sync-timeout 30m] [--transcript-local-retention 24h] [--transcript-max-local-bytes 2GiB]
-  %[1]s supervise --worker-bin PATH [--addr 127.0.0.1:31415] -- [serve flags]
+  %[1]s supervise --worker-bin PATH [--addr 127.0.0.1:31415] [--control-socket /var/run/subrouter-supervisor.sock] -- [serve flags]
   %[1]s accounts
   %[1]s codex [codex args...]
   %[1]s install-daemon [--start=true]       macOS LaunchAgent

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -874,7 +874,7 @@ Usage:
   %[1]s gemini             Manage Gemini profiles
 
   %[1]s serve [--addr 127.0.0.1:31415] [--fetch-usage=true] [--codex-upstream URL] [--claude-upstream URL] [--kimi-upstream URL] [--zai-upstream URL] [--transcripts DIR] [--transcript-gcs-uri gs://bucket/prefix] [--transcript-gcs-sync-timeout 30m] [--transcript-local-retention 24h] [--transcript-max-local-bytes 2GiB]
-  %[1]s supervise --worker-bin PATH [--addr 127.0.0.1:31415] [--control-socket /var/run/subrouter-supervisor.sock] -- [serve flags]
+  %[1]s supervise --worker-bin PATH [--addr 127.0.0.1:31415] [--control-socket /var/run/subrouter-supervisor.sock] [--drain-timeout 10m] -- [serve flags]
   %[1]s accounts
   %[1]s codex [codex args...]
   %[1]s install-daemon [--start=true]       macOS LaunchAgent

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -58,7 +58,7 @@ func configureDefaultLogger(program string, args []string) {
 }
 
 func shouldUseProcessLogger(_ string, args []string) bool {
-	return len(args) > 0 && args[0] == "serve"
+	return len(args) > 0 && (args[0] == "serve" || args[0] == "supervise")
 }
 
 func newCLIFileLogHandler(path string) slog.Handler {
@@ -100,6 +100,8 @@ func runForProgram(program string, args []string) error {
 	switch args[0] {
 	case "serve":
 		return serve(args[1:])
+	case "supervise":
+		return supervise(args[1:])
 	case "accounts":
 		return listAccounts()
 	case "codex":
@@ -581,6 +583,16 @@ func listenAndServeWithSignals(server *http.Server, lifecycle *proxy.Lifecycle, 
 }
 
 func listenAndServeHTTP(server *http.Server, logger *slog.Logger) error {
+	listener, err := inheritedListenerFromEnv()
+	if err != nil {
+		return err
+	}
+	if listener != nil {
+		if logger != nil {
+			logger.Info("using inherited supervisor socket", "addr", listener.Addr().String())
+		}
+		return server.Serve(listener)
+	}
 	listeners, err := inheritedSystemdListeners()
 	if err != nil {
 		return err
@@ -862,6 +874,7 @@ Usage:
   %[1]s gemini             Manage Gemini profiles
 
   %[1]s serve [--addr 127.0.0.1:31415] [--fetch-usage=true] [--codex-upstream URL] [--claude-upstream URL] [--kimi-upstream URL] [--zai-upstream URL] [--transcripts DIR] [--transcript-gcs-uri gs://bucket/prefix] [--transcript-gcs-sync-timeout 30m] [--transcript-local-retention 24h] [--transcript-max-local-bytes 2GiB]
+  %[1]s supervise --worker-bin PATH [--addr 127.0.0.1:31415] -- [serve flags]
   %[1]s accounts
   %[1]s codex [codex args...]
   %[1]s install-daemon [--start=true]       macOS LaunchAgent

--- a/cmd/subrouter/main_test.go
+++ b/cmd/subrouter/main_test.go
@@ -45,6 +45,19 @@ func TestConfigureDefaultLoggerLeavesServeLoggerAlone(t *testing.T) {
 	}
 }
 
+func TestConfigureDefaultLoggerLeavesSupervisorLoggerAlone(t *testing.T) {
+	previous := slog.Default()
+	defer slog.SetDefault(previous)
+
+	sentinel := slog.New(slog.NewTextHandler(io.Discard, nil))
+	slog.SetDefault(sentinel)
+
+	configureDefaultLogger("subrouter", []string{"supervise"})
+	if slog.Default() != sentinel {
+		t.Fatal("supervise should keep the process logger")
+	}
+}
+
 func TestSystemdListenFDsParsesCurrentProcess(t *testing.T) {
 	env := map[string]string{
 		"LISTEN_PID": "123",

--- a/cmd/subrouter/supervisor.go
+++ b/cmd/subrouter/supervisor.go
@@ -68,6 +68,7 @@ type supervisor struct {
 	fatal  chan error
 
 	upgradeMu sync.Mutex
+	stopping  bool
 	workersMu sync.Mutex
 	workers   map[string]*workerGeneration
 }
@@ -284,9 +285,10 @@ func (s *supervisor) run() error {
 	}
 	defer os.Remove(s.config.ControlSocket)
 	controlServer := &http.Server{Handler: s.controlHandler(), ReadHeaderTimeout: 5 * time.Second}
-	errCh := make(chan error, 2)
-	go func() { errCh <- s.router.Serve(listener) }()
-	go func() { errCh <- controlServer.Serve(controlListener) }()
+	routerErrCh := make(chan error, 1)
+	controlErrCh := make(chan error, 1)
+	go func() { routerErrCh <- s.router.Serve(listener) }()
+	go func() { controlErrCh <- controlServer.Serve(controlListener) }()
 
 	slog.Info("subrouter supervisor listening", "addr", s.config.Addr, "control_socket", s.config.ControlSocket, "worker", s.router.Active().ID)
 	sigCh := make(chan os.Signal, 2)
@@ -298,12 +300,19 @@ func (s *supervisor) run() error {
 		case err := <-s.fatal:
 			_ = listener.Close()
 			_ = controlServer.Close()
+			s.beginShutdown()
+			<-routerErrCh
 			s.stopAllWorkers()
 			return err
-		case err := <-errCh:
+		case err := <-routerErrCh:
+			if !errors.Is(err, net.ErrClosed) {
+				_ = controlServer.Close()
+				s.stopAllWorkers()
+				return err
+			}
+		case err := <-controlErrCh:
 			if !errors.Is(err, net.ErrClosed) && !errors.Is(err, http.ErrServerClosed) {
 				_ = listener.Close()
-				_ = controlServer.Close()
 				s.stopAllWorkers()
 				return err
 			}
@@ -318,6 +327,10 @@ func (s *supervisor) run() error {
 			}
 			_ = listener.Close()
 			_ = controlServer.Close()
+			s.beginShutdown()
+			// Join the accept loop before checking connection counts. Accept and
+			// acquireActive are synchronous, so no connection can appear afterward.
+			<-routerErrCh
 			drainCtx, cancel := context.WithTimeout(context.Background(), s.config.DrainTimeout)
 			if err := s.router.WaitAllIdle(drainCtx); err != nil {
 				slog.Warn("subrouter supervisor drain timed out", "timeout", s.config.DrainTimeout, "error", err)
@@ -327,6 +340,12 @@ func (s *supervisor) run() error {
 			return nil
 		}
 	}
+}
+
+func (s *supervisor) beginShutdown() {
+	s.upgradeMu.Lock()
+	s.stopping = true
+	s.upgradeMu.Unlock()
 }
 
 func prepareControlSocket(path string) error {
@@ -353,6 +372,9 @@ func (s *supervisor) upgrade() error {
 }
 
 func (s *supervisor) upgradeLocked() error {
+	if s.stopping {
+		return errors.New("supervisor is shutting down")
+	}
 	next, err := startWorkerGeneration(s.config)
 	if err != nil {
 		return err

--- a/cmd/subrouter/supervisor.go
+++ b/cmd/subrouter/supervisor.go
@@ -173,11 +173,24 @@ func startWorkerGeneration(config supervisorConfig) (*workerGeneration, error) {
 	}
 	go func() { generation.setWaitError(command.Wait()) }()
 	if err := waitForWorkerReady(generation, config.ReadyTimeout); err != nil {
-		_ = command.Process.Signal(syscall.SIGTERM)
+		terminateWorker(generation, time.Second)
 		return nil, err
 	}
 	slog.Info("subrouter worker ready", "generation", generation.id, "pid", command.Process.Pid, "addr", address)
 	return generation, nil
+}
+
+func terminateWorker(worker *workerGeneration, gracePeriod time.Duration) {
+	_ = worker.command.Process.Signal(syscall.SIGTERM)
+	timer := time.NewTimer(gracePeriod)
+	defer timer.Stop()
+	select {
+	case <-worker.done:
+		return
+	case <-timer.C:
+	}
+	_ = worker.command.Process.Kill()
+	<-worker.done
 }
 
 func waitForWorkerReady(generation *workerGeneration, timeout time.Duration) error {
@@ -295,15 +308,12 @@ func (s *supervisor) upgradeLocked() error {
 
 func (s *supervisor) monitorWorker(worker *workerGeneration) {
 	err := worker.waitError()
-	if s.router.Active().ID != worker.id {
-		return
-	}
-	slog.Error("active subrouter worker exited", "generation", worker.id, "pid", worker.command.Process.Pid, "error", err)
 	s.upgradeMu.Lock()
 	defer s.upgradeMu.Unlock()
 	if s.router.Active().ID != worker.id {
 		return
 	}
+	slog.Error("active subrouter worker exited", "generation", worker.id, "pid", worker.command.Process.Pid, "error", err)
 	if replaceErr := s.upgradeLocked(); replaceErr != nil {
 		slog.Error("subrouter worker recovery failed", "generation", worker.id, "error", replaceErr)
 	}

--- a/cmd/subrouter/supervisor.go
+++ b/cmd/subrouter/supervisor.go
@@ -1,0 +1,387 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/front"
+)
+
+const inheritedListenerFDEnv = "SUBROUTER_LISTEN_FD"
+
+type supervisorConfig struct {
+	Addr         string
+	ControlAddr  string
+	WorkerBin    string
+	ReadyTimeout time.Duration
+	WorkerArgs   []string
+}
+
+type workerGeneration struct {
+	id      string
+	address string
+	command *exec.Cmd
+	done    chan struct{}
+
+	mu  sync.Mutex
+	err error
+}
+
+func (g *workerGeneration) setWaitError(err error) {
+	g.mu.Lock()
+	g.err = err
+	g.mu.Unlock()
+	close(g.done)
+}
+
+func (g *workerGeneration) waitError() error {
+	<-g.done
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.err
+}
+
+type supervisor struct {
+	config supervisorConfig
+	router *front.Router
+
+	upgradeMu sync.Mutex
+	workersMu sync.Mutex
+	workers   map[string]*workerGeneration
+}
+
+func supervise(args []string) error {
+	config, err := parseSupervisorConfig(args)
+	if err != nil {
+		return err
+	}
+	if err := validateSupervisorConfig(config); err != nil {
+		return err
+	}
+	initial, err := startWorkerGeneration(config)
+	if err != nil {
+		return err
+	}
+	router, err := front.NewRouter(front.Backend{ID: initial.id, Address: initial.address})
+	if err != nil {
+		_ = initial.command.Process.Signal(syscall.SIGTERM)
+		return err
+	}
+	s := &supervisor{
+		config:  config,
+		router:  router,
+		workers: map[string]*workerGeneration{initial.id: initial},
+	}
+	go s.monitorWorker(initial)
+	return s.run()
+}
+
+func parseSupervisorConfig(args []string) (supervisorConfig, error) {
+	flags := flag.NewFlagSet("supervise", flag.ContinueOnError)
+	config := supervisorConfig{}
+	flags.StringVar(&config.Addr, "addr", "127.0.0.1:31415", "stable client listen address")
+	flags.StringVar(&config.ControlAddr, "control-addr", "127.0.0.1:31414", "loopback supervisor control address")
+	flags.StringVar(&config.WorkerBin, "worker-bin", "", "replaceable subrouter worker binary")
+	flags.DurationVar(&config.ReadyTimeout, "ready-timeout", 30*time.Second, "maximum time for a new worker to become ready")
+	if err := flags.Parse(args); err != nil {
+		return supervisorConfig{}, err
+	}
+	config.WorkerArgs = flags.Args()
+	if len(config.WorkerArgs) > 0 && config.WorkerArgs[0] == "serve" {
+		config.WorkerArgs = config.WorkerArgs[1:]
+	}
+	return config, nil
+}
+
+func validateSupervisorConfig(config supervisorConfig) error {
+	if strings.TrimSpace(config.Addr) == "" {
+		return errors.New("addr is required")
+	}
+	if strings.TrimSpace(config.ControlAddr) == "" {
+		return errors.New("control-addr is required")
+	}
+	controlHost, _, err := net.SplitHostPort(config.ControlAddr)
+	if err != nil {
+		return fmt.Errorf("control-addr must include host and port: %w", err)
+	}
+	if controlHost != "127.0.0.1" && controlHost != "localhost" && controlHost != "::1" {
+		return fmt.Errorf("control-addr must be loopback, got %q", config.ControlAddr)
+	}
+	if strings.TrimSpace(config.WorkerBin) == "" {
+		return errors.New("worker-bin is required")
+	}
+	if config.ReadyTimeout <= 0 {
+		return errors.New("ready-timeout must be positive")
+	}
+	for i, arg := range config.WorkerArgs {
+		if arg == "--addr" || strings.HasPrefix(arg, "--addr=") {
+			return fmt.Errorf("worker argument %d sets --addr; the supervisor owns worker addresses", i+1)
+		}
+	}
+	return nil
+}
+
+func startWorkerGeneration(config supervisorConfig) (*workerGeneration, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	tcpListener, ok := listener.(*net.TCPListener)
+	if !ok {
+		_ = listener.Close()
+		return nil, errors.New("worker listener is not TCP")
+	}
+	file, err := tcpListener.File()
+	if err != nil {
+		_ = listener.Close()
+		return nil, err
+	}
+	address := listener.Addr().String()
+	workerArgs := append([]string{"serve", "--addr", address}, config.WorkerArgs...)
+	command := exec.Command(config.WorkerBin, workerArgs...)
+	command.ExtraFiles = []*os.File{file}
+	command.Env = append(os.Environ(), inheritedListenerFDEnv+"=3")
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Start(); err != nil {
+		_ = file.Close()
+		_ = listener.Close()
+		return nil, err
+	}
+	_ = file.Close()
+	_ = listener.Close()
+
+	generation := &workerGeneration{
+		id:      fmt.Sprintf("%d-%d", time.Now().UTC().UnixNano(), command.Process.Pid),
+		address: address,
+		command: command,
+		done:    make(chan struct{}),
+	}
+	go func() { generation.setWaitError(command.Wait()) }()
+	if err := waitForWorkerReady(generation, config.ReadyTimeout); err != nil {
+		_ = command.Process.Signal(syscall.SIGTERM)
+		return nil, err
+	}
+	slog.Info("subrouter worker ready", "generation", generation.id, "pid", command.Process.Pid, "addr", address)
+	return generation, nil
+}
+
+func waitForWorkerReady(generation *workerGeneration, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			connection, err := (&net.Dialer{Timeout: time.Second}).DialContext(ctx, network, address)
+			if err != nil {
+				return nil, err
+			}
+			if err := front.WriteProxyProtocolHeader(connection, nil, nil); err != nil {
+				_ = connection.Close()
+				return nil, err
+			}
+			return connection, nil
+		},
+	}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{Timeout: time.Second, Transport: transport}
+	readyURL := "http://" + generation.address + "/_subrouter/ready"
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		request, _ := http.NewRequestWithContext(ctx, http.MethodGet, readyURL, nil)
+		response, err := client.Do(request)
+		if err == nil {
+			_ = response.Body.Close()
+			if response.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		select {
+		case <-generation.done:
+			return fmt.Errorf("worker exited before readiness: %w", generation.waitError())
+		case <-ctx.Done():
+			return fmt.Errorf("worker readiness timed out after %s", timeout)
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *supervisor) run() error {
+	listener, err := net.Listen("tcp", s.config.Addr)
+	if err != nil {
+		s.stopAllWorkers()
+		return err
+	}
+	controlListener, err := net.Listen("tcp", s.config.ControlAddr)
+	if err != nil {
+		_ = listener.Close()
+		s.stopAllWorkers()
+		return err
+	}
+	controlServer := &http.Server{Handler: s.controlHandler(), ReadHeaderTimeout: 5 * time.Second}
+	errCh := make(chan error, 2)
+	go func() { errCh <- s.router.Serve(listener) }()
+	go func() { errCh <- controlServer.Serve(controlListener) }()
+
+	slog.Info("subrouter supervisor listening", "addr", s.config.Addr, "control_addr", s.config.ControlAddr, "worker", s.router.Active().ID)
+	sigCh := make(chan os.Signal, 2)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
+	defer signal.Stop(sigCh)
+
+	for {
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, net.ErrClosed) && !errors.Is(err, http.ErrServerClosed) {
+				_ = listener.Close()
+				_ = controlServer.Close()
+				s.stopAllWorkers()
+				return err
+			}
+		case sig := <-sigCh:
+			if sig == syscall.SIGHUP {
+				go func() {
+					if err := s.upgrade(); err != nil {
+						slog.Error("subrouter worker upgrade failed", "error", err)
+					}
+				}()
+				continue
+			}
+			_ = listener.Close()
+			_ = controlServer.Close()
+			s.stopAllWorkers()
+			return nil
+		}
+	}
+}
+
+func (s *supervisor) upgrade() error {
+	s.upgradeMu.Lock()
+	defer s.upgradeMu.Unlock()
+	return s.upgradeLocked()
+}
+
+func (s *supervisor) upgradeLocked() error {
+	next, err := startWorkerGeneration(s.config)
+	if err != nil {
+		return err
+	}
+	s.workersMu.Lock()
+	s.workers[next.id] = next
+	s.workersMu.Unlock()
+	go s.monitorWorker(next)
+	previous := s.router.Active()
+	if err := s.router.Switch(front.Backend{ID: next.id, Address: next.address}); err != nil {
+		_ = next.command.Process.Signal(syscall.SIGTERM)
+		return err
+	}
+	slog.Info("subrouter worker switched", "from", previous.ID, "to", next.id)
+	go s.reapWhenIdle(previous.ID)
+	return nil
+}
+
+func (s *supervisor) monitorWorker(worker *workerGeneration) {
+	err := worker.waitError()
+	if s.router.Active().ID != worker.id {
+		return
+	}
+	slog.Error("active subrouter worker exited", "generation", worker.id, "pid", worker.command.Process.Pid, "error", err)
+	s.upgradeMu.Lock()
+	defer s.upgradeMu.Unlock()
+	if s.router.Active().ID != worker.id {
+		return
+	}
+	if replaceErr := s.upgradeLocked(); replaceErr != nil {
+		slog.Error("subrouter worker recovery failed", "generation", worker.id, "error", replaceErr)
+	}
+}
+
+func (s *supervisor) reapWhenIdle(id string) {
+	s.router.WaitIdle(id)
+	s.workersMu.Lock()
+	worker := s.workers[id]
+	s.workersMu.Unlock()
+	if worker == nil {
+		return
+	}
+	slog.Info("subrouter worker drained", "generation", id, "pid", worker.command.Process.Pid)
+	_ = worker.command.Process.Signal(syscall.SIGTERM)
+	if err := worker.waitError(); err != nil {
+		slog.Warn("subrouter worker exited after drain", "generation", id, "error", err)
+	}
+	_ = s.router.Forget(id)
+	s.workersMu.Lock()
+	delete(s.workers, id)
+	s.workersMu.Unlock()
+}
+
+func (s *supervisor) controlHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /_subrouter/supervisor-status", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"active":   s.router.Active(),
+			"backends": s.router.Status(),
+		})
+	})
+	mux.HandleFunc("POST /_subrouter/upgrade", func(w http.ResponseWriter, _ *http.Request) {
+		if err := s.upgrade(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"active": s.router.Active()})
+	})
+	return mux
+}
+
+func (s *supervisor) stopAllWorkers() {
+	s.workersMu.Lock()
+	workers := make([]*workerGeneration, 0, len(s.workers))
+	for _, worker := range s.workers {
+		workers = append(workers, worker)
+	}
+	s.workersMu.Unlock()
+	for _, worker := range workers {
+		_ = worker.command.Process.Signal(syscall.SIGTERM)
+	}
+}
+
+func inheritedListenerFromEnv() (net.Listener, error) {
+	raw := strings.TrimSpace(os.Getenv(inheritedListenerFDEnv))
+	if raw == "" {
+		return nil, nil
+	}
+	fd, err := strconv.Atoi(raw)
+	if err != nil || fd < 3 {
+		return nil, fmt.Errorf("invalid %s %q", inheritedListenerFDEnv, raw)
+	}
+	_ = os.Unsetenv(inheritedListenerFDEnv)
+	file := os.NewFile(uintptr(fd), "subrouter-supervisor-listener")
+	if file == nil {
+		return nil, fmt.Errorf("listener fd %d is unavailable", fd)
+	}
+	listener, err := net.FileListener(file)
+	closeErr := file.Close()
+	if err != nil {
+		return nil, err
+	}
+	if closeErr != nil {
+		_ = listener.Close()
+		return nil, closeErr
+	}
+	return front.NewProxyProtocolListener(listener), nil
+}

--- a/cmd/subrouter/supervisor.go
+++ b/cmd/subrouter/supervisor.go
@@ -29,6 +29,7 @@ type supervisorConfig struct {
 	ControlSocket string
 	WorkerBin     string
 	ReadyTimeout  time.Duration
+	DrainTimeout  time.Duration
 	WorkerArgs    []string
 }
 
@@ -105,6 +106,7 @@ func parseSupervisorConfig(args []string) (supervisorConfig, error) {
 	flags.StringVar(&config.ControlSocket, "control-socket", "/var/run/subrouter-supervisor.sock", "permissioned supervisor control socket")
 	flags.StringVar(&config.WorkerBin, "worker-bin", "", "replaceable subrouter worker binary")
 	flags.DurationVar(&config.ReadyTimeout, "ready-timeout", 30*time.Second, "maximum time for a new worker to become ready")
+	flags.DurationVar(&config.DrainTimeout, "drain-timeout", 10*time.Minute, "maximum time to drain connections during supervisor shutdown")
 	if err := flags.Parse(args); err != nil {
 		return supervisorConfig{}, err
 	}
@@ -127,6 +129,9 @@ func validateSupervisorConfig(config supervisorConfig) error {
 	}
 	if config.ReadyTimeout <= 0 {
 		return errors.New("ready-timeout must be positive")
+	}
+	if config.DrainTimeout <= 0 {
+		return errors.New("drain-timeout must be positive")
 	}
 	for i, arg := range config.WorkerArgs {
 		if arg == "--addr" || strings.HasPrefix(arg, "--addr=") {
@@ -313,6 +318,11 @@ func (s *supervisor) run() error {
 			}
 			_ = listener.Close()
 			_ = controlServer.Close()
+			drainCtx, cancel := context.WithTimeout(context.Background(), s.config.DrainTimeout)
+			if err := s.router.WaitAllIdle(drainCtx); err != nil {
+				slog.Warn("subrouter supervisor drain timed out", "timeout", s.config.DrainTimeout, "error", err)
+			}
+			cancel()
 			s.stopAllWorkers()
 			return nil
 		}

--- a/cmd/subrouter/supervisor.go
+++ b/cmd/subrouter/supervisor.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -24,11 +25,11 @@ import (
 const inheritedListenerFDEnv = "SUBROUTER_LISTEN_FD"
 
 type supervisorConfig struct {
-	Addr         string
-	ControlAddr  string
-	WorkerBin    string
-	ReadyTimeout time.Duration
-	WorkerArgs   []string
+	Addr          string
+	ControlSocket string
+	WorkerBin     string
+	ReadyTimeout  time.Duration
+	WorkerArgs    []string
 }
 
 type workerGeneration struct {
@@ -94,7 +95,7 @@ func parseSupervisorConfig(args []string) (supervisorConfig, error) {
 	flags := flag.NewFlagSet("supervise", flag.ContinueOnError)
 	config := supervisorConfig{}
 	flags.StringVar(&config.Addr, "addr", "127.0.0.1:31415", "stable client listen address")
-	flags.StringVar(&config.ControlAddr, "control-addr", "127.0.0.1:31414", "loopback supervisor control address")
+	flags.StringVar(&config.ControlSocket, "control-socket", "/var/run/subrouter-supervisor.sock", "permissioned supervisor control socket")
 	flags.StringVar(&config.WorkerBin, "worker-bin", "", "replaceable subrouter worker binary")
 	flags.DurationVar(&config.ReadyTimeout, "ready-timeout", 30*time.Second, "maximum time for a new worker to become ready")
 	if err := flags.Parse(args); err != nil {
@@ -111,15 +112,8 @@ func validateSupervisorConfig(config supervisorConfig) error {
 	if strings.TrimSpace(config.Addr) == "" {
 		return errors.New("addr is required")
 	}
-	if strings.TrimSpace(config.ControlAddr) == "" {
-		return errors.New("control-addr is required")
-	}
-	controlHost, _, err := net.SplitHostPort(config.ControlAddr)
-	if err != nil {
-		return fmt.Errorf("control-addr must include host and port: %w", err)
-	}
-	if controlHost != "127.0.0.1" && controlHost != "localhost" && controlHost != "::1" {
-		return fmt.Errorf("control-addr must be loopback, got %q", config.ControlAddr)
+	if !filepath.IsAbs(config.ControlSocket) {
+		return fmt.Errorf("control-socket must be an absolute path, got %q", config.ControlSocket)
 	}
 	if strings.TrimSpace(config.WorkerBin) == "" {
 		return errors.New("worker-bin is required")
@@ -239,18 +233,31 @@ func (s *supervisor) run() error {
 		s.stopAllWorkers()
 		return err
 	}
-	controlListener, err := net.Listen("tcp", s.config.ControlAddr)
+	if err := prepareControlSocket(s.config.ControlSocket); err != nil {
+		_ = listener.Close()
+		s.stopAllWorkers()
+		return err
+	}
+	controlListener, err := net.Listen("unix", s.config.ControlSocket)
 	if err != nil {
 		_ = listener.Close()
 		s.stopAllWorkers()
 		return err
 	}
+	if err := os.Chmod(s.config.ControlSocket, 0o600); err != nil {
+		_ = listener.Close()
+		_ = controlListener.Close()
+		_ = os.Remove(s.config.ControlSocket)
+		s.stopAllWorkers()
+		return err
+	}
+	defer os.Remove(s.config.ControlSocket)
 	controlServer := &http.Server{Handler: s.controlHandler(), ReadHeaderTimeout: 5 * time.Second}
 	errCh := make(chan error, 2)
 	go func() { errCh <- s.router.Serve(listener) }()
 	go func() { errCh <- controlServer.Serve(controlListener) }()
 
-	slog.Info("subrouter supervisor listening", "addr", s.config.Addr, "control_addr", s.config.ControlAddr, "worker", s.router.Active().ID)
+	slog.Info("subrouter supervisor listening", "addr", s.config.Addr, "control_socket", s.config.ControlSocket, "worker", s.router.Active().ID)
 	sigCh := make(chan os.Signal, 2)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 	defer signal.Stop(sigCh)
@@ -279,6 +286,23 @@ func (s *supervisor) run() error {
 			return nil
 		}
 	}
+}
+
+func prepareControlSocket(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("control-socket path exists and is not a socket: %s", path)
+	}
+	return os.Remove(path)
 }
 
 func (s *supervisor) upgrade() error {

--- a/cmd/subrouter/supervisor.go
+++ b/cmd/subrouter/supervisor.go
@@ -59,6 +59,7 @@ func (g *workerGeneration) waitError() error {
 type supervisor struct {
 	config supervisorConfig
 	router *front.Router
+	fatal  chan error
 
 	upgradeMu sync.Mutex
 	workersMu sync.Mutex
@@ -85,6 +86,7 @@ func supervise(args []string) error {
 	s := &supervisor{
 		config:  config,
 		router:  router,
+		fatal:   make(chan error, 1),
 		workers: map[string]*workerGeneration{initial.id: initial},
 	}
 	go s.monitorWorker(initial)
@@ -264,6 +266,11 @@ func (s *supervisor) run() error {
 
 	for {
 		select {
+		case err := <-s.fatal:
+			_ = listener.Close()
+			_ = controlServer.Close()
+			s.stopAllWorkers()
+			return err
 		case err := <-errCh:
 			if !errors.Is(err, net.ErrClosed) && !errors.Is(err, http.ErrServerClosed) {
 				_ = listener.Close()
@@ -340,6 +347,10 @@ func (s *supervisor) monitorWorker(worker *workerGeneration) {
 	slog.Error("active subrouter worker exited", "generation", worker.id, "pid", worker.command.Process.Pid, "error", err)
 	if replaceErr := s.upgradeLocked(); replaceErr != nil {
 		slog.Error("subrouter worker recovery failed", "generation", worker.id, "error", replaceErr)
+		select {
+		case s.fatal <- fmt.Errorf("active worker recovery failed: %w", replaceErr):
+		default:
+		}
 	}
 }
 

--- a/cmd/subrouter/supervisor.go
+++ b/cmd/subrouter/supervisor.go
@@ -33,10 +33,12 @@ type supervisorConfig struct {
 }
 
 type workerGeneration struct {
-	id      string
-	address string
-	command *exec.Cmd
-	done    chan struct{}
+	id        string
+	network   string
+	address   string
+	socketDir string
+	command   *exec.Cmd
+	done      chan struct{}
 
 	mu  sync.Mutex
 	err error
@@ -46,6 +48,9 @@ func (g *workerGeneration) setWaitError(err error) {
 	g.mu.Lock()
 	g.err = err
 	g.mu.Unlock()
+	if g.socketDir != "" {
+		_ = os.RemoveAll(g.socketDir)
+	}
 	close(g.done)
 }
 
@@ -78,7 +83,7 @@ func supervise(args []string) error {
 	if err != nil {
 		return err
 	}
-	router, err := front.NewRouter(front.Backend{ID: initial.id, Address: initial.address})
+	router, err := front.NewRouter(front.Backend{ID: initial.id, Network: initial.network, Address: initial.address})
 	if err != nil {
 		_ = initial.command.Process.Signal(syscall.SIGTERM)
 		return err
@@ -132,21 +137,37 @@ func validateSupervisorConfig(config supervisorConfig) error {
 }
 
 func startWorkerGeneration(config supervisorConfig) (*workerGeneration, error) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	socketDir, err := os.MkdirTemp("", "subrouter-worker-")
 	if err != nil {
 		return nil, err
 	}
-	tcpListener, ok := listener.(*net.TCPListener)
+	if err := os.Chmod(socketDir, 0o700); err != nil {
+		_ = os.RemoveAll(socketDir)
+		return nil, err
+	}
+	address := filepath.Join(socketDir, "worker.sock")
+	listener, err := net.Listen("unix", address)
+	if err != nil {
+		_ = os.RemoveAll(socketDir)
+		return nil, err
+	}
+	if err := os.Chmod(address, 0o600); err != nil {
+		_ = listener.Close()
+		_ = os.RemoveAll(socketDir)
+		return nil, err
+	}
+	fileListener, ok := listener.(interface{ File() (*os.File, error) })
 	if !ok {
 		_ = listener.Close()
-		return nil, errors.New("worker listener is not TCP")
+		_ = os.RemoveAll(socketDir)
+		return nil, errors.New("worker listener cannot be inherited")
 	}
-	file, err := tcpListener.File()
+	file, err := fileListener.File()
 	if err != nil {
 		_ = listener.Close()
+		_ = os.RemoveAll(socketDir)
 		return nil, err
 	}
-	address := listener.Addr().String()
 	workerArgs := append([]string{"serve", "--addr", address}, config.WorkerArgs...)
 	command := exec.Command(config.WorkerBin, workerArgs...)
 	command.ExtraFiles = []*os.File{file}
@@ -156,16 +177,19 @@ func startWorkerGeneration(config supervisorConfig) (*workerGeneration, error) {
 	if err := command.Start(); err != nil {
 		_ = file.Close()
 		_ = listener.Close()
+		_ = os.RemoveAll(socketDir)
 		return nil, err
 	}
 	_ = file.Close()
 	_ = listener.Close()
 
 	generation := &workerGeneration{
-		id:      fmt.Sprintf("%d-%d", time.Now().UTC().UnixNano(), command.Process.Pid),
-		address: address,
-		command: command,
-		done:    make(chan struct{}),
+		id:        fmt.Sprintf("%d-%d", time.Now().UTC().UnixNano(), command.Process.Pid),
+		network:   "unix",
+		address:   address,
+		socketDir: socketDir,
+		command:   command,
+		done:      make(chan struct{}),
 	}
 	go func() { generation.setWaitError(command.Wait()) }()
 	if err := waitForWorkerReady(generation, config.ReadyTimeout); err != nil {
@@ -193,8 +217,8 @@ func waitForWorkerReady(generation *workerGeneration, timeout time.Duration) err
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	transport := &http.Transport{
-		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
-			connection, err := (&net.Dialer{Timeout: time.Second}).DialContext(ctx, network, address)
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			connection, err := (&net.Dialer{Timeout: time.Second}).DialContext(ctx, generation.network, generation.address)
 			if err != nil {
 				return nil, err
 			}
@@ -207,7 +231,7 @@ func waitForWorkerReady(generation *workerGeneration, timeout time.Duration) err
 	}
 	defer transport.CloseIdleConnections()
 	client := &http.Client{Timeout: time.Second, Transport: transport}
-	readyURL := "http://" + generation.address + "/_subrouter/ready"
+	readyURL := "http://subrouter-worker/_subrouter/ready"
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	for {
@@ -328,7 +352,7 @@ func (s *supervisor) upgradeLocked() error {
 	s.workersMu.Unlock()
 	go s.monitorWorker(next)
 	previous := s.router.Active()
-	if err := s.router.Switch(front.Backend{ID: next.id, Address: next.address}); err != nil {
+	if err := s.router.Switch(front.Backend{ID: next.id, Network: next.network, Address: next.address}); err != nil {
 		_ = next.command.Process.Signal(syscall.SIGTERM)
 		return err
 	}

--- a/cmd/subrouter/supervisor_test.go
+++ b/cmd/subrouter/supervisor_test.go
@@ -91,6 +91,14 @@ func TestMonitorWorkerReportsFatalWhenRecoveryFails(t *testing.T) {
 	}
 }
 
+func TestUpgradeRejectedAfterShutdownBegins(t *testing.T) {
+	s := &supervisor{stopping: true}
+	err := s.upgradeLocked()
+	if err == nil || !strings.Contains(err.Error(), "shutting down") {
+		t.Fatalf("upgrade error = %v, want shutdown rejection", err)
+	}
+}
+
 func TestValidateSupervisorConfigRejectsRelativeControlSocket(t *testing.T) {
 	config := supervisorConfig{
 		Addr:          "0.0.0.0:31415",

--- a/cmd/subrouter/supervisor_test.go
+++ b/cmd/subrouter/supervisor_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"testing"
 	"time"
@@ -15,7 +16,7 @@ import (
 func TestParseSupervisorConfigSeparatesWorkerArguments(t *testing.T) {
 	config, err := parseSupervisorConfig([]string{
 		"--addr", "0.0.0.0:31415",
-		"--control-addr", "127.0.0.1:31414",
+		"--control-socket", "/var/run/subrouter-test.sock",
 		"--worker-bin", "/usr/local/bin/subrouter",
 		"--",
 		"serve", "--sr-switch-interval", "10m", "--bedrock",
@@ -26,31 +27,51 @@ func TestParseSupervisorConfigSeparatesWorkerArguments(t *testing.T) {
 	if config.Addr != "0.0.0.0:31415" || config.WorkerBin != "/usr/local/bin/subrouter" {
 		t.Fatalf("unexpected config: %+v", config)
 	}
+	if config.ControlSocket != "/var/run/subrouter-test.sock" {
+		t.Fatalf("control socket = %q", config.ControlSocket)
+	}
 	want := []string{"--sr-switch-interval", "10m", "--bedrock"}
 	if fmt.Sprint(config.WorkerArgs) != fmt.Sprint(want) {
 		t.Fatalf("worker args = %v, want %v", config.WorkerArgs, want)
 	}
 }
 
-func TestValidateSupervisorConfigRejectsPublicControlAddress(t *testing.T) {
+func TestPrepareControlSocketRefusesRegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "control.sock")
+	if err := os.WriteFile(path, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareControlSocket(path); err == nil {
+		t.Fatal("expected regular control-socket path to be rejected")
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "keep" {
+		t.Fatalf("regular file was modified: %q", body)
+	}
+}
+
+func TestValidateSupervisorConfigRejectsRelativeControlSocket(t *testing.T) {
 	config := supervisorConfig{
-		Addr:         "0.0.0.0:31415",
-		ControlAddr:  "0.0.0.0:31414",
-		WorkerBin:    "/usr/local/bin/subrouter",
-		ReadyTimeout: time.Second,
+		Addr:          "0.0.0.0:31415",
+		ControlSocket: "subrouter.sock",
+		WorkerBin:     "/usr/local/bin/subrouter",
+		ReadyTimeout:  time.Second,
 	}
 	if err := validateSupervisorConfig(config); err == nil {
-		t.Fatal("expected public control address to be rejected")
+		t.Fatal("expected relative control socket to be rejected")
 	}
 }
 
 func TestValidateSupervisorConfigRejectsWorkerAddress(t *testing.T) {
 	config := supervisorConfig{
-		Addr:         "0.0.0.0:31415",
-		ControlAddr:  "127.0.0.1:31414",
-		WorkerBin:    "/usr/local/bin/subrouter",
-		ReadyTimeout: time.Second,
-		WorkerArgs:   []string{"--addr", "127.0.0.1:1"},
+		Addr:          "0.0.0.0:31415",
+		ControlSocket: "/var/run/subrouter-test.sock",
+		WorkerBin:     "/usr/local/bin/subrouter",
+		ReadyTimeout:  time.Second,
+		WorkerArgs:    []string{"--addr", "127.0.0.1:1"},
 	}
 	if err := validateSupervisorConfig(config); err == nil {
 		t.Fatal("expected worker --addr to be rejected")

--- a/cmd/subrouter/supervisor_test.go
+++ b/cmd/subrouter/supervisor_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestParseSupervisorConfigSeparatesWorkerArguments(t *testing.T) {
+	config, err := parseSupervisorConfig([]string{
+		"--addr", "0.0.0.0:31415",
+		"--control-addr", "127.0.0.1:31414",
+		"--worker-bin", "/usr/local/bin/subrouter",
+		"--",
+		"serve", "--sr-switch-interval", "10m", "--bedrock",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Addr != "0.0.0.0:31415" || config.WorkerBin != "/usr/local/bin/subrouter" {
+		t.Fatalf("unexpected config: %+v", config)
+	}
+	want := []string{"--sr-switch-interval", "10m", "--bedrock"}
+	if fmt.Sprint(config.WorkerArgs) != fmt.Sprint(want) {
+		t.Fatalf("worker args = %v, want %v", config.WorkerArgs, want)
+	}
+}
+
+func TestValidateSupervisorConfigRejectsPublicControlAddress(t *testing.T) {
+	config := supervisorConfig{
+		Addr:         "0.0.0.0:31415",
+		ControlAddr:  "0.0.0.0:31414",
+		WorkerBin:    "/usr/local/bin/subrouter",
+		ReadyTimeout: time.Second,
+	}
+	if err := validateSupervisorConfig(config); err == nil {
+		t.Fatal("expected public control address to be rejected")
+	}
+}
+
+func TestValidateSupervisorConfigRejectsWorkerAddress(t *testing.T) {
+	config := supervisorConfig{
+		Addr:         "0.0.0.0:31415",
+		ControlAddr:  "127.0.0.1:31414",
+		WorkerBin:    "/usr/local/bin/subrouter",
+		ReadyTimeout: time.Second,
+		WorkerArgs:   []string{"--addr", "127.0.0.1:1"},
+	}
+	if err := validateSupervisorConfig(config); err == nil {
+		t.Fatal("expected worker --addr to be rejected")
+	}
+}
+
+func TestInheritedListenerFromEnv(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tcpListener := listener.(*net.TCPListener)
+	file, err := tcpListener.File()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = listener.Close()
+	t.Setenv(inheritedListenerFDEnv, fmt.Sprint(file.Fd()))
+
+	inherited, err := inheritedListenerFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer inherited.Close()
+	if inherited == nil {
+		t.Fatal("expected inherited listener")
+	}
+	accepted := make(chan struct{})
+	go func() {
+		connection, acceptErr := inherited.Accept()
+		if acceptErr == nil {
+			_ = connection.Close()
+			close(accepted)
+		}
+	}()
+	connection, err := net.Dial("tcp", inherited.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = fmt.Fprint(connection, "PROXY TCP4 192.0.2.10 198.51.100.20 43210 31415\r\n")
+	_ = connection.Close()
+	select {
+	case <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("inherited listener did not accept a connection")
+	}
+	_ = file.Close()
+	if value := os.Getenv(inheritedListenerFDEnv); value != "" {
+		t.Fatalf("%s was not cleared", inheritedListenerFDEnv)
+	}
+}

--- a/cmd/subrouter/supervisor_test.go
+++ b/cmd/subrouter/supervisor_test.go
@@ -2,15 +2,19 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/front"
 )
 
 func TestParseSupervisorConfigSeparatesWorkerArguments(t *testing.T) {
@@ -50,6 +54,40 @@ func TestPrepareControlSocketRefusesRegularFile(t *testing.T) {
 	}
 	if string(body) != "keep" {
 		t.Fatalf("regular file was modified: %q", body)
+	}
+}
+
+func TestMonitorWorkerReportsFatalWhenRecoveryFails(t *testing.T) {
+	router, err := front.NewRouter(front.Backend{ID: "failed", Address: "127.0.0.1:1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	close(done)
+	worker := &workerGeneration{
+		id:      "failed",
+		command: &exec.Cmd{Process: &os.Process{Pid: 12345}},
+		done:    done,
+		err:     errors.New("worker exited"),
+	}
+	s := &supervisor{
+		config: supervisorConfig{
+			WorkerBin:    filepath.Join(t.TempDir(), "missing-subrouter"),
+			ReadyTimeout: time.Second,
+		},
+		router:  router,
+		fatal:   make(chan error, 1),
+		workers: map[string]*workerGeneration{"failed": worker},
+	}
+
+	s.monitorWorker(worker)
+	select {
+	case fatalErr := <-s.fatal:
+		if !strings.Contains(fatalErr.Error(), "active worker recovery failed") {
+			t.Fatalf("fatal error = %v", fatalErr)
+		}
+	default:
+		t.Fatal("failed active-worker recovery was not reported as fatal")
 	}
 }
 

--- a/cmd/subrouter/supervisor_test.go
+++ b/cmd/subrouter/supervisor_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -96,5 +100,41 @@ func TestInheritedListenerFromEnv(t *testing.T) {
 	_ = file.Close()
 	if value := os.Getenv(inheritedListenerFDEnv); value != "" {
 		t.Fatalf("%s was not cleared", inheritedListenerFDEnv)
+	}
+}
+
+func TestTerminateWorkerKillsAfterGracePeriod(t *testing.T) {
+	if os.Getenv("SUBROUTER_TEST_IGNORE_TERM") == "1" {
+		signal.Ignore(syscall.SIGTERM)
+		fmt.Println("ready")
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+
+	command := exec.Command(os.Args[0], "-test.run=TestTerminateWorkerKillsAfterGracePeriod")
+	command.Env = append(os.Environ(), "SUBROUTER_TEST_IGNORE_TERM=1")
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	command.Stderr = os.Stderr
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if command.ProcessState == nil {
+			_ = command.Process.Kill()
+		}
+	})
+	worker := &workerGeneration{command: command, done: make(chan struct{})}
+	go func() { worker.setWaitError(command.Wait()) }()
+	if !bufio.NewScanner(stdout).Scan() {
+		t.Fatal("worker helper did not become ready")
+	}
+
+	terminateWorker(worker, 10*time.Millisecond)
+	if command.ProcessState == nil || command.ProcessState.Success() {
+		t.Fatalf("worker was not killed after grace period: %v", command.ProcessState)
 	}
 }

--- a/deploy/macos/migrate-launchdaemon-to-supervisor.sh
+++ b/deploy/macos/migrate-launchdaemon-to-supervisor.sh
@@ -26,7 +26,7 @@ fi
 }
 
 prepared="${PLIST}.supervised"
-PLIST="$PLIST" PREPARED="$prepared" WORKER_BIN="$WORKER_BIN" \
+public_addr="$(PLIST="$PLIST" PREPARED="$prepared" WORKER_BIN="$WORKER_BIN" \
 SUPERVISOR_BIN="$SUPERVISOR_BIN" CONTROL_ADDR="$CONTROL_ADDR" python3 <<'PY'
 import os
 import plistlib
@@ -82,7 +82,9 @@ with open(temporary, "wb") as stream:
     plistlib.dump(plist, stream, fmt=plistlib.FMT_XML, sort_keys=False)
 os.chmod(temporary, 0o644)
 os.replace(temporary, destination)
+print(public_addr)
 PY
+)"
 
 plutil -lint "$prepared"
 echo "Prepared $prepared"
@@ -99,7 +101,7 @@ launchctl bootstrap system "$PLIST"
 
 i=0
 until curl -fsS "http://${CONTROL_ADDR}/_subrouter/supervisor-status" >/dev/null 2>&1 \
-  && curl -fsS "http://127.0.0.1:31415/_subrouter/health" >/dev/null 2>&1; do
+  && curl -fsS "http://${public_addr}/_subrouter/health" >/dev/null 2>&1; do
   i=$((i + 1))
   if [ "$i" -ge 60 ]; then
     echo "supervised service failed health checks; restore $backup" >&2

--- a/deploy/macos/migrate-launchdaemon-to-supervisor.sh
+++ b/deploy/macos/migrate-launchdaemon-to-supervisor.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Convert an existing macOS Subrouter LaunchDaemon to the stable supervisor
+# layout. Preparation is non-disruptive. --activate performs the one-time
+# service transition; all later worker updates are zero-disruption.
+set -euo pipefail
+
+LABEL="${SUBROUTER_LABEL:-ai.manaflow.subrouter-team}"
+PLIST="${SUBROUTER_PLIST:-/Library/LaunchDaemons/${LABEL}.plist}"
+WORKER_BIN="${SUBROUTER_BIN:-/usr/local/bin/subrouter}"
+SUPERVISOR_BIN="${SUBROUTER_SUPERVISOR_BIN:-/usr/local/libexec/subrouter-supervisor}"
+CONTROL_ADDR="${SUBROUTER_CONTROL_ADDR:-127.0.0.1:31414}"
+ACTIVATE=0
+[ "${1:-}" = "--activate" ] && ACTIVATE=1
+
+[ "$(id -u)" -eq 0 ] || { echo "run as root" >&2; exit 1; }
+[ -f "$PLIST" ] || { echo "missing $PLIST" >&2; exit 1; }
+[ -x "$WORKER_BIN" ] || { echo "missing $WORKER_BIN" >&2; exit 1; }
+
+mkdir -p "$(dirname "$SUPERVISOR_BIN")"
+if [ ! -x "$SUPERVISOR_BIN" ]; then
+  install -m 0755 "$WORKER_BIN" "$SUPERVISOR_BIN"
+fi
+"$SUPERVISOR_BIN" help 2>/dev/null | grep -q ' supervise ' || {
+  echo "$SUPERVISOR_BIN does not support supervise" >&2
+  exit 1
+}
+
+prepared="${PLIST}.supervised"
+PLIST="$PLIST" PREPARED="$prepared" WORKER_BIN="$WORKER_BIN" \
+SUPERVISOR_BIN="$SUPERVISOR_BIN" CONTROL_ADDR="$CONTROL_ADDR" python3 <<'PY'
+import os
+import plistlib
+
+source = os.environ["PLIST"]
+destination = os.environ["PREPARED"]
+worker_bin = os.environ["WORKER_BIN"]
+supervisor_bin = os.environ["SUPERVISOR_BIN"]
+control_addr = os.environ["CONTROL_ADDR"]
+
+with open(source, "rb") as stream:
+    plist = plistlib.load(stream)
+
+arguments = list(plist.get("ProgramArguments") or [])
+if len(arguments) < 2 or arguments[1] != "serve":
+    raise SystemExit("existing ProgramArguments must start with '<binary> serve'")
+
+worker_args = arguments[2:]
+public_addr = "127.0.0.1:31415"
+filtered = []
+i = 0
+while i < len(worker_args):
+    argument = worker_args[i]
+    if argument == "--addr":
+        if i + 1 >= len(worker_args):
+            raise SystemExit("existing --addr has no value")
+        public_addr = worker_args[i + 1]
+        i += 2
+        continue
+    if argument.startswith("--addr="):
+        public_addr = argument.split("=", 1)[1]
+        i += 1
+        continue
+    filtered.append(argument)
+    i += 1
+
+plist["Program"] = supervisor_bin
+plist["ProgramArguments"] = [
+    supervisor_bin,
+    "supervise",
+    "--addr", public_addr,
+    "--control-addr", control_addr,
+    "--worker-bin", worker_bin,
+    "--",
+    *filtered,
+]
+plist["ProcessType"] = "Interactive"
+plist["ThrottleInterval"] = 10
+plist["ExitTimeOut"] = 600
+
+temporary = destination + ".new"
+with open(temporary, "wb") as stream:
+    plistlib.dump(plist, stream, fmt=plistlib.FMT_XML, sort_keys=False)
+os.chmod(temporary, 0o644)
+os.replace(temporary, destination)
+PY
+
+plutil -lint "$prepared"
+echo "Prepared $prepared"
+if [ "$ACTIVATE" -ne 1 ]; then
+  echo "Not activated. Re-run with --activate for the one-time listener transition."
+  exit 0
+fi
+
+backup="${PLIST}.backup-$(date +%Y%m%d-%H%M%S)"
+cp -p "$PLIST" "$backup"
+mv -f "$prepared" "$PLIST"
+launchctl bootout "system/${LABEL}" 2>/dev/null || true
+launchctl bootstrap system "$PLIST"
+
+i=0
+until curl -fsS "http://${CONTROL_ADDR}/_subrouter/supervisor-status" >/dev/null 2>&1 \
+  && curl -fsS "http://127.0.0.1:31415/_subrouter/health" >/dev/null 2>&1; do
+  i=$((i + 1))
+  if [ "$i" -ge 60 ]; then
+    echo "supervised service failed health checks; restore $backup" >&2
+    exit 1
+  fi
+  sleep 1
+done
+echo "Activated supervised Subrouter. Backup: $backup"

--- a/deploy/macos/migrate-launchdaemon-to-supervisor.sh
+++ b/deploy/macos/migrate-launchdaemon-to-supervisor.sh
@@ -8,7 +8,7 @@ LABEL="${SUBROUTER_LABEL:-ai.manaflow.subrouter-team}"
 PLIST="${SUBROUTER_PLIST:-/Library/LaunchDaemons/${LABEL}.plist}"
 WORKER_BIN="${SUBROUTER_BIN:-/usr/local/bin/subrouter}"
 SUPERVISOR_BIN="${SUBROUTER_SUPERVISOR_BIN:-/usr/local/libexec/subrouter-supervisor}"
-CONTROL_ADDR="${SUBROUTER_CONTROL_ADDR:-127.0.0.1:31414}"
+CONTROL_SOCKET="${SUBROUTER_CONTROL_SOCKET:-/var/run/subrouter-supervisor.sock}"
 ACTIVATE=0
 [ "${1:-}" = "--activate" ] && ACTIVATE=1
 
@@ -27,7 +27,7 @@ fi
 
 prepared="${PLIST}.supervised"
 public_addr="$(PLIST="$PLIST" PREPARED="$prepared" WORKER_BIN="$WORKER_BIN" \
-SUPERVISOR_BIN="$SUPERVISOR_BIN" CONTROL_ADDR="$CONTROL_ADDR" python3 <<'PY'
+SUPERVISOR_BIN="$SUPERVISOR_BIN" CONTROL_SOCKET="$CONTROL_SOCKET" python3 <<'PY'
 import os
 import plistlib
 
@@ -35,7 +35,7 @@ source = os.environ["PLIST"]
 destination = os.environ["PREPARED"]
 worker_bin = os.environ["WORKER_BIN"]
 supervisor_bin = os.environ["SUPERVISOR_BIN"]
-control_addr = os.environ["CONTROL_ADDR"]
+control_socket = os.environ["CONTROL_SOCKET"]
 
 with open(source, "rb") as stream:
     plist = plistlib.load(stream)
@@ -68,7 +68,7 @@ plist["ProgramArguments"] = [
     supervisor_bin,
     "supervise",
     "--addr", public_addr,
-    "--control-addr", control_addr,
+    "--control-socket", control_socket,
     "--worker-bin", worker_bin,
     "--",
     *filtered,
@@ -100,7 +100,7 @@ launchctl bootout "system/${LABEL}" 2>/dev/null || true
 launchctl bootstrap system "$PLIST"
 
 i=0
-until curl -fsS "http://${CONTROL_ADDR}/_subrouter/supervisor-status" >/dev/null 2>&1 \
+until curl -fsS --unix-socket "$CONTROL_SOCKET" "http://localhost/_subrouter/supervisor-status" >/dev/null 2>&1 \
   && curl -fsS "http://${public_addr}/_subrouter/health" >/dev/null 2>&1; do
   i=$((i + 1))
   if [ "$i" -ge 60 ]; then

--- a/deploy/macos/subrouter-autoupdate.sh
+++ b/deploy/macos/subrouter-autoupdate.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 REPO="${SUBROUTER_REPO:-manaflow-ai/subrouter}"
 BIN="${SUBROUTER_BIN:-/usr/local/bin/subrouter}"
 VERSION_FILE="${SUBROUTER_VERSION_FILE:-/etc/subrouter-version}"
-CONTROL_URL="${SUBROUTER_CONTROL_URL:-http://127.0.0.1:31414}"
+CONTROL_SOCKET="${SUBROUTER_CONTROL_SOCKET:-/var/run/subrouter-supervisor.sock}"
 HEALTH_URL="${SUBROUTER_HEALTH_URL:-http://127.0.0.1:31415/_subrouter/health}"
 
 log() { echo "subrouter-autoupdate: $*"; }
@@ -46,7 +46,7 @@ cp -p "$BIN" "$backup"
 install -m 0755 "${tmp}/${asset}" "${BIN}.new"
 mv -f "${BIN}.new" "$BIN"
 
-if ! response="$(curl -fsS -X POST "${CONTROL_URL}/_subrouter/upgrade")"; then
+if ! response="$(curl -fsS --unix-socket "$CONTROL_SOCKET" -X POST "http://localhost/_subrouter/upgrade")"; then
   log "new worker failed readiness; restoring previous worker binary"
   install -m 0755 "$backup" "${BIN}.rollback"
   mv -f "${BIN}.rollback" "$BIN"
@@ -57,7 +57,7 @@ if ! curl -fsS "$HEALTH_URL" >/dev/null; then
   log "new generation switched but public health failed; rolling new connections back"
   install -m 0755 "$backup" "${BIN}.rollback"
   mv -f "${BIN}.rollback" "$BIN"
-  curl -fsS -X POST "${CONTROL_URL}/_subrouter/upgrade" >/dev/null || true
+  curl -fsS --unix-socket "$CONTROL_SOCKET" -X POST "http://localhost/_subrouter/upgrade" >/dev/null || true
   exit 1
 fi
 

--- a/deploy/macos/subrouter-autoupdate.sh
+++ b/deploy/macos/subrouter-autoupdate.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Pull-based macOS worker updater for a supervised Subrouter service.
+# The stable supervisor keeps the public listener and existing connections;
+# this script replaces only the worker binary and asks the supervisor to start
+# a new generation for future connections.
+set -euo pipefail
+
+REPO="${SUBROUTER_REPO:-manaflow-ai/subrouter}"
+BIN="${SUBROUTER_BIN:-/usr/local/bin/subrouter}"
+VERSION_FILE="${SUBROUTER_VERSION_FILE:-/etc/subrouter-version}"
+CONTROL_URL="${SUBROUTER_CONTROL_URL:-http://127.0.0.1:31414}"
+HEALTH_URL="${SUBROUTER_HEALTH_URL:-http://127.0.0.1:31415/_subrouter/health}"
+
+log() { echo "subrouter-autoupdate: $*"; }
+
+case "$(uname -m)" in
+  x86_64|amd64) arch="amd64" ;;
+  arm64|aarch64) arch="arm64" ;;
+  *) log "unsupported arch $(uname -m)"; exit 1 ;;
+esac
+
+latest_tag="$(curl -fsSL -H 'Accept: application/vnd.github+json' \
+  "https://api.github.com/repos/${REPO}/releases/latest" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])')"
+[ -n "$latest_tag" ] || { log "could not resolve latest release tag"; exit 1; }
+
+installed=""
+[ -f "$VERSION_FILE" ] && installed="$(sed -n '1p' "$VERSION_FILE" 2>/dev/null || true)"
+[ "$latest_tag" != "$installed" ] || exit 0
+
+version="${latest_tag#v}"
+asset="subrouter_${version}_darwin_${arch}"
+base="https://github.com/${REPO}/releases/download/${latest_tag}"
+tmp="$(mktemp -d)"
+backup="${BIN}.backup-$(date +%Y%m%d-%H%M%S)"
+trap 'rm -rf "$tmp"' EXIT
+
+log "updating worker ${installed:-none} -> ${latest_tag} (${asset})"
+curl -fsSL -o "${tmp}/${asset}" "${base}/${asset}"
+curl -fsSL -o "${tmp}/SHA256SUMS" "${base}/SHA256SUMS"
+(cd "$tmp" && grep " ${asset}\$" SHA256SUMS | shasum -a 256 -c -)
+chmod 0755 "${tmp}/${asset}"
+"${tmp}/${asset}" --help >/dev/null
+
+cp -p "$BIN" "$backup"
+install -m 0755 "${tmp}/${asset}" "${BIN}.new"
+mv -f "${BIN}.new" "$BIN"
+
+if ! response="$(curl -fsS -X POST "${CONTROL_URL}/_subrouter/upgrade")"; then
+  log "new worker failed readiness; restoring previous worker binary"
+  install -m 0755 "$backup" "${BIN}.rollback"
+  mv -f "${BIN}.rollback" "$BIN"
+  exit 1
+fi
+
+if ! curl -fsS "$HEALTH_URL" >/dev/null; then
+  log "new generation switched but public health failed; rolling new connections back"
+  install -m 0755 "$backup" "${BIN}.rollback"
+  mv -f "${BIN}.rollback" "$BIN"
+  curl -fsS -X POST "${CONTROL_URL}/_subrouter/upgrade" >/dev/null || true
+  exit 1
+fi
+
+active="$(printf '%s' "$response" | python3 -c 'import json,sys; print(json.load(sys.stdin)["active"]["id"])')"
+printf '%s\n' "$latest_tag" >"${VERSION_FILE}.new"
+mv -f "${VERSION_FILE}.new" "$VERSION_FILE"
+log "updated to ${latest_tag}; active generation=${active}; old connections are draining"

--- a/docs/production.md
+++ b/docs/production.md
@@ -61,8 +61,10 @@ Current production-safe behavior:
 - SIGTERM/SIGINT switches the process into drain mode.
 - The HTTP server waits up to `--shutdown-timeout` for in-flight proxy requests to finish.
 - systemd units use `TimeoutStopSec=10min`.
+- On macOS, `subrouter supervise` owns the stable client listener and starts workers on inherited private sockets. `POST /_subrouter/upgrade` starts and health-checks the replacement worker, routes new connections to it, and keeps every existing connection pinned to the old worker until it closes.
+- The supervisor binary is installed separately and is not replaced by routine worker updates.
 
-True zero-drop binary upgrades still need a stable supervisor listener that owns `:31415` and routes to versioned workers. The worker primitives are now present: `/_subrouter/ready`, `/_subrouter/drain`, and active proxy request accounting.
+The macOS updater and one-time LaunchDaemon migration scripts live in `deploy/macos/`. Run the migration without `--activate` first to prepare and validate the supervised plist. Activation is the last upgrade that replaces the public listener; later worker upgrades do not restart the supervisor.
 
 ## Launch checks
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -63,6 +63,7 @@ Current production-safe behavior:
 - systemd units use `TimeoutStopSec=10min`.
 - On macOS, `subrouter supervise` owns the stable client listener and starts workers on inherited private sockets. `POST /_subrouter/upgrade` starts and health-checks the replacement worker, routes new connections to it, and keeps every existing connection pinned to the old worker until it closes.
 - The supervisor binary is installed separately and is not replaced by routine worker updates.
+- SIGTERM/SIGINT closes the supervisor listener, waits up to `--drain-timeout` (default `10m`) for accepted connections, then stops its workers.
 
 The macOS updater and one-time LaunchDaemon migration scripts live in `deploy/macos/`. Run the migration without `--activate` first to prepare and validate the supervised plist. Activation is the last upgrade that replaces the public listener; later worker upgrades do not restart the supervisor.
 

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -31,8 +31,8 @@ Replace the worker binary atomically, then ask the stable supervisor to create a
 ```bash
 install -m 0755 ./subrouter /usr/local/bin/subrouter.new
 mv -f /usr/local/bin/subrouter.new /usr/local/bin/subrouter
-curl -fsS -X POST http://127.0.0.1:31414/_subrouter/upgrade
-curl -fsS http://127.0.0.1:31414/_subrouter/supervisor-status | jq
+curl -fsS --unix-socket /var/run/subrouter-supervisor.sock -X POST http://localhost/_subrouter/upgrade
+curl -fsS --unix-socket /var/run/subrouter-supervisor.sock http://localhost/_subrouter/supervisor-status | jq
 ```
 
 `deploy/macos/subrouter-autoupdate.sh` performs the same sequence with release checksum verification and automatic worker-binary rollback when readiness fails.
@@ -169,10 +169,10 @@ For a successful compact, expect a `subrouter_meta` row for `POST /responses/com
 
 ## Supervisor status
 
-The loopback-only control endpoint reports the active generation and the connection count pinned to every draining generation:
+The permissioned Unix control socket reports the active generation and the connection count pinned to every draining generation. Browser pages cannot reach this socket or trigger upgrades:
 
 ```bash
-curl -fsS http://127.0.0.1:31414/_subrouter/supervisor-status | jq
+curl -fsS --unix-socket /var/run/subrouter-supervisor.sock http://localhost/_subrouter/supervisor-status | jq
 ```
 
 There is intentionally no drain timeout. A routine upgrade never terminates a worker that still owns a client connection.

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -2,9 +2,44 @@
 
 Use this runbook for local macOS daemon upgrades when Codex is already pointed at `127.0.0.1:31415`.
 
-## Current safe handoff
+## Supervised handoff
 
-This path has a listener restart on macOS. New builds enter drain mode and wait for in-flight proxy requests on SIGTERM/SIGINT, but clients can still see a short connection gap because the same process owns the public listener. Do not change client base URLs for a local binary upgrade.
+On macOS, run Subrouter behind `subrouter supervise`. The supervisor owns the public listener, starts each worker on an inherited private socket, and pins accepted TCP connections to that worker generation. An upgrade starts and health-checks the replacement before switching new connections. Old WebSockets, SSE streams, HTTP requests, and keep-alive connections remain on the old worker. The old worker exits only after its connection count reaches zero.
+
+The supervisor is deliberately separate from the replaceable worker binary. Routine releases update `/usr/local/bin/subrouter`; they do not replace or restart `/usr/local/libexec/subrouter-supervisor`.
+
+### One-time LaunchDaemon migration
+
+Preparation does not touch the running service:
+
+```bash
+sudo ./deploy/macos/migrate-launchdaemon-to-supervisor.sh
+```
+
+Inspect the generated `.plist.supervised`, then perform the one-time listener transition:
+
+```bash
+sudo ./deploy/macos/migrate-launchdaemon-to-supervisor.sh --activate
+```
+
+The one-time transition cannot preserve connections accepted by an older, unsupervised process because that process owns their file descriptors. Perform it in a maintenance window. All later worker upgrades preserve connections.
+
+### Worker upgrade
+
+Replace the worker binary atomically, then ask the stable supervisor to create a generation:
+
+```bash
+install -m 0755 ./subrouter /usr/local/bin/subrouter.new
+mv -f /usr/local/bin/subrouter.new /usr/local/bin/subrouter
+curl -fsS -X POST http://127.0.0.1:31414/_subrouter/upgrade
+curl -fsS http://127.0.0.1:31414/_subrouter/supervisor-status | jq
+```
+
+`deploy/macos/subrouter-autoupdate.sh` performs the same sequence with release checksum verification and automatic worker-binary rollback when readiness fails.
+
+## Legacy unsupervised handoff
+
+The following guarded path is only for installations that have not migrated yet. It still has a listener restart. New builds enter drain mode and wait for in-flight proxy requests on SIGTERM/SIGINT, but clients can see a connection gap because the worker owns the public listener.
 
 On macOS, use the new binary's `install-daemon` path so launchd re-registers the LaunchAgent. Modern launchd can attach launch constraints to the binary it bootstrapped; a plain `mv` plus `launchctl kickstart -k` can fail with `OS_REASON_CODESIGNING | Launch Constraint Violation`.
 
@@ -132,10 +167,12 @@ tail -n 50000 "$HOME/.subrouter/transcripts/by-agent/codex/by-session/$session_i
 
 For a successful compact, expect a `subrouter_meta` row for `POST /responses/compact`, a full `client_to_upstream` body byte count matching `Content-Length`, then an `upstream_to_client` row with status `200`.
 
-## Zero-disruption target
+## Supervisor status
 
-True no-drop upgrades need a stable front listener that is separate from the Subrouter worker.
+The loopback-only control endpoint reports the active generation and the connection count pinned to every draining generation:
 
-The front listener should own `127.0.0.1:31415`. Each Subrouter build starts as a versioned worker on a Unix socket or private loopback port. The listener health-checks the new worker, routes only new requests to it, and keeps existing HTTP streams and WebSockets pinned to the old worker until they finish or hit a drain timeout. Rollback is just changing the active worker pointer back.
+```bash
+curl -fsS http://127.0.0.1:31414/_subrouter/supervisor-status | jq
+```
 
-Until that supervisor exists, the guarded launchd handoff above is the safest local upgrade path.
+There is intentionally no drain timeout. A routine upgrade never terminates a worker that still owns a client connection.

--- a/internal/front/proxy_protocol.go
+++ b/internal/front/proxy_protocol.go
@@ -1,0 +1,125 @@
+package front
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const maxProxyProtocolLine = 108
+
+// WriteProxyProtocolHeader forwards the original TCP endpoints to a private
+// worker. Non-TCP or nil endpoints are encoded as PROXY UNKNOWN.
+func WriteProxyProtocolHeader(writer io.Writer, source, destination net.Addr) error {
+	sourceTCP, sourceOK := source.(*net.TCPAddr)
+	destinationTCP, destinationOK := destination.(*net.TCPAddr)
+	if !sourceOK || !destinationOK {
+		_, err := io.WriteString(writer, "PROXY UNKNOWN\r\n")
+		return err
+	}
+	family := "TCP6"
+	if sourceTCP.IP.To4() != nil && destinationTCP.IP.To4() != nil {
+		family = "TCP4"
+	}
+	_, err := fmt.Fprintf(writer, "PROXY %s %s %s %d %d\r\n",
+		family, sourceTCP.IP.String(), destinationTCP.IP.String(), sourceTCP.Port, destinationTCP.Port)
+	return err
+}
+
+type proxyProtocolListener struct {
+	net.Listener
+}
+
+// NewProxyProtocolListener restores client addresses forwarded by Router.
+// It must only wrap a private listener that accepts supervisor connections.
+func NewProxyProtocolListener(listener net.Listener) net.Listener {
+	return &proxyProtocolListener{Listener: listener}
+}
+
+func (l *proxyProtocolListener) Accept() (net.Conn, error) {
+	connection, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	wrapped, err := readProxyProtocolHeader(connection)
+	if err != nil {
+		_ = connection.Close()
+		return nil, err
+	}
+	return wrapped, nil
+}
+
+type proxyProtocolConn struct {
+	net.Conn
+	reader     *bufio.Reader
+	remoteAddr net.Addr
+	localAddr  net.Addr
+}
+
+func (c *proxyProtocolConn) Read(buffer []byte) (int, error) {
+	return c.reader.Read(buffer)
+}
+
+func (c *proxyProtocolConn) RemoteAddr() net.Addr {
+	return c.remoteAddr
+}
+
+func (c *proxyProtocolConn) LocalAddr() net.Addr {
+	return c.localAddr
+}
+
+func readProxyProtocolHeader(connection net.Conn) (net.Conn, error) {
+	_ = connection.SetReadDeadline(time.Now().Add(5 * time.Second))
+	reader := bufio.NewReaderSize(connection, maxProxyProtocolLine+1)
+	line, err := reader.ReadString('\n')
+	_ = connection.SetReadDeadline(time.Time{})
+	if err != nil {
+		return nil, fmt.Errorf("read PROXY header: %w", err)
+	}
+	if len(line) > maxProxyProtocolLine {
+		return nil, errors.New("PROXY header is too long")
+	}
+	fields := strings.Fields(strings.TrimSpace(line))
+	if len(fields) == 2 && fields[0] == "PROXY" && fields[1] == "UNKNOWN" {
+		return &proxyProtocolConn{
+			Conn:       connection,
+			reader:     reader,
+			remoteAddr: connection.RemoteAddr(),
+			localAddr:  connection.LocalAddr(),
+		}, nil
+	}
+	if len(fields) != 6 || fields[0] != "PROXY" || (fields[1] != "TCP4" && fields[1] != "TCP6") {
+		return nil, errors.New("invalid PROXY header")
+	}
+	remoteAddr, err := proxyTCPAddr(fields[2], fields[4])
+	if err != nil {
+		return nil, fmt.Errorf("invalid PROXY source: %w", err)
+	}
+	localAddr, err := proxyTCPAddr(fields[3], fields[5])
+	if err != nil {
+		return nil, fmt.Errorf("invalid PROXY destination: %w", err)
+	}
+	return &proxyProtocolConn{
+		Conn:       connection,
+		reader:     reader,
+		remoteAddr: remoteAddr,
+		localAddr:  localAddr,
+	}, nil
+}
+
+func proxyTCPAddr(host, rawPort string) (*net.TCPAddr, error) {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil, fmt.Errorf("invalid IP %q", host)
+	}
+	port, err := strconv.Atoi(rawPort)
+	if err != nil || port < 0 || port > 65535 {
+		return nil, fmt.Errorf("invalid port %q", rawPort)
+	}
+	return &net.TCPAddr{IP: ip, Port: port}, nil
+}

--- a/internal/front/proxy_protocol.go
+++ b/internal/front/proxy_protocol.go
@@ -42,16 +42,18 @@ func NewProxyProtocolListener(listener net.Listener) net.Listener {
 }
 
 func (l *proxyProtocolListener) Accept() (net.Conn, error) {
-	connection, err := l.Listener.Accept()
-	if err != nil {
-		return nil, err
+	for {
+		connection, err := l.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+		wrapped, err := readProxyProtocolHeader(connection)
+		if err != nil {
+			_ = connection.Close()
+			continue
+		}
+		return wrapped, nil
 	}
-	wrapped, err := readProxyProtocolHeader(connection)
-	if err != nil {
-		_ = connection.Close()
-		return nil, err
-	}
-	return wrapped, nil
 }
 
 type proxyProtocolConn struct {

--- a/internal/front/proxy_protocol_test.go
+++ b/internal/front/proxy_protocol_test.go
@@ -68,3 +68,49 @@ func TestProxyProtocolListenerRejectsMissingHeader(t *testing.T) {
 		t.Fatal("expected missing PROXY header to fail")
 	}
 }
+
+func TestProxyProtocolListenerSkipsMalformedConnection(t *testing.T) {
+	base, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener := NewProxyProtocolListener(base)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	accepted := make(chan net.Conn, 1)
+	errs := make(chan error, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			errs <- acceptErr
+			return
+		}
+		accepted <- connection
+	}()
+
+	malformed, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = fmt.Fprint(malformed, "GET / HTTP/1.1\r\n")
+	_ = malformed.Close()
+
+	valid, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer valid.Close()
+	_, _ = fmt.Fprint(valid, "PROXY TCP4 192.0.2.10 198.51.100.20 43210 31415\r\n")
+
+	select {
+	case err := <-errs:
+		t.Fatal(err)
+	case connection := <-accepted:
+		defer connection.Close()
+		if got := connection.RemoteAddr().String(); got != "192.0.2.10:43210" {
+			t.Fatalf("remote address = %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("listener did not continue after malformed connection")
+	}
+}

--- a/internal/front/proxy_protocol_test.go
+++ b/internal/front/proxy_protocol_test.go
@@ -1,0 +1,70 @@
+package front
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestProxyProtocolListenerRestoresAddressesAndPayload(t *testing.T) {
+	base, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener := NewProxyProtocolListener(base)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	accepted := make(chan net.Conn, 1)
+	errs := make(chan error, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			errs <- acceptErr
+			return
+		}
+		accepted <- connection
+	}()
+
+	client, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	_, _ = fmt.Fprint(client, "PROXY TCP4 192.0.2.10 198.51.100.20 43210 31415\r\nhello\n")
+
+	var server net.Conn
+	select {
+	case err := <-errs:
+		t.Fatal(err)
+	case server = <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("listener did not accept PROXY connection")
+	}
+	defer server.Close()
+	if got := server.RemoteAddr().String(); got != "192.0.2.10:43210" {
+		t.Fatalf("remote address = %q", got)
+	}
+	if got := server.LocalAddr().String(); got != "198.51.100.20:31415" {
+		t.Fatalf("local address = %q", got)
+	}
+	payload, err := bufio.NewReader(server).ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload != "hello\n" {
+		t.Fatalf("payload = %q", payload)
+	}
+}
+
+func TestProxyProtocolListenerRejectsMissingHeader(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close()
+	go func() {
+		_, _ = fmt.Fprint(client, "GET / HTTP/1.1\r\n")
+	}()
+	if _, err := readProxyProtocolHeader(server); err == nil {
+		t.Fatal("expected missing PROXY header to fail")
+	}
+}

--- a/internal/front/router.go
+++ b/internal/front/router.go
@@ -143,12 +143,12 @@ func (r *Router) Serve(listener net.Listener) error {
 		if err != nil {
 			return err
 		}
-		go r.serveConnection(client)
+		state := r.acquireActive()
+		go r.serveConnection(client, state)
 	}
 }
 
-func (r *Router) serveConnection(client net.Conn) {
-	state := r.acquireActive()
+func (r *Router) serveConnection(client net.Conn, state *backendState) {
 	defer r.release(state)
 	defer client.Close()
 

--- a/internal/front/router.go
+++ b/internal/front/router.go
@@ -1,6 +1,7 @@
 package front
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -35,6 +36,7 @@ type backendState struct {
 type Router struct {
 	mu       sync.Mutex
 	changed  *sync.Cond
+	activity chan struct{}
 	active   *backendState
 	backends map[string]*backendState
 	dial     func(network, address string) (net.Conn, error)
@@ -49,6 +51,7 @@ func NewRouter(initial Backend) (*Router, error) {
 	router := &Router{
 		active:   state,
 		backends: map[string]*backendState{initial.ID: state},
+		activity: make(chan struct{}),
 		dial: func(network, address string) (net.Conn, error) {
 			return net.DialTimeout(network, address, 10*time.Second)
 		},
@@ -134,6 +137,31 @@ func (r *Router) WaitIdle(id string) {
 	}
 }
 
+// WaitAllIdle waits until every accepted client connection has closed or the
+// context expires.
+func (r *Router) WaitAllIdle(ctx context.Context) error {
+	for {
+		r.mu.Lock()
+		idle := true
+		for _, state := range r.backends {
+			if state.connections != 0 {
+				idle = false
+				break
+			}
+		}
+		activity := r.activity
+		r.mu.Unlock()
+		if idle {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-activity:
+		}
+	}
+}
+
 // Forget removes an idle, inactive backend from status tracking.
 func (r *Router) Forget(id string) error {
 	r.mu.Lock()
@@ -190,6 +218,8 @@ func (r *Router) release(state *backendState) {
 	r.mu.Lock()
 	state.connections--
 	r.changed.Broadcast()
+	close(r.activity)
+	r.activity = make(chan struct{})
 	r.mu.Unlock()
 }
 

--- a/internal/front/router.go
+++ b/internal/front/router.go
@@ -1,0 +1,194 @@
+package front
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// Backend identifies one worker generation behind the stable front listener.
+type Backend struct {
+	ID      string `json:"id"`
+	Address string `json:"address"`
+}
+
+// BackendStatus is a point-in-time view of a worker generation.
+type BackendStatus struct {
+	ID          string `json:"id"`
+	Address     string `json:"address"`
+	Connections int    `json:"connections"`
+	Active      bool   `json:"active"`
+}
+
+type backendState struct {
+	backend     Backend
+	connections int
+}
+
+// Router pins each accepted client connection to the backend that was active
+// when the connection arrived. Switching affects only future connections.
+type Router struct {
+	mu       sync.Mutex
+	changed  *sync.Cond
+	active   *backendState
+	backends map[string]*backendState
+	dial     func(network, address string) (net.Conn, error)
+}
+
+func NewRouter(initial Backend) (*Router, error) {
+	if err := validateBackend(initial); err != nil {
+		return nil, err
+	}
+	state := &backendState{backend: initial}
+	router := &Router{
+		active:   state,
+		backends: map[string]*backendState{initial.ID: state},
+		dial: func(network, address string) (net.Conn, error) {
+			return net.DialTimeout(network, address, 10*time.Second)
+		},
+	}
+	router.changed = sync.NewCond(&router.mu)
+	return router, nil
+}
+
+func validateBackend(backend Backend) error {
+	if backend.ID == "" {
+		return errors.New("backend id is required")
+	}
+	if backend.Address == "" {
+		return errors.New("backend address is required")
+	}
+	return nil
+}
+
+// Switch atomically selects backend for new connections. Existing connections
+// remain pinned to their original backend.
+func (r *Router) Switch(backend Backend) error {
+	if err := validateBackend(backend); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if state, ok := r.backends[backend.ID]; ok {
+		if state.backend.Address != backend.Address {
+			return fmt.Errorf("backend %q already uses address %q", backend.ID, state.backend.Address)
+		}
+		r.active = state
+		return nil
+	}
+	state := &backendState{backend: backend}
+	r.backends[backend.ID] = state
+	r.active = state
+	return nil
+}
+
+func (r *Router) Active() Backend {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.active.backend
+}
+
+func (r *Router) Status() []BackendStatus {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	statuses := make([]BackendStatus, 0, len(r.backends))
+	for _, state := range r.backends {
+		statuses = append(statuses, BackendStatus{
+			ID:          state.backend.ID,
+			Address:     state.backend.Address,
+			Connections: state.connections,
+			Active:      state == r.active,
+		})
+	}
+	return statuses
+}
+
+// WaitIdle waits until a retired backend has no pinned client connections.
+func (r *Router) WaitIdle(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for {
+		state, ok := r.backends[id]
+		if !ok || state.connections == 0 {
+			return
+		}
+		r.changed.Wait()
+	}
+}
+
+// Forget removes an idle, inactive backend from status tracking.
+func (r *Router) Forget(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	state, ok := r.backends[id]
+	if !ok {
+		return nil
+	}
+	if state == r.active {
+		return fmt.Errorf("cannot forget active backend %q", id)
+	}
+	if state.connections != 0 {
+		return fmt.Errorf("cannot forget backend %q with %d connections", id, state.connections)
+	}
+	delete(r.backends, id)
+	return nil
+}
+
+func (r *Router) Serve(listener net.Listener) error {
+	for {
+		client, err := listener.Accept()
+		if err != nil {
+			return err
+		}
+		go r.serveConnection(client)
+	}
+}
+
+func (r *Router) serveConnection(client net.Conn) {
+	state := r.acquireActive()
+	defer r.release(state)
+	defer client.Close()
+
+	upstream, err := r.dial("tcp", state.backend.Address)
+	if err != nil {
+		return
+	}
+	defer upstream.Close()
+	if err := WriteProxyProtocolHeader(upstream, client.RemoteAddr(), client.LocalAddr()); err != nil {
+		return
+	}
+	proxyBidirectional(client, upstream)
+}
+
+func (r *Router) acquireActive() *backendState {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	state := r.active
+	state.connections++
+	return state
+}
+
+func (r *Router) release(state *backendState) {
+	r.mu.Lock()
+	state.connections--
+	r.changed.Broadcast()
+	r.mu.Unlock()
+}
+
+func proxyBidirectional(client, upstream net.Conn) {
+	done := make(chan struct{}, 2)
+	copyOneWay := func(dst, src net.Conn) {
+		_, _ = io.Copy(dst, src)
+		if closer, ok := dst.(interface{ CloseWrite() error }); ok {
+			_ = closer.CloseWrite()
+		}
+		done <- struct{}{}
+	}
+	go copyOneWay(upstream, client)
+	go copyOneWay(client, upstream)
+	<-done
+	<-done
+}

--- a/internal/front/router.go
+++ b/internal/front/router.go
@@ -11,6 +11,7 @@ import (
 
 // Backend identifies one worker generation behind the stable front listener.
 type Backend struct {
+	Network string `json:"network"`
 	ID      string `json:"id"`
 	Address string `json:"address"`
 }
@@ -18,6 +19,7 @@ type Backend struct {
 // BackendStatus is a point-in-time view of a worker generation.
 type BackendStatus struct {
 	ID          string `json:"id"`
+	Network     string `json:"network"`
 	Address     string `json:"address"`
 	Connections int    `json:"connections"`
 	Active      bool   `json:"active"`
@@ -39,6 +41,7 @@ type Router struct {
 }
 
 func NewRouter(initial Backend) (*Router, error) {
+	initial = normalizeBackend(initial)
 	if err := validateBackend(initial); err != nil {
 		return nil, err
 	}
@@ -61,12 +64,23 @@ func validateBackend(backend Backend) error {
 	if backend.Address == "" {
 		return errors.New("backend address is required")
 	}
+	if backend.Network != "tcp" && backend.Network != "unix" {
+		return fmt.Errorf("unsupported backend network %q", backend.Network)
+	}
 	return nil
+}
+
+func normalizeBackend(backend Backend) Backend {
+	if backend.Network == "" {
+		backend.Network = "tcp"
+	}
+	return backend
 }
 
 // Switch atomically selects backend for new connections. Existing connections
 // remain pinned to their original backend.
 func (r *Router) Switch(backend Backend) error {
+	backend = normalizeBackend(backend)
 	if err := validateBackend(backend); err != nil {
 		return err
 	}
@@ -98,6 +112,7 @@ func (r *Router) Status() []BackendStatus {
 	for _, state := range r.backends {
 		statuses = append(statuses, BackendStatus{
 			ID:          state.backend.ID,
+			Network:     state.backend.Network,
 			Address:     state.backend.Address,
 			Connections: state.connections,
 			Active:      state == r.active,
@@ -152,7 +167,7 @@ func (r *Router) serveConnection(client net.Conn, state *backendState) {
 	defer r.release(state)
 	defer client.Close()
 
-	upstream, err := r.dial("tcp", state.backend.Address)
+	upstream, err := r.dial(state.backend.Network, state.backend.Address)
 	if err != nil {
 		return
 	}

--- a/internal/front/router_test.go
+++ b/internal/front/router_test.go
@@ -2,6 +2,7 @@ package front
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -72,6 +73,36 @@ func TestWaitIdleDoesNotRaceWithConnectionSelection(t *testing.T) {
 	case <-idle:
 	case <-time.After(time.Second):
 		t.Fatal("old backend did not become idle after its connection closed")
+	}
+}
+
+func TestWaitAllIdleWaitsForAcceptedConnections(t *testing.T) {
+	backend := startLineBackend(t, "a")
+	router, err := NewRouter(Backend{ID: "a", Address: backend})
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() { _ = router.Serve(listener) }()
+
+	connection := dialLineClient(t, listener.Addr().String())
+	assertReply(t, connection, "one", "a:one")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	idle := make(chan error, 1)
+	go func() { idle <- router.WaitAllIdle(ctx) }()
+	select {
+	case err := <-idle:
+		t.Fatalf("router became idle while connection was open: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	_ = connection.Close()
+	if err := <-idle; err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/front/router_test.go
+++ b/internal/front/router_test.go
@@ -1,0 +1,128 @@
+package front
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSwitchKeepsExistingConnectionOnOldBackend(t *testing.T) {
+	backendA := startLineBackend(t, "a")
+	backendB := startLineBackend(t, "b")
+	router, err := NewRouter(Backend{ID: "a", Address: backendA})
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() { _ = router.Serve(listener) }()
+
+	oldConnection := dialLineClient(t, listener.Addr().String())
+	defer oldConnection.Close()
+	assertReply(t, oldConnection, "one", "a:one")
+
+	if err := router.Switch(Backend{ID: "b", Address: backendB}); err != nil {
+		t.Fatal(err)
+	}
+	assertReply(t, oldConnection, "two", "a:two")
+
+	newConnection := dialLineClient(t, listener.Addr().String())
+	defer newConnection.Close()
+	assertReply(t, newConnection, "three", "b:three")
+}
+
+func TestWaitIdleDoesNotRaceWithConnectionSelection(t *testing.T) {
+	backendA := startLineBackend(t, "a")
+	backendB := startLineBackend(t, "b")
+	router, err := NewRouter(Backend{ID: "a", Address: backendA})
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() { _ = router.Serve(listener) }()
+
+	oldConnection := dialLineClient(t, listener.Addr().String())
+	assertReply(t, oldConnection, "one", "a:one")
+	if err := router.Switch(Backend{ID: "b", Address: backendB}); err != nil {
+		t.Fatal(err)
+	}
+
+	idle := make(chan struct{})
+	go func() {
+		router.WaitIdle("a")
+		close(idle)
+	}()
+	select {
+	case <-idle:
+		t.Fatal("old backend became idle while its connection was open")
+	case <-time.After(50 * time.Millisecond):
+	}
+	_ = oldConnection.Close()
+	select {
+	case <-idle:
+	case <-time.After(time.Second):
+		t.Fatal("old backend did not become idle after its connection closed")
+	}
+}
+
+func startLineBackend(t *testing.T, name string) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			connection, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer connection.Close()
+				scanner := bufio.NewScanner(connection)
+				if !scanner.Scan() || !strings.HasPrefix(scanner.Text(), "PROXY ") {
+					return
+				}
+				for scanner.Scan() {
+					_, _ = fmt.Fprintf(connection, "%s:%s\n", name, scanner.Text())
+				}
+			}()
+		}
+	}()
+	return listener.Addr().String()
+}
+
+func dialLineClient(t *testing.T, address string) net.Conn {
+	t.Helper()
+	connection, err := net.Dial("tcp", address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return connection
+}
+
+func assertReply(t *testing.T, connection net.Conn, request, expected string) {
+	t.Helper()
+	_ = connection.SetDeadline(time.Now().Add(time.Second))
+	if _, err := fmt.Fprintf(connection, "%s\n", request); err != nil {
+		t.Fatal(err)
+	}
+	reply, err := bufio.NewReader(connection).ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply != expected+"\n" {
+		t.Fatalf("reply = %q, want %q", reply, expected+"\n")
+	}
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -27,7 +27,12 @@ type Store struct {
 
 func NewStore(path string) (*Store, error) {
 	store := &Store{path: path, data: map[string]Assignment{}}
-	if err := store.load(); err != nil {
+	lock, err := lockSessionStore(path)
+	if err != nil {
+		return nil, err
+	}
+	defer lock.Close()
+	if err := store.loadLocked(); err != nil {
 		return nil, err
 	}
 	return store, nil
@@ -36,6 +41,7 @@ func NewStore(path string) (*Store, error) {
 func (s *Store) Get(agentType, sessionID string) (Assignment, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.reloadBestEffortLocked()
 	assignment, ok := s.data[ScopedSessionKey(agentType, sessionID)]
 	return assignment, ok
 }
@@ -43,6 +49,14 @@ func (s *Store) Get(agentType, sessionID string) (Assignment, bool) {
 func (s *Store) Put(agentType, sessionID, accountID, userEmail string) (Assignment, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	lock, err := lockSessionStore(s.path)
+	if err != nil {
+		return Assignment{}, err
+	}
+	defer lock.Close()
+	if err := s.loadLocked(); err != nil {
+		return Assignment{}, err
+	}
 
 	now := time.Now().UTC()
 	normalizedAgent := NormalizeAgentType(agentType)
@@ -72,6 +86,7 @@ func (s *Store) Put(agentType, sessionID, accountID, userEmail string) (Assignme
 func (s *Store) All() []Assignment {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.reloadBestEffortLocked()
 
 	assignments := make([]Assignment, 0, len(s.data))
 	for _, assignment := range s.data {
@@ -83,6 +98,7 @@ func (s *Store) All() []Assignment {
 func (s *Store) CountByAccount() map[string]int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.reloadBestEffortLocked()
 
 	counts := make(map[string]int)
 	for _, assignment := range s.data {
@@ -91,17 +107,29 @@ func (s *Store) CountByAccount() map[string]int {
 	return counts
 }
 
-func (s *Store) load() error {
+func (s *Store) reloadBestEffortLocked() {
+	lock, err := lockSessionStore(s.path)
+	if err != nil {
+		return
+	}
+	defer lock.Close()
+	_ = s.loadLocked()
+}
+
+func (s *Store) loadLocked() error {
 	body, err := os.ReadFile(s.path)
 	if errors.Is(err, os.ErrNotExist) {
+		s.data = map[string]Assignment{}
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	if err := json.Unmarshal(body, &s.data); err != nil {
+	data := map[string]Assignment{}
+	if err := json.Unmarshal(body, &data); err != nil {
 		return err
 	}
+	s.data = data
 	s.migrateLoadedAssignments()
 	return nil
 }

--- a/internal/session/store_lock_unix.go
+++ b/internal/session/store_lock_unix.go
@@ -1,0 +1,37 @@
+//go:build !windows
+
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+type storeFileLock struct {
+	file *os.File
+}
+
+func lockSessionStore(path string) (*storeFileLock, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return &storeFileLock{file: file}, nil
+}
+
+func (l *storeFileLock) Close() error {
+	unlockErr := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	closeErr := l.file.Close()
+	if unlockErr != nil {
+		return unlockErr
+	}
+	return closeErr
+}

--- a/internal/session/store_lock_windows.go
+++ b/internal/session/store_lock_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package session
+
+import (
+	"os"
+	"path/filepath"
+)
+
+type storeFileLock struct {
+	file *os.File
+}
+
+func lockSessionStore(path string) (*storeFileLock, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	return &storeFileLock{file: file}, nil
+}
+
+func (l *storeFileLock) Close() error {
+	return l.file.Close()
+}

--- a/internal/session/store_lock_windows.go
+++ b/internal/session/store_lock_windows.go
@@ -3,12 +3,24 @@
 package session
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+const lockFileExclusiveLock = 0x00000002
+
+var (
+	kernel32     = syscall.NewLazyDLL("kernel32.dll")
+	lockFileEx   = kernel32.NewProc("LockFileEx")
+	unlockFileEx = kernel32.NewProc("UnlockFileEx")
 )
 
 type storeFileLock struct {
-	file *os.File
+	file       *os.File
+	overlapped syscall.Overlapped
 }
 
 func lockSessionStore(path string) (*storeFileLock, error) {
@@ -19,9 +31,33 @@ func lockSessionStore(path string) (*storeFileLock, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &storeFileLock{file: file}, nil
+	lock := &storeFileLock{file: file}
+	result, _, callErr := lockFileEx.Call(
+		file.Fd(),
+		lockFileExclusiveLock,
+		0,
+		uintptr(^uint32(0)),
+		uintptr(^uint32(0)),
+		uintptr(unsafe.Pointer(&lock.overlapped)),
+	)
+	if result == 0 {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock session store: %w", callErr)
+	}
+	return lock, nil
 }
 
 func (l *storeFileLock) Close() error {
-	return l.file.Close()
+	result, _, callErr := unlockFileEx.Call(
+		l.file.Fd(),
+		0,
+		uintptr(^uint32(0)),
+		uintptr(^uint32(0)),
+		uintptr(unsafe.Pointer(&l.overlapped)),
+	)
+	closeErr := l.file.Close()
+	if result == 0 {
+		return fmt.Errorf("unlock session store: %w", callErr)
+	}
+	return closeErr
 }

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -114,6 +114,34 @@ func TestStoreScopesAssignmentsByAgentType(t *testing.T) {
 	}
 }
 
+func TestStoresReloadAndMergeConcurrentGenerationWrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sessions.json")
+	oldGeneration, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newGeneration, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := oldGeneration.Put("codex", "old-session", "account-a", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newGeneration.Put("codex", "new-session", "account-b", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := oldGeneration.Get("codex", "new-session"); !ok {
+		t.Fatal("old generation did not reload the new generation's assignment")
+	}
+	reloaded, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(reloaded.All()); got != 2 {
+		t.Fatalf("stored assignments = %d, want 2", got)
+	}
+}
+
 func TestStoreMigratesUnscopedAssignmentsToCodex(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "sessions.json")
 	if err := os.WriteFile(path, []byte(`{


### PR DESCRIPTION
## Summary
- add a stable supervisor that pins accepted TCP connections to worker generations
- health-check replacement workers before routing new connections and drain old workers without a timeout
- preserve original client addresses with private PROXY-protocol metadata
- add safe macOS migration and auto-update scripts

## Testing
- `go test -race ./internal/front ./cmd/subrouter`
- `go test ./...`
- `go vet ./...`
- alternate-port live handoff on `cmux-macmini`: old generation retained an established keep-alive connection while new health traffic reached the replacement; old generation exited after the held connection closed
- production listener PID and health remained unchanged

## Related
- https://blog.exe.dev/adding-features-without-interrupting-network-connections

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786411007&installation_id=133855650&pr_number=74&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F74&signature=fcb3703ea0b14d9e0d2a48cd7e824b389c7ad3f777791835b099eebf8afe161b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stable supervisor that owns the public listener, pins each TCP connection to a worker generation for zero‑disruption upgrades, and serializes shutdown by draining accepted connections before stopping workers.

- **New Features**
  - `subrouter supervise` owns `--addr`, starts workers on private per‑generation Unix sockets inherited via `SUBROUTER_LISTEN_FD`, and switches on `SIGHUP` or `POST /_subrouter/upgrade`; auto‑recovers if the active worker exits and fails fast if recovery fails.
  - Graceful, serialized shutdown: on SIGTERM/SIGINT the supervisor closes the public listener, joins the accept loop, rejects new upgrades, waits up to `--drain-timeout` (default `10m`) for all accepted connections via `WaitAllIdle`, then stops workers.
  - Front router with per‑connection pinning and private PROXY support (`WriteProxyProtocolHeader`, `NewProxyProtocolListener`) to preserve client IPs; worker sockets are created under 0700 dirs with 0600 perms, malformed connections are dropped.
  - Control API on a permissioned Unix socket (`/_subrouter/upgrade`, `/_subrouter/supervisor-status`); path must be absolute and the socket is created with 0600 perms.
  - Overlapping generation safety: old workers drain with no timeout; `WaitIdle`/`Forget` to track idle backends; session store uses cross‑process file locks and best‑effort reloads to merge concurrent writes across generations.

- **Migration**
  - macOS: run `deploy/macos/migrate-launchdaemon-to-supervisor.sh` to prepare; activate once with `--activate`. Routine worker updates use `deploy/macos/subrouter-autoupdate.sh` or replace the worker and call `POST /_subrouter/upgrade`. The supervisor binary is installed separately and is not replaced by worker updates.

<sup>Written for commit aa49388d68c4b596c8bf4b49559083e936da9f5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a supervisor mode that manages worker processes and supports seamless traffic handoffs during upgrades.
  - Added supervisor status and upgrade controls, preserving existing connections while routing new traffic to replacement workers.
  - Added PROXY protocol support to preserve client connection information.
  - Added macOS migration and automatic worker update scripts with validation and rollback safeguards.

- **Documentation**
  - Updated production and upgrade guides with supervised macOS deployment and upgrade procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->