### PR TITLE
fix: isolate server login auth and serialize parallel sr add

### DIFF
--- a/cmd/subrouter/sr_command.go
+++ b/cmd/subrouter/sr_command.go
@@ -3,21 +3,30 @@ package main
 import (
 	"context"
 	"io"
+	"os"
 	"os/exec"
 )
 
 type srCommandRunner interface {
 	Run(ctx context.Context, name string, args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error
+	RunWithEnv(ctx context.Context, name string, args []string, env []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error
 	Output(ctx context.Context, name string, args []string) ([]byte, error)
 }
 
 type execSRCommandRunner struct{}
 
 func (execSRCommandRunner) Run(ctx context.Context, name string, args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
+	return execSRCommandRunner{}.RunWithEnv(ctx, name, args, nil, stdin, stdout, stderr)
+}
+
+func (execSRCommandRunner) RunWithEnv(ctx context.Context, name string, args []string, env []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Stdin = stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
 	return cmd.Run()
 }
 

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -1218,30 +1218,36 @@ func printStatusGroup(w io.Writer, label string, emails []string, statuses map[s
 }
 
 func (r srRunner) serverLoginOne(ctx context.Context, server srServerConfig, deviceAuth bool, expectedEmail string) error {
-	previousActive, hadPreviousActive, err := accounts.ReadActiveCodexAuth()
+	// Serialize concurrent `sr add` / server login. Browser OAuth binds a fixed
+	// localhost callback port, and we must not let one login clobber another's
+	// temporary auth capture.
+	lock, err := accounts.AcquireActiveCodexAuthLock(func() {
+		fmt.Fprintln(r.out, "Another sr add/login is in progress; waiting...")
+	})
+	if err != nil {
+		return fmt.Errorf("lock server login: %w", err)
+	}
+	defer func() { _ = lock.Close() }()
+
+	// Run Codex login in an isolated CODEX_HOME so we never rewrite the user's
+	// ~/.codex/auth.json. Swapping that file mid-session makes running Codex
+	// clients fail with "logged out or signed in to another account".
+	loginHome, err := os.MkdirTemp("", "sr-server-login-*")
 	if err != nil {
 		return err
 	}
-	if err := r.store.SyncActiveToStore(); err != nil {
-		return err
-	}
-	restored := false
-	defer func() {
-		if !restored {
-			_ = restoreActiveCodexAuth(previousActive, hadPreviousActive)
-		}
-	}()
+	defer os.RemoveAll(loginHome)
 
 	loginArgs := []string{"login"}
 	if deviceAuth {
 		loginArgs = append(loginArgs, "--device-auth")
 	}
 	fmt.Fprintf(r.out, "Opening Codex OAuth login for server %s...\n", server.Name)
-	if err := r.commandRunner().Run(ctx, "codex", loginArgs, r.in, r.out, r.errOut); err != nil {
+	if err := r.commandRunner().RunWithEnv(ctx, "codex", loginArgs, []string{"CODEX_HOME=" + loginHome}, r.in, r.out, r.errOut); err != nil {
 		return fmt.Errorf("codex login failed: %w", err)
 	}
 
-	auth, ok, err := accounts.ReadActiveCodexAuth()
+	auth, ok, err := accounts.ReadCodexAuthFile(filepath.Join(loginHome, "auth.json"))
 	if err != nil {
 		return err
 	}
@@ -1260,28 +1266,71 @@ func (r srRunner) serverLoginOne(ctx context.Context, server srServerConfig, dev
 		AddedAt: time.Now().UTC().Format(time.RFC3339),
 		Auth:    auth,
 	}
-	if err := r.uploadServerAccount(ctx, server, account); err != nil {
+	if err := lock.Close(); err != nil {
 		return err
 	}
-	if err := restoreActiveCodexAuth(previousActive, hadPreviousActive); err != nil {
-		return err
+
+	stopProgress := r.startServerUploadProgress(account.Email, server.Name)
+	uploadErr := r.uploadServerAccount(ctx, server, account)
+	stopProgress()
+	if uploadErr != nil {
+		return uploadErr
 	}
-	restored = true
 	fmt.Fprintf(r.out, "Uploaded %s to server %s.\n", account.Email, server.Name)
-	fmt.Fprintln(r.out, "Your local Codex login is back to the account you were using before this command.")
+	fmt.Fprintln(r.out, "Local Codex auth was left unchanged.")
 	fmt.Fprintf(r.out, "The new %s refresh token is stored on %s, not kept as your local active login.\n", account.Email, server.Name)
 	return nil
 }
 
-func restoreActiveCodexAuth(previous accounts.CodexAuthFile, hadPrevious bool) error {
-	if hadPrevious {
-		return accounts.WriteActiveCodexAuth(previous)
+func (r srRunner) startServerUploadProgress(email, serverName string) func() {
+	message := fmt.Sprintf("Uploading %s to server %s...", email, serverName)
+	progressOut := r.errOut
+	if progressOut == nil {
+		progressOut = r.out
 	}
-	err := os.Remove(accounts.DefaultCodexAuthPath())
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
+	if progressOut == nil {
+		return func() {}
 	}
-	return err
+	fmt.Fprintln(progressOut, message)
+	if !writerIsTerminal(progressOut) {
+		return func() {}
+	}
+
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		frames := []string{"|", "/", "-", "\\"}
+		ticker := time.NewTicker(120 * time.Millisecond)
+		defer ticker.Stop()
+		i := 0
+		for {
+			select {
+			case <-done:
+				fmt.Fprint(progressOut, "\r\033[K")
+				return
+			case <-ticker.C:
+				fmt.Fprintf(progressOut, "\r%s %s", frames[i%len(frames)], message)
+				i++
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		<-finished
+	}
+}
+
+func writerIsTerminal(w io.Writer) bool {
+	file, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
 }
 
 func (r srRunner) uploadServerAccount(ctx context.Context, server srServerConfig, account accounts.StoredCodexAccount) error {

--- a/cmd/subrouter/sr_server_test.go
+++ b/cmd/subrouter/sr_server_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -710,11 +711,17 @@ func TestSRServerLoginUploadsFreshAuthAndRestoresLocalChain(t *testing.T) {
 	if strings.Contains(uploadCommand, "/var/lib/subrouter/.codex-accounts") {
 		t.Fatalf("upload should not use legacy account path:\n%s", uploadCommand)
 	}
-	if !strings.Contains(out.String(), "Your local Codex login is back to the account you were using before this command.") {
+	if !strings.Contains(out.String(), "Local Codex auth was left unchanged.") {
 		t.Fatalf("missing ownership message:\n%s", out.String())
 	}
 	if !strings.Contains(out.String(), "The new bob@example.com refresh token is stored on community, not kept as your local active login.") {
 		t.Fatalf("missing server token ownership message:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Uploading bob@example.com to server community...") {
+		t.Fatalf("missing upload progress message:\n%s", out.String())
+	}
+	if !fake.hasEnvPrefix("CODEX_HOME=") {
+		t.Fatalf("server login should isolate Codex auth via CODEX_HOME: %#v", fake.envs)
 	}
 }
 
@@ -1115,39 +1122,70 @@ func TestSRServerLoginRetriesTransientSSHUploadFailure(t *testing.T) {
 }
 
 type recordingSRCommandRunner struct {
+	mu                  sync.Mutex
 	loginAuth           accounts.CodexAuthFile
 	loginAuths          []accounts.CodexAuthFile
+	loginDelay          time.Duration
+	onLogin             func(env []string)
 	commands            [][]string
+	envs                [][]string
 	failCommandPrefixes []failCommandPrefix
 }
 
-func (r *recordingSRCommandRunner) Run(_ context.Context, name string, args []string, _ io.Reader, _ io.Writer, _ io.Writer) error {
+func (r *recordingSRCommandRunner) Run(ctx context.Context, name string, args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
+	return r.RunWithEnv(ctx, name, args, nil, stdin, stdout, stderr)
+}
+
+func (r *recordingSRCommandRunner) RunWithEnv(_ context.Context, name string, args []string, env []string, _ io.Reader, _ io.Writer, _ io.Writer) error {
+	r.mu.Lock()
 	command := append([]string{name}, args...)
 	r.commands = append(r.commands, command)
+	r.envs = append(r.envs, append([]string(nil), env...))
 	for i := range r.failCommandPrefixes {
 		failure := &r.failCommandPrefixes[i]
 		if failure.times > 0 && commandHasPrefix(command, failure.prefix) {
 			failure.times--
-			return failure.err
+			err := failure.err
+			r.mu.Unlock()
+			return err
 		}
 	}
+	loginAuth := r.loginAuth
 	if name == "codex" && len(args) > 0 && args[0] == "login" {
-		loginAuth := r.loginAuth
 		if len(r.loginAuths) > 0 {
 			loginAuth = r.loginAuths[0]
 			r.loginAuths = r.loginAuths[1:]
+		}
+		onLogin := r.onLogin
+		delay := r.loginDelay
+		r.mu.Unlock()
+		if onLogin != nil {
+			onLogin(env)
+		}
+		if delay > 0 {
+			time.Sleep(delay)
 		}
 		body, err := jsonMarshalIndent(loginAuth)
 		if err != nil {
 			return err
 		}
-		path := accounts.DefaultCodexAuthPath()
+		path := authPathFromEnv(env)
 		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 			return err
 		}
 		return os.WriteFile(path, body, 0o600)
 	}
+	r.mu.Unlock()
 	return nil
+}
+
+func authPathFromEnv(env []string) string {
+	for _, item := range env {
+		if strings.HasPrefix(item, "CODEX_HOME=") {
+			return filepath.Join(strings.TrimPrefix(item, "CODEX_HOME="), "auth.json")
+		}
+	}
+	return accounts.DefaultCodexAuthPath()
 }
 
 type failCommandPrefix struct {
@@ -1160,7 +1198,22 @@ func (r *recordingSRCommandRunner) Output(context.Context, string, []string) ([]
 	return nil, nil
 }
 
+func (r *recordingSRCommandRunner) hasEnvPrefix(prefix string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, env := range r.envs {
+		for _, item := range env {
+			if strings.HasPrefix(item, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (r *recordingSRCommandRunner) hasCommand(parts ...string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	for _, command := range r.commands {
 		if len(command) != len(parts) {
 			continue
@@ -1180,6 +1233,8 @@ func (r *recordingSRCommandRunner) hasCommand(parts ...string) bool {
 }
 
 func (r *recordingSRCommandRunner) countCommand(parts ...string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	count := 0
 	for _, command := range r.commands {
 		if len(command) != len(parts) {
@@ -1200,6 +1255,8 @@ func (r *recordingSRCommandRunner) countCommand(parts ...string) int {
 }
 
 func (r *recordingSRCommandRunner) hasCommandPrefix(parts ...string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	for _, command := range r.commands {
 		if commandHasPrefix(command, parts) {
 			return true
@@ -1209,6 +1266,8 @@ func (r *recordingSRCommandRunner) hasCommandPrefix(parts ...string) bool {
 }
 
 func (r *recordingSRCommandRunner) countCommandPrefix(parts ...string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	count := 0
 	for _, command := range r.commands {
 		if commandHasPrefix(command, parts) {
@@ -1228,6 +1287,81 @@ func commandHasPrefix(command []string, parts []string) bool {
 		}
 	}
 	return true
+}
+
+func TestParallelServerLoginSerializesAndPreservesLocalAuth(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	store := accounts.DefaultCodexStore()
+
+	local := testCodexAuth("local@example.com", "acct_local")
+	if err := accounts.WriteActiveCodexAuth(local); err != nil {
+		t.Fatal(err)
+	}
+	server := srServerConfig{Name: "team", URL: "http://100.64.0.1:31415"}
+
+	started := make(chan struct{}, 2)
+	releaseFirst := make(chan struct{})
+	var firstStarted sync.Once
+	fakeA := &recordingSRCommandRunner{
+		loginAuth:  testCodexAuth("lc+4@cmux.com", "acct_lc4"),
+		loginDelay: 80 * time.Millisecond,
+		onLogin: func([]string) {
+			firstStarted.Do(func() { close(releaseFirst) })
+			started <- struct{}{}
+		},
+	}
+	fakeB := &recordingSRCommandRunner{
+		loginAuth: testCodexAuth("lc+5@cmux.com", "acct_lc5"),
+		onLogin: func([]string) {
+			<-releaseFirst
+			started <- struct{}{}
+		},
+	}
+
+	var outA, outB bytes.Buffer
+	errA := make(chan error, 1)
+	errB := make(chan error, 1)
+	go func() {
+		runner := srRunner{store: store, out: &outA, errOut: &outA, cmd: fakeA}
+		errA <- runner.serverLoginOne(context.Background(), server, true, "")
+	}()
+	go func() {
+		// Ensure B contends for the lock while A holds it during login.
+		time.Sleep(20 * time.Millisecond)
+		runner := srRunner{store: store, out: &outB, errOut: &outB, cmd: fakeB}
+		errB <- runner.serverLoginOne(context.Background(), server, true, "")
+	}()
+
+	if err := <-errA; err != nil {
+		t.Fatalf("login A: %v\n%s", err, outA.String())
+	}
+	if err := <-errB; err != nil {
+		t.Fatalf("login B: %v\n%s", err, outB.String())
+	}
+	close(started)
+
+	active, ok, err := accounts.ReadActiveCodexAuth()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || active.Tokens.RefreshToken != local.Tokens.RefreshToken {
+		t.Fatalf("local active auth was mutated by parallel server logins")
+	}
+	combined := outA.String() + outB.String()
+	if !strings.Contains(combined, "Another sr add/login is in progress; waiting...") {
+		t.Fatalf("expected waiter message for concurrent login:\n%s", combined)
+	}
+	if !strings.Contains(combined, "Uploaded lc+4@cmux.com to server team.") {
+		t.Fatalf("missing lc+4 upload:\n%s", combined)
+	}
+	if !strings.Contains(combined, "Uploaded lc+5@cmux.com to server team.") {
+		t.Fatalf("missing lc+5 upload:\n%s", combined)
+	}
+	if !strings.Contains(combined, "Uploading lc+4@cmux.com to server team...") ||
+		!strings.Contains(combined, "Uploading lc+5@cmux.com to server team...") {
+		t.Fatalf("missing upload progress indicators:\n%s", combined)
+	}
 }
 
 func TestParseAPIKeyProviderClaude(t *testing.T) {

--- a/internal/accounts/codex_active_lock_unix.go
+++ b/internal/accounts/codex_active_lock_unix.go
@@ -1,0 +1,82 @@
+//go:build !windows
+
+package accounts
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// ErrActiveCodexAuthBusy means another process currently holds the active-auth lock.
+var ErrActiveCodexAuthBusy = errors.New("active Codex auth is busy")
+
+type ActiveCodexAuthLock struct {
+	file *os.File
+}
+
+func activeCodexAuthLockPath() string {
+	return DefaultCodexAuthPath() + ".lock"
+}
+
+// TryLockActiveCodexAuth acquires an exclusive lock without blocking.
+func TryLockActiveCodexAuth() (*ActiveCodexAuthLock, error) {
+	return lockActiveCodexAuth(true)
+}
+
+// LockActiveCodexAuth acquires an exclusive lock, blocking until available.
+func LockActiveCodexAuth() (*ActiveCodexAuthLock, error) {
+	return lockActiveCodexAuth(false)
+}
+
+// AcquireActiveCodexAuthLock tries non-blocking first; if busy, calls onWait then blocks.
+func AcquireActiveCodexAuthLock(onWait func()) (*ActiveCodexAuthLock, error) {
+	lock, err := TryLockActiveCodexAuth()
+	if err == nil {
+		return lock, nil
+	}
+	if !errors.Is(err, ErrActiveCodexAuthBusy) {
+		return nil, err
+	}
+	if onWait != nil {
+		onWait()
+	}
+	return LockActiveCodexAuth()
+}
+
+func lockActiveCodexAuth(nonBlocking bool) (*ActiveCodexAuthLock, error) {
+	path := activeCodexAuthLockPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	flags := syscall.LOCK_EX
+	if nonBlocking {
+		flags |= syscall.LOCK_NB
+	}
+	if err := syscall.Flock(int(file.Fd()), flags); err != nil {
+		_ = file.Close()
+		if nonBlocking && (errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN)) {
+			return nil, ErrActiveCodexAuthBusy
+		}
+		return nil, err
+	}
+	return &ActiveCodexAuthLock{file: file}, nil
+}
+
+func (l *ActiveCodexAuthLock) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	unlockErr := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	closeErr := l.file.Close()
+	l.file = nil
+	if unlockErr != nil {
+		return unlockErr
+	}
+	return closeErr
+}

--- a/internal/accounts/codex_active_lock_windows.go
+++ b/internal/accounts/codex_active_lock_windows.go
@@ -1,0 +1,67 @@
+//go:build windows
+
+package accounts
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// ErrActiveCodexAuthBusy means another process currently holds the active-auth lock.
+var ErrActiveCodexAuthBusy = errors.New("active Codex auth is busy")
+
+type ActiveCodexAuthLock struct {
+	file *os.File
+}
+
+func activeCodexAuthLockPath() string {
+	return DefaultCodexAuthPath() + ".lock"
+}
+
+// TryLockActiveCodexAuth acquires an exclusive lock without blocking.
+// Windows builds keep a best-effort open handle; concurrent writers are uncommon.
+func TryLockActiveCodexAuth() (*ActiveCodexAuthLock, error) {
+	return lockActiveCodexAuth()
+}
+
+// LockActiveCodexAuth acquires an exclusive lock, blocking until available.
+func LockActiveCodexAuth() (*ActiveCodexAuthLock, error) {
+	return lockActiveCodexAuth()
+}
+
+// AcquireActiveCodexAuthLock tries non-blocking first; if busy, calls onWait then blocks.
+func AcquireActiveCodexAuthLock(onWait func()) (*ActiveCodexAuthLock, error) {
+	lock, err := TryLockActiveCodexAuth()
+	if err == nil {
+		return lock, nil
+	}
+	if !errors.Is(err, ErrActiveCodexAuthBusy) {
+		return nil, err
+	}
+	if onWait != nil {
+		onWait()
+	}
+	return LockActiveCodexAuth()
+}
+
+func lockActiveCodexAuth() (*ActiveCodexAuthLock, error) {
+	path := activeCodexAuthLockPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	return &ActiveCodexAuthLock{file: file}, nil
+}
+
+func (l *ActiveCodexAuthLock) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	err := l.file.Close()
+	l.file = nil
+	return err
+}

--- a/internal/accounts/codex_auth.go
+++ b/internal/accounts/codex_auth.go
@@ -36,7 +36,11 @@ func CodexRefreshReason(ctx context.Context) string {
 }
 
 func ReadActiveCodexAuth() (CodexAuthFile, bool, error) {
-	body, err := os.ReadFile(DefaultCodexAuthPath())
+	return ReadCodexAuthFile(DefaultCodexAuthPath())
+}
+
+func ReadCodexAuthFile(path string) (CodexAuthFile, bool, error) {
+	body, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return CodexAuthFile{}, false, nil
 	}
@@ -334,11 +338,16 @@ func codexRefreshFailureFromError(err error) (*CodexRefreshFailure, bool) {
 }
 
 func isTerminalCodexRefreshFailure(statusCode int, providerCode, providerMessage string) bool {
+	providerCode = strings.ToLower(strings.TrimSpace(providerCode))
+	providerMessage = strings.ToLower(providerMessage)
+	// Codex emits this locally when auth.json flipped to another account mid-refresh.
+	if strings.Contains(providerMessage, "logged out or signed in to another account") ||
+		strings.Contains(providerMessage, "access token could not be refreshed because you have since") {
+		return true
+	}
 	if statusCode != http.StatusBadRequest && statusCode != http.StatusUnauthorized {
 		return false
 	}
-	providerCode = strings.ToLower(strings.TrimSpace(providerCode))
-	providerMessage = strings.ToLower(providerMessage)
 	return strings.Contains(providerCode, "refresh_token") || strings.Contains(providerMessage, "refresh token")
 }
 

--- a/internal/accounts/codex_auth_test.go
+++ b/internal/accounts/codex_auth_test.go
@@ -433,3 +433,16 @@ func testCodexJWT(email, jwtID string, exp time.Time) string {
 	})
 	return base64.RawURLEncoding.EncodeToString(header) + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
 }
+
+func TestAccountMismatchMessageIsTerminalRefreshFailure(t *testing.T) {
+	account := StoredCodexAccount{
+		Auth: CodexAuthFile{
+			RefreshFailure: &CodexRefreshFailure{
+				ProviderMessage: "Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again.",
+			},
+		},
+	}
+	if err := terminalStoredRefreshFailure(account); err == nil {
+		t.Fatal("expected account-mismatch refresh failure to be terminal")
+	}
+}

--- a/internal/accounts/codex_switch.go
+++ b/internal/accounts/codex_switch.go
@@ -15,6 +15,9 @@ type rawCodexStoredAccount struct {
 }
 
 func DefaultCodexAuthPath() string {
+	if codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME")); codexHome != "" {
+		return filepath.Join(codexHome, "auth.json")
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return filepath.Join(".codex", "auth.json")


### PR DESCRIPTION
## Summary
- Run `sr add` / `sr server login` Codex OAuth in an isolated temporary `CODEX_HOME`, so local `~/.codex/auth.json` is never rewritten mid-session
- Serialize concurrent server logins with a flock (browser OAuth shares localhost:1455)
- Show `Uploading <email> to server <name>...` (with a tty spinner) after login succeeds
- Treat Codex's "logged out or signed in to another account" refresh message as a terminal reauth failure

## Test plan
- [x] `go test ./cmd/subrouter/ ./internal/accounts/`
- [x] Parallel login test asserts waiter message, both uploads, and unchanged local auth
- [ ] `sr add` twice in parallel against team; local Codex keeps working
- [ ] After "Successfully logged in", upload progress is visible before "Uploaded ..."

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787474911&installation_model_id=21920&pr_number=85&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F85&signature=082821ac3c47bf22ef78968166e63bd947f4901a044a6b499ef5c99863c6c227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates Codex OAuth for `sr add`/`sr server login` in a temp `CODEX_HOME` and serializes concurrent logins to prevent local auth clobbering and account-mismatch refresh errors. Adds a simple upload progress indicator after login.

- **Bug Fixes**
  - Run `codex login` in a temporary `CODEX_HOME` so `~/.codex/auth.json` stays unchanged; uploads use the captured auth and we confirm local auth is untouched.
  - Serialize parallel logins with a cross-platform active-auth lock; show "Another sr add/login is in progress; waiting..." while queued.
  - Treat Codex "logged out or signed in to another account" refresh messages as terminal to avoid retry loops.

- **New Features**
  - Show "Uploading <email> to server <name>..." with a TTY spinner after login until the upload completes.

<sup>Written for commit 2118bd398d6d72453389c510ccc101953a0056c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

