### PR TITLE
Always route Claude subscriptions before fallbacks

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -196,7 +196,7 @@ func serve(args []string) error {
 	bedrockGatewayToken := flags.String("bedrock-gateway-token", "", "optional bearer token clients must present to the Bedrock gateway; defaults to SUBROUTER_BEDROCK_GATEWAY_TOKEN")
 	bedrockProfiles := flags.String("bedrock-profiles", "", "comma-separated AWS profiles for the Bedrock gateway; defaults to SUBROUTER_BEDROCK_PROFILES or discovered awN profiles")
 	bedrockAutoBump := flags.Bool("bedrock-autobump", false, "request a Service Quotas increase (2x, deduped) when Bedrock throttles Fable/Opus")
-	fableBedrockPrimary := flags.Bool("fable-bedrock-primary", false, "route Claude Fable to Bedrock first (before the subscription pool); defaults to SUBROUTER_FABLE_BEDROCK_PRIMARY")
+	fableBedrockPrimary := flags.Bool("fable-bedrock-primary", false, "deprecated and ignored; Claude subscriptions are always tried before Bedrock and API keys")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -321,6 +321,11 @@ func serve(args []string) error {
 		Transport: outboundTransport,
 	})
 
+	fableBedrockPrimaryRequested := *fableBedrockPrimary || envTrue("SUBROUTER_FABLE_BEDROCK_PRIMARY")
+	if fableBedrockPrimaryRequested {
+		slog.Warn("fable-bedrock-primary is deprecated and ignored; Claude subscriptions remain primary")
+	}
+
 	server := proxy.Server{
 		Upstream:            upstream,
 		CodexUpstream:       codexUpstream,
@@ -340,7 +345,7 @@ func serve(args []string) error {
 		MaxBodyBytes:        *maxBodyBytes,
 		Bedrock:             bedrockConfig,
 		ClaudeFableAPIKey:   strings.TrimSpace(os.Getenv("SUBROUTER_CLAUDE_FABLE_API_KEY")),
-		FableBedrockPrimary: *fableBedrockPrimary || envTrue("SUBROUTER_FABLE_BEDROCK_PRIMARY"),
+		FableBedrockPrimary: fableBedrockPrimaryRequested,
 		Transcripts:         transcript.NewRecorder(*transcriptDir),
 	}
 	transcriptGCSSyncer := transcript.NewGCSSyncer(transcript.GCSSyncerConfig{

--- a/internal/proxy/bedrock_stream_test.go
+++ b/internal/proxy/bedrock_stream_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
-	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -165,72 +164,5 @@ func TestTranscodeBedrockToSSEMalformedHeadersDoNotBreakPayloadExtraction(t *tes
 	result = transcodeBedrockToSSE(rec, bytes.NewReader(garbageHeaderLen), nil, "", "")
 	if !result.SawMessageStop {
 		t.Fatalf("result = %+v, want message_stop despite garbage headersLen", result)
-	}
-}
-
-func TestServeClaudeFableBedrockPrimaryFallsThroughOnExceptionFirstStream(t *testing.T) {
-	bodyStr := `{"model":"claude-fable-5","stream":true,"max_tokens":8,"messages":[]}`
-	var logBuf bytes.Buffer
-	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewReader(buildBedrockExceptionFrame(t, "modelStreamErrorException", `{"message":"boom"}`))),
-			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
-		}, nil
-	})
-	s := Server{
-		MaxBodyBytes:        1 << 20,
-		FableBedrockPrimary: true,
-		Logger:              slog.New(slog.NewTextHandler(&logBuf, nil)),
-		Bedrock:             &BedrockConfig{Regions: []string{"us-east-1"}, Credentials: staticBedrockCreds(), Transport: rt},
-	}
-	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(bodyStr))
-	rec := httptest.NewRecorder()
-	if s.serveClaudeFableBedrockPrimary(rec, req) {
-		t.Fatal("expected exception-first stream to fall through")
-	}
-	if rec.Body.Len() != 0 {
-		t.Fatalf("recorder body = %q, want untouched", rec.Body.String())
-	}
-	restored, err := io.ReadAll(req.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(restored) != bodyStr {
-		t.Fatalf("restored body = %q, want %q", string(restored), bodyStr)
-	}
-	if logs := logBuf.String(); !strings.Contains(logs, "claude-fable bedrock stream failed before first event") || !strings.Contains(logs, "exception_type=modelStreamErrorException") {
-		t.Fatalf("missing first-event failure log:\n%s", logs)
-	}
-}
-
-func TestServeClaudeFableBedrockPrimaryFallsThroughOnEmptyStream(t *testing.T) {
-	bodyStr := `{"model":"claude-fable-5","stream":true,"max_tokens":8,"messages":[]}`
-	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewReader(nil)),
-			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
-		}, nil
-	})
-	s := Server{
-		MaxBodyBytes:        1 << 20,
-		FableBedrockPrimary: true,
-		Bedrock:             &BedrockConfig{Regions: []string{"us-east-1"}, Credentials: staticBedrockCreds(), Transport: rt},
-	}
-	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(bodyStr))
-	rec := httptest.NewRecorder()
-	if s.serveClaudeFableBedrockPrimary(rec, req) {
-		t.Fatal("expected empty stream to fall through")
-	}
-	if rec.Body.Len() != 0 {
-		t.Fatalf("recorder body = %q, want untouched", rec.Body.String())
-	}
-	restored, err := io.ReadAll(req.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(restored) != bodyStr {
-		t.Fatalf("restored body = %q, want %q", string(restored), bodyStr)
 	}
 }

