### PR TITLE
Fix supervised worker socket unlink; harden one-time supervisor activation

### DIFF
--- a/cmd/subrouter/supervisor.go
+++ b/cmd/subrouter/supervisor.go
@@ -162,13 +162,18 @@ func startWorkerGeneration(config supervisorConfig) (*workerGeneration, error) {
 		_ = os.RemoveAll(socketDir)
 		return nil, err
 	}
-	fileListener, ok := listener.(interface{ File() (*os.File, error) })
+	unixListener, ok := listener.(*net.UnixListener)
 	if !ok {
 		_ = listener.Close()
 		_ = os.RemoveAll(socketDir)
 		return nil, errors.New("worker listener cannot be inherited")
 	}
-	file, err := fileListener.File()
+	// The supervisor closes its copy of the listener after the worker
+	// inherits the fd, but it keeps dialing the socket path for readiness
+	// checks and client routing. Without this, Close unlinks the path and
+	// every dial fails until the readiness timeout kills the worker.
+	unixListener.SetUnlinkOnClose(false)
+	file, err := unixListener.File()
 	if err != nil {
 		_ = listener.Close()
 		_ = os.RemoveAll(socketDir)
@@ -240,6 +245,7 @@ func waitForWorkerReady(generation *workerGeneration, timeout time.Duration) err
 	readyURL := "http://subrouter-worker/_subrouter/ready"
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
+	var lastErr error
 	for {
 		request, _ := http.NewRequestWithContext(ctx, http.MethodGet, readyURL, nil)
 		response, err := client.Do(request)
@@ -248,11 +254,17 @@ func waitForWorkerReady(generation *workerGeneration, timeout time.Duration) err
 			if response.StatusCode == http.StatusOK {
 				return nil
 			}
+			lastErr = fmt.Errorf("ready check returned status %d", response.StatusCode)
+		} else {
+			lastErr = err
 		}
 		select {
 		case <-generation.done:
 			return fmt.Errorf("worker exited before readiness: %w", generation.waitError())
 		case <-ctx.Done():
+			if lastErr != nil {
+				return fmt.Errorf("worker readiness timed out after %s: last error: %w", timeout, lastErr)
+			}
 			return fmt.Errorf("worker readiness timed out after %s", timeout)
 		case <-ticker.C:
 		}

--- a/cmd/subrouter/supervisor_test.go
+++ b/cmd/subrouter/supervisor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -16,6 +17,35 @@ import (
 
 	"github.com/manaflow-ai/subrouter/internal/front"
 )
+
+// TestMain lets the test binary double as a minimal supervised worker so
+// startWorkerGeneration can be exercised end to end without a real build.
+func TestMain(m *testing.M) {
+	if os.Getenv("SUBROUTER_TEST_FAKE_WORKER") == "1" {
+		runFakeWorker()
+		return
+	}
+	os.Exit(m.Run())
+}
+
+func runFakeWorker() {
+	listener, err := inheritedListenerFromEnv()
+	if err != nil || listener == nil {
+		fmt.Fprintln(os.Stderr, "fake worker: no inherited listener:", err)
+		os.Exit(1)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_subrouter/ready", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("fake-worker"))
+	})
+	if err := (&http.Server{Handler: mux}).Serve(listener); err != nil {
+		fmt.Fprintln(os.Stderr, "fake worker:", err)
+		os.Exit(1)
+	}
+}
 
 func TestParseSupervisorConfigSeparatesWorkerArguments(t *testing.T) {
 	config, err := parseSupervisorConfig([]string{
@@ -203,5 +233,49 @@ func TestTerminateWorkerKillsAfterGracePeriod(t *testing.T) {
 	terminateWorker(worker, 10*time.Millisecond)
 	if command.ProcessState == nil || command.ProcessState.Success() {
 		t.Fatalf("worker was not killed after grace period: %v", command.ProcessState)
+	}
+}
+
+// Regression: the supervisor closes its copy of the worker's unix listener
+// after the fork. That close must not unlink the socket path, because the
+// supervisor keeps dialing that path for readiness checks and client routing.
+func TestStartWorkerGenerationKeepsSocketPathDialable(t *testing.T) {
+	t.Setenv("SUBROUTER_TEST_FAKE_WORKER", "1")
+	config := supervisorConfig{
+		WorkerBin:    os.Args[0],
+		ReadyTimeout: 10 * time.Second,
+	}
+	generation, err := startWorkerGeneration(config)
+	if err != nil {
+		t.Fatalf("startWorkerGeneration: %v", err)
+	}
+	t.Cleanup(func() { terminateWorker(generation, time.Second) })
+
+	info, err := os.Lstat(generation.address)
+	if err != nil {
+		t.Fatalf("worker socket path was unlinked: %v", err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("worker socket path is not a socket: %v", info.Mode())
+	}
+
+	connection, err := net.DialTimeout(generation.network, generation.address, time.Second)
+	if err != nil {
+		t.Fatalf("dial worker socket: %v", err)
+	}
+	defer connection.Close()
+	if err := front.WriteProxyProtocolHeader(connection, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprint(connection, "GET /_subrouter/ready HTTP/1.0\r\nHost: worker\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	_ = connection.SetReadDeadline(time.Now().Add(2 * time.Second))
+	status, err := bufio.NewReader(connection).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read worker response: %v", err)
+	}
+	if !strings.Contains(status, "200") {
+		t.Fatalf("worker ready status = %q", status)
 	}
 }

--- a/deploy/macos/migrate-launchdaemon-to-supervisor.sh
+++ b/deploy/macos/migrate-launchdaemon-to-supervisor.sh
@@ -93,19 +93,75 @@ if [ "$ACTIVATE" -ne 1 ]; then
   exit 0
 fi
 
+health_host="$public_addr"
+case "$health_host" in
+  0.0.0.0:*) health_host="127.0.0.1:${public_addr#0.0.0.0:}" ;;
+  \[::\]:*) health_host="127.0.0.1:${public_addr#\[::\]:}" ;;
+esac
+
+wait_for_bootout() {
+  # launchctl bootout returns before the job is unloaded; bootstrapping while
+  # the old job is still terminating fails with "Input/output error".
+  local i=0
+  while launchctl print "system/${LABEL}" >/dev/null 2>&1; do
+    i=$((i + 1))
+    if [ "$i" -ge 120 ]; then
+      echo "system/${LABEL} did not unload after bootout" >&2
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+bootstrap_with_retry() {
+  local i=0
+  until launchctl bootstrap system "$PLIST"; do
+    i=$((i + 1))
+    if [ "$i" -ge 10 ]; then
+      return 1
+    fi
+    sleep 2
+  done
+}
+
+wait_healthy() {
+  local i=0
+  until curl -fsS "http://${health_host}/_subrouter/health" >/dev/null 2>&1; do
+    i=$((i + 1))
+    if [ "$i" -ge 60 ]; then
+      return 1
+    fi
+    sleep 1
+  done
+}
+
 backup="${PLIST}.backup-$(date +%Y%m%d-%H%M%S)"
 cp -p "$PLIST" "$backup"
+
+rollback() {
+  echo "activation failed; rolling back to $backup" >&2
+  launchctl bootout "system/${LABEL}" 2>/dev/null || true
+  wait_for_bootout || true
+  cp -p "$backup" "$PLIST"
+  if bootstrap_with_retry && wait_healthy; then
+    echo "rolled back to previous unsupervised service" >&2
+  else
+    echo "ROLLBACK FAILED; service is down. Restore manually from $backup" >&2
+  fi
+  exit 1
+}
+
 mv -f "$prepared" "$PLIST"
 launchctl bootout "system/${LABEL}" 2>/dev/null || true
-launchctl bootstrap system "$PLIST"
+wait_for_bootout || rollback
+bootstrap_with_retry || rollback
 
 i=0
 until curl -fsS --unix-socket "$CONTROL_SOCKET" "http://localhost/_subrouter/supervisor-status" >/dev/null 2>&1 \
-  && curl -fsS "http://${public_addr}/_subrouter/health" >/dev/null 2>&1; do
+  && curl -fsS "http://${health_host}/_subrouter/health" >/dev/null 2>&1; do
   i=$((i + 1))
   if [ "$i" -ge 60 ]; then
-    echo "supervised service failed health checks; restore $backup" >&2
-    exit 1
+    rollback
   fi
   sleep 1
 done

--- a/deploy/macos/migrate-launchdaemon-to-supervisor.sh
+++ b/deploy/macos/migrate-launchdaemon-to-supervisor.sh
@@ -8,7 +8,7 @@ LABEL="${SUBROUTER_LABEL:-ai.manaflow.subrouter-team}"
 PLIST="${SUBROUTER_PLIST:-/Library/LaunchDaemons/${LABEL}.plist}"
 WORKER_BIN="${SUBROUTER_BIN:-/usr/local/bin/subrouter}"
 SUPERVISOR_BIN="${SUBROUTER_SUPERVISOR_BIN:-/usr/local/libexec/subrouter-supervisor}"
-CONTROL_SOCKET="${SUBROUTER_CONTROL_SOCKET:-/var/run/subrouter-supervisor.sock}"
+CONTROL_SOCKET="${SUBROUTER_CONTROL_SOCKET:-}"
 ACTIVATE=0
 [ "${1:-}" = "--activate" ] && ACTIVATE=1
 
@@ -26,7 +26,7 @@ fi
 }
 
 prepared="${PLIST}.supervised"
-public_addr="$(PLIST="$PLIST" PREPARED="$prepared" WORKER_BIN="$WORKER_BIN" \
+transform_output="$(PLIST="$PLIST" PREPARED="$prepared" WORKER_BIN="$WORKER_BIN" \
 SUPERVISOR_BIN="$SUPERVISOR_BIN" CONTROL_SOCKET="$CONTROL_SOCKET" python3 <<'PY'
 import os
 import plistlib
@@ -39,6 +39,17 @@ control_socket = os.environ["CONTROL_SOCKET"]
 
 with open(source, "rb") as stream:
     plist = plistlib.load(stream)
+
+if not control_socket:
+    # A non-root service user cannot bind a unix socket inside root-owned
+    # /var/run, so default to the service's own state directory.
+    if plist.get("UserName"):
+        state_dir = (plist.get("EnvironmentVariables") or {}).get(
+            "SUBROUTER_STATE_DIR", "/var/lib/subrouter"
+        )
+        control_socket = os.path.join(state_dir, "supervisor.sock")
+    else:
+        control_socket = "/var/run/subrouter-supervisor.sock"
 
 arguments = list(plist.get("ProgramArguments") or [])
 if len(arguments) < 2 or arguments[1] != "serve":
@@ -83,11 +94,14 @@ with open(temporary, "wb") as stream:
 os.chmod(temporary, 0o644)
 os.replace(temporary, destination)
 print(public_addr)
+print(control_socket)
 PY
 )"
+public_addr="$(printf '%s\n' "$transform_output" | sed -n 1p)"
+CONTROL_SOCKET="$(printf '%s\n' "$transform_output" | sed -n 2p)"
 
 plutil -lint "$prepared"
-echo "Prepared $prepared"
+echo "Prepared $prepared (control socket: $CONTROL_SOCKET)"
 if [ "$ACTIVATE" -ne 1 ]; then
   echo "Not activated. Re-run with --activate for the one-time listener transition."
   exit 0

--- a/deploy/macos/subrouter-autoupdate.sh
+++ b/deploy/macos/subrouter-autoupdate.sh
@@ -8,10 +8,31 @@ set -euo pipefail
 REPO="${SUBROUTER_REPO:-manaflow-ai/subrouter}"
 BIN="${SUBROUTER_BIN:-/usr/local/bin/subrouter}"
 VERSION_FILE="${SUBROUTER_VERSION_FILE:-/etc/subrouter-version}"
-CONTROL_SOCKET="${SUBROUTER_CONTROL_SOCKET:-/var/run/subrouter-supervisor.sock}"
+LABEL="${SUBROUTER_LABEL:-ai.manaflow.subrouter-team}"
+PLIST="${SUBROUTER_PLIST:-/Library/LaunchDaemons/${LABEL}.plist}"
+CONTROL_SOCKET="${SUBROUTER_CONTROL_SOCKET:-}"
 HEALTH_URL="${SUBROUTER_HEALTH_URL:-http://127.0.0.1:31415/_subrouter/health}"
 
 log() { echo "subrouter-autoupdate: $*"; }
+
+if [ -z "$CONTROL_SOCKET" ] && [ -f "$PLIST" ]; then
+  # The migration script places the control socket in the service's state
+  # directory; read the authoritative path from the LaunchDaemon.
+  CONTROL_SOCKET="$(PLIST="$PLIST" python3 - <<'PY'
+import os, plistlib
+with open(os.environ["PLIST"], "rb") as stream:
+    arguments = plistlib.load(stream).get("ProgramArguments") or []
+for i, argument in enumerate(arguments):
+    if argument == "--control-socket" and i + 1 < len(arguments):
+        print(arguments[i + 1])
+        break
+    if argument.startswith("--control-socket="):
+        print(argument.split("=", 1)[1])
+        break
+PY
+)"
+fi
+CONTROL_SOCKET="${CONTROL_SOCKET:-/var/run/subrouter-supervisor.sock}"
 
 case "$(uname -m)" in
   x86_64|amd64) arch="amd64" ;;

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -31,9 +31,11 @@ Replace the worker binary atomically, then ask the stable supervisor to create a
 ```bash
 install -m 0755 ./subrouter /usr/local/bin/subrouter.new
 mv -f /usr/local/bin/subrouter.new /usr/local/bin/subrouter
-curl -fsS --unix-socket /var/run/subrouter-supervisor.sock -X POST http://localhost/_subrouter/upgrade
-curl -fsS --unix-socket /var/run/subrouter-supervisor.sock http://localhost/_subrouter/supervisor-status | jq
+curl -fsS --unix-socket /var/lib/subrouter/supervisor.sock -X POST http://localhost/_subrouter/upgrade
+curl -fsS --unix-socket /var/lib/subrouter/supervisor.sock http://localhost/_subrouter/supervisor-status | jq
 ```
+
+The control socket lives in the service's state directory (`/var/lib/subrouter/supervisor.sock` for a `_subrouter` service user) because a non-root service cannot bind inside root-owned `/var/run`. The migration script writes the chosen path into the LaunchDaemon `--control-socket` argument, and `subrouter-autoupdate.sh` reads it back from the plist.
 
 `deploy/macos/subrouter-autoupdate.sh` performs the same sequence with release checksum verification and automatic worker-binary rollback when readiness fails.
 
@@ -172,7 +174,7 @@ For a successful compact, expect a `subrouter_meta` row for `POST /responses/com
 The permissioned Unix control socket reports the active generation and the connection count pinned to every draining generation. Browser pages cannot reach this socket or trigger upgrades:
 
 ```bash
-curl -fsS --unix-socket /var/run/subrouter-supervisor.sock http://localhost/_subrouter/supervisor-status | jq
+curl -fsS --unix-socket /var/lib/subrouter/supervisor.sock http://localhost/_subrouter/supervisor-status | jq
 ```
 
 There is intentionally no drain timeout. A routine upgrade never terminates a worker that still owns a client connection.


### PR DESCRIPTION
## Summary

Activating `subrouter supervise` on cmux-mac-mini took the service down: the supervisor started workers, every readiness probe timed out after 30s, the supervisor killed the healthy worker, and launchd looped. Root cause: Go's `UnixListener.Close` unlinks the socket path by default. The supervisor closes its copy of the worker listener right after the worker inherits the fd, which removed the exact path the supervisor dials for readiness checks and client routing. The fix is `SetUnlinkOnClose(false)` before handing the fd to the worker. Readiness timeouts now also include the last probe error so the next failure like this is diagnosable from the log.

The first commit adds the failing regression test (worker socket path must remain a dialable socket after `startWorkerGeneration`), the second adds the fix, per the red/green convention.

The third commit hardens `migrate-launchdaemon-to-supervisor.sh --activate`. On the mini, `launchctl bootstrap` immediately after `bootout` failed with `Input/output error` because the old job was still unloading, and `set -e` exited mid-transition leaving no service loaded. Activation now waits for the old job to unload, retries bootstrap, normalizes `0.0.0.0`/`[::]` listen addresses for health probes, and rolls back to the backup plist automatically if the supervised service does not become healthy.

Verified locally end to end: supervised listener binds, `POST /_subrouter/upgrade` via the control socket switches new connections to a fresh worker while a held-open client connection keeps being served by the old generation, and the old worker is reaped once its connection count reaches zero.

## Test plan

- [x] `go test ./cmd/subrouter/ -count=1` (regression test fails without the fix, passes with it)
- [x] `go test ./...`
- [x] `bash -n deploy/macos/migrate-launchdaemon-to-supervisor.sh`
- [x] Local `supervise` e2e: health over TCP, upgrade via control socket, held connection survives upgrade, drained worker reaped
- [ ] Activate on cmux-mac-mini and confirm codex + claude traffic

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786874022&installation_id=133855650&pr_number=78&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F78&signature=d8771e2d76c89c58eda858d076a28054c9a96c5af801bee7cc391c7b7630f1d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical supervisor bug that unlinked the worker UNIX socket, breaking readiness checks and routing. Also hardens macOS activation, moves the control socket to a safe path for non-root services, and makes autoupdate discover it automatically.

- **Bug Fixes**
  - Preserve the worker socket by calling `SetUnlinkOnClose(false)` on `net.UnixListener` before handing the fd to the worker; readiness timeouts now include the last probe error.
  - Added a regression test using a fake worker to ensure the socket remains dialable after fork.

- **Migration**
  - Activation waits for `launchctl bootout`, retries `bootstrap`, normalizes `0.0.0.0`/`[::]` to `127.0.0.1` for health checks, and auto-rolls back if the service isn’t healthy.
  - Default the supervisor control socket to the service’s state directory for non-root services (e.g., `/var/lib/subrouter/supervisor.sock`) and surface the chosen path; docs updated.
  - `deploy/macos/subrouter-autoupdate.sh` reads the authoritative `--control-socket` from the LaunchDaemon plist instead of assuming `/var/run`.

<sup>Written for commit 486c432bd4a8fd227ea90d37fcc2d0a205f6d86c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker startup and readiness reporting, including more informative timeout errors.
  * Preserved worker Unix socket paths when supervisor processes close their listener copies.
  * Strengthened macOS service migration with normalized health checks, retry handling, and lifecycle validation.
  * Added automatic rollback to the previous service configuration when supervised activation fails health checks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->