### PR TITLE
sr claude add: boot straight to the browser OAuth page

### DIFF
--- a/cmd/subrouter/sr_claude.go
+++ b/cmd/subrouter/sr_claude.go
@@ -3,11 +3,13 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -155,6 +157,9 @@ func (r claudeRunner) add(ctx context.Context, name string) error {
 		}
 	}
 	claudeConfigDir := r.store.PreferredInstancePath(instancePath)
+	if err := prepareClaudeLoginFastPath(claudeConfigDir); err != nil {
+		fmt.Fprintf(r.errOut, "Warning: could not pre-seed the login fast path: %s\n", err)
+	}
 
 	fmt.Fprintln(r.out, "Starting Claude Code...")
 	fmt.Fprintln(r.out, "Complete the OAuth login in your browser; Claude closes automatically once the login lands.")
@@ -217,6 +222,53 @@ func (r claudeRunner) add(ctx context.Context, name string) error {
 	fmt.Fprintf(r.out, "\n  sr claude switch %s\n", profileName)
 	fmt.Fprintf(r.out, "  sr claude run %s\n", profileName)
 	return nil
+}
+
+// prepareClaudeLoginFastPath seeds a fresh profile's config dir so Claude
+// Code boots straight into the browser OAuth flow instead of walking the
+// first-run wizard: onboarding is marked complete (skips the theme picker
+// and tour) and the login method is pinned to the Claude-account flow
+// (skips the claude.ai-vs-Console picker). Existing values are preserved,
+// so re-running add against a lived-in profile changes nothing.
+func prepareClaudeLoginFastPath(configDir string) error {
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		return err
+	}
+	statePath := filepath.Join(configDir, ".claude.json")
+	state := map[string]any{}
+	if body, err := os.ReadFile(statePath); err == nil {
+		if err := json.Unmarshal(body, &state); err != nil {
+			return fmt.Errorf("parse %s: %w", statePath, err)
+		}
+	}
+	if onboarded, _ := state["hasCompletedOnboarding"].(bool); !onboarded {
+		state["hasCompletedOnboarding"] = true
+		out, err := json.MarshalIndent(state, "", "  ")
+		if err != nil {
+			return err
+		}
+		out = append(out, '\n')
+		if err := os.WriteFile(statePath, out, 0o600); err != nil {
+			return err
+		}
+	}
+	settingsPath := filepath.Join(configDir, "settings.json")
+	settings := map[string]any{}
+	if body, err := os.ReadFile(settingsPath); err == nil {
+		if err := json.Unmarshal(body, &settings); err != nil {
+			return fmt.Errorf("parse %s: %w", settingsPath, err)
+		}
+	}
+	if _, ok := settings["forceLoginMethod"]; ok {
+		return nil
+	}
+	settings["forceLoginMethod"] = "claudeai"
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	out = append(out, '\n')
+	return os.WriteFile(settingsPath, out, 0o600)
 }
 
 func (r claudeRunner) list(ctx context.Context, numbered bool) error {

--- a/cmd/subrouter/sr_claude_test.go
+++ b/cmd/subrouter/sr_claude_test.go
@@ -112,3 +112,46 @@ func TestClaudeFlagsRunActiveProfile(t *testing.T) {
 		t.Fatalf("Claude did not receive flags:\n%s", got)
 	}
 }
+
+func TestPrepareClaudeLoginFastPathSeedsFreshDir(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "profile")
+	if err := prepareClaudeLoginFastPath(configDir); err != nil {
+		t.Fatalf("prepareClaudeLoginFastPath: %v", err)
+	}
+	state, err := os.ReadFile(filepath.Join(configDir, ".claude.json"))
+	if err != nil {
+		t.Fatalf("read .claude.json: %v", err)
+	}
+	if !strings.Contains(string(state), `"hasCompletedOnboarding": true`) {
+		t.Fatalf("onboarding not seeded:\n%s", state)
+	}
+	settings, err := os.ReadFile(filepath.Join(configDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	if !strings.Contains(string(settings), `"forceLoginMethod": "claudeai"`) {
+		t.Fatalf("login method not seeded:\n%s", settings)
+	}
+}
+
+func TestPrepareClaudeLoginFastPathPreservesExistingChoices(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".claude.json"), []byte(`{"theme":"light"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(`{"forceLoginMethod":"console"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareClaudeLoginFastPath(dir); err != nil {
+		t.Fatalf("prepareClaudeLoginFastPath: %v", err)
+	}
+	state, _ := os.ReadFile(filepath.Join(dir, ".claude.json"))
+	if !strings.Contains(string(state), `"theme": "light"`) || !strings.Contains(string(state), `"hasCompletedOnboarding": true`) {
+		t.Fatalf("existing state not preserved:\n%s", state)
+	}
+	settings, _ := os.ReadFile(filepath.Join(dir, "settings.json"))
+	if !strings.Contains(string(settings), `"forceLoginMethod":"console"`) {
+		t.Fatalf("existing login method overwritten:\n%s", settings)
+	}
+}


### PR DESCRIPTION
`sr claude add` currently launches the full Claude Code first-run wizard in the fresh CLAUDE_CONFIG_DIR — theme picker, tour, then the claude.ai-vs-Console login picker — several Enter presses before the browser OAuth page opens.

This seeds the fresh profile dir before launching Claude:
- `.claude.json`: `hasCompletedOnboarding: true` (skips theme picker/tour)
- `settings.json`: `forceLoginMethod: "claudeai"` only when unset (skips the login-method picker; sr profiles target subscription accounts)

Existing values are preserved, so re-running add on a lived-in profile is a no-op. Two unit tests cover fresh-dir seeding and preservation of existing choices.

Motivation: the cmux subrouter sidebar's add-account button opens a terminal running this command; it should take the user straight to the auth page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787462498&installation_model_id=21920&pr_number=83&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F83&signature=5bce6e7af68159289ec4462a0b931deb45fa7b58c8288bff135120bba5d6b11f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `sr claude add` open the browser OAuth page immediately by skipping the first-run wizard. This removes extra keypresses and makes the sidebar “add account” flow faster.

- **New Features**
  - Pre-seed `.claude.json` with `"hasCompletedOnboarding": true` to skip theme picker and tour.
  - Set `settings.json` `"forceLoginMethod": "claudeai"` only when unset to skip the login method picker; existing values are preserved.
  - Added tests for fresh-dir seeding and preserving existing choices.

<sup>Written for commit f3dc63874e358f8a550429d1d29bc4c74bd64c64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

