### PR TITLE
Reroute Codex WebSockets after account quota errors

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2099,7 +2099,22 @@ func (s Server) copyWebSocketMessages(ctx context.Context, agentType, sessionID,
 		if direction == "upstream_to_client" && messageType == websocket.TextMessage {
 			switch {
 			case usageLimitJSON(body):
-				s.markAccountExhausted(provider, accountID, poolModel)
+				exhaustionPool := poolModel
+				if provider == accounts.ProviderCodex {
+					exhaustionPool = ""
+				}
+				s.markAccountExhausted(provider, accountID, exhaustionPool)
+				if provider == accounts.ProviderCodex && s.rerouteCodexWebSocketUsageLimit(
+					ctx,
+					agentType,
+					sessionID,
+					userEmail,
+					accountID,
+					modelState.current(),
+				) {
+					closeWebSocketForAccountRetry(dst)
+					return
+				}
 			case provider == accounts.ProviderCodex && codexChatGPTModelUnsupportedJSON(body):
 				if model := modelState.current(); model != "" {
 					_, _ = s.rerouteModelIncompatibility(ctx, provider, agentType, sessionID, userEmail, accountID, model, nil)
@@ -2113,6 +2128,61 @@ func (s Server) copyWebSocketMessages(ctx context.Context, agentType, sessionID,
 			return
 		}
 	}
+}
+
+// rerouteCodexWebSocketUsageLimit binds the session to a healthy account before
+// the client reconnects. Replaying the captured response.create inside the
+// proxy is unsafe because a reused Codex WebSocket can send only an incremental
+// delta plus a previous_response_id owned by the depleted account.
+func (s Server) rerouteCodexWebSocketUsageLimit(ctx context.Context, agentType, sessionID, userEmail, accountID, model string) bool {
+	tried := map[string]struct{}{accountID: {}}
+	next, err := s.oauthRetryAccount(
+		ctx,
+		accounts.ProviderCodex,
+		agentType,
+		sessionID,
+		userEmail,
+		model,
+		tried,
+		true,
+	)
+	if err != nil {
+		if s.Logger != nil {
+			s.Logger.Warn(
+				"websocket usage-limit retry has no alternate account",
+				"agent", agentType,
+				"session", sessionID,
+				"account", accountID,
+				"model", model,
+				"error", err,
+			)
+		}
+		return false
+	}
+	if s.Logger != nil {
+		s.Logger.Warn(
+			"rerouting websocket after usage limit",
+			"agent", agentType,
+			"session", sessionID,
+			"previous_account", accountID,
+			"account", next.ID,
+			"model", model,
+		)
+	}
+	return true
+}
+
+const webSocketAccountRetryCloseTimeout = time.Second
+
+// closeWebSocketForAccountRetry turns an account-specific terminal error into
+// the retryable stream interruption Codex already handles by reconnecting and
+// resending a full response.create.
+func closeWebSocketForAccountRetry(conn *websocket.Conn) {
+	_ = conn.WriteControl(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseServiceRestart, "retrying with another account"),
+		time.Now().Add(webSocketAccountRetryCloseTimeout),
+	)
 }
 
 func (s Server) markAccountExhausted(provider accounts.Provider, accountID, poolKey string) {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -2960,6 +2960,134 @@ func TestHandlerMarksWebSocketUsageLimitAccountExhausted(t *testing.T) {
 	}
 }
 
+func TestHandlerRetriesWebSocketUsageLimitOnAlternateOAuthAccount(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
+	var mu sync.Mutex
+	var auths []string
+	var requests [][]byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade: %v", err)
+		}
+		defer conn.Close()
+
+		_, request, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read client message: %v", err)
+		}
+		auth := r.Header.Get("Authorization")
+		mu.Lock()
+		auths = append(auths, auth)
+		requests = append(requests, append([]byte(nil), request...))
+		mu.Unlock()
+
+		if auth == "Bearer empty-token" {
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(`{
+				"type":"error",
+				"status":429,
+				"error":{
+					"type":"usage_limit_reached",
+					"message":"The usage limit has been reached",
+					"plan_type":"pro",
+					"resets_at":1785518160
+				}
+			}`)); err != nil {
+				t.Fatalf("write usage error: %v", err)
+			}
+			return
+		}
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.created","response":{"id":"resp-healthy"}}`)); err != nil {
+			t.Fatalf("write created: %v", err)
+		}
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.completed","response":{"id":"resp-healthy"}}`)); err != nil {
+			t.Fatalf("write completed: %v", err)
+		}
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("codex", "session-1", "empty@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+		{AccountID: "empty@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
+		{AccountID: "healthy@example.com", Headroom: 0.80, ShortHeadroom: 0.80},
+	}))
+	handler := Server{
+		Upstream: upstreamURL,
+		Accounts: []accounts.Account{
+			{ID: "empty@example.com", AuthMode: accounts.AuthModeOAuth, Token: "empty-token"},
+			{ID: "healthy@example.com", AuthMode: accounts.AuthModeOAuth, Token: "healthy-token"},
+		},
+		Sessions:     store,
+		SchedulerRef: schedulerRef,
+		MaxBodyBytes: 1024,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(subrouter.URL, "http") + "/v1/responses"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, http.Header{
+		"X-Subrouter-Session": []string{"session-1"},
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	request := []byte(`{"type":"response.create","response":{"model":"gpt-5.6-sol","input":[]}}`)
+	if err := conn.WriteMessage(websocket.TextMessage, request); err != nil {
+		t.Fatalf("write create: %v", err)
+	}
+
+	_, first, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read created: %v", err)
+	}
+	if usageLimitJSON(first) {
+		t.Fatalf("client received usage limit instead of transparent failover: %s", first)
+	}
+	if !strings.Contains(string(first), `"response.created"`) {
+		t.Fatalf("first event = %s, want response.created", first)
+	}
+	_, second, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read completed: %v", err)
+	}
+	if !strings.Contains(string(second), `"response.completed"`) {
+		t.Fatalf("second event = %s, want response.completed", second)
+	}
+
+	mu.Lock()
+	gotAuths := append([]string(nil), auths...)
+	gotRequests := append([][]byte(nil), requests...)
+	mu.Unlock()
+	wantAuths := []string{"Bearer empty-token", "Bearer healthy-token"}
+	if strings.Join(gotAuths, "\x00") != strings.Join(wantAuths, "\x00") {
+		t.Fatalf("auths = %#v, want %#v", gotAuths, wantAuths)
+	}
+	if len(gotRequests) != 2 || !bytes.Equal(gotRequests[0], request) || !bytes.Equal(gotRequests[1], request) {
+		t.Fatalf("requests = %q, want the same response.create replayed once", gotRequests)
+	}
+	assignment, ok := store.Get("codex", "session-1")
+	if !ok {
+		t.Fatal("missing session-1 assignment")
+	}
+	if assignment.AccountID != "healthy@example.com" {
+		t.Fatalf("AccountID = %q, want healthy@example.com", assignment.AccountID)
+	}
+	if _, marked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "empty@example.com", ""); !marked {
+		t.Fatal("empty account must be marked exhausted")
+	}
+}
+
 func TestHandlerRetriesHTTPUsageLimitOnAlternateOAuthAccount(t *testing.T) {
 	var auths []string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -2917,11 +2917,15 @@ func TestHandlerMarksWebSocketUsageLimitAccountExhausted(t *testing.T) {
 		t.Fatalf("write create: %v", err)
 	}
 	_, body, err := conn.ReadMessage()
-	if err != nil {
-		t.Fatalf("read usage error: %v", err)
+	if err == nil {
+		t.Fatalf("websocket body = %q, want retryable close instead of usage limit", string(body))
 	}
-	if !strings.Contains(string(body), "usage_limit_reached") {
-		t.Fatalf("websocket body = %q, want usage limit error", string(body))
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("read error = %v, want WebSocket close frame", err)
+	}
+	if closeErr.Code != websocket.CloseServiceRestart {
+		t.Fatalf("close code = %d, want %d", closeErr.Code, websocket.CloseServiceRestart)
 	}
 	_ = conn.Close()
 	if _, accountMarked := schedulerRef.ExhaustedUntilFor(accounts.ProviderCodex, "empty@example.com", ""); !accountMarked {
@@ -3048,21 +3052,47 @@ func TestHandlerRetriesWebSocketUsageLimitOnAlternateOAuthAccount(t *testing.T) 
 	}
 
 	_, first, err := conn.ReadMessage()
+	if err == nil {
+		t.Fatalf("websocket body = %q, want retryable close instead of usage limit", string(first))
+	}
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("read error = %v, want WebSocket close frame", err)
+	}
+	if closeErr.Code != websocket.CloseServiceRestart {
+		t.Fatalf("close code = %d, want %d", closeErr.Code, websocket.CloseServiceRestart)
+	}
+	if strings.Contains(closeErr.Text, "usage") {
+		t.Fatalf("close reason must not surface terminal usage error: %q", closeErr.Text)
+	}
+	_ = conn.Close()
+
+	retryConn, _, err := websocket.DefaultDialer.Dial(wsURL, http.Header{
+		"X-Subrouter-Session": []string{"session-1"},
+	})
+	if err != nil {
+		t.Fatalf("retry dial: %v", err)
+	}
+	defer retryConn.Close()
+	if err := retryConn.WriteMessage(websocket.TextMessage, request); err != nil {
+		t.Fatalf("retry create: %v", err)
+	}
+	_, first, err = retryConn.ReadMessage()
 	if err != nil {
 		t.Fatalf("read created: %v", err)
 	}
 	if usageLimitJSON(first) {
-		t.Fatalf("client received usage limit instead of transparent failover: %s", first)
+		t.Fatalf("client received usage limit after account retry: %s", first)
 	}
 	if !strings.Contains(string(first), `"response.created"`) {
-		t.Fatalf("first event = %s, want response.created", first)
+		t.Fatalf("first retry event = %s, want response.created", first)
 	}
-	_, second, err := conn.ReadMessage()
+	_, second, err := retryConn.ReadMessage()
 	if err != nil {
 		t.Fatalf("read completed: %v", err)
 	}
 	if !strings.Contains(string(second), `"response.completed"`) {
-		t.Fatalf("second event = %s, want response.completed", second)
+		t.Fatalf("second retry event = %s, want response.completed", second)
 	}
 
 	mu.Lock()


### PR DESCRIPTION
Codex WebSocket sessions forwarded `usage_limit_reached` from their pinned account even when the pool had healthy accounts.

This binds the session to an alternate OAuth account, suppresses the terminal quota event, and closes with WebSocket 1012 so Codex retries with a full request. Replaying inside the proxy would be unsafe because reused WebSockets may send an incremental payload tied to the old account’s response ID.

Tests: `go test ./...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787442227&installation_model_id=21920&pr_number=82&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F82&signature=c86b8d04cf54eff362ae1c9bdaaaaf973027021211a4227b68c931dedbd2e5ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Codex WebSocket sessions that surfaced `usage_limit_reached` even when other accounts were available. Sessions now reroute to a healthy OAuth account and close with code 1012 so the client retries with a full request.

- Bug Fixes
  - On `usage_limit_reached` from Codex, mark the account exhausted (no pool) and bind the session to a healthy OAuth account when available.
  - Close the WebSocket with 1012 (Service Restart) and suppress the terminal error so the client reconnects and resends the full request.
  - Do not replay inside the proxy because Codex WebSockets can send incremental deltas tied to a `previous_response_id`; tests cover reroute, close code, and session reassignment.

<sup>Written for commit d41d4f706f810b9230b19c8a7fb280ba5c1fb75e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