--- a/internal/proxy/claude_fable.go
+++ b/internal/proxy/claude_fable.go
@@ -36,56 +36,6 @@ func (s Server) claudeFableRequest(r *http.Request) bool {
 	return claudeFableModel(session.ExtractModel(r, s.MaxBodyBytes))
 }
 
-// serveClaudeFableBedrockPrimary serves a Fable request from AWS Bedrock before
-// the subscription pool is consulted (FableBedrockPrimary mode). It streams the
-// response only on a 2xx from Bedrock; on any non-2xx status or a Bedrock error
-// it restores the request body and returns false so the caller continues to the
-// normal pool path (which keeps its own Bedrock/API-key fallback). This makes
-// Bedrock the primary Fable route without ever hard-failing when Bedrock is
-// throttled or unreachable.
-func (s Server) serveClaudeFableBedrockPrimary(w http.ResponseWriter, r *http.Request) bool {
-	body, err := io.ReadAll(io.LimitReader(r.Body, replayablePostMaxBodyBytes))
-	if err != nil {
-		return false
-	}
-	restore := func() {
-		r.Body = io.NopCloser(bytes.NewReader(body))
-		r.ContentLength = int64(len(body))
-		r.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(body)), nil }
-	}
-	resp, err := s.claudeFableBedrockResponse(r.Context(), body)
-	if err != nil {
-		if s.Logger != nil && r.Context().Err() == nil {
-			s.Logger.Warn("fable bedrock-primary request failed, falling through to pool", "error", err)
-		}
-		restore()
-		return false
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		if s.Logger != nil {
-			s.Logger.Warn("fable bedrock-primary non-2xx, falling through to pool", "status", resp.StatusCode)
-		}
-		_ = resp.Body.Close()
-		restore()
-		return false
-	}
-	if s.Logger != nil {
-		s.Logger.Info("serving claude fable via bedrock-primary", "status", resp.StatusCode)
-	}
-	defer resp.Body.Close()
-	for key, values := range resp.Header {
-		if isHopByHopHeader(key) {
-			continue
-		}
-		for _, value := range values {
-			w.Header().Add(key, value)
-		}
-	}
-	w.WriteHeader(resp.StatusCode)
-	flushingCopy(w, resp.Body, nil)
-	return true
-}
-
 // serveClaudeFableFallback serves a Fable request straight off the fallback
 // chain (Bedrock, then the dedicated API key). Used when the subscription pool
 // cannot even start: no usable Claude OAuth account or selection failed. It

--- a/internal/proxy/claude_fable_test.go
+++ b/internal/proxy/claude_fable_test.go
@@ -56,6 +56,68 @@ func TestClaudeFableRequestDetection(t *testing.T) {
 	}
 }
 
