### PR TITLE
Fail over Codex model entitlement errors

### DIFF
--- a/internal/proxy/claude_failover_test.go
+++ b/internal/proxy/claude_failover_test.go
@@ -307,7 +307,7 @@ func TestCaptureResponseBodyClaude401MarksExhausted(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"authentication_error"}}`)),
 		Header:     http.Header{},
 	}
-	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "", "/v1/messages")
+	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "", "", "/v1/messages")
 	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
 		t.Fatal("claude 401 should mark the account exhausted via passive inspection")
 	}
@@ -341,7 +341,7 @@ func TestCaptureResponseBodyClaude429MarksExhausted(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error"}}`)),
 		Header:     h,
 	}
-	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "", "/v1/messages")
+	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "", "", "/v1/messages")
 	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
 		t.Fatal("claude rejected-header 429 should mark the account exhausted via passive inspection")
 	}
@@ -357,7 +357,7 @@ func TestCaptureResponseBodyClaudeBare429DoesNotPoison(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}`)),
 		Header:     http.Header{},
 	}
-	server.captureResponseBody(response, "claude", "session-1", "healthy@example.com", accounts.ProviderClaude, "", "/v1/messages")
+	server.captureResponseBody(response, "claude", "session-1", "healthy@example.com", accounts.ProviderClaude, "", "", "/v1/messages")
 	if server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "healthy@example.com") {
 		t.Fatal("a bare (headerless) 429 must NOT mark a healthy account exhausted")
 	}

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -1091,7 +1091,7 @@ func TestClaudeUpstreamServerErrorLoggedNotExhausted(t *testing.T) {
 		Header:     http.Header{},
 		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"overloaded_error"}}`)),
 	}
-	server.captureResponseBody(response, "claude", "session-1", "acct@example.com", accounts.ProviderClaude, "", "/v1/messages")
+	server.captureResponseBody(response, "claude", "session-1", "acct@example.com", accounts.ProviderClaude, "", "", "/v1/messages")
 	logs := logBuf.String()
 	if !strings.Contains(logs, "claude upstream server error") || !strings.Contains(logs, "status=529") {
 		t.Fatalf("expected a 529 upstream-server-error log; logs=\n%s", logs)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2074,7 +2074,7 @@ func codexWebSocketResponseFinished(body []byte) bool {
 		return false
 	}
 	switch strings.ToLower(stringField(event, "type")) {
-	case "error", "response.completed", "response.failed", "response.incomplete":
+	case "error", "response.completed", "response.failed", "response.incomplete", "response.done":
 		return true
 	default:
 		return false

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2016,36 +2016,69 @@ func cloneWebSocketResponseHeaders(headers http.Header) http.Header {
 }
 
 type webSocketModelState struct {
-	mu    sync.RWMutex
-	model string
+	mu      sync.RWMutex
+	model   string
+	pending []string
 }
 
 func (s *webSocketModelState) observe(body []byte) {
-	model := codexWebSocketRequestModel(body)
-	if model == "" {
+	model, ok := codexWebSocketRequestModelEvent(body)
+	if !ok {
 		return
 	}
 	s.mu.Lock()
-	s.model = model
+	if model == "" {
+		model = s.model
+	}
+	s.pending = append(s.pending, model)
 	s.mu.Unlock()
 }
 
 func (s *webSocketModelState) current() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	if len(s.pending) > 0 {
+		return s.pending[0]
+	}
 	return s.model
 }
 
+func (s *webSocketModelState) complete() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.pending) > 0 {
+		s.pending = s.pending[1:]
+	}
+}
+
 func codexWebSocketRequestModel(body []byte) string {
+	model, _ := codexWebSocketRequestModelEvent(body)
+	return model
+}
+
+func codexWebSocketRequestModelEvent(body []byte) (string, bool) {
 	var event map[string]any
 	if err := json.Unmarshal(body, &event); err != nil || !strings.EqualFold(stringField(event, "type"), "response.create") {
-		return ""
+		return "", false
 	}
 	if model := session.NormalizeModel(stringField(event, "model")); model != "" {
-		return model
+		return model, true
 	}
 	response, _ := event["response"].(map[string]any)
-	return session.NormalizeModel(stringField(response, "model"))
+	return session.NormalizeModel(stringField(response, "model")), true
+}
+
+func codexWebSocketResponseFinished(body []byte) bool {
+	var event map[string]any
+	if err := json.Unmarshal(body, &event); err != nil {
+		return false
+	}
+	switch strings.ToLower(stringField(event, "type")) {
+	case "error", "response.completed", "response.failed", "response.incomplete":
+		return true
+	default:
+		return false
+	}
 }
 
 func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, poolModel string, modelState *webSocketModelState, direction string, src, dst *websocket.Conn) {
@@ -2071,6 +2104,9 @@ func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, poolModel
 				if model := modelState.current(); model != "" {
 					s.markAccountExhausted(provider, accountID, model)
 				}
+			}
+			if provider == accounts.ProviderCodex && codexWebSocketResponseFinished(body) {
+				modelState.complete()
 			}
 		}
 		if err := dst.WriteMessage(messageType, body); err != nil {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3520,7 +3520,7 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			// "allowed"/"allowed_warning" 429 still fails over for this request.
 			exhausted = claudeAccountExhaustedByResponse(response.StatusCode, response.Header)
 		}
