### PR TITLE
Contain Codex model compatibility errors and reroute

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -176,6 +176,7 @@ func serve(args []string) error {
 	kimiUpstreamRaw := flags.String("kimi-upstream", "https://api.kimi.com/coding/v1", "Kimi For Coding upstream base URL")
 	zaiUpstreamRaw := flags.String("zai-upstream", "https://api.z.ai/api/coding/paas/v4", "Z.AI coding upstream base URL")
 	sessionPath := flags.String("sessions", session.DefaultStorePath(), "session assignment store")
+	modelIncompatibilityDir := flags.String("model-incompatibilities", "", "durable account/model routing exclusions; defaults next to --sessions")
 	transcriptDir := flags.String("transcripts", "", "directory for raw Subrouter transcript JSONL files")
 	transcriptGCSURI := flags.String("transcript-gcs-uri", "", "optional gs:// bucket/prefix for background transcript sync")
 	transcriptGCSSyncInterval := flags.Duration("transcript-gcs-sync-interval", 5*time.Minute, "interval for background transcript GCS sync; 0 disables")
@@ -208,6 +209,9 @@ func serve(args []string) error {
 	}
 	if *adminToken == "" {
 		*adminToken = strings.TrimSpace(os.Getenv("SUBROUTER_ADMIN_TOKEN"))
+	}
+	if strings.TrimSpace(*modelIncompatibilityDir) == "" {
+		*modelIncompatibilityDir = filepath.Join(filepath.Dir(*sessionPath), "model-incompatibilities")
 	}
 
 	var upstream *url.URL
@@ -260,7 +264,13 @@ func serve(args []string) error {
 	// a deploy restart, so the real scores are fetched in the background and
 	// swapped in once ready. Per-request 401/429 failover covers the brief
 	// window before fresh scores land.
-	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler(fallbackScores(codexAccounts)))
+	schedulerRef, err := selectacct.NewSchedulerRefWithModelStore(
+		selectacct.NewScheduler(fallbackScores(codexAccounts)),
+		selectacct.ModelIncompatibilityStore{Dir: *modelIncompatibilityDir},
+	)
+	if err != nil {
+		return fmt.Errorf("load model incompatibilities: %w", err)
+	}
 	if *fetchUsage {
 		go func() {
 			fetchedScores, successful := fetchCodexScoresWithStore(context.Background(), codexStore, codexAccounts)

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -100,24 +100,25 @@ type srSwitchOptions struct {
 }
 
 type srUsageRow struct {
-	email              string
-	active             bool
-	planType           string
-	windows            []accounts.UsageWindow
-	credits            *accounts.CreditsInfo
-	complimentaryReset *accounts.ComplimentaryResetInfo
-	apiKeySpend        *accounts.APIKeyUsageSnapshot
-	apiKeyHint         string
-	err                error
-	score              selectacct.Score
-	gtoReason          string
-	gtoRecommended     bool
-	cooked             bool
-	cookedReason       string
-	tempCooked         bool
-	tempCookedReason   string
-	authMode           accounts.AuthMode
-	provider           accounts.Provider
+	email                  string
+	active                 bool
+	planType               string
+	windows                []accounts.UsageWindow
+	credits                *accounts.CreditsInfo
+	complimentaryReset     *accounts.ComplimentaryResetInfo
+	apiKeySpend            *accounts.APIKeyUsageSnapshot
+	apiKeyHint             string
+	err                    error
+	score                  selectacct.Score
+	gtoReason              string
+	gtoRecommended         bool
+	cooked                 bool
+	cookedReason           string
+	tempCooked             bool
+	tempCookedReason       string
+	modelIncompatibilities []selectacct.ModelIncompatibility
+	authMode               accounts.AuthMode
+	provider               accounts.Provider
 }
 
 func cxAlias(args []string) error {
@@ -1665,6 +1666,27 @@ func displayUsageRowsGrid(out io.Writer, rows []srUsageRow, numbered, perGroupNu
 		}
 		fmt.Fprintln(out)
 	}
+	if usageRowsHaveModelIncompatibilities(rows) {
+		for _, row := range rows {
+			for _, issue := range row.modelIncompatibilities {
+				message := issue.Message
+				if message == "" {
+					message = issue.Code
+				}
+				observed := ""
+				if !issue.ObservedAt.IsZero() {
+					observed = " (observed " + issue.ObservedAt.UTC().Format(time.RFC3339) + ")"
+				}
+				fmt.Fprintf(out, "  %s %s: %s blocked: %s%s\n",
+					style(colored, ansiBold+ansiWhite, displayAccountName(row.email)),
+					style(colored, ansiDim, "["+string(usageProvider(row))+"]"),
+					style(colored, ansiYellow, issue.Model),
+					style(colored, ansiYellow, message),
+					style(colored, ansiDim, observed))
+			}
+		}
+		fmt.Fprintln(out)
+	}
 }
 
 // printAccountCountSummary prints a one-line total across providers so the user
@@ -1961,6 +1983,9 @@ func usageGridState(row srUsageRow) string {
 	if row.err != nil {
 		states = append(states, "error")
 	}
+	if len(row.modelIncompatibilities) > 0 {
+		states = append(states, "model block")
+	}
 	return strings.Join(states, ", ")
 }
 
@@ -1968,7 +1993,7 @@ func usageGridStateColor(row srUsageRow) string {
 	switch {
 	case row.err != nil || row.cooked:
 		return ansiRed
-	case row.tempCooked:
+	case row.tempCooked || len(row.modelIncompatibilities) > 0:
 		return ansiYellow
 	case row.gtoRecommended:
 		return ansiGreen
@@ -1983,7 +2008,7 @@ func usageGridPickColor(row srUsageRow) string {
 	switch {
 	case row.err != nil || row.cooked:
 		return ansiRed
-	case row.tempCooked || !recommendedForNewSession(row):
+	case row.tempCooked || len(row.modelIncompatibilities) > 0 || !recommendedForNewSession(row):
 		if usageProvider(row) == accounts.ProviderClaude {
 			return ""
 		}
@@ -2019,7 +2044,7 @@ func compactPickReason(row srUsageRow) string {
 		return "Claude profile"
 	}
 	left := fmt.Sprintf("%d%% left", int(row.score.Headroom*100+0.5))
-	suffix := exhaustedModelSuffix(row.windows)
+	suffix := exhaustedModelSuffix(row.windows) + modelIncompatibilitySuffix(row.modelIncompatibilities)
 	if !usableForNewSession(row.score) {
 		return fmt.Sprintf("%s, protected < %d%%%s", left, int(selectacct.MinNewSessionHeadroom*100), suffix)
 	}
@@ -2030,6 +2055,27 @@ func compactPickReason(row srUsageRow) string {
 		return fmt.Sprintf("%s, 5h reset %s%s", left, formatDuration(row.score.ShortResetAfterSeconds), suffix)
 	}
 	return left + suffix
+}
+
+func modelIncompatibilitySuffix(issues []selectacct.ModelIncompatibility) string {
+	if len(issues) == 0 {
+		return ""
+	}
+	models := make([]string, 0, len(issues))
+	seen := make(map[string]bool, len(issues))
+	for _, issue := range issues {
+		model := strings.TrimSpace(issue.Model)
+		key := selectacct.ModelKey(model)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		models = append(models, model)
+	}
+	if len(models) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(models, "/") + " blocked)"
 }
 
 // exhaustedModelSuffix names any per-model quota pools that are fully consumed
@@ -2164,6 +2210,15 @@ func usageGridCreditsCell(row srUsageRow) usageGridCell {
 func usageRowsHaveErrors(rows []srUsageRow) bool {
 	for _, row := range rows {
 		if row.err != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func usageRowsHaveModelIncompatibilities(rows []srUsageRow) bool {
+	for _, row := range rows {
+		if len(row.modelIncompatibilities) > 0 {
 			return true
 		}
 	}

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -739,20 +739,21 @@ type remoteServerAccountStatus struct {
 }
 
 type remoteServerUsageStatus struct {
-	ID                 string                           `json:"id"`
-	Provider           accounts.Provider                `json:"provider"`
-	AuthMode           accounts.AuthMode                `json:"auth_mode"`
-	Email              string                           `json:"email,omitempty"`
-	Source             string                           `json:"source"`
-	AuthChecked        bool                             `json:"auth_checked"`
-	AuthValid          bool                             `json:"auth_valid"`
-	Refreshed          bool                             `json:"refreshed,omitempty"`
-	Error              string                           `json:"error,omitempty"`
-	Active             bool                             `json:"active,omitempty"`
-	PlanType           string                           `json:"plan_type,omitempty"`
-	Windows            []accounts.UsageWindow           `json:"windows,omitempty"`
-	Credits            *accounts.CreditsInfo            `json:"credits,omitempty"`
-	ComplimentaryReset *accounts.ComplimentaryResetInfo `json:"complimentary_reset,omitempty"`
+	ID                     string                            `json:"id"`
+	Provider               accounts.Provider                 `json:"provider"`
+	AuthMode               accounts.AuthMode                 `json:"auth_mode"`
+	Email                  string                            `json:"email,omitempty"`
+	Source                 string                            `json:"source"`
+	AuthChecked            bool                              `json:"auth_checked"`
+	AuthValid              bool                              `json:"auth_valid"`
+	Refreshed              bool                              `json:"refreshed,omitempty"`
+	Error                  string                            `json:"error,omitempty"`
+	Active                 bool                              `json:"active,omitempty"`
+	PlanType               string                            `json:"plan_type,omitempty"`
+	Windows                []accounts.UsageWindow            `json:"windows,omitempty"`
+	Credits                *accounts.CreditsInfo             `json:"credits,omitempty"`
+	ComplimentaryReset     *accounts.ComplimentaryResetInfo  `json:"complimentary_reset,omitempty"`
+	ModelIncompatibilities []selectacct.ModelIncompatibility `json:"model_incompatibilities,omitempty"`
 }
 
 func (r srRunner) fetchServerAccountsResponse(ctx context.Context, server srServerConfig) (*http.Response, error) {
@@ -869,14 +870,15 @@ func usageRowsFromServerUsageStatuses(statuses []remoteServerUsageStatus) []srUs
 			email = "server"
 		}
 		row := srUsageRow{
-			email:              email,
-			active:             status.Active,
-			authMode:           status.AuthMode,
-			planType:           status.PlanType,
-			windows:            status.Windows,
-			credits:            status.Credits,
-			complimentaryReset: status.ComplimentaryReset,
-			provider:           status.Provider,
+			email:                  email,
+			active:                 status.Active,
+			authMode:               status.AuthMode,
+			planType:               status.PlanType,
+			windows:                status.Windows,
+			credits:                status.Credits,
+			complimentaryReset:     status.ComplimentaryReset,
+			modelIncompatibilities: status.ModelIncompatibilities,
+			provider:               status.Provider,
 		}
 		if status.Provider == accounts.ProviderClaude && row.planType == "" {
 			row.planType = "claude"

--- a/cmd/subrouter/sr_server_test.go
+++ b/cmd/subrouter/sr_server_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/internal/selectacct"
 )
 
 func TestSRServerAddStoresGCPServer(t *testing.T) {
@@ -116,6 +117,13 @@ func TestSRServerStatusSendsAdminToken(t *testing.T) {
 				PlanType:           "pro",
 				Windows:            []accounts.UsageWindow{{UsedPercent: 20, LimitWindowSeconds: int64((5 * time.Hour) / time.Second)}},
 				ComplimentaryReset: &accounts.ComplimentaryResetInfo{Known: true, Available: true},
+				ModelIncompatibilities: []selectacct.ModelIncompatibility{{
+					Provider:  accounts.ProviderCodex,
+					AccountID: "acct@example.com",
+					Model:     "gpt-5.6-sol",
+					Code:      selectacct.ModelIncompatibilityCode,
+					Message:   "The model is not supported for this ChatGPT account.",
+				}},
 			}})
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -132,6 +140,9 @@ func TestSRServerStatusSendsAdminToken(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "avail") {
 		t.Fatalf("status did not render complimentary reset status:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "gpt-5.6-sol blocked") || !strings.Contains(out.String(), "The model is not supported for this ChatGPT account.") {
+		t.Fatalf("status did not surface the model incompatibility:\n%s", out.String())
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -286,12 +286,13 @@ type AccountStatus struct {
 
 type AccountUsageStatus struct {
 	AccountStatus
-	Active             bool                             `json:"active,omitempty"`
-	PlanType           string                           `json:"plan_type,omitempty"`
-	Windows            []accounts.UsageWindow           `json:"windows,omitempty"`
-	Credits            *accounts.CreditsInfo            `json:"credits,omitempty"`
-	ComplimentaryReset *accounts.ComplimentaryResetInfo `json:"complimentary_reset,omitempty"`
-	UsageFresh         bool                             `json:"-"`
+	Active                 bool                              `json:"active,omitempty"`
+	PlanType               string                            `json:"plan_type,omitempty"`
+	Windows                []accounts.UsageWindow            `json:"windows,omitempty"`
+	Credits                *accounts.CreditsInfo             `json:"credits,omitempty"`
+	ComplimentaryReset     *accounts.ComplimentaryResetInfo  `json:"complimentary_reset,omitempty"`
+	ModelIncompatibilities []selectacct.ModelIncompatibility `json:"model_incompatibilities,omitempty"`
+	UsageFresh             bool                              `json:"-"`
 }
 
 func NewAccountRef(store accounts.CodexStore, initial []accounts.Account, client *http.Client) *AccountRef {
@@ -1087,8 +1088,16 @@ func (s Server) withRequestTimeExhaustionWindows(statuses []AccountUsageStatus) 
 	}
 	now := time.Now()
 	out := append([]AccountUsageStatus(nil), statuses...)
+	issuesByAccount := make(map[string][]selectacct.ModelIncompatibility)
+	for _, issue := range s.SchedulerRef.ModelIncompatibilities() {
+		key := selectacct.ScoreKey(issue.Provider, issue.AccountID)
+		issuesByAccount[key] = append(issuesByAccount[key], issue)
+	}
 	for i := range out {
 		status := &out[i]
+		if issues := issuesByAccount[selectacct.ScoreKey(status.Provider, status.ID)]; len(issues) > 0 {
+			status.ModelIncompatibilities = append([]selectacct.ModelIncompatibility(nil), issues...)
+		}
 		if status.AuthMode != accounts.AuthModeOAuth {
 			continue
 		}
@@ -2097,12 +2106,13 @@ func (s Server) copyWebSocketMessages(ctx context.Context, agentType, sessionID,
 			modelState.observe(body)
 		}
 		if direction == "upstream_to_client" && messageType == websocket.TextMessage {
-			switch {
-			case usageLimitJSON(body):
+			if usageLimitJSON(body) {
 				s.markAccountExhausted(provider, accountID, poolModel)
-			case provider == accounts.ProviderCodex && codexChatGPTModelUnsupportedJSON(body):
-				if model := modelState.current(); model != "" {
-					_, _ = s.rerouteModelIncompatibility(ctx, provider, agentType, sessionID, userEmail, accountID, model, nil)
+			} else if provider == accounts.ProviderCodex {
+				if message, unsupported := codexChatGPTModelUnsupportedDetailJSON(body); unsupported {
+					if model := modelState.current(); model != "" {
+						_, _ = s.rerouteModelIncompatibility(ctx, provider, agentType, sessionID, userEmail, accountID, model, message, nil)
+					}
 				}
 			}
 			if provider == accounts.ProviderCodex && codexWebSocketResponseFinished(body) {
@@ -2231,26 +2241,62 @@ func usageLimitMessage(value string) bool {
 }
 
 func codexChatGPTModelUnsupportedJSON(body []byte) bool {
-	var event map[string]any
-	if err := json.Unmarshal(body, &event); err != nil {
-		return false
-	}
-	return codexChatGPTModelUnsupportedMap(event)
+	_, unsupported := codexChatGPTModelUnsupportedDetailJSON(body)
+	return unsupported
 }
 
-func codexChatGPTModelUnsupportedMap(event map[string]any) bool {
-	message := strings.ToLower(stringField(event, "message"))
-	if strings.Contains(message, "model is not supported when using codex with a chatgpt account") ||
-		(strings.Contains(message, "model") &&
-			strings.Contains(message, "not supported") &&
-			strings.Contains(message, "codex") &&
-			strings.Contains(message, "chatgpt account")) {
-		return true
+func codexChatGPTModelUnsupportedDetailJSON(body []byte) (string, bool) {
+	var event any
+	if err := json.Unmarshal(body, &event); err != nil {
+		return "", false
 	}
-	if nested, ok := event["error"].(map[string]any); ok {
-		return codexChatGPTModelUnsupportedMap(nested)
+	return codexChatGPTModelUnsupportedValue(event)
+}
+
+func codexChatGPTModelUnsupportedValue(value any) (string, bool) {
+	switch value := value.(type) {
+	case string:
+		message := strings.Join(strings.Fields(value), " ")
+		lower := strings.ToLower(message)
+		unsupported := strings.Contains(lower, "model is not supported when using codex with a chatgpt account") ||
+			(strings.Contains(lower, "model") &&
+				strings.Contains(lower, "not supported") &&
+				strings.Contains(lower, "codex") &&
+				strings.Contains(lower, "chatgpt account"))
+		return message, unsupported
+	case map[string]any:
+		// Upstream has used both {"error":{"message":...}} and
+		// {"detail":...}. Inspect the common envelope keys first, then recurse
+		// through the rest so a harmless schema wrapper cannot disable failover.
+		visited := make(map[string]bool, len(value))
+		for _, key := range []string{"detail", "message", "error"} {
+			visited[key] = true
+			if nested, ok := value[key]; ok {
+				if message, unsupported := codexChatGPTModelUnsupportedValue(nested); unsupported {
+					return message, true
+				}
+			}
+		}
+		keys := make([]string, 0, len(value))
+		for key := range value {
+			if !visited[key] {
+				keys = append(keys, key)
+			}
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			if message, unsupported := codexChatGPTModelUnsupportedValue(value[key]); unsupported {
+				return message, true
+			}
+		}
+	case []any:
+		for _, nested := range value {
+			if message, unsupported := codexChatGPTModelUnsupportedValue(nested); unsupported {
+				return message, true
+			}
+		}
 	}
-	return false
+	return "", false
 }
 
 func stringField(values map[string]any, key string) string {
@@ -2448,8 +2494,10 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 				// default TTL.
 				s.markAccountExhaustedFromResponse(provider, accountID, poolModel, response.StatusCode, response.Header)
 			}
-			if inspectModelCompatibility && codexChatGPTModelUnsupportedJSON(body) {
-				_, _ = s.rerouteModelIncompatibility(responseCtx, provider, agentType, sessionID, "", accountID, compatibilityModel, nil)
+			if inspectModelCompatibility {
+				if message, unsupported := codexChatGPTModelUnsupportedDetailJSON(body); unsupported {
+					_, _ = s.rerouteModelIncompatibility(responseCtx, provider, agentType, sessionID, "", accountID, compatibilityModel, message, nil)
+				}
 			}
 			// Only log the body for the original hard rate-limit statuses
 			// (429/401), whose body is a known rate-limit/auth error envelope. A
@@ -2818,6 +2866,18 @@ func (s Server) accountForSessionProvider(provider accounts.Provider, agentType,
 		// OAuth account usable, selection fails and the handler serves the
 		// fallback chain directly.
 		availableAccounts = oauthAccounts(availableAccounts)
+	}
+	if provider == accounts.ProviderCodex && model != "" && s.SchedulerRef != nil {
+		compatible := make([]accounts.Account, 0, len(availableAccounts))
+		for _, account := range availableAccounts {
+			if !s.SchedulerRef.ModelIncompatible(account.Provider, account.ID, model) {
+				compatible = append(compatible, account)
+			}
+		}
+		if len(compatible) == 0 {
+			return accounts.Account{}, sessionID, userEmail, fmt.Errorf("no %s accounts support model %q", provider, model)
+		}
+		availableAccounts = compatible
 	}
 	if provider == accounts.ProviderCodex || provider == accounts.ProviderClaude {
 		s.refreshUsageScoresIfStale(r.Context())
@@ -3585,8 +3645,9 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			return response, nil
 		}
 		modelUnsupported := false
+		modelUnsupportedMessage := ""
 		if !usageLimited && t.provider == accounts.ProviderCodex {
-			modelUnsupported, inspectErr = responseCodexChatGPTModelUnsupported(response)
+			modelUnsupportedMessage, modelUnsupported, inspectErr = responseCodexChatGPTModelUnsupported(response)
 			if inspectErr != nil {
 				if t.logger != nil {
 					t.logger.Warn("codex model compatibility response inspection failed", "agent", t.agent, "session", t.session, "account", accountID, "method", t.method, "path", t.path, "upstream", t.upstream, "error", inspectErr)
@@ -3619,7 +3680,7 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 		var compatibilityPickErr error
 		if modelUnsupported && t.server != nil {
 			compatibilityNext, compatibilityPickErr = t.server.rerouteModelIncompatibility(
-				req.Context(), t.provider, t.agent, t.session, t.userEmail, accountID, exhaustionPool, tried,
+				req.Context(), t.provider, t.agent, t.session, t.userEmail, accountID, t.poolModel, modelUnsupportedMessage, tried,
 			)
 		}
 		if t.server != nil && exhausted && !modelUnsupported {
@@ -3785,9 +3846,24 @@ func isTerminalCredentialError(err error) bool {
 // pool to OAuth accounts; Fable requests with a fallback chain set it so a
 // metered API-key pool account never preempts the Bedrock stage (the dedicated
 // Fable API key is the chain's own last stage).
-func (s Server) rerouteModelIncompatibility(ctx context.Context, provider accounts.Provider, agentType, sessionID, userEmail, accountID, model string, tried map[string]struct{}) (accounts.Account, error) {
+func (s Server) rerouteModelIncompatibility(ctx context.Context, provider accounts.Provider, agentType, sessionID, userEmail, accountID, model, message string, tried map[string]struct{}) (accounts.Account, error) {
 	if model != "" && s.SchedulerRef != nil {
-		s.SchedulerRef.MarkModelIncompatible(provider, accountID, model)
+		persistErr := s.SchedulerRef.MarkModelIncompatible(provider, accountID, model, message)
+		if s.Logger != nil {
+			fields := []any{
+				"provider", provider,
+				"agent", agentType,
+				"session", sessionID,
+				"account", accountID,
+				"model", model,
+				"message", message,
+			}
+			if persistErr != nil {
+				s.Logger.Error("model incompatibility persistence failed", append(fields, "error", persistErr)...)
+			} else {
+				s.Logger.Warn("account excluded from incompatible model", fields...)
+			}
+		}
 	}
 	if tried == nil {
 		tried = make(map[string]struct{}, 1)
@@ -3933,9 +4009,9 @@ func responseUsageLimit(response *http.Response) (bool, error) {
 	return usageLimitJSON(prefix), nil
 }
 
-func responseCodexChatGPTModelUnsupported(response *http.Response) (bool, error) {
+func responseCodexChatGPTModelUnsupported(response *http.Response) (string, bool, error) {
 	if response == nil || response.Body == nil || response.StatusCode != http.StatusBadRequest {
-		return false, nil
+		return "", false, nil
 	}
 	body := response.Body
 	prefix, err := io.ReadAll(io.LimitReader(body, usageLimitInspectMaxBytes+1))
@@ -3944,21 +4020,22 @@ func responseCodexChatGPTModelUnsupported(response *http.Response) (bool, error)
 			Reader: io.MultiReader(bytes.NewReader(prefix), body),
 			Closer: body,
 		}
-		return false, err
+		return "", false, err
 	}
 	if int64(len(prefix)) > usageLimitInspectMaxBytes {
 		response.Body = prefixReadCloser{
 			Reader: io.MultiReader(bytes.NewReader(prefix), body),
 			Closer: body,
 		}
-		return false, nil
+		return "", false, nil
 	}
 	closeErr := body.Close()
 	response.Body = io.NopCloser(bytes.NewReader(prefix))
 	if closeErr != nil {
-		return false, closeErr
+		return "", false, closeErr
 	}
-	return codexChatGPTModelUnsupportedJSON(prefix), nil
+	message, unsupported := codexChatGPTModelUnsupportedDetailJSON(prefix)
+	return message, unsupported, nil
 }
 
 func (t replayablePostRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1875,6 +1875,11 @@ func (s Server) proxyHandler() http.Handler {
 		}
 		rp.Transport = transport
 		rp.ModifyResponse = func(response *http.Response) error {
+			if requestProvider == accounts.ProviderCodex && account.AuthMode == accounts.AuthModeOAuth {
+				if err := s.replaceEscapedCodexModelCompatibilityResponse(response, sessionAgentType, sessionID, userEmail, account.ID, retryPoolModel); err != nil {
+					return err
+				}
+			}
 			s.captureResponseBody(response, sessionAgentType, sessionID, account.ID, account.Provider, requestPoolModel, retryPoolModel, proxyRequest.URL.Path)
 			return nil
 		}
@@ -1937,21 +1942,8 @@ func baseURLProbeRequest(r *http.Request) bool {
 	return r.Method == http.MethodHead && (r.URL.Path == "" || r.URL.Path == "/")
 }
 
-func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account accounts.Account, agentType, sessionID, userEmail, poolModel, compatibilityModel string, upstream *url.URL) {
-	upstreamURL := cloneURL(r.URL)
-	upstreamURL.Scheme = websocketScheme(upstream.Scheme)
-	upstreamURL.Host = upstream.Host
-	upstreamURL.Path = joinURLPath(upstream.Path, s.pathForUpstream(upstreamURL.Path, account))
-	upstreamURL.RawPath = ""
-
-	headers := r.Header.Clone()
-	stripWebSocketDialHeaders(headers)
-	session.StripSubrouterHeaders(headers)
-	stripOutboundForwardingHeaders(headers)
-	setAccountAuthHeaders(headers, account)
-	s.recordWebSocketMeta(r, upstreamURL, headers, agentType, sessionID, userEmail, account, upstream)
-
-	upstreamConn, response, err := websocket.DefaultDialer.Dial(upstreamURL.String(), headers)
+func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account accounts.Account, agentType, sessionID, userEmail, poolModel, compatibilityModel string, _ *url.URL) {
+	upstreamConn, response, err := s.dialWebSocketAccount(r.Context(), r, account, agentType, sessionID, userEmail)
 	if err != nil {
 		status := 502
 		if response != nil {
@@ -1980,6 +1972,10 @@ func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account a
 	defer clientConn.Close()
 
 	modelState := &webSocketModelState{model: compatibilityModel}
+	if providerForRequest(agentType, r.URL.Path) == accounts.ProviderCodex {
+		s.proxyCodexWebSocket(r.Context(), r, clientConn, upstreamConn, account, agentType, sessionID, userEmail, modelState)
+		return
+	}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -1993,6 +1989,265 @@ func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account a
 		_ = clientConn.Close()
 	}()
 	wg.Wait()
+}
+
+func (s Server) dialWebSocketAccount(ctx context.Context, r *http.Request, account accounts.Account, agentType, sessionID, userEmail string) (*websocket.Conn, *http.Response, error) {
+	upstream := s.upstreamForRequest(r.URL.Path, account)
+	if upstream == nil {
+		return nil, nil, errors.New("no upstream configured")
+	}
+	upstreamURL := cloneURL(r.URL)
+	upstreamURL.Scheme = websocketScheme(upstream.Scheme)
+	upstreamURL.Host = upstream.Host
+	upstreamURL.Path = joinURLPath(upstream.Path, s.pathForUpstream(r.URL.Path, account))
+	upstreamURL.RawPath = ""
+
+	headers := r.Header.Clone()
+	stripWebSocketDialHeaders(headers)
+	session.StripSubrouterHeaders(headers)
+	stripOutboundForwardingHeaders(headers)
+	setAccountAuthHeaders(headers, account)
+	s.recordWebSocketMeta(r, upstreamURL, headers, agentType, sessionID, userEmail, account, upstream)
+	return websocket.DefaultDialer.DialContext(ctx, upstreamURL.String(), headers)
+}
+
+type webSocketReadResult struct {
+	generation  uint64
+	messageType int
+	body        []byte
+	err         error
+}
+
+type codexWebSocketTurn struct {
+	messageType int
+	body        []byte
+	model       string
+	tried       map[string]struct{}
+}
+
+func readWebSocketResults(ctx context.Context, conn *websocket.Conn, generation uint64, out chan<- webSocketReadResult) {
+	for {
+		messageType, body, err := conn.ReadMessage()
+		result := webSocketReadResult{generation: generation, messageType: messageType, body: body, err: err}
+		select {
+		case out <- result:
+		case <-ctx.Done():
+			return
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// proxyCodexWebSocket owns the account and turn together. A client WebSocket
+// exists longer than any one response, and the model is not known until a
+// response.create frame arrives. Keeping both decisions in this coordinator
+// lets it check durable compatibility before forwarding a turn and replay the
+// same frame on a replacement upstream without exposing the rejected response.
+func (s Server) proxyCodexWebSocket(ctx context.Context, r *http.Request, clientConn, initialUpstream *websocket.Conn, initialAccount accounts.Account, agentType, sessionID, userEmail string, modelState *webSocketModelState) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	clientReads := make(chan webSocketReadResult, 16)
+	upstreamReads := make(chan webSocketReadResult, 16)
+	go readWebSocketResults(ctx, clientConn, 0, clientReads)
+
+	activeConn := initialUpstream
+	defer func() { _ = activeConn.Close() }()
+	activeAccount := initialAccount
+	generation := uint64(1)
+	go readWebSocketResults(ctx, activeConn, generation, upstreamReads)
+	turns := make([]codexWebSocketTurn, 0, 1)
+
+	record := func(direction string, result webSocketReadResult) {
+		if s.Transcripts == nil || result.err != nil {
+			return
+		}
+		s.Transcripts.RecordPayload(agentType, sessionID, "websocket_message", direction, result.body, map[string]any{
+			"opcode": websocketMessageType(result.messageType),
+		})
+	}
+
+	switchAccount := func(next accounts.Account) error {
+		nextConn, response, err := s.dialWebSocketAccount(ctx, r, next, agentType, sessionID, userEmail)
+		if response != nil && response.Body != nil {
+			_ = response.Body.Close()
+		}
+		if err != nil {
+			return err
+		}
+		oldConn := activeConn
+		activeConn = nextConn
+		activeAccount = next
+		generation++
+		go readWebSocketResults(ctx, activeConn, generation, upstreamReads)
+		_ = oldConn.Close()
+		return nil
+	}
+
+	ensureCompatibleAccount := func(turn *codexWebSocketTurn) error {
+		if turn == nil || turn.model == "" || s.SchedulerRef == nil || !s.SchedulerRef.ModelIncompatible(accounts.ProviderCodex, activeAccount.ID, turn.model) {
+			return nil
+		}
+		if turn.tried == nil {
+			turn.tried = make(map[string]struct{})
+		}
+		turn.tried[activeAccount.ID] = struct{}{}
+		for {
+			next, err := s.compatibilityRetryAccount(ctx, accounts.ProviderCodex, agentType, sessionID, userEmail, turn.model, turn.tried)
+			if err != nil {
+				return err
+			}
+			turn.tried[next.ID] = struct{}{}
+			if err := switchAccount(next); err == nil {
+				return nil
+			}
+		}
+	}
+
+	sendFrontTurn := func() error {
+		if len(turns) == 0 {
+			return nil
+		}
+		turn := &turns[0]
+		if err := ensureCompatibleAccount(turn); err != nil {
+			return err
+		}
+		return activeConn.WriteMessage(turn.messageType, turn.body)
+	}
+
+	finishFrontTurn := func() error {
+		if len(turns) > 0 {
+			turns = turns[1:]
+			modelState.complete()
+		}
+		return sendFrontTurn()
+	}
+
+	writeUnavailable := func(model string) error {
+		return clientConn.WriteMessage(websocket.TextMessage, codexWebSocketModelUnavailableEvent(model))
+	}
+
+	for {
+		select {
+		case result := <-clientReads:
+			if result.err != nil {
+				return
+			}
+			record("client_to_upstream", result)
+			if result.messageType == websocket.TextMessage {
+				if model, create := codexWebSocketRequestModelEvent(result.body); create {
+					if model == "" {
+						model = modelState.current()
+					}
+					modelState.observe(result.body)
+					turns = append(turns, codexWebSocketTurn{
+						messageType: result.messageType,
+						body:        append([]byte(nil), result.body...),
+						model:       model,
+						tried:       map[string]struct{}{activeAccount.ID: {}},
+					})
+					if len(turns) > 1 {
+						continue
+					}
+					if err := sendFrontTurn(); err != nil {
+						if writeErr := writeUnavailable(model); writeErr != nil {
+							return
+						}
+						_ = finishFrontTurn()
+					}
+					continue
+				}
+			}
+			if err := activeConn.WriteMessage(result.messageType, result.body); err != nil {
+				return
+			}
+
+		case result := <-upstreamReads:
+			if result.generation != generation {
+				continue
+			}
+			if result.err != nil {
+				return
+			}
+			record("upstream_to_client", result)
+			if result.messageType == websocket.TextMessage {
+				if message, unsupported := codexWebSocketModelUnsupportedDetailJSON(result.body); unsupported {
+					model := codexModelFromUnsupportedMessage(message)
+					var turn *codexWebSocketTurn
+					if len(turns) > 0 {
+						turn = &turns[0]
+						if turn.model != "" {
+							model = turn.model
+						}
+					}
+					tried := map[string]struct{}{activeAccount.ID: {}}
+					if turn != nil {
+						if turn.tried == nil {
+							turn.tried = tried
+						}
+						tried = turn.tried
+					}
+					next, retryErr := s.rerouteModelIncompatibility(ctx, accounts.ProviderCodex, agentType, sessionID, userEmail, activeAccount.ID, model, message, tried)
+					for retryErr == nil && turn != nil {
+						tried[next.ID] = struct{}{}
+						retryErr = switchAccount(next)
+						if retryErr == nil {
+							retryErr = activeConn.WriteMessage(turn.messageType, turn.body)
+						}
+						if retryErr == nil {
+							break
+						}
+						next, retryErr = s.compatibilityRetryAccount(ctx, accounts.ProviderCodex, agentType, sessionID, userEmail, model, tried)
+					}
+					if retryErr == nil && turn != nil {
+						if s.Logger != nil {
+							s.Logger.Warn("retrying Codex WebSocket turn after model incompatibility", "agent", agentType, "session", sessionID, "account", activeAccount.ID, "model", model)
+						}
+						continue
+					}
+					if s.Logger != nil {
+						s.Logger.Warn("Codex model incompatibility suppressed before WebSocket client", "agent", agentType, "session", sessionID, "account", activeAccount.ID, "model", model, "error", retryErr)
+					}
+					if err := writeUnavailable(model); err != nil {
+						return
+					}
+					if err := finishFrontTurn(); err != nil {
+						return
+					}
+					continue
+				}
+				if usageLimitJSON(result.body) {
+					s.markAccountExhausted(accounts.ProviderCodex, activeAccount.ID, "")
+				}
+			}
+			if err := clientConn.WriteMessage(result.messageType, result.body); err != nil {
+				return
+			}
+			if result.messageType == websocket.TextMessage && codexWebSocketResponseFinished(result.body) {
+				if err := finishFrontTurn(); err != nil {
+					return
+				}
+			}
+		}
+	}
+}
+
+func codexWebSocketModelUnavailableEvent(model string) []byte {
+	errorBody := map[string]any{
+		"type": "error",
+		"error": map[string]any{
+			"type":    "subrouter_model_unavailable",
+			"code":    codexNoCompatibleAccountCode,
+			"message": "Subrouter has no compatible account for the requested model. Run `sr` to inspect blocked accounts.",
+		},
+	}
+	if model = session.NormalizeModel(model); model != "" {
+		errorBody["error"].(map[string]any)["model"] = model
+	}
+	body, _ := json.Marshal(errorBody)
+	return body
 }
 
 func stripWebSocketDialHeaders(headers http.Header) {
@@ -2109,7 +2364,7 @@ func (s Server) copyWebSocketMessages(ctx context.Context, agentType, sessionID,
 			if usageLimitJSON(body) {
 				s.markAccountExhausted(provider, accountID, poolModel)
 			} else if provider == accounts.ProviderCodex {
-				if message, unsupported := codexChatGPTModelUnsupportedDetailJSON(body); unsupported {
+				if message, unsupported := codexWebSocketModelUnsupportedDetailJSON(body); unsupported {
 					if model := modelState.current(); model != "" {
 						_, _ = s.rerouteModelIncompatibility(ctx, provider, agentType, sessionID, userEmail, accountID, model, message, nil)
 					}
@@ -2246,57 +2501,92 @@ func codexChatGPTModelUnsupportedJSON(body []byte) bool {
 }
 
 func codexChatGPTModelUnsupportedDetailJSON(body []byte) (string, bool) {
-	var event any
+	var event map[string]any
 	if err := json.Unmarshal(body, &event); err != nil {
 		return "", false
 	}
-	return codexChatGPTModelUnsupportedValue(event)
-}
-
-func codexChatGPTModelUnsupportedValue(value any) (string, bool) {
-	switch value := value.(type) {
+	// Only documented error-envelope fields are evidence. Recursing through an
+	// arbitrary response frame lets ordinary assistant text or tool arguments
+	// impersonate an upstream error and permanently quarantine a healthy
+	// account.
+	for _, key := range []string{"detail", "message"} {
+		if message, unsupported := codexChatGPTModelUnsupportedMessage(event[key]); unsupported {
+			return message, true
+		}
+	}
+	switch value := event["error"].(type) {
 	case string:
-		message := strings.Join(strings.Fields(value), " ")
-		lower := strings.ToLower(message)
-		unsupported := strings.Contains(lower, "model is not supported when using codex with a chatgpt account") ||
-			(strings.Contains(lower, "model") &&
-				strings.Contains(lower, "not supported") &&
-				strings.Contains(lower, "codex") &&
-				strings.Contains(lower, "chatgpt account"))
-		return message, unsupported
+		return codexChatGPTModelUnsupportedMessage(value)
 	case map[string]any:
-		// Upstream has used both {"error":{"message":...}} and
-		// {"detail":...}. Inspect the common envelope keys first, then recurse
-		// through the rest so a harmless schema wrapper cannot disable failover.
-		visited := make(map[string]bool, len(value))
-		for _, key := range []string{"detail", "message", "error"} {
-			visited[key] = true
-			if nested, ok := value[key]; ok {
-				if message, unsupported := codexChatGPTModelUnsupportedValue(nested); unsupported {
-					return message, true
-				}
-			}
-		}
-		keys := make([]string, 0, len(value))
-		for key := range value {
-			if !visited[key] {
-				keys = append(keys, key)
-			}
-		}
-		sort.Strings(keys)
-		for _, key := range keys {
-			if message, unsupported := codexChatGPTModelUnsupportedValue(value[key]); unsupported {
-				return message, true
-			}
-		}
-	case []any:
-		for _, nested := range value {
-			if message, unsupported := codexChatGPTModelUnsupportedValue(nested); unsupported {
+		for _, key := range []string{"message", "detail"} {
+			if message, unsupported := codexChatGPTModelUnsupportedMessage(value[key]); unsupported {
 				return message, true
 			}
 		}
 	}
 	return "", false
+}
+
+func codexChatGPTModelUnsupportedMessage(value any) (string, bool) {
+	message, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	message = strings.Join(strings.Fields(message), " ")
+	lower := strings.ToLower(message)
+	return message, strings.Contains(lower, "model is not supported when using codex with a chatgpt account")
+}
+
+func codexModelFromUnsupportedMessage(message string) string {
+	lower := strings.ToLower(message)
+	marker := " model is not supported when using codex with a chatgpt account"
+	markerIndex := strings.Index(lower, marker)
+	if markerIndex < 0 {
+		return ""
+	}
+	prefix := message[:markerIndex]
+	end := strings.LastIndex(prefix, "'")
+	if end <= 0 {
+		return ""
+	}
+	start := strings.LastIndex(prefix[:end], "'")
+	if start < 0 || start+1 >= end {
+		return ""
+	}
+	return session.NormalizeModel(prefix[start+1 : end])
+}
+
+func codexWebSocketModelUnsupportedDetailJSON(body []byte) (string, bool) {
+	var event map[string]any
+	if err := json.Unmarshal(body, &event); err != nil {
+		return "", false
+	}
+	eventType := stringField(event, "type")
+	if eventType != "" && !strings.EqualFold(eventType, "error") {
+		return "", false
+	}
+	// The Responses WebSocket protocol normally wraps failures in a typed error
+	// event. Some ChatGPT gateways instead send the same HTTP-style root detail
+	// or error envelope after the upgrade. Accept those exact envelope shapes,
+	// while still rejecting response/tool frames whose nested text merely quotes
+	// the compatibility message.
+	if eventType == "" {
+		if message, unsupported := codexChatGPTModelUnsupportedMessage(event["detail"]); unsupported {
+			return message, true
+		}
+		switch value := event["error"].(type) {
+		case string:
+			return codexChatGPTModelUnsupportedMessage(value)
+		case map[string]any:
+			for _, key := range []string{"message", "detail"} {
+				if message, unsupported := codexChatGPTModelUnsupportedMessage(value[key]); unsupported {
+					return message, true
+				}
+			}
+		}
+		return "", false
+	}
+	return codexChatGPTModelUnsupportedDetailJSON(body)
 }
 
 func stringField(values map[string]any, key string) string {
@@ -2799,6 +3089,32 @@ func (s Server) pathForUpstream(path string, account accounts.Account) string {
 	return path
 }
 
+// routeRequestToAccount reapplies the same account-specific upstream mapping
+// used by the handler's first attempt. Compatibility failover can cross from a
+// ChatGPT subscription to the OpenAI API-key endpoint, so swapping only the
+// Authorization header would send the right credential to the wrong host.
+func (s Server) routeRequestToAccount(r *http.Request, publicPath string, account accounts.Account) error {
+	if r == nil || r.URL == nil {
+		return errors.New("request URL is required")
+	}
+	// Direct transport tests and embedders may supply an already-routed base
+	// RoundTripper without configuring Server upstream URLs. In that mode the
+	// transport remains the routing owner, as it was before cross-host retry.
+	if s.Upstream == nil && s.CodexUpstream == nil && s.APIUpstream == nil {
+		return nil
+	}
+	upstream := s.upstreamForRequest(publicPath, account)
+	if upstream == nil {
+		return errors.New("no upstream configured for retry account")
+	}
+	r.URL.Scheme = upstream.Scheme
+	r.URL.Host = upstream.Host
+	r.URL.Path = joinURLPath(upstream.Path, s.pathForUpstream(publicPath, account))
+	r.URL.RawPath = ""
+	r.Host = ""
+	return nil
+}
+
 func chatGPTBackendUpstream(codexUpstream *url.URL) *url.URL {
 	upstream := cloneURL(codexUpstream)
 	if upstream == nil {
@@ -2851,6 +3167,9 @@ func (s Server) accountForSessionProvider(provider accounts.Provider, agentType,
 		if provider == accounts.ProviderCodex && chatGPTBackendPath(r.URL.Path) && account.AuthMode != accounts.AuthModeOAuth {
 			return accounts.Account{}, sessionID, userEmail, fmt.Errorf("requested account %q cannot be used for ChatGPT backend paths", forcedAccountID)
 		}
+		if provider == accounts.ProviderCodex && model != "" && s.SchedulerRef != nil && s.SchedulerRef.ModelIncompatible(provider, account.ID, model) {
+			return accounts.Account{}, sessionID, userEmail, fmt.Errorf("requested account %q does not support model %q", forcedAccountID, model)
+		}
 		assignment, err := s.Sessions.Put(agentType, sessionID, account.ID, userEmail)
 		if err != nil {
 			return accounts.Account{}, sessionID, userEmail, err
@@ -2870,7 +3189,7 @@ func (s Server) accountForSessionProvider(provider accounts.Provider, agentType,
 	if provider == accounts.ProviderCodex && model != "" && s.SchedulerRef != nil {
 		compatible := make([]accounts.Account, 0, len(availableAccounts))
 		for _, account := range availableAccounts {
-			if !s.SchedulerRef.ModelIncompatible(account.Provider, account.ID, model) {
+			if !s.SchedulerRef.ModelIncompatible(provider, account.ID, model) {
 				compatible = append(compatible, account)
 			}
 		}
@@ -3579,6 +3898,15 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 	if maxAttempts < 1 {
 		maxAttempts = 1
 	}
+	// A compatibility rejection is account-specific. Give a replayable Codex
+	// request enough attempts to exhaust every configured subscription before
+	// its final API-key candidate, even when the generic usage-limit retry budget
+	// is smaller than the account pool.
+	if t.provider == accounts.ProviderCodex && t.poolModel != "" && t.server != nil {
+		if accountCount := len(filterAccountsForProvider(t.server.accountList(), t.provider)); accountCount > maxAttempts {
+			maxAttempts = accountCount
+		}
+	}
 	base := t.base
 	if base == nil {
 		base = http.DefaultTransport
@@ -3697,6 +4025,9 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			if fallback, ok := t.fableFallbackResponse(response, accountID, reason); ok {
 				return fallback, nil
 			}
+			if modelUnsupported {
+				return codexModelUnavailableResponse(response, t.poolModel), nil
+			}
 			t.logClaudeFailoverExhausted(response, accountID, reason, attempt, maxAttempts, len(tried))
 			return response, nil
 		}
@@ -3710,6 +4041,9 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			}
 			if fallback, ok := t.fableFallbackResponse(response, accountID, "no_alternate_account"); ok {
 				return fallback, nil
+			}
+			if modelUnsupported {
+				return codexModelUnavailableResponse(response, t.poolModel), nil
 			}
 			t.logClaudeFailoverExhausted(response, accountID, "no_alternate_account", attempt, maxAttempts, len(tried))
 			return response, nil
@@ -3735,9 +4069,18 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 		attemptReq.Body = body
 		attemptReq.GetBody = req.GetBody
 		attemptReq.ContentLength = req.ContentLength
+		if t.provider == accounts.ProviderCodex {
+			if err := t.server.routeRequestToAccount(attemptReq, t.path, nextAccount); err != nil {
+				return nil, err
+			}
+		}
 		setAccountAuthHeaders(attemptReq.Header, nextAccount)
 		if t.logger != nil {
-			t.logger.Warn("retrying replayable upstream request after usage limit", "agent", t.agent, "session", t.session, "previous_account", previousAccount, "account", accountID, "method", t.method, "path", t.path, "upstream", t.upstream, "attempt", attempt+1, "max_attempts", maxAttempts)
+			message := "retrying replayable upstream request after usage limit"
+			if modelUnsupported {
+				message = "retrying replayable upstream request after model incompatibility"
+			}
+			t.logger.Warn(message, "agent", t.agent, "session", t.session, "previous_account", previousAccount, "account", accountID, "method", t.method, "path", t.path, "upstream", attemptReq.URL.Host, "attempt", attempt+1, "max_attempts", maxAttempts)
 		}
 	}
 	return base.RoundTrip(req)
@@ -3871,9 +4214,11 @@ func (s Server) rerouteModelIncompatibility(ctx context.Context, provider accoun
 	if accountID != "" {
 		tried[accountID] = struct{}{}
 	}
-	account, err := s.oauthRetryAccount(ctx, provider, agentType, sessionID, userEmail, model, tried, true)
+	// Try every compatible subscription before a metered account. The second
+	// pass admits API keys only after the OAuth pool is incompatible or unusable.
+	account, err := s.compatibilityRetryAccount(ctx, provider, agentType, sessionID, userEmail, model, tried)
 	if err != nil && s.Logger != nil {
-		s.Logger.Warn("model incompatibility has no alternate OAuth account",
+		s.Logger.Warn("model incompatibility has no compatible fallback account",
 			"provider", provider,
 			"agent", agentType,
 			"session", sessionID,
@@ -3882,6 +4227,14 @@ func (s Server) rerouteModelIncompatibility(ctx context.Context, provider accoun
 			"error", err)
 	}
 	return account, err
+}
+
+func (s Server) compatibilityRetryAccount(ctx context.Context, provider accounts.Provider, agentType, sessionID, userEmail, model string, tried map[string]struct{}) (accounts.Account, error) {
+	account, err := s.oauthRetryAccount(ctx, provider, agentType, sessionID, userEmail, model, tried, true)
+	if err == nil {
+		return account, nil
+	}
+	return s.oauthRetryAccount(ctx, provider, agentType, sessionID, userEmail, model, tried, false)
 }
 
 func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provider, agentType, sessionID, userEmail, poolModel string, tried map[string]struct{}, oauthOnly bool) (accounts.Account, error) {
@@ -3907,6 +4260,9 @@ func (s Server) oauthRetryAccount(ctx context.Context, provider accounts.Provide
 				continue
 			}
 			if oauthOnly && account.AuthMode != accounts.AuthModeOAuth {
+				continue
+			}
+			if poolModel != "" && s.SchedulerRef != nil && s.SchedulerRef.ModelIncompatible(provider, account.ID, poolModel) {
 				continue
 			}
 			if account.AuthMode == accounts.AuthModeOAuth && scheduler.Exhausted(account.Provider, account.ID) {
@@ -4010,7 +4366,7 @@ func responseUsageLimit(response *http.Response) (bool, error) {
 }
 
 func responseCodexChatGPTModelUnsupported(response *http.Response) (string, bool, error) {
-	if response == nil || response.Body == nil || response.StatusCode != http.StatusBadRequest {
+	if response == nil || response.Body == nil || response.StatusCode < http.StatusBadRequest || response.StatusCode >= http.StatusInternalServerError {
 		return "", false, nil
 	}
 	body := response.Body
@@ -4036,6 +4392,69 @@ func responseCodexChatGPTModelUnsupported(response *http.Response) (string, bool
 	}
 	message, unsupported := codexChatGPTModelUnsupportedDetailJSON(prefix)
 	return message, unsupported, nil
+}
+
+// replaceEscapedCodexModelCompatibilityResponse is the final HTTP boundary.
+// Active retry normally consumes compatibility failures inside the transport,
+// but oversized/non-replayable requests and future transport changes still
+// pass through ModifyResponse. This guard makes the raw upstream rejection
+// impossible to write to a client.
+func (s Server) replaceEscapedCodexModelCompatibilityResponse(response *http.Response, agentType, sessionID, userEmail, accountID, model string) error {
+	message, unsupported, err := responseCodexChatGPTModelUnsupported(response)
+	if err != nil || !unsupported {
+		return err
+	}
+	if model == "" {
+		model = codexModelFromUnsupportedMessage(message)
+	}
+	if model != "" {
+		responseCtx := context.Background()
+		if response.Request != nil {
+			responseCtx = response.Request.Context()
+		}
+		_, _ = s.rerouteModelIncompatibility(responseCtx, accounts.ProviderCodex, agentType, sessionID, userEmail, accountID, model, message, nil)
+	}
+	if s.Logger != nil {
+		s.Logger.Warn("Codex model incompatibility suppressed before HTTP client", "agent", agentType, "session", sessionID, "account", accountID, "model", model)
+	}
+	replacement := codexModelUnavailableResponse(response, model)
+	*response = *replacement
+	return nil
+}
+
+const codexNoCompatibleAccountCode = "subrouter_no_compatible_account"
+
+func codexModelUnavailableResponse(original *http.Response, model string) *http.Response {
+	if original == nil {
+		original = &http.Response{}
+	}
+	if original.Body != nil {
+		_ = original.Body.Close()
+	}
+	model = session.NormalizeModel(model)
+	payload := map[string]any{
+		"error": map[string]any{
+			"type":    "subrouter_model_unavailable",
+			"code":    codexNoCompatibleAccountCode,
+			"message": "Subrouter has no compatible account for the requested model. Run `sr` to inspect blocked accounts.",
+		},
+	}
+	if model != "" {
+		payload["error"].(map[string]any)["model"] = model
+	}
+	body, _ := json.Marshal(payload)
+	body = append(body, '\n')
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	header.Set("X-Subrouter-Error", codexNoCompatibleAccountCode)
+	return &http.Response{
+		StatusCode:    http.StatusServiceUnavailable,
+		Status:        fmt.Sprintf("%d %s", http.StatusServiceUnavailable, http.StatusText(http.StatusServiceUnavailable)),
+		Header:        header,
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Request:       original.Request,
+	}
 }
 
 func (t replayablePostRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -1109,6 +1109,41 @@ func TestUsageStatusEndpointIncludesClaudeRequestTimeExhaustion(t *testing.T) {
 	t.Fatalf("missing Fable window: %+v", statuses[0].Windows)
 }
 
+func TestUsageStatusEndpointIncludesModelIncompatibility(t *testing.T) {
+	ref := selectacct.NewSchedulerRef(selectacct.NewScheduler(nil))
+	message := "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."
+	if err := ref.MarkModelIncompatible(accounts.ProviderCodex, "free@example.com", "gpt-5.6-sol", message); err != nil {
+		t.Fatal(err)
+	}
+	handler := Server{
+		Accounts: []accounts.Account{{
+			ID:       "free@example.com",
+			Provider: accounts.ProviderCodex,
+			AuthMode: accounts.AuthModeOAuth,
+			Email:    "free@example.com",
+		}},
+		SchedulerRef: ref,
+		MaxBodyBytes: 1024,
+	}.Handler()
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/_subrouter/usage-status", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var statuses []AccountUsageStatus
+	if err := json.Unmarshal(recorder.Body.Bytes(), &statuses); err != nil {
+		t.Fatal(err)
+	}
+	if len(statuses) != 1 || len(statuses[0].ModelIncompatibilities) != 1 {
+		t.Fatalf("statuses = %+v", statuses)
+	}
+	issue := statuses[0].ModelIncompatibilities[0]
+	if issue.Model != "gpt-5.6-sol" || issue.Message != message {
+		t.Fatalf("issue = %+v", issue)
+	}
+}
+
 func TestReloadAccountsHotLoadsNewAccountWithoutRestart(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	accountStore := accounts.CodexStore{Dir: t.TempDir()}
@@ -3112,6 +3147,63 @@ func TestHandlerRetriesCodexModelCompatibilityErrorOnAlternateOAuthAccount(t *te
 	}
 	if accountMarked {
 		t.Fatal("model incompatibility must not mark the whole account exhausted")
+	}
+	issues := schedulerRef.ModelIncompatibilities()
+	if len(issues) != 1 || issues[0].Model != "gpt-5.6-sol" {
+		t.Fatalf("model incompatibilities = %+v, want original model name", issues)
+	}
+}
+
+func TestHandlerNeverRoutesKnownModelIncompatibility(t *testing.T) {
+	upstreamCalls := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{{
+		AccountID:     "free@example.com",
+		Provider:      accounts.ProviderCodex,
+		Headroom:      0.80,
+		ShortHeadroom: 0.80,
+	}}))
+	if err := schedulerRef.MarkModelIncompatible(accounts.ProviderCodex, "free@example.com", "gpt-5.6-sol", "unsupported"); err != nil {
+		t.Fatal(err)
+	}
+	handler := Server{
+		Upstream: upstreamURL,
+		Accounts: []accounts.Account{{
+			ID:       "free@example.com",
+			Provider: accounts.ProviderCodex,
+			AuthMode: accounts.AuthModeOAuth,
+			Token:    "free-token",
+		}},
+		Sessions:     store,
+		SchedulerRef: schedulerRef,
+		MaxBodyBytes: 1024,
+	}.Handler()
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5.6-sol","input":[]}`))
+	request.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if upstreamCalls != 0 {
+		t.Fatalf("upstream calls = %d, want 0", upstreamCalls)
+	}
+	if !strings.Contains(recorder.Body.String(), `no codex accounts support model "gpt-5.6-sol"`) {
+		t.Fatalf("body = %q", recorder.Body.String())
 	}
 }
 

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -3207,16 +3207,29 @@ func TestHandlerNeverRoutesKnownModelIncompatibility(t *testing.T) {
 	}
 }
 
-func TestHandlerDoesNotRetryCodexModelCompatibilityErrorOnAPIKeyAccount(t *testing.T) {
-	var auths []string
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		auths = append(auths, r.Header.Get("Authorization"))
+func TestHandlerFallsBackToAPIKeyAfterCodexSubscriptionsRejectModel(t *testing.T) {
+	var subscriptionAuths []string
+	subscriptionUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		subscriptionAuths = append(subscriptionAuths, r.Header.Get("Authorization"))
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"error":{"message":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}}`))
 	}))
-	defer upstream.Close()
+	defer subscriptionUpstream.Close()
 
-	upstreamURL, err := url.Parse(upstream.URL)
+	var apiAuths []string
+	var apiPaths []string
+	apiUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiAuths = append(apiAuths, r.Header.Get("Authorization"))
+		apiPaths = append(apiPaths, r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer apiUpstream.Close()
+
+	subscriptionURL, err := url.Parse(subscriptionUpstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	apiURL, err := url.Parse(apiUpstream.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3228,10 +3241,11 @@ func TestHandlerDoesNotRetryCodexModelCompatibilityErrorOnAPIKeyAccount(t *testi
 		t.Fatal(err)
 	}
 	handler := Server{
-		Upstream: upstreamURL,
+		CodexUpstream: subscriptionURL,
+		APIUpstream:   apiURL,
 		Accounts: []accounts.Account{
-			{ID: "incompatible@example.com", AuthMode: accounts.AuthModeOAuth, Token: "incompatible-token"},
-			{ID: "apikey:team-codex-1", AuthMode: accounts.AuthModeAPIKey, Token: "api-token"},
+			{ID: "incompatible@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "incompatible-token"},
+			{ID: "apikey:team-codex-1", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeAPIKey, Token: "api-token"},
 		},
 		Sessions: store,
 		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
@@ -3253,16 +3267,80 @@ func TestHandlerDoesNotRetryCodexModelCompatibilityErrorOnAPIKeyAccount(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer response.Body.Close()
-	if _, err := io.Copy(io.Discard, response.Body); err != nil {
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if response.StatusCode != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400", response.StatusCode)
+	if err := response.Body.Close(); err != nil {
+		t.Fatal(err)
 	}
-	want := []string{"Bearer incompatible-token"}
-	if strings.Join(auths, "\x00") != strings.Join(want, "\x00") {
-		t.Fatalf("auths = %#v, want %#v", auths, want)
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s, want 204", response.StatusCode, body)
+	}
+	if got, want := subscriptionAuths, []string{"Bearer incompatible-token"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("subscription auths = %#v, want %#v", got, want)
+	}
+	if got, want := apiAuths, []string{"Bearer api-token"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("API auths = %#v, want %#v", got, want)
+	}
+	if got, want := apiPaths, []string{"/v1/responses"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("API paths = %#v, want %#v", got, want)
+	}
+}
+
+func TestHandlerNeverReturnsRawCodexModelCompatibilityErrorWhenFailoverExhausted(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"detail":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}`))
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := Server{
+		Upstream: upstreamURL,
+		Accounts: []accounts.Account{{
+			ID: "incompatible@example.com", AuthMode: accounts.AuthModeOAuth, Token: "incompatible-token",
+		}},
+		Sessions: store,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{{
+			AccountID: "incompatible@example.com", Headroom: 0.80, ShortHeadroom: 0.80,
+		}})),
+		MaxBodyBytes: 1024,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	req, err := http.NewRequest(http.MethodPost, subrouter.URL+"/v1/responses", strings.NewReader(`{"model":"gpt-5.6-sol","input":"hello"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := response.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, body = %s, want 503", response.StatusCode, body)
+	}
+	if strings.Contains(string(body), "not supported when using Codex with a ChatGPT account") {
+		t.Fatalf("raw upstream compatibility error escaped: %s", body)
+	}
+	if !strings.Contains(string(body), "subrouter_no_compatible_account") {
+		t.Fatalf("body = %s, want Subrouter-owned compatibility error", body)
 	}
 }
 
@@ -3357,7 +3435,7 @@ func TestCaptureResponseBodyMarksCodexModelCompatibility(t *testing.T) {
 	}
 }
 
-func TestHandlerMarksWebSocketModelCompatibilityAndReroutesReconnect(t *testing.T) {
+func TestHandlerRetriesWebSocketModelCompatibilityWithinConnection(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
 	var auths []string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3415,25 +3493,23 @@ func TestHandlerMarksWebSocketModelCompatibilityAndReroutesReconnect(t *testing.
 	header := http.Header{
 		"X-Subrouter-Session": []string{"session-1"},
 	}
-	for attempt := 0; attempt < 2; attempt++ {
-		conn, _, err := websocket.DefaultDialer.Dial(wsURL, header)
-		if err != nil {
-			t.Fatalf("dial attempt %d: %v", attempt+1, err)
-		}
-		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","response":{"model":"gpt-5.6-sol"}}`)); err != nil {
-			t.Fatalf("write create attempt %d: %v", attempt+1, err)
-		}
-		_, body, err := conn.ReadMessage()
-		if err != nil {
-			t.Fatalf("read attempt %d: %v", attempt+1, err)
-		}
-		_ = conn.Close()
-		if attempt == 0 && !strings.Contains(string(body), "not supported") {
-			t.Fatalf("first body = %q, want compatibility error", body)
-		}
-		if attempt == 1 && !strings.Contains(string(body), "response.done") {
-			t.Fatalf("second body = %q, want success", body)
-		}
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","response":{"model":"gpt-5.6-sol"}}`)); err != nil {
+		t.Fatal(err)
+	}
+	_, body, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "not supported") {
+		t.Fatalf("raw compatibility error escaped to client: %s", body)
+	}
+	if !strings.Contains(string(body), "response.done") {
+		t.Fatalf("body = %q, want transparently retried success", body)
 	}
 
 	want := []string{"Bearer incompatible-token", "Bearer compatible-token"}
@@ -3445,6 +3521,13 @@ func TestHandlerMarksWebSocketModelCompatibilityAndReroutesReconnect(t *testing.
 	}
 	if _, accountMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", ""); accountMarked {
 		t.Fatal("WebSocket compatibility error must not mark the whole account")
+	}
+}
+
+func TestCodexModelCompatibilityParserIgnoresEchoedRequestText(t *testing.T) {
+	body := []byte(`{"type":"response.output_item.done","item":{"type":"function_call","arguments":"check logs for The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}}`)
+	if message, unsupported := codexChatGPTModelUnsupportedDetailJSON(body); unsupported {
+		t.Fatalf("ordinary model output classified as compatibility evidence: %q", message)
 	}
 }
 

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -29,6 +29,15 @@ import (
 	"github.com/manaflow-ai/subrouter/internal/transcript"
 )
 
+func mustWebSocketSessionStore(t *testing.T) *session.Store {
+	t.Helper()
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
 func TestHandlerProxiesWebSocketWithSelectedAccountAuth(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3207,10 +3216,51 @@ func TestHandlerNeverRoutesKnownModelIncompatibility(t *testing.T) {
 	}
 }
 
+func TestHandlerRejectsForcedKnownModelIncompatibilityBeforeUpstream(t *testing.T) {
+	upstreamCalls := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler(nil))
+	if err := schedulerRef.MarkModelIncompatible(accounts.ProviderCodex, "blocked@example.com", "gpt-5.6-sol", "known rejection"); err != nil {
+		t.Fatal(err)
+	}
+	handler := Server{
+		Upstream: upstreamURL,
+		Accounts: []accounts.Account{{
+			ID: "blocked@example.com", AuthMode: accounts.AuthModeOAuth, Token: "blocked-token",
+		}},
+		Sessions:     mustWebSocketSessionStore(t),
+		SchedulerRef: schedulerRef,
+		MaxBodyBytes: 1024,
+	}.Handler()
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5.6-sol","input":[]}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Subrouter-Account-ID", "blocked@example.com")
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if upstreamCalls != 0 {
+		t.Fatalf("upstream calls = %d, want 0", upstreamCalls)
+	}
+}
+
 func TestHandlerFallsBackToAPIKeyAfterCodexSubscriptionsRejectModel(t *testing.T) {
 	var subscriptionAuths []string
+	var attemptOrder []string
 	subscriptionUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		subscriptionAuths = append(subscriptionAuths, r.Header.Get("Authorization"))
+		auth := r.Header.Get("Authorization")
+		subscriptionAuths = append(subscriptionAuths, auth)
+		attemptOrder = append(attemptOrder, auth)
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"error":{"message":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}}`))
 	}))
@@ -3221,6 +3271,7 @@ func TestHandlerFallsBackToAPIKeyAfterCodexSubscriptionsRejectModel(t *testing.T
 	apiUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		apiAuths = append(apiAuths, r.Header.Get("Authorization"))
 		apiPaths = append(apiPaths, r.URL.Path)
+		attemptOrder = append(attemptOrder, r.Header.Get("Authorization"))
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer apiUpstream.Close()
@@ -3245,11 +3296,15 @@ func TestHandlerFallsBackToAPIKeyAfterCodexSubscriptionsRejectModel(t *testing.T
 		APIUpstream:   apiURL,
 		Accounts: []accounts.Account{
 			{ID: "incompatible@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "incompatible-token"},
+			{ID: "subscription-2@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "subscription-2-token"},
+			{ID: "subscription-3@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "subscription-3-token"},
 			{ID: "apikey:team-codex-1", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeAPIKey, Token: "api-token"},
 		},
 		Sessions: store,
 		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
 			{AccountID: "incompatible@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
+			{AccountID: "subscription-2@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
+			{AccountID: "subscription-3@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
 			{AccountID: "apikey:team-codex-1", Headroom: 0.01, ShortHeadroom: 0.01},
 		})),
 		MaxBodyBytes: 1024,
@@ -3277,8 +3332,8 @@ func TestHandlerFallsBackToAPIKeyAfterCodexSubscriptionsRejectModel(t *testing.T
 	if response.StatusCode != http.StatusNoContent {
 		t.Fatalf("status = %d, body = %s, want 204", response.StatusCode, body)
 	}
-	if got, want := subscriptionAuths, []string{"Bearer incompatible-token"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
-		t.Fatalf("subscription auths = %#v, want %#v", got, want)
+	if len(subscriptionAuths) != 3 {
+		t.Fatalf("subscription auths = %#v, want all three subscriptions", subscriptionAuths)
 	}
 	if got, want := apiAuths, []string{"Bearer api-token"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("API auths = %#v, want %#v", got, want)
@@ -3286,11 +3341,14 @@ func TestHandlerFallsBackToAPIKeyAfterCodexSubscriptionsRejectModel(t *testing.T
 	if got, want := apiPaths, []string{"/v1/responses"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("API paths = %#v, want %#v", got, want)
 	}
+	if got, want := attemptOrder[len(attemptOrder)-1], "Bearer api-token"; got != want {
+		t.Fatalf("attempt order = %#v, want API key last", attemptOrder)
+	}
 }
 
 func TestHandlerNeverReturnsRawCodexModelCompatibilityErrorWhenFailoverExhausted(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusUnprocessableEntity)
 		_, _ = w.Write([]byte(`{"detail":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}`))
 	}))
 	defer upstream.Close()
@@ -3521,6 +3579,226 @@ func TestHandlerRetriesWebSocketModelCompatibilityWithinConnection(t *testing.T)
 	}
 	if _, accountMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "incompatible@example.com", ""); accountMarked {
 		t.Fatal("WebSocket compatibility error must not mark the whole account")
+	}
+}
+
+func TestHandlerNeverSendsWebSocketTurnToKnownIncompatibleAccount(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
+	var mu sync.Mutex
+	blockedMessages := 0
+	compatibleMessages := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		_, _, err = conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		mu.Lock()
+		if auth == "Bearer blocked-token" {
+			blockedMessages++
+		} else {
+			compatibleMessages++
+		}
+		mu.Unlock()
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.done"}`)); err != nil {
+			t.Errorf("write success: %v", err)
+		}
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("codex", "session-1", "blocked@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+		{AccountID: "blocked@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
+		{AccountID: "compatible@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
+	}))
+	if err := schedulerRef.MarkModelIncompatible(accounts.ProviderCodex, "blocked@example.com", "gpt-5.6-sol", "known rejection"); err != nil {
+		t.Fatal(err)
+	}
+	handler := Server{
+		Upstream: upstreamURL,
+		Accounts: []accounts.Account{
+			{ID: "blocked@example.com", AuthMode: accounts.AuthModeOAuth, Token: "blocked-token"},
+			{ID: "compatible@example.com", AuthMode: accounts.AuthModeOAuth, Token: "compatible-token"},
+		},
+		Sessions:     store,
+		SchedulerRef: schedulerRef,
+		MaxBodyBytes: 1024,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(subrouter.URL, "http")+"/v1/responses", http.Header{
+		"X-Subrouter-Session": []string{"session-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","response":{"model":"gpt-5.6-sol"}}`)); err != nil {
+		t.Fatal(err)
+	}
+	_, body, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "response.done") {
+		t.Fatalf("body = %s, want success", body)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if blockedMessages != 0 || compatibleMessages != 1 {
+		t.Fatalf("blocked messages = %d, compatible messages = %d", blockedMessages, compatibleMessages)
+	}
+}
+
+func TestHandlerSanitizesWebSocketCompatibilityErrorWithoutFallback(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return
+		}
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"detail":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}`))
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := Server{
+		Upstream: upstreamURL,
+		Accounts: []accounts.Account{{
+			ID: "incompatible@example.com", AuthMode: accounts.AuthModeOAuth, Token: "incompatible-token",
+		}},
+		Sessions:     mustWebSocketSessionStore(t),
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler(nil)),
+		MaxBodyBytes: 1024,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(subrouter.URL, "http")+"/v1/responses", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"gpt-5.6-sol"}`)); err != nil {
+		t.Fatal(err)
+	}
+	_, body, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "not supported when using Codex with a ChatGPT account") {
+		t.Fatalf("raw compatibility error escaped: %s", body)
+	}
+	if !strings.Contains(string(body), codexNoCompatibleAccountCode) {
+		t.Fatalf("body = %s, want Subrouter-owned error", body)
+	}
+}
+
+func TestHandlerRetriesWebSocketCompatibilityThroughAPIKeyUpstream(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
+	subscriptionUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("subscription upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return
+		}
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","error":{"message":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}}`))
+	}))
+	defer subscriptionUpstream.Close()
+
+	var apiPath, apiAuth string
+	apiUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiPath = r.URL.Path
+		apiAuth = r.Header.Get("Authorization")
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("API upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return
+		}
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.done"}`))
+	}))
+	defer apiUpstream.Close()
+
+	subscriptionURL, err := url.Parse(subscriptionUpstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	apiURL, err := url.Parse(apiUpstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := mustWebSocketSessionStore(t)
+	if _, err := store.Put("codex", "session-1", "incompatible@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	handler := Server{
+		CodexUpstream: subscriptionURL,
+		APIUpstream:   apiURL,
+		Accounts: []accounts.Account{
+			{ID: "incompatible@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "incompatible-token"},
+			{ID: "apikey:team", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeAPIKey, Token: "api-token"},
+		},
+		Sessions: store,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{{
+			AccountID: "incompatible@example.com", Provider: accounts.ProviderCodex, Headroom: 0.80, ShortHeadroom: 0.80,
+		}})),
+		MaxBodyBytes: 1024,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(subrouter.URL, "http")+"/v1/responses", http.Header{
+		"X-Subrouter-Session": []string{"session-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"gpt-5.6-sol"}`)); err != nil {
+		t.Fatal(err)
+	}
+	_, body, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "response.done") {
+		t.Fatalf("body = %s, want API-key success", body)
+	}
+	if apiPath != "/v1/responses" || apiAuth != "Bearer api-token" {
+		t.Fatalf("API path/auth = %q/%q", apiPath, apiAuth)
 	}
 }
 

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -3040,7 +3040,7 @@ func TestHandlerRetriesCodexModelCompatibilityErrorOnAlternateOAuthAccount(t *te
 		auths = append(auths, auth)
 		if auth == "Bearer incompatible-token" {
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(`{"error":{"type":"invalid_request_error","message":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}}`))
+			_, _ = w.Write([]byte(`{"detail":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}`))
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/selectacct/model_incompatibility_store.go
+++ b/internal/selectacct/model_incompatibility_store.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -41,6 +42,47 @@ type modelIncompatibilityFile struct {
 // overlap during a zero-disruption deploy.
 type ModelIncompatibilityStore struct {
 	Dir string
+}
+
+// Get reads one deterministic account/model record directly from the durable
+// store. Workers keep positive records in memory, but a cache miss must consult
+// disk so a still-running generation observes evidence written by a peer
+// immediately instead of waiting for its next restart.
+func (s ModelIncompatibilityStore) Get(provider accounts.Provider, accountID, model string) (ModelIncompatibility, bool, error) {
+	if strings.TrimSpace(s.Dir) == "" {
+		return ModelIncompatibility{}, false, nil
+	}
+	query, err := normalizeModelIncompatibility(ModelIncompatibility{
+		Provider:  provider,
+		AccountID: accountID,
+		Model:     model,
+	})
+	if err != nil {
+		return ModelIncompatibility{}, false, err
+	}
+	path := filepath.Join(s.Dir, modelIncompatibilityFilename(query))
+	body, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return ModelIncompatibility{}, false, nil
+	}
+	if err != nil {
+		return ModelIncompatibility{}, false, fmt.Errorf("read model incompatibility %s: %w", path, err)
+	}
+	var file modelIncompatibilityFile
+	if err := json.Unmarshal(body, &file); err != nil {
+		return ModelIncompatibility{}, false, fmt.Errorf("read model incompatibility %s: %w", path, err)
+	}
+	if file.Version != modelIncompatibilitySchemaVersion {
+		return ModelIncompatibility{}, false, fmt.Errorf("read model incompatibility %s: unsupported version %d", path, file.Version)
+	}
+	issue, err := normalizeModelIncompatibility(file.Issue)
+	if err != nil {
+		return ModelIncompatibility{}, false, fmt.Errorf("read model incompatibility %s: %w", path, err)
+	}
+	if modelIncompatibilityKey(issue.Provider, issue.AccountID, issue.Model) != modelIncompatibilityKey(query.Provider, query.AccountID, query.Model) {
+		return ModelIncompatibility{}, false, fmt.Errorf("read model incompatibility %s: record identity mismatch", path)
+	}
+	return issue, true, nil
 }
 
 func (s ModelIncompatibilityStore) Load() ([]ModelIncompatibility, error) {

--- a/internal/selectacct/model_incompatibility_store.go
+++ b/internal/selectacct/model_incompatibility_store.go
@@ -1,0 +1,183 @@
+package selectacct
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+const modelIncompatibilitySchemaVersion = 1
+
+const ModelIncompatibilityCode = "codex_chatgpt_model_unsupported"
+
+// ModelIncompatibility is durable evidence that one subscription account
+// cannot serve one model. It is deliberately model-scoped so the account stays
+// available for models it supports.
+type ModelIncompatibility struct {
+	Provider   accounts.Provider `json:"provider"`
+	AccountID  string            `json:"account_id"`
+	Model      string            `json:"model"`
+	Code       string            `json:"code"`
+	Message    string            `json:"message"`
+	ObservedAt time.Time         `json:"observed_at"`
+}
+
+type modelIncompatibilityFile struct {
+	Version int                  `json:"version"`
+	Issue   ModelIncompatibility `json:"issue"`
+}
+
+// ModelIncompatibilityStore writes one atomic file per account/model pair.
+// Separate files avoid lost updates while old and new supervised workers
+// overlap during a zero-disruption deploy.
+type ModelIncompatibilityStore struct {
+	Dir string
+}
+
+func (s ModelIncompatibilityStore) Load() ([]ModelIncompatibility, error) {
+	if strings.TrimSpace(s.Dir) == "" {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(s.Dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	byKey := make(map[string]ModelIncompatibility)
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(s.Dir, entry.Name())
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		var file modelIncompatibilityFile
+		if err := json.Unmarshal(body, &file); err != nil {
+			return nil, fmt.Errorf("read model incompatibility %s: %w", path, err)
+		}
+		if file.Version != modelIncompatibilitySchemaVersion {
+			return nil, fmt.Errorf("read model incompatibility %s: unsupported version %d", path, file.Version)
+		}
+		issue, err := normalizeModelIncompatibility(file.Issue)
+		if err != nil {
+			return nil, fmt.Errorf("read model incompatibility %s: %w", path, err)
+		}
+		key := modelIncompatibilityKey(issue.Provider, issue.AccountID, issue.Model)
+		if previous, ok := byKey[key]; !ok || issue.ObservedAt.After(previous.ObservedAt) {
+			byKey[key] = issue
+		}
+	}
+	issues := make([]ModelIncompatibility, 0, len(byKey))
+	for _, issue := range byKey {
+		issues = append(issues, issue)
+	}
+	sortModelIncompatibilities(issues)
+	return issues, nil
+}
+
+func (s ModelIncompatibilityStore) Put(issue ModelIncompatibility) error {
+	if strings.TrimSpace(s.Dir) == "" {
+		return nil
+	}
+	issue, err := normalizeModelIncompatibility(issue)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(s.Dir, 0o700); err != nil {
+		return err
+	}
+	body, err := json.MarshalIndent(modelIncompatibilityFile{
+		Version: modelIncompatibilitySchemaVersion,
+		Issue:   issue,
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	body = append(body, '\n')
+	tmp, err := os.CreateTemp(s.Dir, ".model-incompatibility-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(body); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, filepath.Join(s.Dir, modelIncompatibilityFilename(issue)))
+}
+
+func normalizeModelIncompatibility(issue ModelIncompatibility) (ModelIncompatibility, error) {
+	if issue.Provider == "" {
+		issue.Provider = accounts.ProviderCodex
+	}
+	issue.AccountID = strings.TrimSpace(issue.AccountID)
+	issue.Model = strings.TrimSpace(issue.Model)
+	issue.Code = strings.TrimSpace(issue.Code)
+	issue.Message = strings.Join(strings.Fields(issue.Message), " ")
+	if issue.Code == "" {
+		issue.Code = ModelIncompatibilityCode
+	}
+	if issue.ObservedAt.IsZero() {
+		issue.ObservedAt = time.Now().UTC()
+	} else {
+		issue.ObservedAt = issue.ObservedAt.UTC()
+	}
+	if issue.AccountID == "" {
+		return ModelIncompatibility{}, fmt.Errorf("account id is required")
+	}
+	if ModelKey(issue.Model) == "" {
+		return ModelIncompatibility{}, fmt.Errorf("model is required")
+	}
+	const maxMessageRunes = 512
+	if utf8.RuneCountInString(issue.Message) > maxMessageRunes {
+		issue.Message = string([]rune(issue.Message)[:maxMessageRunes])
+	}
+	return issue, nil
+}
+
+func modelIncompatibilityKey(provider accounts.Provider, accountID, model string) string {
+	return poolScopedExhaustionKey(provider, strings.TrimSpace(accountID), model)
+}
+
+func modelIncompatibilityFilename(issue ModelIncompatibility) string {
+	digest := sha256.Sum256([]byte(modelIncompatibilityKey(issue.Provider, issue.AccountID, issue.Model)))
+	return hex.EncodeToString(digest[:]) + ".json"
+}
+
+func sortModelIncompatibilities(issues []ModelIncompatibility) {
+	sort.Slice(issues, func(i, j int) bool {
+		left, right := issues[i], issues[j]
+		if left.Provider != right.Provider {
+			return left.Provider < right.Provider
+		}
+		if left.AccountID != right.AccountID {
+			return left.AccountID < right.AccountID
+		}
+		return ModelKey(left.Model) < ModelKey(right.Model)
+	})
+}

--- a/internal/selectacct/model_incompatibility_store_test.go
+++ b/internal/selectacct/model_incompatibility_store_test.go
@@ -1,0 +1,64 @@
+package selectacct
+
+import (
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+func TestSchedulerRefPersistsModelIncompatibilityAcrossRestart(t *testing.T) {
+	store := ModelIncompatibilityStore{Dir: t.TempDir()}
+	scheduler := NewScheduler([]Score{
+		{AccountID: "blocked@example.com", Provider: accounts.ProviderCodex, Headroom: 0.8, ShortHeadroom: 0.8},
+		{AccountID: "healthy@example.com", Provider: accounts.ProviderCodex, Headroom: 0.8, ShortHeadroom: 0.8},
+	})
+	ref, err := NewSchedulerRefWithModelStore(scheduler, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	message := "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."
+	if err := ref.MarkModelIncompatible(accounts.ProviderCodex, "blocked@example.com", "gpt-5.6-sol", message); err != nil {
+		t.Fatal(err)
+	}
+
+	restarted, err := NewSchedulerRefWithModelStore(scheduler, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !restarted.Get().ForModel("gpt-5.6-sol").Exhausted(accounts.ProviderCodex, "blocked@example.com") {
+		t.Fatal("restarted scheduler routed to the incompatible account")
+	}
+	if restarted.Get().ForModel("gpt-5.6-sol").Exhausted(accounts.ProviderCodex, "healthy@example.com") {
+		t.Fatal("model incompatibility excluded the healthy account")
+	}
+	issues := restarted.ModelIncompatibilities()
+	if len(issues) != 1 || issues[0].AccountID != "blocked@example.com" || issues[0].Model != "gpt-5.6-sol" || issues[0].Message != message {
+		t.Fatalf("issues = %+v", issues)
+	}
+}
+
+func TestModelIncompatibilityStoreKeepsOverlappingWorkerWrites(t *testing.T) {
+	store := ModelIncompatibilityStore{Dir: t.TempDir()}
+	oldWorker, err := NewSchedulerRefWithModelStore(NewScheduler(nil), store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newWorker, err := NewSchedulerRefWithModelStore(NewScheduler(nil), store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := oldWorker.MarkModelIncompatible(accounts.ProviderCodex, "old@example.com", "gpt-5.6-sol", "old worker rejection"); err != nil {
+		t.Fatal(err)
+	}
+	if err := newWorker.MarkModelIncompatible(accounts.ProviderCodex, "new@example.com", "gpt-5.6-sol", "new worker rejection"); err != nil {
+		t.Fatal(err)
+	}
+
+	restarted, err := NewSchedulerRefWithModelStore(NewScheduler(nil), store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if issues := restarted.ModelIncompatibilities(); len(issues) != 2 {
+		t.Fatalf("issues = %+v, want both worker writes", issues)
+	}
+}

--- a/internal/selectacct/model_incompatibility_store_test.go
+++ b/internal/selectacct/model_incompatibility_store_test.go
@@ -62,3 +62,24 @@ func TestModelIncompatibilityStoreKeepsOverlappingWorkerWrites(t *testing.T) {
 		t.Fatalf("issues = %+v, want both worker writes", issues)
 	}
 }
+
+func TestRunningWorkerReadsModelIncompatibilityWrittenByPeer(t *testing.T) {
+	store := ModelIncompatibilityStore{Dir: t.TempDir()}
+	scheduler := NewScheduler([]Score{{
+		AccountID: "blocked@example.com", Provider: accounts.ProviderCodex, Headroom: 0.8, ShortHeadroom: 0.8,
+	}})
+	writer, err := NewSchedulerRefWithModelStore(scheduler, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := NewSchedulerRefWithModelStore(scheduler, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.MarkModelIncompatible(accounts.ProviderCodex, "blocked@example.com", "gpt-5.6-sol", "peer observation"); err != nil {
+		t.Fatal(err)
+	}
+	if !reader.ModelIncompatible(accounts.ProviderCodex, "blocked@example.com", "gpt-5.6-sol") {
+		t.Fatal("running worker did not observe peer's durable model exclusion")
+	}
+}

--- a/internal/selectacct/model_incompatibility_store_test.go
+++ b/internal/selectacct/model_incompatibility_store_test.go
@@ -79,6 +79,10 @@ func TestRunningWorkerReadsModelIncompatibilityWrittenByPeer(t *testing.T) {
 	if err := writer.MarkModelIncompatible(accounts.ProviderCodex, "blocked@example.com", "gpt-5.6-sol", "peer observation"); err != nil {
 		t.Fatal(err)
 	}
+	issues := reader.ModelIncompatibilities()
+	if len(issues) != 1 || issues[0].AccountID != "blocked@example.com" || issues[0].Model != "gpt-5.6-sol" {
+		t.Fatalf("running worker status issues = %+v, want peer's durable exclusion", issues)
+	}
 	if !reader.ModelIncompatible(accounts.ProviderCodex, "blocked@example.com", "gpt-5.6-sol") {
 		t.Fatal("running worker did not observe peer's durable model exclusion")
 	}

--- a/internal/selectacct/scheduler_ref.go
+++ b/internal/selectacct/scheduler_ref.go
@@ -268,6 +268,7 @@ func (r *SchedulerRef) ModelIncompatibleUntilFor(provider accounts.Provider, acc
 }
 
 func (r *SchedulerRef) ModelIncompatibilities() []ModelIncompatibility {
+	r.refreshModelIncompatibilitiesFromStore()
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	issues := make([]ModelIncompatibility, 0, len(r.modelIncompatibilities))
@@ -282,10 +283,52 @@ func (r *SchedulerRef) ModelIncompatible(provider accounts.Provider, accountID, 
 	if ModelKey(model) == "" {
 		return false
 	}
+	key := modelIncompatibilityKey(provider, accountID, model)
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-	_, ok := r.modelIncompatibilities[modelIncompatibilityKey(provider, accountID, model)]
-	return ok
+	_, ok := r.modelIncompatibilities[key]
+	store := r.modelIncompatibilityStore
+	r.mu.RUnlock()
+	if ok || store == nil {
+		return ok
+	}
+	issue, found, err := store.Get(provider, accountID, model)
+	if err != nil {
+		// Compatibility evidence is a safety boundary. A corrupt or unreadable
+		// record must fail closed so a storage incident cannot route traffic back
+		// to an account that may be known-incompatible.
+		return true
+	}
+	if !found {
+		return false
+	}
+	r.mu.Lock()
+	if r.modelIncompatibilities == nil {
+		r.modelIncompatibilities = make(map[string]ModelIncompatibility)
+	}
+	r.modelIncompatibilities[key] = issue
+	r.mu.Unlock()
+	return true
+}
+
+func (r *SchedulerRef) refreshModelIncompatibilitiesFromStore() {
+	r.mu.RLock()
+	store := r.modelIncompatibilityStore
+	r.mu.RUnlock()
+	if store == nil {
+		return
+	}
+	issues, err := store.Load()
+	if err != nil || len(issues) == 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.modelIncompatibilities == nil {
+		r.modelIncompatibilities = make(map[string]ModelIncompatibility, len(issues))
+	}
+	for _, issue := range issues {
+		r.modelIncompatibilities[modelIncompatibilityKey(issue.Provider, issue.AccountID, issue.Model)] = issue
+	}
 }
 
 var permanentModelIncompatibilityUntil = time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC)

--- a/internal/selectacct/scheduler_ref.go
+++ b/internal/selectacct/scheduler_ref.go
@@ -9,10 +9,12 @@ import (
 )
 
 type SchedulerRef struct {
-	mu         sync.RWMutex
-	scheduler  Scheduler
-	updatedAt  time.Time
-	refreshing bool
+	mu                        sync.RWMutex
+	scheduler                 Scheduler
+	updatedAt                 time.Time
+	refreshing                bool
+	modelIncompatibilityStore *ModelIncompatibilityStore
+	modelIncompatibilities    map[string]ModelIncompatibility
 	// exhaustedUntil expires request-time exhaustion marks. A mark set from a
 	// rejected upstream response is only true until the account's rate-limit
 	// window resets; without an expiry a recovered account stayed zero-scored
@@ -37,13 +39,28 @@ func NewSchedulerRef(scheduler Scheduler) *SchedulerRef {
 	}
 }
 
+func NewSchedulerRefWithModelStore(scheduler Scheduler, store ModelIncompatibilityStore) (*SchedulerRef, error) {
+	issues, err := store.Load()
+	if err != nil {
+		return nil, err
+	}
+	ref := NewSchedulerRef(scheduler)
+	ref.modelIncompatibilityStore = &store
+	if len(issues) > 0 {
+		ref.modelIncompatibilities = make(map[string]ModelIncompatibility, len(issues))
+		for _, issue := range issues {
+			ref.modelIncompatibilities[modelIncompatibilityKey(issue.Provider, issue.AccountID, issue.Model)] = issue
+		}
+	}
+	return ref, nil
+}
+
 func (r *SchedulerRef) Get() Scheduler {
 	now := time.Now()
 	r.pruneExpired(now)
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	scheduler := applyExhaustionMarks(r.scheduler, r.exhaustedUntil, now)
-	return applyExhaustionMarks(scheduler, r.incompatibleUntil, now)
+	return applyExhaustionMarks(r.scheduler, r.expiryMarksLocked(), now)
 }
 
 // pruneExpired drops exhaustion marks whose window has reset. The base snapshot
@@ -203,8 +220,31 @@ func (r *SchedulerRef) MarkModelIncompatibleUntil(provider accounts.Provider, ac
 	r.updatedAt = time.Now()
 }
 
-func (r *SchedulerRef) MarkModelIncompatible(provider accounts.Provider, accountID, model string) {
-	r.MarkModelIncompatibleUntil(provider, accountID, model, time.Now().Add(DefaultExhaustedTTL))
+func (r *SchedulerRef) MarkModelIncompatible(provider accounts.Provider, accountID, model, message string) error {
+	issue, err := normalizeModelIncompatibility(ModelIncompatibility{
+		Provider:   provider,
+		AccountID:  accountID,
+		Model:      model,
+		Code:       ModelIncompatibilityCode,
+		Message:    message,
+		ObservedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		return err
+	}
+	key := modelIncompatibilityKey(issue.Provider, issue.AccountID, issue.Model)
+	r.mu.Lock()
+	if r.modelIncompatibilities == nil {
+		r.modelIncompatibilities = make(map[string]ModelIncompatibility)
+	}
+	r.modelIncompatibilities[key] = issue
+	r.updatedAt = time.Now()
+	store := r.modelIncompatibilityStore
+	r.mu.Unlock()
+	if store == nil {
+		return nil
+	}
+	return store.Put(issue)
 }
 
 // ExhaustedUntilFor reports the expiry recorded for an account's exhaustion
@@ -219,12 +259,39 @@ func (r *SchedulerRef) ExhaustedUntilFor(provider accounts.Provider, accountID, 
 func (r *SchedulerRef) ModelIncompatibleUntilFor(provider accounts.Provider, accountID, model string) (time.Time, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	until, ok := r.incompatibleUntil[poolScopedExhaustionKey(provider, accountID, model)]
+	key := modelIncompatibilityKey(provider, accountID, model)
+	if _, ok := r.modelIncompatibilities[key]; ok {
+		return permanentModelIncompatibilityUntil, true
+	}
+	until, ok := r.incompatibleUntil[key]
 	return until, ok
 }
 
+func (r *SchedulerRef) ModelIncompatibilities() []ModelIncompatibility {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	issues := make([]ModelIncompatibility, 0, len(r.modelIncompatibilities))
+	for _, issue := range r.modelIncompatibilities {
+		issues = append(issues, issue)
+	}
+	sortModelIncompatibilities(issues)
+	return issues
+}
+
+func (r *SchedulerRef) ModelIncompatible(provider accounts.Provider, accountID, model string) bool {
+	if ModelKey(model) == "" {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.modelIncompatibilities[modelIncompatibilityKey(provider, accountID, model)]
+	return ok
+}
+
+var permanentModelIncompatibilityUntil = time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC)
+
 func (r *SchedulerRef) expiryMarksLocked() map[string]time.Time {
-	marks := make(map[string]time.Time, len(r.exhaustedUntil)+len(r.incompatibleUntil))
+	marks := make(map[string]time.Time, len(r.exhaustedUntil)+len(r.incompatibleUntil)+len(r.modelIncompatibilities))
 	for key, until := range r.exhaustedUntil {
 		marks[key] = until
 	}
@@ -232,6 +299,9 @@ func (r *SchedulerRef) expiryMarksLocked() map[string]time.Time {
 		if until.After(marks[key]) {
 			marks[key] = until
 		}
+	}
+	for key := range r.modelIncompatibilities {
+		marks[key] = permanentModelIncompatibilityUntil
 	}
 	return marks
 }


### PR DESCRIPTION
The account decision for Responses WebSockets happened at handshake time, before response.create revealed the model. A ChatGPT account could therefore reject the turn, and Subrouter forwarded the raw compatibility error while only changing the next reconnect.

This change makes one coordinator own the WebSocket account and pending turn. It checks durable account/model exclusions before forwarding, suppresses structured compatibility failures, replays the same turn across every compatible subscription, then uses an API key only as the final fallback. HTTP requests follow the same order and switch upstream hosts when fallback crosses from ChatGPT to the OpenAI API. If no compatible account exists, Subrouter returns subrouter_no_compatible_account instead of the upstream text.

The incompatibility registry now reads peer-worker writes on cache misses, and bare sr reports each blocked account/model. Parsing is restricted to error-envelope fields so prompt and tool text cannot quarantine a healthy account.

Verification:
- regression-only commit fails on the former behavior
- go test ./... -count=1 -p=1
- go vet ./...
- focused race tests for HTTP, WebSocket, persistence, sanitization, and API fallback
- CI green
- Mac mini deployed at combined commit c944d1a with checksum 4c4a1cc6f31c5b981b433eac3751e61564a40edfc5b27ff23084ce31f86bd339
- forced live WebSocket handshake on blocked lc+3@cmux.com produced response.created for gpt-5.6-sol from a Pro subscription
- 232 production gpt-5.6-sol routes after activation, with zero occurrences of the raw compatibility phrase
- bare sr shows verified blocks and omits the parser-created false aifirehose@gmail.com block