### PR TITLE
Scope the sr auto-switch to the Codex pool

### DIFF
--- a/cmd/subrouter/sr_auto_switch.go
+++ b/cmd/subrouter/sr_auto_switch.go
@@ -85,7 +85,11 @@ func srAutoSwitchOnce(ctx context.Context, cfg srAutoSwitchConfig) (string, erro
 	if cfg.AccountsFunc != nil {
 		allAccounts = cfg.AccountsFunc()
 	}
-	candidates := oauthAccounts(allAccounts)
+	// The sr auto-switch picks the active *Codex* account (switchActive writes
+	// the Codex auth via DefaultCodexStore), so it must consider Codex accounts
+	// only. Scoring Claude/other-provider accounts here runs them through the
+	// Codex usage endpoint, which 401s a Claude token and zeroes its score.
+	candidates := codexOAuthAccounts(allAccounts)
 	if len(candidates) == 0 {
 		return "", fmt.Errorf("no OAuth Codex accounts available for sr auto-switch")
 	}
@@ -97,7 +101,11 @@ func srAutoSwitchOnce(ctx context.Context, cfg srAutoSwitchConfig) (string, erro
 
 	scheduler := selectacct.NewScheduler(scores)
 	if cfg.SchedulerRef != nil {
-		cfg.SchedulerRef.Set(scheduler)
+		// Merge, don't replace: these are Codex-only scores, and the shared ref
+		// also holds Claude's pool (maintained by the proxy's provider-aware
+		// per-request refresh). A wholesale Set would drop Claude's keys every
+		// interval, reverting healthy accounts to the optimistic default.
+		cfg.SchedulerRef.UpdateScores(scores)
 	}
 	if cfg.Sessions != nil {
 		scheduler = scheduler.WithSessionCounts(cfg.Sessions.CountByAccount())
@@ -119,12 +127,19 @@ func srAutoSwitchOnce(ctx context.Context, cfg srAutoSwitchConfig) (string, erro
 	return picked.ID, nil
 }
 
-func oauthAccounts(all []accounts.Account) []accounts.Account {
+// codexOAuthAccounts keeps only OAuth accounts belonging to the Codex pool. A
+// bare provider ("") predates provider tagging and defaults to Codex (matching
+// ScoreKey), so it is included; any explicitly non-Codex provider is dropped.
+func codexOAuthAccounts(all []accounts.Account) []accounts.Account {
 	out := make([]accounts.Account, 0, len(all))
 	for _, account := range all {
-		if account.AuthMode == accounts.AuthModeOAuth {
-			out = append(out, account)
+		if account.AuthMode != accounts.AuthModeOAuth {
+			continue
 		}
+		if account.Provider != "" && account.Provider != accounts.ProviderCodex {
+			continue
+		}
+		out = append(out, account)
 	}
 	return out
 }

--- a/cmd/subrouter/sr_auto_switch_test.go
+++ b/cmd/subrouter/sr_auto_switch_test.go
@@ -166,3 +166,54 @@ func TestSRAutoSwitchSkipsWhenOAuthAccountsExhausted(t *testing.T) {
 		t.Fatal("sr switch ran despite exhausted OAuth accounts")
 	}
 }
+
+func TestSRAutoSwitchDoesNotClobberClaudePool(t *testing.T) {
+	// The shared ref already holds a healthy Claude pool (maintained elsewhere
+	// by the proxy's provider-aware refresh).
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+		{AccountID: "claude@x", Provider: accounts.ProviderClaude, Headroom: 0.90, ShortHeadroom: 0.90, Fresh: true},
+	}))
+	_, err := srAutoSwitchOnce(context.Background(), srAutoSwitchConfig{
+		Accounts: []accounts.Account{
+			{ID: "codex@x", AuthMode: accounts.AuthModeOAuth},
+			{ID: "claude@x", AuthMode: accounts.AuthModeOAuth, Provider: accounts.ProviderClaude},
+		},
+		SchedulerRef: schedulerRef,
+		FetchScores: func(_ context.Context, candidates []accounts.Account) ([]selectacct.Score, int) {
+			for _, candidate := range candidates {
+				if candidate.Provider == accounts.ProviderClaude {
+					t.Fatalf("auto-switch scored a Claude account through the Codex path: %#v", candidate)
+				}
+			}
+			return []selectacct.Score{{AccountID: "codex@x", Headroom: 0.80, ShortHeadroom: 0.80, Fresh: true}}, 1
+		},
+		SwitchActive: func(context.Context, string) error { return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sched := schedulerRef.Get()
+	if sched.Exhausted(accounts.ProviderClaude, "claude@x") {
+		t.Fatal("Claude account exhausted after Codex auto-switch (pool clobbered)")
+	}
+	if got := sched.ScoreFor(accounts.ProviderClaude, "claude@x").Headroom; got != 0.90 {
+		t.Fatalf("Claude headroom = %v, want 0.90 preserved", got)
+	}
+}
+
+func TestCodexOAuthAccountsFilter(t *testing.T) {
+	got := codexOAuthAccounts([]accounts.Account{
+		{ID: "bare", AuthMode: accounts.AuthModeOAuth},
+		{ID: "codex", AuthMode: accounts.AuthModeOAuth, Provider: accounts.ProviderCodex},
+		{ID: "claude", AuthMode: accounts.AuthModeOAuth, Provider: accounts.ProviderClaude},
+		{ID: "apikey", AuthMode: accounts.AuthModeAPIKey},
+	})
+	if len(got) != 2 {
+		t.Fatalf("got %d accounts, want 2 (bare + codex)", len(got))
+	}
+	for _, a := range got {
+		if a.ID != "bare" && a.ID != "codex" {
+			t.Fatalf("unexpected account kept by codexOAuthAccounts: %#v", a)
+		}
+	}
+}

--- a/internal/selectacct/scheduler_ref.go
+++ b/internal/selectacct/scheduler_ref.go
@@ -100,11 +100,54 @@ func (r *SchedulerRef) pruneExpired(now time.Time) {
 func (r *SchedulerRef) Set(scheduler Scheduler) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	base := r.scheduler
-	r.scheduler = scheduler
-	r.retainExhaustedExpiriesLocked()
-	r.scheduler = stripCarriedForwardExhaustionOverlays(r.scheduler, base, r.expiryMarksLocked())
+	r.applySnapshotLocked(scheduler, r.scheduler, nil)
+}
+
+// applySnapshotLocked installs next as the base snapshot and reconciles the
+// exhaustion overlay against it. updated scopes the reconciliation to a set of
+// ScoreKeys: nil means "reconcile every mark" (a full replace, as Set and
+// FinishRefresh do), while a partial refresh passes only the keys it actually
+// rescored so it never disturbs another pool's marks. Callers hold r.mu.
+func (r *SchedulerRef) applySnapshotLocked(next, base Scheduler, updated map[string]bool) {
+	r.scheduler = next
+	r.retainExhaustedExpiriesLocked(updated)
+	r.scheduler = stripCarriedForwardExhaustionOverlays(r.scheduler, base, r.expiryMarksLocked(), updated)
 	r.updatedAt = time.Now()
+}
+
+// UpdateScores merges fresh scores for a subset of accounts into the current
+// snapshot, preserving the score of every account not in the update. Unlike
+// Set (which replaces the whole map), a single-provider refresher can call this
+// without clobbering another provider's pool: scores are keyed by
+// ScoreKey(provider, accountID), so a Codex-only refresh leaves Claude's keys
+// untouched instead of dropping them to the optimistic default. Reconciliation
+// and live-debit resets are scoped to the refreshed keys, so another pool's
+// request-time exhaustion marks and accumulated debits are left intact. Passing
+// no scores is a no-op refresh of updatedAt.
+func (r *SchedulerRef) UpdateScores(scores []Score) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	base := r.scheduler
+	merged := make(map[string]Score, len(base.scores)+len(scores))
+	for key, score := range base.scores {
+		merged[key] = score
+	}
+	updated := make(map[string]bool, len(scores))
+	for _, score := range scores {
+		key := ScoreKey(score.Provider, score.AccountID)
+		merged[key] = score
+		updated[key] = true
+		// Fresh scores supersede the live debits accrued against the old
+		// snapshot — but only for the keys this refresh actually rescored, never
+		// another pool's debits (FinishRefresh clears the whole map because it
+		// rescores every account).
+		delete(r.routedSinceRefresh, key)
+	}
+	r.applySnapshotLocked(
+		Scheduler{scores: merged, sessionCounts: base.sessionCounts, liveDebits: base.liveDebits},
+		base,
+		updated,
+	)
 }
 
 // retainExhaustedExpiriesLocked reconciles mark expiries with an incoming
@@ -123,12 +166,19 @@ func (r *SchedulerRef) Set(scheduler Scheduler) {
 //     request-time expiry can never lapse a freshly-observed zero back to the
 //     optimistic default. Expiries only extend here, never shorten, so an
 //     authoritative long reset from a rejected response still holds.
-func (r *SchedulerRef) retainExhaustedExpiriesLocked() {
+func (r *SchedulerRef) retainExhaustedExpiriesLocked(updated map[string]bool) {
 	now := time.Now()
 	for key := range r.exhaustedUntil {
 		scoreKey, _, poolKey, ok := exhaustionKeyParts(key)
 		if !ok {
 			delete(r.exhaustedUntil, key)
+			continue
+		}
+		if updated != nil && !updated[scoreKey] {
+			// Partial refresh: this mark belongs to a pool we did not rescore.
+			// Its base score is unchanged, so reconciling here would delete a
+			// still-valid request-time mark (the base score reads healthy while
+			// the account is actually rate-limited via this overlay).
 			continue
 		}
 		score, ok := r.scheduler.scores[scoreKey]
@@ -347,7 +397,7 @@ func copyModelScores(modelScores map[string]Score) map[string]Score {
 	return out
 }
 
-func stripCarriedForwardExhaustionOverlays(current, base Scheduler, exhaustedUntil map[string]time.Time) Scheduler {
+func stripCarriedForwardExhaustionOverlays(current, base Scheduler, exhaustedUntil map[string]time.Time, updated map[string]bool) Scheduler {
 	if len(exhaustedUntil) == 0 {
 		return current
 	}
@@ -362,6 +412,11 @@ func stripCarriedForwardExhaustionOverlays(current, base Scheduler, exhaustedUnt
 	for key := range exhaustedUntil {
 		scoreKey, _, poolKey, ok := exhaustionKeyParts(key)
 		if !ok {
+			continue
+		}
+		if updated != nil && !updated[scoreKey] {
+			// Partial refresh: leave marks for pools we did not rescore intact
+			// (see retainExhaustedExpiriesLocked).
 			continue
 		}
 		if poolKey != "" && !base.hasModelScore(poolKey) {
@@ -435,10 +490,7 @@ func (r *SchedulerRef) FinishRefresh(scheduler Scheduler, update bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if update {
-		base := r.scheduler
-		r.scheduler = scheduler
-		r.retainExhaustedExpiriesLocked()
-		r.scheduler = stripCarriedForwardExhaustionOverlays(r.scheduler, base, r.expiryMarksLocked())
+		r.applySnapshotLocked(scheduler, r.scheduler, nil)
 		// Fresh scores supersede the live debits accumulated against the old
 		// snapshot. A failed refresh (update=false) keeps them: the snapshot
 		// is still the old one, so its debits still apply.

--- a/internal/selectacct/scheduler_ref_test.go
+++ b/internal/selectacct/scheduler_ref_test.go
@@ -1,6 +1,7 @@
 package selectacct
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -340,5 +341,127 @@ func TestPoolScopedRetainLeavesOtherPoolMark(t *testing.T) {
 	}
 	if !ref.Get().ForModel(opus).Exhausted(accounts.ProviderClaude, "a@example.com") {
 		t.Fatal("opus mark should still apply after fable refresh")
+	}
+}
+
+func TestUpdateScoresPreservesOtherProviders(t *testing.T) {
+	ref := NewSchedulerRef(NewScheduler([]Score{
+		{AccountID: "claude@x", Provider: accounts.ProviderClaude, Headroom: 0.90, ShortHeadroom: 0.90, Fresh: true},
+		{AccountID: "codex@x", Provider: accounts.ProviderCodex, Headroom: 0.50, ShortHeadroom: 0.50, Fresh: true},
+	}))
+	// A Codex-only refresh (mirroring the sr auto-switch) must not touch Claude.
+	ref.UpdateScores([]Score{
+		{AccountID: "codex@x", Provider: accounts.ProviderCodex, Headroom: 0.10, ShortHeadroom: 0.10, Fresh: true},
+	})
+	sched := ref.Get()
+	if got := sched.ScoreFor(accounts.ProviderClaude, "claude@x").Headroom; got != 0.90 {
+		t.Fatalf("Claude headroom = %v, want 0.90 (must survive a Codex-only update)", got)
+	}
+	if sched.Exhausted(accounts.ProviderClaude, "claude@x") {
+		t.Fatal("Claude account became exhausted after a Codex-only update")
+	}
+	if got := sched.ScoreFor(accounts.ProviderCodex, "codex@x").Headroom; got != 0.10 {
+		t.Fatalf("Codex headroom = %v, want 0.10 (the fresh update)", got)
+	}
+}
+
+func TestUpdateScoresAddsNewProviderKeys(t *testing.T) {
+	ref := NewSchedulerRef(NewScheduler(nil))
+	ref.UpdateScores([]Score{
+		{AccountID: "codex@x", Provider: accounts.ProviderCodex, Headroom: 0.30, ShortHeadroom: 0.30, Fresh: true},
+	})
+	if got := ref.Get().ScoreFor(accounts.ProviderClaude, "claude@x").Headroom; got != 1 {
+		t.Fatalf("unscored Claude headroom = %v, want optimistic 1", got)
+	}
+	if got := ref.Get().ScoreFor(accounts.ProviderCodex, "codex@x").Headroom; got != 0.30 {
+		t.Fatalf("Codex headroom = %v, want 0.30", got)
+	}
+}
+
+func TestUpdateScoresPreservesOtherProviderExhaustionMark(t *testing.T) {
+	ref := NewSchedulerRef(NewScheduler([]Score{
+		{AccountID: "claude@x", Provider: accounts.ProviderClaude, Headroom: 0.90, ShortHeadroom: 0.90, Fresh: true},
+		{AccountID: "codex@x", Provider: accounts.ProviderCodex, Headroom: 0.90, ShortHeadroom: 0.90, Fresh: true},
+	}))
+	// Both accounts just 429'd — request-time marks recorded as read-time overlays
+	// (MarkExhausted writes only exhaustedUntil; the base score stays healthy).
+	ref.MarkExhausted(accounts.ProviderClaude, "claude@x", "")
+	ref.MarkExhausted(accounts.ProviderCodex, "codex@x", "")
+	// A Codex-only refresh must not disturb Claude's mark. Codex's own mark is in
+	// scope and correctly reconciled away by its fresh healthy score.
+	ref.UpdateScores([]Score{
+		{AccountID: "codex@x", Provider: accounts.ProviderCodex, Headroom: 0.90, ShortHeadroom: 0.90, Fresh: true},
+	})
+	sched := ref.Get()
+	if !sched.Exhausted(accounts.ProviderClaude, "claude@x") {
+		t.Fatal("Claude request-time exhaustion mark was cleared by a Codex-only UpdateScores")
+	}
+	if sched.Exhausted(accounts.ProviderCodex, "codex@x") {
+		t.Fatal("Codex mark should have been reconciled away by its own fresh healthy score")
+	}
+}
+
+func TestUpdateScoresClearsLiveDebitsForRefreshedKeysOnly(t *testing.T) {
+	ref := NewSchedulerRef(NewScheduler([]Score{
+		{AccountID: "claude@x", Provider: accounts.ProviderClaude, Headroom: 0.90, ShortHeadroom: 0.90, Fresh: true},
+		{AccountID: "codex@x", Provider: accounts.ProviderCodex, Headroom: 0.90, ShortHeadroom: 0.90, Fresh: true},
+	}))
+	ref.NoteRouted(accounts.ProviderClaude, "claude@x")
+	ref.NoteRouted(accounts.ProviderCodex, "codex@x")
+	// Fresh Codex scores supersede Codex's live debit, but Claude's must persist.
+	ref.UpdateScores([]Score{
+		{AccountID: "codex@x", Provider: accounts.ProviderCodex, Headroom: 0.80, ShortHeadroom: 0.80, Fresh: true},
+	})
+	debits := ref.LiveDebits()
+	if _, ok := debits[ScoreKey(accounts.ProviderCodex, "codex@x")]; ok {
+		t.Fatal("refreshed Codex key's live debit should be cleared (fresh score supersedes it)")
+	}
+	if got := debits[ScoreKey(accounts.ProviderClaude, "claude@x")]; got != 1 {
+		t.Fatalf("Claude live debit should survive a Codex-only update; got %v, want 1", got)
+	}
+}
+
+func TestUpdateScoresConcurrentWithRefreshAndReads(t *testing.T) {
+	ref := NewSchedulerRef(NewScheduler([]Score{
+		{AccountID: "codex@x", Provider: accounts.ProviderCodex, Headroom: 0.5, ShortHeadroom: 0.5},
+		{AccountID: "claude@x", Provider: accounts.ProviderClaude, Headroom: 0.5, ShortHeadroom: 0.5},
+	}))
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(4)
+		go func() {
+			defer wg.Done()
+			ref.UpdateScores([]Score{{AccountID: "codex@x", Provider: accounts.ProviderCodex, Headroom: 0.7, ShortHeadroom: 0.7, Fresh: true}})
+		}()
+		go func() {
+			defer wg.Done()
+			ref.FinishRefresh(NewScheduler([]Score{{AccountID: "claude@x", Provider: accounts.ProviderClaude, Headroom: 0.6, ShortHeadroom: 0.6, Fresh: true}}), true)
+		}()
+		go func() {
+			defer wg.Done()
+			ref.NoteRouted(accounts.ProviderCodex, "codex@x")
+		}()
+		go func() {
+			defer wg.Done()
+			_ = ref.Get()
+		}()
+	}
+	wg.Wait()
+}
+
+// TestUpdateScoresNormalizesBareCodexProvider locks the load-bearing invariant:
+// a bare-provider ("") Codex score must collapse to the same ScoreKey as a
+// ProviderCodex-tagged mark, or scoped reconciliation would miss the mark.
+func TestUpdateScoresNormalizesBareCodexProvider(t *testing.T) {
+	ref := NewSchedulerRef(NewScheduler([]Score{
+		{AccountID: "codex@x", Provider: accounts.ProviderCodex, Headroom: 0.9, ShortHeadroom: 0.9, Fresh: true},
+	}))
+	ref.MarkExhausted(accounts.ProviderCodex, "codex@x", "")
+	// Refresh with a bare-provider score (Provider left "").
+	ref.UpdateScores([]Score{
+		{AccountID: "codex@x", Headroom: 0.9, ShortHeadroom: 0.9, Fresh: true},
+	})
+	if ref.Get().Exhausted(accounts.ProviderCodex, "codex@x") {
+		t.Fatal("bare-provider score did not normalize to the ProviderCodex ScoreKey; fresh score failed to reconcile the mark")
 	}
 }


### PR DESCRIPTION
## Summary

The `sr` auto-switch scores every OAuth account through the Codex usage endpoint, which zeroes Claude accounts' scores and makes `claude-sr` return `503 no non-exhausted claude accounts available` while real Claude quota exists.

## Problem

`srAutoSwitchOnce` selects the active **Codex** account (`switchActive` writes the Codex auth via `DefaultCodexStore`), but `oauthAccounts()` filters by `AuthMode` only — so it feeds **all** OAuth accounts, Codex **and** Claude, into `fetchCodexScores`. A Claude OAuth token 401s against the Codex usage endpoint, so `setZeroScore` gives every Claude account `headroom=0`. The auto-switch then calls `SchedulerRef.Set` (a wholesale replace), and that ref is shared with the proxy's Claude routing gate (`scheduler.Exhausted(claude)` → 503).

Observed: a Claude request or `sr status` transiently repairs it (the proxy's per-request `scoreAccounts` is provider-aware and scores Claude against the Anthropic endpoint), but the next auto-switch tick (default 10m) re-zeroes Claude — so it presents as intermittent 503s.

## Fix (per-provider-partitioned)

1. The auto-switch scores Codex accounts only (`codexOAuthAccounts` — OAuth && provider ∈ {codex, ""}).
2. New `SchedulerRef.UpdateScores` **merges** a provider's fresh scores into the shared snapshot instead of replacing it, and scopes exhaustion-mark reconciliation + live-debit resets to the refreshed keys, so a single-provider refresh never touches another pool's marks/scores/debits. `Set`/`FinishRefresh` route through a shared `applySnapshotLocked` with a `nil` scope (= all keys) and are behavior-preserved.

Scores are already keyed by `ScoreKey(provider, accountID)`; this just makes every writer respect that partition.

## Backwards compatibility

No API/flag/serialization changes. `Set` and `FinishRefresh` keep identical behavior (the new `scope` argument is `nil` on those paths, making the guard dead). No new dependencies (stdlib only).

## Tests

Added to `internal/selectacct` and `cmd/subrouter`:
- `UpdateScores` merge + optimistic-default-for-unseen-keys
- exhaustion-mark preservation across a single-provider refresh (fails without the scope fix)
- scoped live-debit clearing (refreshed keys only)
- `ScoreKey` bare-vs-tagged Codex normalization
- a `-race` concurrency test (`UpdateScores` vs `FinishRefresh` vs `Get`/`NoteRouted`)
- `codexOAuthAccounts` filter

## Validation

```
go test -race ./internal/selectacct/ ./cmd/subrouter/
go test ./...
go vet ./...
```

Companion to #73 (both are Claude-pooling fixes we currently carry as patches downstream).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786842891&installation_id=133855650&pr_number=77&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F77&signature=e59a922ae2599d9378e467c11ec72ed6eb91956c3fa7d7947de2cd35ac2307a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the `sr` auto-switch to Codex accounts and merges Codex scores into the shared scheduler to prevent wiping Claude pool state, fixing intermittent `503 no non-exhausted claude accounts available` errors.

- **Bug Fixes**
  - Score Codex OAuth accounts only in `srAutoSwitchOnce` via `codexOAuthAccounts`; stop hitting Codex usage with Claude tokens.
  - Use `SchedulerRef.UpdateScores` during auto-switch to merge Codex scores instead of replacing all provider scores.
  - Scope exhaustion-mark reconciliation and live-debit resets to updated keys so a Codex refresh never alters Claude marks, scores, or debits.

- **Refactors**
  - Added `applySnapshotLocked` and routed `Set`/`FinishRefresh` through it with full scope (behavior unchanged).
  - Normalize bare provider `""` as Codex to align with `ScoreKey` and keep partitioning consistent.

<sup>Written for commit b548d95e65c5fa91c394a5f704ce7308ca3ed9e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatic account switching now targets Codex OAuth accounts, including legacy unscoped OAuth accounts.
  - Non-Codex OAuth accounts are excluded from Codex account selection.

- **Bug Fixes**
  - Switching between Codex accounts no longer affects account availability or health tracking for other providers.
  - Provider-specific usage, exhaustion, and availability state are preserved during partial updates.
  - Improved consistency during simultaneous account refreshes and routing activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->