-		if t.server != nil && exhausted {
+		if t.server != nil && exhausted && (!modelUnsupported || exhaustionPool != "") {
 			// Use the response's own reset time so the mark self-expires when the
 			// window recovers (codex responses lack these headers and fall back
 			// to the default TTL inside claudeExhaustionExpiry).
@@ -3537,7 +3537,7 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			t.logClaudeFailoverExhausted(response, accountID, reason, attempt, maxAttempts, len(tried))
 			return response, nil
 		}
-		nextAccount, pickErr := t.server.oauthRetryAccount(req.Context(), t.provider, t.agent, t.session, t.userEmail, t.poolModel, tried, t.fableFallback != nil)
+		nextAccount, pickErr := t.server.oauthRetryAccount(req.Context(), t.provider, t.agent, t.session, t.userEmail, t.poolModel, tried, t.fableFallback != nil || modelUnsupported)
 		if pickErr != nil {
 			if t.logger != nil {
 				t.logger.Warn("usage-limit retry has no alternate account", "agent", t.agent, "session", t.session, "account", accountID, "method", t.method, "path", t.path, "upstream", t.upstream, "error", pickErr)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1779,7 +1779,7 @@ func (s Server) proxyHandler() http.Handler {
 			return
 		}
 		if websocket.IsWebSocketUpgrade(r) {
-			s.proxyWebSocket(w, r, account, sessionAgentType, sessionID, userEmail, requestPoolModel, upstream)
+			s.proxyWebSocket(w, r, account, sessionAgentType, sessionID, userEmail, requestPoolModel, retryPoolModel, upstream)
 			return
 		}
 		proxyRequest := r.Clone(r.Context())
@@ -1928,7 +1928,7 @@ func baseURLProbeRequest(r *http.Request) bool {
 	return r.Method == http.MethodHead && (r.URL.Path == "" || r.URL.Path == "/")
 }
 
-func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account accounts.Account, agentType, sessionID, userEmail, poolModel string, upstream *url.URL) {
+func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account accounts.Account, agentType, sessionID, userEmail, poolModel, compatibilityModel string, upstream *url.URL) {
 	upstreamURL := cloneURL(r.URL)
 	upstreamURL.Scheme = websocketScheme(upstream.Scheme)
 	upstreamURL.Host = upstream.Host
@@ -1970,16 +1970,17 @@ func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account a
 	}
 	defer clientConn.Close()
 
+	modelState := &webSocketModelState{model: compatibilityModel}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		s.copyWebSocketMessages(agentType, sessionID, account.ID, poolModel, "client_to_upstream", clientConn, upstreamConn)
+		s.copyWebSocketMessages(agentType, sessionID, account.ID, poolModel, modelState, "client_to_upstream", clientConn, upstreamConn)
 		_ = upstreamConn.Close()
 	}()
 	go func() {
 		defer wg.Done()
-		s.copyWebSocketMessages(agentType, sessionID, account.ID, poolModel, "upstream_to_client", upstreamConn, clientConn)
+		s.copyWebSocketMessages(agentType, sessionID, account.ID, poolModel, modelState, "upstream_to_client", upstreamConn, clientConn)
 		_ = clientConn.Close()
 	}()
 	wg.Wait()
@@ -2014,7 +2015,41 @@ func cloneWebSocketResponseHeaders(headers http.Header) http.Header {
 	return out
 }
 
-func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, poolModel, direction string, src, dst *websocket.Conn) {
+type webSocketModelState struct {
+	mu    sync.RWMutex
+	model string
+}
+
+func (s *webSocketModelState) observe(body []byte) {
+	model := codexWebSocketRequestModel(body)
+	if model == "" {
+		return
+	}
+	s.mu.Lock()
+	s.model = model
+	s.mu.Unlock()
+}
+
+func (s *webSocketModelState) current() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.model
+}
+
+func codexWebSocketRequestModel(body []byte) string {
+	var event map[string]any
+	if err := json.Unmarshal(body, &event); err != nil || !strings.EqualFold(stringField(event, "type"), "response.create") {
+		return ""
+	}
+	if model := session.NormalizeModel(stringField(event, "model")); model != "" {
+		return model
+	}
+	response, _ := event["response"].(map[string]any)
+	return session.NormalizeModel(stringField(response, "model"))
+}
+
+func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, poolModel string, modelState *webSocketModelState, direction string, src, dst *websocket.Conn) {
+	provider := providerForRequest(agentType, "")
 	for {
 		messageType, body, err := src.ReadMessage()
 		if err != nil {
@@ -2025,8 +2060,18 @@ func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, poolModel
 				"opcode": websocketMessageType(messageType),
 			})
 		}
-		if direction == "upstream_to_client" && messageType == websocket.TextMessage && usageLimitJSON(body) {
-			s.markAccountExhausted(providerForRequest(agentType, ""), accountID, poolModel)
+		if messageType == websocket.TextMessage && direction == "client_to_upstream" && provider == accounts.ProviderCodex {
+			modelState.observe(body)
+		}
+		if direction == "upstream_to_client" && messageType == websocket.TextMessage {
+			switch {
+			case usageLimitJSON(body):
+				s.markAccountExhausted(provider, accountID, poolModel)
+			case provider == accounts.ProviderCodex && codexChatGPTModelUnsupportedJSON(body):
+				if model := modelState.current(); model != "" {
+					s.markAccountExhausted(provider, accountID, model)
+				}
+			}
 		}
 		if err := dst.WriteMessage(messageType, body); err != nil {
 			return

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1975,12 +1975,12 @@ func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account a
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		s.copyWebSocketMessages(agentType, sessionID, account.ID, poolModel, modelState, "client_to_upstream", clientConn, upstreamConn)
+		s.copyWebSocketMessages(r.Context(), agentType, sessionID, userEmail, account.ID, poolModel, modelState, "client_to_upstream", clientConn, upstreamConn)
 		_ = upstreamConn.Close()
 	}()
 	go func() {
 		defer wg.Done()
-		s.copyWebSocketMessages(agentType, sessionID, account.ID, poolModel, modelState, "upstream_to_client", upstreamConn, clientConn)
+		s.copyWebSocketMessages(r.Context(), agentType, sessionID, userEmail, account.ID, poolModel, modelState, "upstream_to_client", upstreamConn, clientConn)
 		_ = clientConn.Close()
 	}()
 	wg.Wait()
@@ -2081,7 +2081,7 @@ func codexWebSocketResponseFinished(body []byte) bool {
 	}
 }
 