+func TestClaudeFableAlwaysUsesSubscriptionBeforeFallbacks(t *testing.T) {
+	server, store := claudeFailoverServer(t)
+	if _, err := store.Put("claude", "session-subscription-first", "fresh@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	subscriptionCalls := 0
+	apiKeyCalls := 0
+	server.Transport = bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Header.Get("X-Api-Key") != "" {
+			apiKeyCalls++
+		} else {
+			subscriptionCalls++
+			if got := req.Header.Get("Authorization"); got != "Bearer tok-fresh" {
+				t.Errorf("subscription Authorization = %q, want fresh OAuth token", got)
+			}
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"type":"message","route":"subscription"}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	bedrockCalls := 0
+	server.Bedrock = &BedrockConfig{
+		Regions: []string{"us-east-1"},
+		Sources: []BedrockCredentialSource{{Name: "aw0", Credentials: staticBedrockCreds()}},
+		Transport: bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			bedrockCalls++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"type":"message","route":"bedrock"}`)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		}),
+	}
+	server.ClaudeFableAPIKey = "sk-ant-fable-key"
+	server.FableBedrockPrimary = true
+	server.MaxBodyBytes = 1 << 20
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"claude-fable-5","max_tokens":8,"messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Subrouter-Agent", "claude")
+	req.Header.Set("X-Subrouter-Session", "session-subscription-first")
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+	if subscriptionCalls != 1 {
+		t.Fatalf("subscription calls = %d, want 1", subscriptionCalls)
+	}
+	if bedrockCalls != 0 {
+		t.Fatalf("bedrock calls = %d, want 0 while a subscription is usable", bedrockCalls)
+	}
+	if apiKeyCalls != 0 {
+		t.Fatalf("api-key calls = %d, want 0 while a subscription is usable", apiKeyCalls)
+	}
+}
+
 func TestServeClaudeFableFallbackViaAPIKey(t *testing.T) {
 	var captured *http.Request
 	var capturedBody string

--- a/internal/proxy/claude_fable_test.go
+++ b/internal/proxy/claude_fable_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -95,6 +96,7 @@ func TestClaudeFableAlwaysUsesSubscriptionBeforeFallbacks(t *testing.T) {
 	}
 	server.ClaudeFableAPIKey = "sk-ant-fable-key"
 	server.FableBedrockPrimary = true
+	server.ClaudeUpstream = &url.URL{Scheme: "https", Host: "api.anthropic.com"}
 	server.MaxBodyBytes = 1 << 20
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"claude-fable-5","max_tokens":8,"messages":[]}`))
@@ -597,59 +599,5 @@ func TestClaudeFableBedrockStripsUnsupportedFields(t *testing.T) {
 	}
 	if !strings.Contains(forwarded, "anthropic_version") {
 		t.Fatalf("bedrock body missing anthropic_version: %s", forwarded)
-	}
-}
-
-// bedrockPrimaryServer builds a Server with the Bedrock gateway configured and
-// FableBedrockPrimary enabled, whose Bedrock upstream returns the given status
-// and body.
-func bedrockPrimaryServer(status int, body string) Server {
-	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: status,
-			Body:       io.NopCloser(strings.NewReader(body)),
-			Header:     http.Header{"Content-Type": []string{"application/json"}},
-		}, nil
-	})
-	return Server{
-		MaxBodyBytes:        1 << 20,
-		FableBedrockPrimary: true,
-		Bedrock:             &BedrockConfig{Regions: []string{"us-east-1"}, Credentials: staticBedrockCreds(), Transport: rt},
-	}
-}
-
-func TestServeClaudeFableBedrockPrimarySuccess(t *testing.T) {
-	s := bedrockPrimaryServer(200, `{"model":"claude-fable-5","content":[{"type":"text","text":"ok"}]}`)
-	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"claude-fable-5","max_tokens":8,"messages":[]}`))
-	rec := httptest.NewRecorder()
-	if !s.serveClaudeFableBedrockPrimary(rec, req) {
-		t.Fatal("expected bedrock-primary to serve a 2xx Bedrock response")
-	}
-	if rec.Code != 200 {
-		t.Fatalf("status = %d, want 200 (body %q)", rec.Code, rec.Body.String())
-	}
-	if !strings.Contains(rec.Body.String(), "claude-fable-5") {
-		t.Fatalf("body = %q, want forwarded Bedrock body", rec.Body.String())
-	}
-}
-
-func TestServeClaudeFableBedrockPrimaryFallsThroughOnNon2xx(t *testing.T) {
-	s := bedrockPrimaryServer(429, `{"message":"Too many requests"}`)
-	bodyStr := `{"model":"claude-fable-5","max_tokens":8,"messages":[]}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(bodyStr))
-	rec := httptest.NewRecorder()
-	if s.serveClaudeFableBedrockPrimary(rec, req) {
-		t.Fatal("expected bedrock-primary to fall through on a non-2xx Bedrock response")
-	}
-	if rec.Code != 200 { // httptest default; nothing should have been written
-		t.Fatalf("status = %d, want untouched recorder (nothing written)", rec.Code)
-	}
-	// Body must be restored so the pool path can read it.
-	restored, err := io.ReadAll(req.Body)
-	if err != nil {
-		t.Fatalf("read restored body: %v", err)
-	}
-	if string(restored) != bodyStr {
-		t.Fatalf("restored body = %q, want %q", string(restored), bodyStr)
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -60,17 +60,13 @@ type Server struct {
 	ReadCache        *readCache
 	// Bedrock, when set, enables the /bedrock/* SigV4 signing gateway.
 	Bedrock *BedrockConfig
-	// ClaudeFableAPIKey, when set, serves Claude Fable requests via this Anthropic
-	// API key (x-api-key) instead of the subscription pool or Bedrock. It applies
-	// ONLY to Fable; Opus/Sonnet/etc. continue to use the OAuth pool and never
-	// touch this key.
+	// ClaudeFableAPIKey, when set, is the final Claude Fable fallback after the
+	// subscription pool and Bedrock. It applies only to Fable; Opus, Sonnet, and
+	// other models continue to use the normal account pool.
 	ClaudeFableAPIKey string
-	// FableBedrockPrimary, when true, routes Claude Fable requests to AWS Bedrock
-	// FIRST, before the subscription pool, instead of using Bedrock only as a
-	// fallback. It only takes effect when the Bedrock gateway is configured; a
-	// non-2xx Bedrock response (or an unreachable Bedrock) falls through to the
-	// normal pool path, which keeps its own Bedrock/API-key fallback. Applies
-	// ONLY to Fable; other Claude models are unaffected.
+	// FableBedrockPrimary is retained for configuration compatibility and ignored.
+	// Claude subscriptions are always tried before Bedrock and API-key fallbacks.
+	// Deprecated: remove this field after deployed configurations stop setting it.
 	FableBedrockPrimary bool
 }
 
@@ -1737,15 +1733,6 @@ func (s Server) proxyHandler() http.Handler {
 			retryPoolModel = requestPoolModel
 			fableFallbackConfigured = s.claudeFableEnabled() && claudeFableModel(requestModel) &&
 				r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/v1/messages")
-		}
-		// Bedrock-primary: when enabled, serve Fable straight from Bedrock before
-		// touching the subscription pool. A non-2xx or unreachable Bedrock restores
-		// the body and falls through to the normal pool path (which still carries
-		// its own Bedrock/API-key fallback), so this never hard-fails Fable.
-		if s.FableBedrockPrimary && fableFallbackConfigured && s.Bedrock != nil && s.Bedrock.configured() {
-			if s.serveClaudeFableBedrockPrimary(w, r) {
-				return
-			}
 		}
 		sessionAgentType := agentTypeForProviderSession(agentType, requestProvider)
 		account, sessionID, userEmail, err := s.accountForSessionProvider(requestProvider, sessionAgentType, sessionID, r)


### PR DESCRIPTION
The team Mac mini previously started workers with the legacy Bedrock-primary Fable setting, allowing AWS to run before Claude subscriptions.

This change removes that early path. Claude Fable order is fixed to OAuth subscriptions first, Bedrock second, and the dedicated Anthropic API key last. The legacy flag and environment variable remain accepted as ignored compatibility settings with a warning.

This branch is stacked on https://github.com/manaflow-ai/subrouter/pull/80 and is the combined commit deployed to the Mac mini.

Verification:
- regression-only commit fails when Bedrock runs before OAuth
- go test ./... -count=1 -p=1
- go vet ./...
- focused race tests
- CI green
- live Fable request tried default, austinpower1258-gmail, and austin-manaflow-ai subscriptions before Bedrock completed the request
- supervisor restart removed the stale worker generation and legacy runtime flag