### PR TITLE
fix: detect macOS _subrouter owner during server account upload

### DIFF
--- a/cmd/subrouter/sr_claude_upload.go
+++ b/cmd/subrouter/sr_claude_upload.go
@@ -152,10 +152,11 @@ func claudeUploadRemoteCommand(server srServerConfig, profileName, dir string) s
 	return strings.Join([]string{
 		"set -euo pipefail",
 		"cat > " + shellQuote(remotePath),
+		"sr_owner=subrouter; sr_group=subrouter; if [ -e /var/lib/subrouter ]; then sr_owner=$(stat -f '%Su' /var/lib/subrouter 2>/dev/null || stat -c '%U' /var/lib/subrouter); sr_group=$(stat -f '%Sg' /var/lib/subrouter 2>/dev/null || stat -c '%G' /var/lib/subrouter); elif id -u _subrouter >/dev/null 2>&1; then sr_owner=_subrouter; sr_group=_subrouter; fi",
 		"reload_status=$(curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:31415/_subrouter/reload-accounts || true)",
 		"if [ \"$reload_status\" != \"405\" ]; then echo " + shellQuote("Subrouter server is too old for hot account reload; run sr server install "+server.Name+" first.") + " >&2; exit 1; fi",
 		"command -v jq >/dev/null || { echo 'jq is required on the server for claude profile registration' >&2; exit 1; }",
-		"sudo install -d -o subrouter -g subrouter -m 0700 /var/lib/subrouter/codex/claude",
+		"sudo install -d -o \"$sr_owner\" -g \"$sr_group\" -m 0700 /var/lib/subrouter/codex/claude",
 		"sudo tar -C /var/lib/subrouter -xzf " + shellQuote(remotePath),
 		"sudo rm -f " + shellQuote(remotePath),
 		"sudo chmod 700 " + shellQuote("/var/lib/subrouter/codex/claude/"+dir),
@@ -163,7 +164,7 @@ func claudeUploadRemoteCommand(server srServerConfig, profileName, dir string) s
 		"sudo sh -c " + shellQuote("test -s "+registryPath+" || printf '{\"profiles\":{}}' > "+registryPath),
 		"sudo jq --arg name " + shellQuote(profileName) + " --arg dir " + shellQuote(dir) + " --arg created " + shellQuote(createdAt) + " " + shellQuote(jqProgram) + " " + registryPath + " | sudo tee " + registryPath + ".new >/dev/null",
 		"sudo mv " + registryPath + ".new " + registryPath,
-		"sudo chown -R subrouter:subrouter /var/lib/subrouter/codex/claude " + registryPath,
+		"sudo chown -R \"$sr_owner:$sr_group\" /var/lib/subrouter/codex/claude " + registryPath,
 		"curl -fsS -X POST http://127.0.0.1:31415/_subrouter/reload-accounts >/dev/null",
 	}, " && ")
 }

--- a/cmd/subrouter/sr_claude_upload_test.go
+++ b/cmd/subrouter/sr_claude_upload_test.go
@@ -51,11 +51,16 @@ func TestClaudeUploadRemoteCommand(t *testing.T) {
 		"'_p999'",
 		"reload-accounts",
 		"command -v jq",
-		"chown -R subrouter:subrouter",
+		`sr_owner=$(stat -f '%Su' /var/lib/subrouter`,
+		`sudo install -d -o "$sr_owner" -g "$sr_group"`,
+		`chown -R "$sr_owner:$sr_group"`,
 	} {
 		if !strings.Contains(command, want) {
 			t.Fatalf("remote command missing %q:\n%s", want, command)
 		}
+	}
+	if strings.Contains(command, "chown -R subrouter:subrouter") {
+		t.Fatalf("remote command should not hardcode Linux subrouter group:\n%s", command)
 	}
 }
 

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -1340,12 +1340,13 @@ func (r srRunner) uploadServerAccount(ctx context.Context, server srServerConfig
 	}
 	remoteCommand := strings.Join([]string{
 		"set -euo pipefail",
+		"sr_owner=subrouter; sr_group=subrouter; if [ -e /var/lib/subrouter ]; then sr_owner=$(stat -f '%Su' /var/lib/subrouter 2>/dev/null || stat -c '%U' /var/lib/subrouter); sr_group=$(stat -f '%Sg' /var/lib/subrouter 2>/dev/null || stat -c '%G' /var/lib/subrouter); elif id -u _subrouter >/dev/null 2>&1; then sr_owner=_subrouter; sr_group=_subrouter; fi",
 		"reload_status=$(curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:31415/_subrouter/reload-accounts || true)",
 		"if [ \"$reload_status\" != \"405\" ]; then echo " + shellQuote("Subrouter server is too old for hot account reload; run sr server install "+server.Name+" first.") + " >&2; exit 1; fi",
-		"sudo install -d -o subrouter -g subrouter -m 0750 /var/lib/subrouter/codex/accounts",
+		"sudo install -d -o \"$sr_owner\" -g \"$sr_group\" -m 0750 /var/lib/subrouter/codex/accounts",
 		"sudo tar -C /var/lib/subrouter -xzf " + shellQuote(remotePath),
 		"sudo find /var/lib/subrouter/codex -name '._*' -delete",
-		"sudo chown -R subrouter:subrouter /var/lib/subrouter/codex",
+		"sudo chown -R \"$sr_owner:$sr_group\" /var/lib/subrouter/codex",
 		"sudo rm -f " + shellQuote(remotePath),
 		"curl -fsS -X POST http://127.0.0.1:31415/_subrouter/reload-accounts >/dev/null",
 	}, " && ")