-func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, poolModel string, modelState *webSocketModelState, direction string, src, dst *websocket.Conn) {
+func (s Server) copyWebSocketMessages(ctx context.Context, agentType, sessionID, userEmail, accountID, poolModel string, modelState *webSocketModelState, direction string, src, dst *websocket.Conn) {
 	provider := providerForRequest(agentType, "")
 	for {
 		messageType, body, err := src.ReadMessage()
@@ -2102,7 +2102,7 @@ func (s Server) copyWebSocketMessages(agentType, sessionID, accountID, poolModel
 				s.markAccountExhausted(provider, accountID, poolModel)
 			case provider == accounts.ProviderCodex && codexChatGPTModelUnsupportedJSON(body):
 				if model := modelState.current(); model != "" {
-					s.markAccountExhausted(provider, accountID, model)
+					_, _ = s.rerouteModelIncompatibility(ctx, provider, agentType, sessionID, userEmail, accountID, model, nil)
 				}
 			}
 			if provider == accounts.ProviderCodex && codexWebSocketResponseFinished(body) {
@@ -2431,6 +2431,10 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 		return
 	}
 	payload := map[string]any{"status": response.StatusCode}
+	responseCtx := context.Background()
+	if response.Request != nil {
+		responseCtx = response.Request.Context()
+	}
 	var inspect func([]byte)
 	if inspectUsageLimit || inspectModelCompatibility || claudeUnusable {
 		loggedBody := false
@@ -2442,7 +2446,7 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 				s.markAccountExhaustedFromResponse(provider, accountID, poolModel, response.StatusCode, response.Header)
 			}
 			if inspectModelCompatibility && codexChatGPTModelUnsupportedJSON(body) {
-				s.markAccountExhausted(provider, accountID, compatibilityModel)
+				_, _ = s.rerouteModelIncompatibility(responseCtx, provider, agentType, sessionID, "", accountID, compatibilityModel, nil)
 			}
 			// Only log the body for the original hard rate-limit statuses
 			// (429/401), whose body is a known rate-limit/auth error envelope. A
@@ -3608,7 +3612,14 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			// "allowed"/"allowed_warning" 429 still fails over for this request.
 			exhausted = claudeAccountExhaustedByResponse(response.StatusCode, response.Header)
 		}
-		if t.server != nil && exhausted && (!modelUnsupported || exhaustionPool != "") {
+		var compatibilityNext accounts.Account
+		var compatibilityPickErr error
+		if modelUnsupported && t.server != nil {
+			compatibilityNext, compatibilityPickErr = t.server.rerouteModelIncompatibility(
+				req.Context(), t.provider, t.agent, t.session, t.userEmail, accountID, exhaustionPool, tried,
+			)
+		}
+		if t.server != nil && exhausted && !modelUnsupported {
 			// Use the response's own reset time so the mark self-expires when the
 			// window recovers (codex responses lack these headers and fall back
 			// to the default TTL inside claudeExhaustionExpiry).
@@ -3625,7 +3636,10 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			t.logClaudeFailoverExhausted(response, accountID, reason, attempt, maxAttempts, len(tried))
 			return response, nil
 		}
-		nextAccount, pickErr := t.server.oauthRetryAccount(req.Context(), t.provider, t.agent, t.session, t.userEmail, t.poolModel, tried, t.fableFallback != nil || modelUnsupported)
+		nextAccount, pickErr := compatibilityNext, compatibilityPickErr
+		if !modelUnsupported {
+			nextAccount, pickErr = t.server.oauthRetryAccount(req.Context(), t.provider, t.agent, t.session, t.userEmail, t.poolModel, tried, t.fableFallback != nil)
+		}
 		if pickErr != nil {
 			if t.logger != nil {
 				t.logger.Warn("usage-limit retry has no alternate account", "agent", t.agent, "session", t.session, "account", accountID, "method", t.method, "path", t.path, "upstream", t.upstream, "error", pickErr)
@@ -3768,6 +3782,29 @@ func isTerminalCredentialError(err error) bool {
 // pool to OAuth accounts; Fable requests with a fallback chain set it so a
 // metered API-key pool account never preempts the Bedrock stage (the dedicated
 // Fable API key is the chain's own last stage).
+func (s Server) rerouteModelIncompatibility(ctx context.Context, provider accounts.Provider, agentType, sessionID, userEmail, accountID, model string, tried map[string]struct{}) (accounts.Account, error) {
+	if model != "" {
+		s.markAccountExhausted(provider, accountID, model)
+	}
+	if tried == nil {
+		tried = make(map[string]struct{}, 1)
+	}
+	if accountID != "" {
+		tried[accountID] = struct{}{}
+	}
+	account, err := s.oauthRetryAccount(ctx, provider, agentType, sessionID, userEmail, model, tried, true)
+	if err != nil && s.Logger != nil {
+		s.Logger.Warn("model incompatibility has no alternate OAuth account",
+			"provider", provider,
+			"agent", agentType,
+			"session", sessionID,
+			"account", accountID,
+			"model", model,
+			"error", err)
+	}
+	return account, err
+}
+
 func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provider, agentType, sessionID, userEmail, poolModel string, tried map[string]struct{}, oauthOnly bool) (accounts.Account, error) {
 	allCandidates := filterAccountsForProvider(s.accountList(), provider)
 	if len(allCandidates) == 0 {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1717,13 +1717,15 @@ func (s Server) proxyHandler() http.Handler {
 		// or cannot start (no usable OAuth account). Other Claude models use the
 		// normal pool unchanged.
 		requestPoolModel := ""
+		retryPoolModel := ""
 		if requestProvider == accounts.ProviderCodex {
-			requestPoolModel = session.ExtractModel(r, s.MaxBodyBytes)
+			retryPoolModel = session.ExtractModel(r, s.MaxBodyBytes)
 		}
 		fableFallbackConfigured := false
 		if requestProvider == accounts.ProviderClaude {
 			requestModel := session.ExtractModel(r, s.MaxBodyBytes)
 			requestPoolModel = claudePoolModel(requestModel)
+			retryPoolModel = requestPoolModel
 			fableFallbackConfigured = s.claudeFableEnabled() && claudeFableModel(requestModel) &&
 				r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/v1/messages")
 		}
@@ -1844,7 +1846,7 @@ func (s Server) proxyHandler() http.Handler {
 				path:          proxyRequest.URL.Path,
 				upstream:      upstream.Host,
 				maxAttempts:   s.usageLimitRetryMaxAttempts(requestProvider),
-				poolModel:     requestPoolModel,
+				poolModel:     retryPoolModel,
 				fableFallback: fableFallback,
 			}
 		}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1717,6 +1717,9 @@ func (s Server) proxyHandler() http.Handler {
 		// or cannot start (no usable OAuth account). Other Claude models use the
 		// normal pool unchanged.
 		requestPoolModel := ""
+		if requestProvider == accounts.ProviderCodex {
+			requestPoolModel = session.ExtractModel(r, s.MaxBodyBytes)
+		}
 		fableFallbackConfigured := false
 		if requestProvider == accounts.ProviderClaude {
 			requestModel := session.ExtractModel(r, s.MaxBodyBytes)
@@ -2142,6 +2145,29 @@ func usageLimitMessage(value string) bool {
 	lower := strings.ToLower(value)
 	return strings.Contains(lower, "usage limit") &&
 		(strings.Contains(lower, "reached") || strings.Contains(lower, "hit") || strings.Contains(lower, "exceeded"))
+}
+
+func codexChatGPTModelUnsupportedJSON(body []byte) bool {
+	var event map[string]any
+	if err := json.Unmarshal(body, &event); err != nil {
+		return false
+	}
+	return codexChatGPTModelUnsupportedMap(event)
+}
+
+func codexChatGPTModelUnsupportedMap(event map[string]any) bool {
+	message := strings.ToLower(stringField(event, "message"))
+	if strings.Contains(message, "model is not supported when using codex with a chatgpt account") ||
+		(strings.Contains(message, "model") &&
+			strings.Contains(message, "not supported") &&
+			strings.Contains(message, "codex") &&
+			strings.Contains(message, "chatgpt account")) {
+		return true
+	}
+	if nested, ok := event["error"].(map[string]any); ok {
+		return codexChatGPTModelUnsupportedMap(nested)
+	}
+	return false
 }
 
 func stringField(values map[string]any, key string) string {
@@ -3463,10 +3489,27 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			}
 			return response, nil
 		}
-		if !usageLimited {
+		modelUnsupported := false
+		if !usageLimited && t.provider == accounts.ProviderCodex {
+			modelUnsupported, inspectErr = responseCodexChatGPTModelUnsupported(response)
+			if inspectErr != nil {
+				if t.logger != nil {
+					t.logger.Warn("codex model compatibility response inspection failed", "agent", t.agent, "session", t.session, "account", accountID, "method", t.method, "path", t.path, "upstream", t.upstream, "error", inspectErr)
+				}
+				return response, nil
+			}
+		}
+		if !usageLimited && !modelUnsupported {
 			return response, nil
 		}
 		exhausted := true
+		exhaustionPool := selectacct.ModelKey(t.poolModel)
+		if t.provider == accounts.ProviderCodex && usageLimited {
+			// Codex usage_limit_reached exhausts the subscription account, not
+			// only the model named by this request. Model compatibility errors
+			// below remain scoped to the rejected model.
+			exhaustionPool = ""
+		}
 		if t.provider == accounts.ProviderClaude {
 			// Surface the genuine upstream rate-limit signal. The active retry
 			// path consumes this 429 before the passive ModifyResponse capture
@@ -3481,7 +3524,7 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			// Use the response's own reset time so the mark self-expires when the
 			// window recovers (codex responses lack these headers and fall back
 			// to the default TTL inside claudeExhaustionExpiry).
-			t.server.markAccountExhaustedFromResponse(t.provider, accountID, selectacct.ModelKey(t.poolModel), response.StatusCode, response.Header)
+			t.server.markAccountExhaustedFromResponse(t.provider, accountID, exhaustionPool, response.StatusCode, response.Header)
 		}
 		if attempt == maxAttempts || t.server == nil {
 			reason := "max_attempts"
@@ -3760,6 +3803,34 @@ func responseUsageLimit(response *http.Response) (bool, error) {
 		return false, closeErr
 	}
 	return usageLimitJSON(prefix), nil
+}
+
+func responseCodexChatGPTModelUnsupported(response *http.Response) (bool, error) {
+	if response == nil || response.Body == nil || response.StatusCode != http.StatusBadRequest {
+		return false, nil
+	}
+	body := response.Body
+	prefix, err := io.ReadAll(io.LimitReader(body, usageLimitInspectMaxBytes+1))
+	if err != nil {
+		response.Body = prefixReadCloser{
+			Reader: io.MultiReader(bytes.NewReader(prefix), body),
+			Closer: body,
+		}
+		return false, err
+	}
+	if int64(len(prefix)) > usageLimitInspectMaxBytes {
+		response.Body = prefixReadCloser{
+			Reader: io.MultiReader(bytes.NewReader(prefix), body),
+			Closer: body,
+		}
+		return false, nil
+	}
+	closeErr := body.Close()
+	response.Body = io.NopCloser(bytes.NewReader(prefix))
+	if closeErr != nil {
+		return false, closeErr
+	}
+	return codexChatGPTModelUnsupportedJSON(prefix), nil
 }
 
 func (t replayablePostRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1866,7 +1866,7 @@ func (s Server) proxyHandler() http.Handler {
 		}
 		rp.Transport = transport
 		rp.ModifyResponse = func(response *http.Response) error {
-			s.captureResponseBody(response, sessionAgentType, sessionID, account.ID, account.Provider, requestPoolModel, proxyRequest.URL.Path)
+			s.captureResponseBody(response, sessionAgentType, sessionID, account.ID, account.Provider, requestPoolModel, retryPoolModel, proxyRequest.URL.Path)
 			return nil
 		}
 		if s.Logger != nil {
@@ -2374,7 +2374,7 @@ func (s Server) recordReplayableRequestBody(r *http.Request, agentType, sessionI
 	s.Transcripts.RecordPayloadSummary(agentType, sessionID, "http_body", "client_to_upstream", streamID, bytesRead, hex.EncodeToString(hasher.Sum(nil)), chunks, nil)
 }
 
-func (s Server) captureResponseBody(response *http.Response, agentType, sessionID, accountID string, provider accounts.Provider, poolModel, path string) {
+func (s Server) captureResponseBody(response *http.Response, agentType, sessionID, accountID string, provider accounts.Provider, poolModel, compatibilityModel, path string) {
 	// Anthropic signals subscription exhaustion with a plain 429 and a dead or
 	// expired OAuth token with a plain 401, neither with a codex-style
 	// usage-limit body to inspect. Both mean this account can't serve the
@@ -2425,12 +2425,14 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 			}, claudeRateLimitHeaderFields(response.Header)...)...)
 	}
 	inspectUsageLimit := s.SchedulerRef != nil && accountID != "" && responseStatusCanExhaust(response.StatusCode)
-	if response.Body == nil || (s.Transcripts == nil && s.Logger == nil && !inspectUsageLimit && !claudeUnusable) {
+	inspectModelCompatibility := s.SchedulerRef != nil && accountID != "" && compatibilityModel != "" &&
+		provider == accounts.ProviderCodex && response.StatusCode == http.StatusBadRequest
+	if response.Body == nil || (s.Transcripts == nil && s.Logger == nil && !inspectUsageLimit && !inspectModelCompatibility && !claudeUnusable) {
 		return
 	}
 	payload := map[string]any{"status": response.StatusCode}
 	var inspect func([]byte)
-	if inspectUsageLimit || claudeUnusable {
+	if inspectUsageLimit || inspectModelCompatibility || claudeUnusable {
 		loggedBody := false
 		inspect = func(body []byte) {
 			if inspectUsageLimit && usageLimitJSON(body) {
@@ -2438,6 +2440,9 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 				// above is recomputed identically, not overwritten with the short
 				// default TTL.
 				s.markAccountExhaustedFromResponse(provider, accountID, poolModel, response.StatusCode, response.Header)
+			}
+			if inspectModelCompatibility && codexChatGPTModelUnsupportedJSON(body) {
+				s.markAccountExhausted(provider, accountID, compatibilityModel)
 			}
 			// Only log the body for the original hard rate-limit statuses
 			// (429/401), whose body is a known rate-limit/auth error envelope. A

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3786,8 +3786,8 @@ func isTerminalCredentialError(err error) bool {
 // metered API-key pool account never preempts the Bedrock stage (the dedicated
 // Fable API key is the chain's own last stage).
 func (s Server) rerouteModelIncompatibility(ctx context.Context, provider accounts.Provider, agentType, sessionID, userEmail, accountID, model string, tried map[string]struct{}) (accounts.Account, error) {
-	if model != "" {
-		s.markAccountExhausted(provider, accountID, model)
+	if model != "" && s.SchedulerRef != nil {
+		s.SchedulerRef.MarkModelIncompatible(provider, accountID, model)
 	}
 	if tried == nil {
 		tried = make(map[string]struct{}, 1)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2375,6 +2375,9 @@ func (s Server) recordReplayableRequestBody(r *http.Request, agentType, sessionI
 }
 
 func (s Server) captureResponseBody(response *http.Response, agentType, sessionID, accountID string, provider accounts.Provider, poolModel, compatibilityModel, path string) {
+	if provider == "" {
+		provider = accounts.ProviderCodex
+	}
 	// Anthropic signals subscription exhaustion with a plain 429 and a dead or
 	// expired OAuth token with a plain 401, neither with a codex-style
 	// usage-limit body to inspect. Both mean this account can't serve the

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -2906,7 +2906,10 @@ func TestHandlerMarksWebSocketUsageLimitAccountExhausted(t *testing.T) {
 	defer subrouter.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(subrouter.URL, "http") + "/v1/responses"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, http.Header{"X-Subrouter-Session": []string{"session-1"}})
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, http.Header{
+		"X-Subrouter-Session": []string{"session-1"},
+		"X-Subrouter-Model":   []string{"gpt-5.6-sol"},
+	})
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
@@ -2921,6 +2924,12 @@ func TestHandlerMarksWebSocketUsageLimitAccountExhausted(t *testing.T) {
 		t.Fatalf("websocket body = %q, want usage limit error", string(body))
 	}
 	_ = conn.Close()
+	if _, accountMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "empty@example.com", ""); !accountMarked {
+		t.Fatal("Codex usage limit must mark the whole account exhausted")
+	}
+	if _, modelMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "empty@example.com", "gpt-5.6-sol"); modelMarked {
+		t.Fatal("Codex usage limit must not be scoped to the request model")
+	}
 
 	req, err := http.NewRequest(http.MethodPost, subrouter.URL+"/v1/responses", strings.NewReader(`{}`))
 	if err != nil {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -3236,6 +3236,35 @@ func TestHandlerDoesNotMarkCodexAccountWideWhenCompatibilityModelIsUnknown(t *te
 	}
 }
 
+func TestCaptureResponseBodyMarksCodexModelCompatibility(t *testing.T) {
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{{
+		AccountID:     "incompatible@example.com",
+		Provider:      accounts.ProviderCodex,
+		Headroom:      0.8,
+		ShortHeadroom: 0.8,
+	}}))
+	server := Server{SchedulerRef: schedulerRef}
+	response := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}}`)),
+	}
+	server.captureResponseBody(response, "codex", "session-1", "incompatible@example.com", accounts.ProviderCodex, "", "gpt-5.6-sol", "/v1/responses")
+	if _, err := io.Copy(io.Discard, response.Body); err != nil {
+		t.Fatal(err)
+	}
+	if err := response.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, modelMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", "gpt-5.6-sol"); !modelMarked {
+		t.Fatal("passive compatibility inspection must mark the rejected model")
+	}
+	if _, accountMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", ""); accountMarked {
+		t.Fatal("passive compatibility inspection must not mark the whole account")
+	}
+}
+
 func TestHandlerMarksWebSocketModelCompatibilityAndReroutesReconnect(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
 	var auths []string

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -3322,7 +3322,6 @@ func TestHandlerMarksWebSocketModelCompatibilityAndReroutesReconnect(t *testing.
 	wsURL := "ws" + strings.TrimPrefix(subrouter.URL, "http") + "/v1/responses"
 	header := http.Header{
 		"X-Subrouter-Session": []string{"session-1"},
-		"X-Subrouter-Model":   []string{"gpt-5.6-sol"},
 	}
 	for attempt := 0; attempt < 2; attempt++ {
 		conn, _, err := websocket.DefaultDialer.Dial(wsURL, header)

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -3071,6 +3071,7 @@ func TestHandlerRetriesCodexModelCompatibilityErrorOnAlternateOAuthAccount(t *te
 		t.Fatal(err)
 	}
 	req.Header.Set("X-Subrouter-Session", "session-1")
+	req.Header.Set("Content-Type", "application/json")
 	response, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -3095,10 +3096,12 @@ func TestHandlerRetriesCodexModelCompatibilityErrorOnAlternateOAuthAccount(t *te
 	if assignment.AccountID != "compatible@example.com" {
 		t.Fatalf("AccountID = %q, want compatible@example.com", assignment.AccountID)
 	}
-	if _, ok := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", "gpt-5.6-sol"); !ok {
-		t.Fatal("missing model-scoped incompatibility mark")
+	_, modelMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", "gpt-5.6-sol")
+	_, accountMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", "")
+	if !modelMarked {
+		t.Fatalf("missing model-scoped incompatibility mark (account_marked=%t)", accountMarked)
 	}
-	if _, ok := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", ""); ok {
+	if accountMarked {
 		t.Fatal("model incompatibility must not mark the whole account exhausted")
 	}
 }

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -2927,7 +2927,7 @@ func TestHandlerMarksWebSocketUsageLimitAccountExhausted(t *testing.T) {
 	if _, accountMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "empty@example.com", ""); !accountMarked {
 		t.Fatal("Codex usage limit must mark the whole account exhausted")
 	}
-	if _, modelMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "empty@example.com", "gpt-5.6-sol"); modelMarked {
+	if _, modelMarked := schedulerRef.ModelIncompatibleUntilFor(accounts.ProviderCodex, "empty@example.com", "gpt-5.6-sol"); modelMarked {
 		t.Fatal("Codex usage limit must not be scoped to the request model")
 	}
 
@@ -3105,7 +3105,7 @@ func TestHandlerRetriesCodexModelCompatibilityErrorOnAlternateOAuthAccount(t *te
 	if assignment.AccountID != "compatible@example.com" {
 		t.Fatalf("AccountID = %q, want compatible@example.com", assignment.AccountID)
 	}
-	_, modelMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", "gpt-5.6-sol")
+	_, modelMarked := schedulerRef.ModelIncompatibleUntilFor(accounts.ProviderCodex, "incompatible@example.com", "gpt-5.6-sol")
 	_, accountMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", "")
 	if !modelMarked {
 		t.Fatalf("missing model-scoped incompatibility mark (account_marked=%t)", accountMarked)
@@ -3257,7 +3257,7 @@ func TestCaptureResponseBodyMarksCodexModelCompatibility(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, modelMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", "gpt-5.6-sol"); !modelMarked {
+	if _, modelMarked := schedulerRef.ModelIncompatibleUntilFor(accounts.ProviderCodex, "incompatible@example.com", "gpt-5.6-sol"); !modelMarked {
 		t.Fatal("passive compatibility inspection must mark the rejected model")
 	}
 	if _, accountMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", ""); accountMarked {
@@ -3348,7 +3348,7 @@ func TestHandlerMarksWebSocketModelCompatibilityAndReroutesReconnect(t *testing.
 	if strings.Join(auths, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("auths = %#v, want %#v", auths, want)
 	}
-	if _, modelMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", "gpt-5.6-sol"); !modelMarked {
+	if _, modelMarked := schedulerRef.ModelIncompatibleUntilFor(accounts.ProviderCodex, "incompatible@example.com", "gpt-5.6-sol"); !modelMarked {
 		t.Fatal("WebSocket compatibility error must mark the rejected model")
 	}
 	if _, accountMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", ""); accountMarked {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -3346,6 +3346,20 @@ func TestCodexWebSocketRequestModel(t *testing.T) {
 	}
 }
 
+func TestWebSocketModelStateTracksSequentialResponses(t *testing.T) {
+	state := &webSocketModelState{model: "default-model"}
+	state.observe([]byte(`{"type":"response.create","model":"model-a"}`))
+	state.observe([]byte(`{"type":"response.create","model":"model-b"}`))
+
+	if got := state.current(); got != "model-a" {
+		t.Fatalf("first current model = %q, want model-a", got)
+	}
+	state.complete()
+	if got := state.current(); got != "model-b" {
+		t.Fatalf("second current model = %q, want model-b", got)
+	}
+}
+
 func TestHandlerRetriesHTTPUsageLimitToBelowThresholdFallback(t *testing.T) {
 	var auths []string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -3236,6 +3236,116 @@ func TestHandlerDoesNotMarkCodexAccountWideWhenCompatibilityModelIsUnknown(t *te
 	}
 }
 
+func TestHandlerMarksWebSocketModelCompatibilityAndReroutesReconnect(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
+	var auths []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		auths = append(auths, auth)
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade: %v", err)
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Fatalf("read client message: %v", err)
+		}
+		if auth == "Bearer incompatible-token" {
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","error":{"message":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}}`)); err != nil {
+				t.Fatalf("write compatibility error: %v", err)
+			}
+			return
+		}
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.done"}`)); err != nil {
+			t.Fatalf("write success: %v", err)
+		}
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("codex", "session-1", "incompatible@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+		{AccountID: "incompatible@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
+		{AccountID: "compatible@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
+	}))
+	handler := Server{
+		Upstream: upstreamURL,
+		Accounts: []accounts.Account{
+			{ID: "incompatible@example.com", AuthMode: accounts.AuthModeOAuth, Token: "incompatible-token"},
+			{ID: "compatible@example.com", AuthMode: accounts.AuthModeOAuth, Token: "compatible-token"},
+		},
+		Sessions:     store,
+		SchedulerRef: schedulerRef,
+		MaxBodyBytes: 1024,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(subrouter.URL, "http") + "/v1/responses"
+	header := http.Header{
+		"X-Subrouter-Session": []string{"session-1"},
+		"X-Subrouter-Model":   []string{"gpt-5.6-sol"},
+	}
+	for attempt := 0; attempt < 2; attempt++ {
+		conn, _, err := websocket.DefaultDialer.Dial(wsURL, header)
+		if err != nil {
+			t.Fatalf("dial attempt %d: %v", attempt+1, err)
+		}
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","response":{"model":"gpt-5.6-sol"}}`)); err != nil {
+			t.Fatalf("write create attempt %d: %v", attempt+1, err)
+		}
+		_, body, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read attempt %d: %v", attempt+1, err)
+		}
+		_ = conn.Close()
+		if attempt == 0 && !strings.Contains(string(body), "not supported") {
+			t.Fatalf("first body = %q, want compatibility error", body)
+		}
+		if attempt == 1 && !strings.Contains(string(body), "response.done") {
+			t.Fatalf("second body = %q, want success", body)
+		}
+	}
+
+	want := []string{"Bearer incompatible-token", "Bearer compatible-token"}
+	if strings.Join(auths, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("auths = %#v, want %#v", auths, want)
+	}
+	if _, modelMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", "gpt-5.6-sol"); !modelMarked {
+		t.Fatal("WebSocket compatibility error must mark the rejected model")
+	}
+	if _, accountMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", ""); accountMarked {
+		t.Fatal("WebSocket compatibility error must not mark the whole account")
+	}
+}
+
+func TestCodexWebSocketRequestModel(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "nested response", body: `{"type":"response.create","response":{"model":"gpt-5.6-sol"}}`, want: "gpt-5.6-sol"},
+		{name: "top level", body: `{"type":"response.create","model":"gpt-5.6-sol"}`, want: "gpt-5.6-sol"},
+		{name: "other event", body: `{"type":"response.done","response":{"model":"gpt-5.6-sol"}}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := codexWebSocketRequestModel([]byte(test.body)); got != test.want {
+				t.Fatalf("model = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestHandlerRetriesHTTPUsageLimitToBelowThresholdFallback(t *testing.T) {
 	var auths []string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -3374,6 +3374,19 @@ func TestCodexWebSocketRequestModel(t *testing.T) {
 	}
 }
 
+func TestCodexWebSocketResponseFinished(t *testing.T) {
+	for _, eventType := range []string{"response.completed", "response.failed", "response.incomplete", "response.done", "error"} {
+		t.Run(eventType, func(t *testing.T) {
+			if !codexWebSocketResponseFinished([]byte(`{"type":"` + eventType + `"}`)) {
+				t.Fatalf("%s should finish the current WebSocket response", eventType)
+			}
+		})
+	}
+	if codexWebSocketResponseFinished([]byte(`{"type":"response.output_text.delta"}`)) {
+		t.Fatal("streaming delta must not finish the current WebSocket response")
+	}
+}
+
 func TestWebSocketModelStateTracksSequentialResponses(t *testing.T) {
 	state := &webSocketModelState{model: "default-model"}
 	state.observe([]byte(`{"type":"response.create","model":"model-a"}`))

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -3106,6 +3106,127 @@ func TestHandlerRetriesCodexModelCompatibilityErrorOnAlternateOAuthAccount(t *te
 	}
 }
 
+func TestHandlerDoesNotRetryCodexModelCompatibilityErrorOnAPIKeyAccount(t *testing.T) {
+	var auths []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auths = append(auths, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}}`))
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("codex", "session-1", "incompatible@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	handler := Server{
+		Upstream: upstreamURL,
+		Accounts: []accounts.Account{
+			{ID: "incompatible@example.com", AuthMode: accounts.AuthModeOAuth, Token: "incompatible-token"},
+			{ID: "apikey:team-codex-1", AuthMode: accounts.AuthModeAPIKey, Token: "api-token"},
+		},
+		Sessions: store,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+			{AccountID: "incompatible@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
+			{AccountID: "apikey:team-codex-1", Headroom: 0.01, ShortHeadroom: 0.01},
+		})),
+		MaxBodyBytes: 1024,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	req, err := http.NewRequest(http.MethodPost, subrouter.URL+"/v1/responses", strings.NewReader(`{"model":"gpt-5.6-sol","input":"hello"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Subrouter-Session", "session-1")
+	req.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if _, err := io.Copy(io.Discard, response.Body); err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", response.StatusCode)
+	}
+	want := []string{"Bearer incompatible-token"}
+	if strings.Join(auths, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("auths = %#v, want %#v", auths, want)
+	}
+}
+
+func TestHandlerDoesNotMarkCodexAccountWideWhenCompatibilityModelIsUnknown(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer incompatible-token" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("codex", "session-1", "incompatible@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+		{AccountID: "incompatible@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
+		{AccountID: "compatible@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
+	}))
+	handler := Server{
+		Upstream: upstreamURL,
+		Accounts: []accounts.Account{
+			{ID: "incompatible@example.com", AuthMode: accounts.AuthModeOAuth, Token: "incompatible-token"},
+			{ID: "compatible@example.com", AuthMode: accounts.AuthModeOAuth, Token: "compatible-token"},
+		},
+		Sessions:     store,
+		SchedulerRef: schedulerRef,
+		MaxBodyBytes: 1024,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	requestBody := `{"input":"` + strings.Repeat("x", (8<<20)+1) + `","model":"gpt-5.6-sol"}`
+	req, err := http.NewRequest(http.MethodPost, subrouter.URL+"/v1/responses", strings.NewReader(requestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Subrouter-Session", "session-1")
+	req.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if _, err := io.Copy(io.Discard, response.Body); err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", response.StatusCode)
+	}
+	if _, accountMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", ""); accountMarked {
+		t.Fatal("unknown compatibility model must not mark the whole account exhausted")
+	}
+}
+
 func TestHandlerRetriesHTTPUsageLimitToBelowThresholdFallback(t *testing.T) {
 	var auths []string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -3024,6 +3024,85 @@ func TestHandlerRetriesHTTPUsageLimitOnAlternateOAuthAccount(t *testing.T) {
 	}
 }
 
+func TestHandlerRetriesCodexModelCompatibilityErrorOnAlternateOAuthAccount(t *testing.T) {
+	var auths []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		auths = append(auths, auth)
+		if auth == "Bearer incompatible-token" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"type":"invalid_request_error","message":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("codex", "session-1", "incompatible@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+		{AccountID: "incompatible@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
+		{AccountID: "compatible@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
+	}))
+	handler := Server{
+		Upstream: upstreamURL,
+		Accounts: []accounts.Account{
+			{ID: "incompatible@example.com", AuthMode: accounts.AuthModeOAuth, Token: "incompatible-token"},
+			{ID: "compatible@example.com", AuthMode: accounts.AuthModeOAuth, Token: "compatible-token"},
+		},
+		Sessions:     store,
+		SchedulerRef: schedulerRef,
+		MaxBodyBytes: 1024,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	req, err := http.NewRequest(http.MethodPost, subrouter.URL+"/v1/responses", strings.NewReader(`{"model":"gpt-5.6-sol","input":"hello"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Subrouter-Session", "session-1")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(io.Discard, response.Body); err != nil {
+		t.Fatal(err)
+	}
+	if err := response.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", response.StatusCode)
+	}
+	want := []string{"Bearer incompatible-token", "Bearer compatible-token"}
+	if strings.Join(auths, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("auths = %#v, want %#v", auths, want)
+	}
+	assignment, ok := store.Get("codex", "session-1")
+	if !ok {
+		t.Fatal("missing session-1 assignment")
+	}
+	if assignment.AccountID != "compatible@example.com" {
+		t.Fatalf("AccountID = %q, want compatible@example.com", assignment.AccountID)
+	}
+	if _, ok := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", "gpt-5.6-sol"); !ok {
+		t.Fatal("missing model-scoped incompatibility mark")
+	}
+	if _, ok := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", ""); ok {
+		t.Fatal("model incompatibility must not mark the whole account exhausted")
+	}
+}
+
 func TestHandlerRetriesHTTPUsageLimitToBelowThresholdFallback(t *testing.T) {
 	var auths []string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -3249,7 +3249,7 @@ func TestCaptureResponseBodyMarksCodexModelCompatibility(t *testing.T) {
 		Header:     http.Header{},
 		Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}}`)),
 	}
-	server.captureResponseBody(response, "codex", "session-1", "incompatible@example.com", accounts.ProviderCodex, "", "gpt-5.6-sol", "/v1/responses")
+	server.captureResponseBody(response, "codex", "session-1", "incompatible@example.com", "", "", "gpt-5.6-sol", "/v1/responses")
 	if _, err := io.Copy(io.Discard, response.Body); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/selectacct/scheduler_ref.go
+++ b/internal/selectacct/scheduler_ref.go
@@ -19,6 +19,10 @@ type SchedulerRef struct {
 	// until the next SUCCESSFUL usage refresh, which under load can fail for
 	// hours, leaving real quota unroutable while clients got 429s.
 	exhaustedUntil map[string]time.Time
+	// incompatibleUntil records account/model exclusions learned from upstream
+	// entitlement errors. Usage refreshes cannot supersede these marks because
+	// quota headroom says nothing about whether an account supports a model.
+	incompatibleUntil map[string]time.Time
 	// routedSinceRefresh counts requests the proxy routed per account (by
 	// ScoreKey) since the last successful usage refresh. Pick debits headroom
 	// by LiveDebitPerRequest per routed request so concurrent traffic spreads
@@ -38,7 +42,8 @@ func (r *SchedulerRef) Get() Scheduler {
 	r.pruneExpired(now)
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return applyExhaustionMarks(r.scheduler, r.exhaustedUntil, now)
+	scheduler := applyExhaustionMarks(r.scheduler, r.exhaustedUntil, now)
+	return applyExhaustionMarks(scheduler, r.incompatibleUntil, now)
 }
 
 // pruneExpired drops exhaustion marks whose window has reset. The base snapshot
@@ -64,6 +69,14 @@ func (r *SchedulerRef) pruneExpired(now time.Time) {
 			break
 		}
 	}
+	if !anyExpired {
+		for _, until := range r.incompatibleUntil {
+			if !until.After(now) {
+				anyExpired = true
+				break
+			}
+		}
+	}
 	r.mu.RUnlock()
 	if !anyExpired {
 		return
@@ -76,6 +89,12 @@ func (r *SchedulerRef) pruneExpired(now time.Time) {
 		}
 		delete(r.exhaustedUntil, key)
 	}
+	for key, until := range r.incompatibleUntil {
+		if until.After(now) {
+			continue
+		}
+		delete(r.incompatibleUntil, key)
+	}
 }
 
 func (r *SchedulerRef) Set(scheduler Scheduler) {
@@ -84,7 +103,7 @@ func (r *SchedulerRef) Set(scheduler Scheduler) {
 	base := r.scheduler
 	r.scheduler = scheduler
 	r.retainExhaustedExpiriesLocked()
-	r.scheduler = stripCarriedForwardExhaustionOverlays(r.scheduler, base, r.exhaustedUntil)
+	r.scheduler = stripCarriedForwardExhaustionOverlays(r.scheduler, base, r.expiryMarksLocked())
 	r.updatedAt = time.Now()
 }
 
@@ -168,6 +187,26 @@ func (r *SchedulerRef) MarkExhaustedUntil(provider accounts.Provider, accountID,
 	r.updatedAt = time.Now()
 }
 
+// MarkModelIncompatibleUntil excludes one account from one model until the
+// supplied expiry. Unlike quota exhaustion, usage-score refreshes cannot clear
+// this mark because they do not carry entitlement evidence.
+func (r *SchedulerRef) MarkModelIncompatibleUntil(provider accounts.Provider, accountID, model string, until time.Time) {
+	if accountID == "" || model == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.incompatibleUntil == nil {
+		r.incompatibleUntil = make(map[string]time.Time)
+	}
+	r.incompatibleUntil[poolScopedExhaustionKey(provider, accountID, model)] = until
+	r.updatedAt = time.Now()
+}
+
+func (r *SchedulerRef) MarkModelIncompatible(provider accounts.Provider, accountID, model string) {
+	r.MarkModelIncompatibleUntil(provider, accountID, model, time.Now().Add(DefaultExhaustedTTL))
+}
+
 // ExhaustedUntilFor reports the expiry recorded for an account's exhaustion
 // mark, if any. Used by tests and diagnostics to verify TTL selection.
 func (r *SchedulerRef) ExhaustedUntilFor(provider accounts.Provider, accountID, poolKey string) (time.Time, bool) {
@@ -175,6 +214,26 @@ func (r *SchedulerRef) ExhaustedUntilFor(provider accounts.Provider, accountID, 
 	defer r.mu.RUnlock()
 	until, ok := r.exhaustedUntil[poolScopedExhaustionKey(provider, accountID, poolKey)]
 	return until, ok
+}
+
+func (r *SchedulerRef) ModelIncompatibleUntilFor(provider accounts.Provider, accountID, model string) (time.Time, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	until, ok := r.incompatibleUntil[poolScopedExhaustionKey(provider, accountID, model)]
+	return until, ok
+}
+
+func (r *SchedulerRef) expiryMarksLocked() map[string]time.Time {
+	marks := make(map[string]time.Time, len(r.exhaustedUntil)+len(r.incompatibleUntil))
+	for key, until := range r.exhaustedUntil {
+		marks[key] = until
+	}
+	for key, until := range r.incompatibleUntil {
+		if until.After(marks[key]) {
+			marks[key] = until
+		}
+	}
+	return marks
 }
 
 func poolScopedExhaustionKey(provider accounts.Provider, accountID, poolKey string) string {
@@ -379,7 +438,7 @@ func (r *SchedulerRef) FinishRefresh(scheduler Scheduler, update bool) {
 		base := r.scheduler
 		r.scheduler = scheduler
 		r.retainExhaustedExpiriesLocked()
-		r.scheduler = stripCarriedForwardExhaustionOverlays(r.scheduler, base, r.exhaustedUntil)
+		r.scheduler = stripCarriedForwardExhaustionOverlays(r.scheduler, base, r.expiryMarksLocked())
 		// Fresh scores supersede the live debits accumulated against the old
 		// snapshot. A failed refresh (update=false) keeps them: the snapshot
 		// is still the old one, so its debits still apply.

--- a/internal/selectacct/scheduler_ref.go
+++ b/internal/selectacct/scheduler_ref.go
@@ -90,7 +90,10 @@ func (r *SchedulerRef) Set(scheduler Scheduler) {
 
 // retainExhaustedExpiriesLocked reconciles mark expiries with an incoming
 // refresh, by evidence class:
-//   - Score shows headroom (or is gone): the mark is superseded; drop the expiry.
+//   - A pool-scoped mark has no matching refreshed pool score: keep the expiry;
+//     the refresh has no evidence about that pool.
+//   - A matching score shows headroom (or the account is gone): the mark is
+//     superseded; drop the expiry.
 //   - Carried-forward zero (the account's own usage fetch failed, seed dragged
 //     along, Fresh=false): keep the existing expiry. Clearing it would make the
 //     request-time mark permanent again, recreating the stranded-recovered-
@@ -111,9 +114,11 @@ func (r *SchedulerRef) retainExhaustedExpiriesLocked() {
 		}
 		score, ok := r.scheduler.scores[scoreKey]
 		if ok && poolKey != "" {
-			if modelScore, modelOK := score.ModelScores[poolKey]; modelOK {
-				score = modelScore
+			modelScore, modelOK := score.ModelScores[poolKey]
+			if !modelOK {
+				continue
 			}
+			score = modelScore
 		}
 		switch {
 		case !ok || !score.exhausted():

--- a/internal/selectacct/scheduler_ref_test.go
+++ b/internal/selectacct/scheduler_ref_test.go
@@ -285,6 +285,38 @@ func TestPoolScopedRefreshWithoutPoolEvidenceKeepsExpiry(t *testing.T) {
 	}
 }
 
+func TestModelIncompatibilitySurvivesHealthyPoolRefresh(t *testing.T) {
+	const model = "gpt-5.6-sol"
+	ref := NewSchedulerRef(NewScheduler(nil))
+	ref.MarkModelIncompatibleUntil(accounts.ProviderCodex, "incompatible@example.com", model, time.Now().Add(time.Hour))
+	ref.FinishRefresh(NewScheduler([]Score{{
+		AccountID:     "incompatible@example.com",
+		Provider:      accounts.ProviderCodex,
+		Headroom:      0.8,
+		ShortHeadroom: 0.8,
+		Fresh:         true,
+		ModelScores: map[string]Score{
+			model: {
+				AccountID:     "incompatible@example.com",
+				Provider:      accounts.ProviderCodex,
+				Headroom:      0.8,
+				ShortHeadroom: 0.8,
+				Fresh:         true,
+			},
+		},
+	}}), true)
+
+	if _, ok := ref.ModelIncompatibleUntilFor(accounts.ProviderCodex, "incompatible@example.com", model); !ok {
+		t.Fatal("quota refresh must not clear account/model incompatibility")
+	}
+	if !ref.Get().ForModel(model).Exhausted(accounts.ProviderCodex, "incompatible@example.com") {
+		t.Fatal("incompatible account must remain excluded for the rejected model")
+	}
+	if ref.Get().Exhausted(accounts.ProviderCodex, "incompatible@example.com") {
+		t.Fatal("model incompatibility must not exhaust the base account score")
+	}
+}
+
 func TestPoolScopedRetainLeavesOtherPoolMark(t *testing.T) {
 	const (
 		fable = "claudefable"

--- a/internal/selectacct/scheduler_ref_test.go
+++ b/internal/selectacct/scheduler_ref_test.go
@@ -262,6 +262,29 @@ func TestPoolScopedRecoveredRefreshDropsExpiry(t *testing.T) {
 	}
 }
 
+func TestPoolScopedRefreshWithoutPoolEvidenceKeepsExpiry(t *testing.T) {
+	const model = "gpt-5.6-sol"
+	ref := NewSchedulerRef(NewScheduler(nil))
+	ref.MarkExhaustedUntil(accounts.ProviderCodex, "incompatible@example.com", model, time.Now().Add(time.Hour))
+	ref.FinishRefresh(NewScheduler([]Score{{
+		AccountID:     "incompatible@example.com",
+		Provider:      accounts.ProviderCodex,
+		Headroom:      0.8,
+		ShortHeadroom: 0.8,
+		Fresh:         true,
+	}}), true)
+
+	if _, ok := ref.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", model); !ok {
+		t.Fatal("account-wide refresh without model evidence must keep the model-scoped mark")
+	}
+	if !ref.Get().ForModel(model).Exhausted(accounts.ProviderCodex, "incompatible@example.com") {
+		t.Fatal("model-scoped mark must survive a refresh that cannot evaluate that model")
+	}
+	if ref.Get().Exhausted(accounts.ProviderCodex, "incompatible@example.com") {
+		t.Fatal("model-scoped mark must not exhaust the base account score")
+	}
+}
+
 func TestPoolScopedRetainLeavesOtherPoolMark(t *testing.T) {
 	const (
 		fable = "claudefable"


### PR DESCRIPTION
## Summary
- retry replayable Codex requests on another OAuth account when ChatGPT rejects the requested model for the selected account
- quarantine only the rejected account/model pair for ten minutes
- preserve account-wide handling for real Codex usage-limit responses

## Testing
- `go test ./internal/proxy -run 'TestHandlerRetries(CodexModelCompatibilityError|HTTPUsageLimit)|TestHandlerMarksWebSocketUsageLimitAccountExhausted' -count=1`
- `go test ./...`

## Issue
- Reproduces and fixes: `The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786437845&installation_id=133855650&pr_number=75&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F75&signature=434de0c37cb8003a158c31d8f75f1e918775b825f1b67ff8ab55aa691587a6c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail over Codex requests and WebSocket sessions when ChatGPT rejects the requested model. Quarantine only the rejected account+model; keep true Codex quota limits account‑wide.

- **Bug Fixes**
  - Detects Codex+ChatGPT model-compat errors in HTTP 400 bodies (top‑level or under `error`) and WebSocket error frames, quarantines just that account+model, and retries on another OAuth account; centralized across HTTP and WebSocket and never falls back to an API key.
  - For WebSockets, observes the model from client messages or `X-Subrouter-Model`, tracks response models in order, advances on `response.done`, and reroutes on reconnects even without an explicit model.
  - Keeps Codex usage-limit exhaustion account‑wide (including WebSocket), not scoped to the model.
  - Persists model‑scoped incompatibility marks across quota refreshes, independent of usage headroom or per‑model scores.

<sup>Written for commit f8b74440165562813fa681f9393c89644dfa0885. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Codex request handling by recognizing when a selected model is incompatible with an account.
  - Automatically retries compatible Codex requests using an alternate account when possible.
  - Improved usage-limit tracking so model compatibility errors and subscription limits are handled separately.
  - Enhanced model-specific routing to select more appropriate accounts for Codex requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->