@@ -1364,12 +1365,13 @@ func (r srRunner) uploadServerAccountSSH(ctx context.Context, server srServerCon
 	remoteCommand := strings.Join([]string{
 		"set -euo pipefail",
 		"cat > " + shellQuote(remotePath),
+		"sr_owner=subrouter; sr_group=subrouter; if [ -e /var/lib/subrouter ]; then sr_owner=$(stat -f '%Su' /var/lib/subrouter 2>/dev/null || stat -c '%U' /var/lib/subrouter); sr_group=$(stat -f '%Sg' /var/lib/subrouter 2>/dev/null || stat -c '%G' /var/lib/subrouter); elif id -u _subrouter >/dev/null 2>&1; then sr_owner=_subrouter; sr_group=_subrouter; fi",
 		"reload_status=$(curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:31415/_subrouter/reload-accounts || true)",
 		"if [ \"$reload_status\" != \"405\" ]; then echo " + shellQuote("Subrouter server is too old for hot account reload; run sr server install "+server.Name+" first.") + " >&2; exit 1; fi",
-		"sudo install -d -o subrouter -g subrouter -m 0750 /var/lib/subrouter/codex/accounts",
+		"sudo install -d -o \"$sr_owner\" -g \"$sr_group\" -m 0750 /var/lib/subrouter/codex/accounts",
 		"sudo tar -C /var/lib/subrouter -xzf " + shellQuote(remotePath),
 		"sudo find /var/lib/subrouter/codex -name '._*' -delete",
-		"sudo chown -R subrouter:subrouter /var/lib/subrouter/codex",
+		"sudo chown -R \"$sr_owner:$sr_group\" /var/lib/subrouter/codex",
 		"sudo rm -f " + shellQuote(remotePath),
 		"curl -fsS -X POST http://127.0.0.1:31415/_subrouter/reload-accounts >/dev/null",
 	}, " && ")

--- a/cmd/subrouter/sr_server_test.go
+++ b/cmd/subrouter/sr_server_test.go
@@ -698,6 +698,15 @@ func TestSRServerLoginUploadsFreshAuthAndRestoresLocalChain(t *testing.T) {
 	if !strings.Contains(uploadCommand, "/var/lib/subrouter/codex/accounts") {
 		t.Fatalf("upload should install accounts into subrouter state dir:\n%s", uploadCommand)
 	}
+	if !strings.Contains(uploadCommand, `sr_owner=$(stat -f '%Su' /var/lib/subrouter`) {
+		t.Fatalf("upload should detect state-dir owner for macOS _subrouter installs:\n%s", uploadCommand)
+	}
+	if !strings.Contains(uploadCommand, `sudo install -d -o "$sr_owner" -g "$sr_group"`) {
+		t.Fatalf("upload should chown via detected owner/group, not hardcode subrouter:\n%s", uploadCommand)
+	}
+	if strings.Contains(uploadCommand, "install -d -o subrouter -g subrouter") {
+		t.Fatalf("upload should not hardcode Linux subrouter group on macOS servers:\n%s", uploadCommand)
+	}
 	if strings.Contains(uploadCommand, "/var/lib/subrouter/.codex-accounts") {
 		t.Fatalf("upload should not use legacy account path:\n%s", uploadCommand)
 	}


### PR DESCRIPTION
## Summary
- Detect `/var/lib/subrouter` owner/group (or fall back to `_subrouter`) before `install -d` / `chown` during Codex and Claude server uploads
- Fixes `install: unknown group subrouter` on the team Mac mini, which runs as `_subrouter` rather than Linux `subrouter`

## Test plan
- [x] `go test ./cmd/subrouter/ -run 'TestClaudeUploadRemoteCommand|Upload|SSH|ServerSync|serverLogin'`
- [x] Remote owner detection on cmux-mac-mini returns `_subrouter:_subrouter`
- [ ] `sr add` / `sr server sync` uploads succeed against team without unknown-group errors

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787474259&installation_model_id=21920&pr_number=84&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F84&signature=cf5dd977f40110a396b9dc1b7ed41aee718a4ec398d8b72fa2bc05c9560d33c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect and use the real owner/group of `/var/lib/subrouter` during Claude profile and server account uploads. Prevents “unknown group subrouter” on macOS hosts that run as `_subrouter`.

- **Bug Fixes**
  - Auto-detect owner/group from `/var/lib/subrouter` via `stat` (macOS and Linux); fallback to `_subrouter` if present.
  - Apply detected owner/group in `install -d` and `chown` for Claude and server account uploads (local and SSH).
  - Updated tests to assert detection and to avoid hardcoded `subrouter:subrouter`.

<sup>Written for commit bee925c3c7ad2a9b2fe4cb202beafbc2a3f1a82a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

