### PR TITLE
Add /_subrouter/switch-account so remote clients can move the active account

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -332,6 +332,7 @@ func serve(args []string) error {
 		ClaudeFableAPIKey:   strings.TrimSpace(os.Getenv("SUBROUTER_CLAUDE_FABLE_API_KEY")),
 		FableBedrockPrimary: *fableBedrockPrimary || envTrue("SUBROUTER_FABLE_BEDROCK_PRIMARY"),
 		Transcripts:         transcript.NewRecorder(*transcriptDir),
+		SwitchAccount:       serveSwitchAccount(codexStore, agentclaude.DefaultStore(), slog.Default()),
 	}
 	transcriptGCSSyncer := transcript.NewGCSSyncer(transcript.GCSSyncerConfig{
 		SourceDir:      *transcriptDir,

--- a/cmd/subrouter/serve_switch.go
+++ b/cmd/subrouter/serve_switch.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
+)
+
+// serveSwitchAccount backs /_subrouter/switch-account: the remote analogue
+// of `sr switch` (Codex) and `sr claude switch` (Claude), executed on the
+// daemon host. Codex first folds the host's current auth.json back into the
+// store — matching `sr switch` — so a manually-logged-in account is not
+// lost by the overwrite; a sync failure only logs because the switch target
+// comes from the store, not the active file.
+func serveSwitchAccount(codexStore accounts.CodexStore, claudeStore agentclaude.Store, logger *slog.Logger) func(context.Context, string, string) error {
+	return func(ctx context.Context, provider, accountID string) error {
+		switch provider {
+		case string(accounts.ProviderCodex):
+			if err := codexStore.SyncActiveToStore(); err != nil {
+				logSRAutoSwitch(logger, slog.LevelWarn, "switch-account sync active to store failed", "error", err)
+			}
+			return switchActiveCodexAccount(ctx, codexStore, logger, "switch-endpoint", accountID)
+		case string(accounts.ProviderClaude):
+			profile, ok, err := claudeStore.MatchProfile(accountID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("no Claude profile matching %q", accountID)
+			}
+			return claudeStore.SetActiveProfile(profile.Name)
+		default:
+			return fmt.Errorf("unsupported provider %q", provider)
+		}
+	}
+}

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -282,7 +282,10 @@ func (r srRunner) runRemoteAccountCommand(ctx context.Context, server srServerCo
 		if selector == "" {
 			return r.serverStatus(ctx, defaultSRServerStore(r.store), server.Name)
 		}
-		return r.unsupportedRemoteCommand(command, server, "remote servers select accounts per session; use SUBROUTER_CODEX_ACCOUNT_ID for a one-off forced account")
+		// Sessions the server routes are unaffected (the scheduler ignores
+		// the active flag); this moves the server host's active credential
+		// files, i.e. what its interactive tools and usage-status report.
+		return r.switchRemoteAccount(ctx, server, selector)
 	case "import":
 		return r.unsupportedRemoteCommand(command, server, "copying a local refresh-token chain to a server is unsafe; use "+r.programOrSubrouter()+" add or "+r.programOrSubrouter()+" server sync "+server.Name)
 	case "remove", "rm", "trace", "breadcrumbs", "why", "add-admin-key", "list-admin-keys", "admin-keys", "remove-admin-key", "attach-project":

--- a/cmd/subrouter/sr_auto_switch.go
+++ b/cmd/subrouter/sr_auto_switch.go
@@ -24,6 +24,37 @@ type srAutoSwitchConfig struct {
 	SwitchActive func(context.Context, string) error
 }
 
+// switchActiveCodexAccount writes accountID's stored credentials as the
+// host's active Codex auth (plus the compatible-tool copies) — the shared
+// switch body behind the daemon's auto-switch loop and the
+// /_subrouter/switch-account endpoint. A failed token refresh falls back to
+// the cached tokens rather than failing the switch.
+func switchActiveCodexAccount(ctx context.Context, store accounts.CodexStore, logger *slog.Logger, refreshReason, accountID string) error {
+	stored, ok, err := store.FindStored(accountID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("account %q not found", accountID)
+	}
+	refreshCtx := accounts.WithCodexRefreshReason(ctx, refreshReason)
+	refreshed, _, err := store.RefreshStoredIfExpired(refreshCtx, nil, stored)
+	if err == nil {
+		stored = refreshed
+	} else {
+		logSRAutoSwitch(logger, slog.LevelWarn, "switch token refresh failed, using cached tokens", "account", accountID, "error", err)
+	}
+	if err := accounts.WriteActiveCodexAuth(stored.Auth); err != nil {
+		return err
+	}
+	for _, result := range syncCodexCompatibleAuth(stored) {
+		if result.Err != nil {
+			logSRAutoSwitch(logger, slog.LevelWarn, "switch compatible auth sync failed", "tool", result.Tool, "error", result.Err)
+		}
+	}
+	return nil
+}
+
 func runSRAutoSwitch(ctx context.Context, cfg srAutoSwitchConfig) {
 	if cfg.Interval <= 0 {
 		return
@@ -54,30 +85,7 @@ func srAutoSwitchOnce(ctx context.Context, cfg srAutoSwitchConfig) (string, erro
 	switchActive := cfg.SwitchActive
 	if switchActive == nil {
 		switchActive = func(ctx context.Context, accountID string) error {
-			store := accounts.DefaultCodexStore()
-			stored, ok, err := store.FindStored(accountID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return fmt.Errorf("account %q not found", accountID)
-			}
-			refreshCtx := accounts.WithCodexRefreshReason(ctx, "sr-auto-switch")
-			refreshed, _, err := store.RefreshStoredIfExpired(refreshCtx, nil, stored)
-			if err == nil {
-				stored = refreshed
-			} else {
-				logSRAutoSwitch(cfg.Logger, slog.LevelWarn, "sr auto-switch token refresh failed, using cached tokens", "account", accountID, "error", err)
-			}
-			if err := accounts.WriteActiveCodexAuth(stored.Auth); err != nil {
-				return err
-			}
-			for _, result := range syncCodexCompatibleAuth(stored) {
-				if result.Err != nil {
-					logSRAutoSwitch(cfg.Logger, slog.LevelWarn, "sr auto-switch compatible auth sync failed", "tool", result.Tool, "error", result.Err)
-				}
-			}
-			return nil
+			return switchActiveCodexAccount(ctx, accounts.DefaultCodexStore(), cfg.Logger, "sr-auto-switch", accountID)
 		}
 	}
 

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -900,6 +900,50 @@ func usageRowsFromServerUsageStatuses(statuses []remoteServerUsageStatus) []srUs
 	return rows
 }
 
+// switchRemoteAccount asks a server to move its active Codex account via
+// POST /_subrouter/switch-account — the remote analogue of the local
+// credential-file switch. The raw selector is sent as-is; the server
+// resolves it against its own account store.
+func (r srRunner) switchRemoteAccount(ctx context.Context, server srServerConfig, selector string) error {
+	payload, err := json.Marshal(map[string]string{
+		"provider":   string(accounts.ProviderCodex),
+		"account_id": selector,
+	})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/_subrouter/switch-account", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	addServerAdminAuth(req, server)
+	client := r.client
+	if client == nil {
+		// The server-side switch can refresh OAuth tokens before writing;
+		// give it more headroom than the read-only server calls.
+		client = &http.Client{Timeout: 60 * time.Second}
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusNotImplemented {
+		return fmt.Errorf("server %s does not support remote switch; upgrade the server so /_subrouter/switch-account is available", server.Name)
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		detail, _ := io.ReadAll(io.LimitReader(res.Body, 512))
+		message := strings.TrimSpace(string(detail))
+		if message == "" {
+			message = res.Status
+		}
+		return fmt.Errorf("server switch failed: %s", message)
+	}
+	fmt.Fprintf(r.out, "Server %s active Codex account: %s\n", server.Name, selector)
+	return nil
+}
+
 func addServerAdminAuth(req *http.Request, server srServerConfig) {
 	if strings.TrimSpace(server.AdminToken) == "" {
 		return

--- a/cmd/subrouter/sr_server_test.go
+++ b/cmd/subrouter/sr_server_test.go
@@ -545,10 +545,35 @@ func TestSRSwitchDoesNotMutateLocalWhenDefaultRemoteServerSelected(t *testing.T)
 	}
 
 	var out bytes.Buffer
-	runner := srRunner{program: "sr", store: store, out: &out, errOut: &out}
-	err := runner.run(context.Background(), []string{"switch", "remote@example.com"})
-	if err == nil || !strings.Contains(err.Error(), "will not edit local Codex state") {
-		t.Fatalf("err = %v, want remote guard", err)
+	runner := srRunner{
+		program: "sr",
+		store:   store,
+		out:     &out,
+		errOut:  &out,
+		client: &http.Client{Transport: srRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/_subrouter/switch-account" || req.Method != http.MethodPost {
+				t.Fatalf("request = %s %s, want POST /_subrouter/switch-account", req.Method, req.URL.Path)
+			}
+			body, _ := io.ReadAll(req.Body)
+			var payload map[string]string
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("body = %q: %v", body, err)
+			}
+			if payload["provider"] != "codex" || payload["account_id"] != "remote@example.com" {
+				t.Fatalf("payload = %v", payload)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			}, nil
+		})},
+	}
+	if err := runner.run(context.Background(), []string{"switch", "remote@example.com"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "Server team active Codex account: remote@example.com") {
+		t.Fatalf("missing remote switch confirmation:\n%s", out.String())
 	}
 	active, ok, err := accounts.ReadActiveCodexAuth()
 	if err != nil {
@@ -556,6 +581,41 @@ func TestSRSwitchDoesNotMutateLocalWhenDefaultRemoteServerSelected(t *testing.T)
 	}
 	if !ok || active.Tokens.RefreshToken != localAuth.Tokens.RefreshToken {
 		t.Fatalf("active local auth was mutated")
+	}
+}
+
+func TestSRSwitchExplainsWhenRemoteServerLacksSwitchEndpoint(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	store := accounts.DefaultCodexStore()
+	if err := defaultSRServerStore(store).save(srServerFile{
+		Default: "team",
+		Servers: []srServerConfig{{
+			Name: "team",
+			URL:  "http://100.64.0.1:31415",
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	runner := srRunner{
+		program: "sr",
+		store:   store,
+		out:     &out,
+		errOut:  &out,
+		client: &http.Client{Transport: srRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			// Older servers route unknown /_subrouter/ paths to NotFound.
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("404 page not found")),
+			}, nil
+		})},
+	}
+	err := runner.run(context.Background(), []string{"switch", "remote@example.com"})
+	if err == nil || !strings.Contains(err.Error(), "does not support remote switch") {
+		t.Fatalf("err = %v, want upgrade guidance", err)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -50,14 +50,19 @@ type Server struct {
 	// RefreshAccountFn, when set, replaces the default OAuth refresh path. Test
 	// seam for simulating dead/expired refresh tokens; nil in production.
 	RefreshAccountFn func(context.Context, accounts.Account) (accounts.Account, error)
-	Transport        http.RoundTripper
-	Logger           *slog.Logger
-	ActiveSessions   *ActiveSessions
-	Lifecycle        *Lifecycle
-	AdminToken       string
-	MaxBodyBytes     int64
-	Transcripts      *transcript.Recorder
-	ReadCache        *readCache
+	// SwitchAccount, when set, moves the daemon host's active account for a
+	// provider ("codex" or "claude") — the same credential-file rewrite
+	// `sr switch` performs locally, executed on the server host. Backs
+	// /_subrouter/switch-account; nil answers that endpoint with 501.
+	SwitchAccount  func(ctx context.Context, provider, accountID string) error
+	Transport      http.RoundTripper
+	Logger         *slog.Logger
+	ActiveSessions *ActiveSessions
+	Lifecycle      *Lifecycle
+	AdminToken     string
+	MaxBodyBytes   int64
+	Transcripts    *transcript.Recorder
+	ReadCache      *readCache
 	// Bedrock, when set, enables the /bedrock/* SigV4 signing gateway.
 	Bedrock *BedrockConfig
 	// ClaudeFableAPIKey, when set, serves Claude Fable requests via this Anthropic
@@ -910,6 +915,7 @@ func (s Server) Handler() http.Handler {
 	mux.HandleFunc("/_subrouter/rate-limit-reset", s.requireAdmin(s.handleRateLimitReset))
 	mux.HandleFunc("/_subrouter/reset-credits", s.requireAdmin(s.handleResetCredits))
 	mux.HandleFunc("/_subrouter/reload-accounts", s.requireAdmin(s.handleReloadAccounts))
+	mux.HandleFunc("/_subrouter/switch-account", s.requireAdmin(s.handleSwitchAccount))
 	mux.HandleFunc("/_subrouter/sessions", s.requireAdmin(s.handleSessions))
 	mux.HandleFunc("/_subrouter/dashboard", s.requireAdmin(s.handleDashboard))
 	mux.HandleFunc("/_subrouter/transcripts", s.requireAdmin(s.handleTranscriptList))
@@ -1176,6 +1182,54 @@ func (s Server) reloadAccounts(ctx context.Context) (int, int, error) {
 	}
 	s.SchedulerRef.Set(scheduler)
 	return len(loaded), scored, nil
+}
+
+// handleSwitchAccount moves the daemon host's active account for one
+// provider — the remote analogue of `sr switch` / `sr claude switch`.
+// Admin-gated but deliberately NOT loopback-only: its whole purpose is
+// letting remote clients (cmux, `sr switch` against a selected server)
+// perform the switch. Routing is unaffected — the scheduler never reads
+// the active flag — so this only changes what the host's interactive
+// tools use and what usage-status reports as active.
+func (s Server) handleSwitchAccount(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.SwitchAccount == nil {
+		http.Error(w, "switch-account is not configured on this server", http.StatusNotImplemented)
+		return
+	}
+	var payload struct {
+		Provider  string `json:"provider"`
+		AccountID string `json:"account_id"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&payload); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	provider := strings.ToLower(strings.TrimSpace(payload.Provider))
+	accountID := strings.TrimSpace(payload.AccountID)
+	if provider == "" || accountID == "" {
+		http.Error(w, "provider and account_id are required", http.StatusBadRequest)
+		return
+	}
+	if provider != string(accounts.ProviderCodex) && provider != string(accounts.ProviderClaude) {
+		http.Error(w, fmt.Sprintf("unsupported provider %q, expected codex or claude", provider), http.StatusBadRequest)
+		return
+	}
+	if err := s.SwitchAccount(r.Context(), provider, accountID); err != nil {
+		// 422: the daemon is healthy but the switch was rejected (unknown
+		// account, refresh failure) — distinct from transport-level 5xx.
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+	// The active flag in usage-status mirrors the files just rewritten;
+	// drop the cache so the next poll reports the new active account.
+	if s.AccountRef != nil {
+		s.AccountRef.InvalidateUsageStatusCache()
+	}
+	writeJSON(w, map[string]any{"ok": true, "provider": provider, "account_id": accountID})
 }
 
 // RateLimitResetResult is the per-account outcome of a rate-limit reset

--- a/internal/proxy/switch_account_test.go
+++ b/internal/proxy/switch_account_test.go
@@ -1,0 +1,112 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func switchTestServer(switchAccount func(context.Context, string, string) error) http.Handler {
+	return Server{
+		AdminToken:    "secret",
+		MaxBodyBytes:  1024,
+		SwitchAccount: switchAccount,
+	}.Handler()
+}
+
+func postSwitch(handler http.Handler, remoteAddr, token, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/_subrouter/switch-account", strings.NewReader(body))
+	req.RemoteAddr = remoteAddr
+	if token != "" {
+		req.Header.Set("X-Subrouter-Admin-Token", token)
+	}
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func TestSwitchAccountEndpointCallsCallbackAndReportsOK(t *testing.T) {
+	var gotProvider, gotAccount string
+	handler := switchTestServer(func(_ context.Context, provider, accountID string) error {
+		gotProvider, gotAccount = provider, accountID
+		return nil
+	})
+	recorder := postSwitch(handler, "100.64.0.2:12345", "secret", `{"provider":"codex","account_id":"a@example.com"}`)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if gotProvider != "codex" || gotAccount != "a@example.com" {
+		t.Fatalf("callback got (%q, %q)", gotProvider, gotAccount)
+	}
+	if !strings.Contains(recorder.Body.String(), `"ok": true`) {
+		t.Fatalf("body = %s", recorder.Body.String())
+	}
+}
+
+func TestSwitchAccountEndpointRequiresAdminTokenOffLoopback(t *testing.T) {
+	handler := switchTestServer(func(_ context.Context, _, _ string) error { return nil })
+	recorder := postSwitch(handler, "100.64.0.2:12345", "", `{"provider":"codex","account_id":"a@example.com"}`)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("status without token = %d", recorder.Code)
+	}
+}
+
+func TestSwitchAccountEndpointRejectsNonPost(t *testing.T) {
+	handler := switchTestServer(func(_ context.Context, _, _ string) error { return nil })
+	req := httptest.NewRequest(http.MethodGet, "/_subrouter/switch-account", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d", recorder.Code)
+	}
+}
+
+func TestSwitchAccountEndpointAnswers501WhenUnwired(t *testing.T) {
+	handler := switchTestServer(nil)
+	recorder := postSwitch(handler, "127.0.0.1:12345", "", `{"provider":"codex","account_id":"a@example.com"}`)
+	if recorder.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d", recorder.Code)
+	}
+}
+
+func TestSwitchAccountEndpointValidatesBody(t *testing.T) {
+	called := false
+	handler := switchTestServer(func(_ context.Context, _, _ string) error {
+		called = true
+		return nil
+	})
+	for name, body := range map[string]string{
+		"not json":         `not-json`,
+		"missing account":  `{"provider":"codex"}`,
+		"missing provider": `{"account_id":"a@example.com"}`,
+		"unknown provider": `{"provider":"gemini","account_id":"a@example.com"}`,
+	} {
+		recorder := postSwitch(handler, "127.0.0.1:12345", "", body)
+		if recorder.Code != http.StatusBadRequest {
+			t.Fatalf("%s: status = %d, body = %s", name, recorder.Code, recorder.Body.String())
+		}
+	}
+	if called {
+		t.Fatal("callback ran for an invalid request")
+	}
+}
+
+func TestSwitchAccountEndpointMapsCallbackErrorTo422(t *testing.T) {
+	handler := switchTestServer(func(_ context.Context, _, accountID string) error {
+		return &accountNotFoundError{accountID}
+	})
+	recorder := postSwitch(handler, "127.0.0.1:12345", "", `{"provider":"claude","account_id":"nope"}`)
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d", recorder.Code)
+	}
+	if !strings.Contains(recorder.Body.String(), "nope") {
+		t.Fatalf("body = %s", recorder.Body.String())
+	}
+}
+
+type accountNotFoundError struct{ id string }
+
+func (e *accountNotFoundError) Error() string { return "account " + e.id + " not found" }


### PR DESCRIPTION
## What

Adds a remote switch path for the daemon's active account. Until now the active account (what `usage-status` reports as `active`, and what the host's interactive tools use) could only change via a local credential-file rewrite: `sr switch` refused outright when a remote server was selected, and cmux's account switcher UI had no way to switch against a remote server at all.

## How

- **proxy**: new `POST /_subrouter/switch-account` — admin-token-gated but deliberately **not** loopback-only (its whole purpose is remote callers). Validates `{provider, account_id}` (codex/claude), runs the server's wired `SwitchAccount` callback, then invalidates the usage-status cache so the next poll reports the new active account. Servers without a wired callback answer 501.
- **serve wiring**: Codex reuses the auto-switch loop's credential rewrite (extracted as `switchActiveCodexAccount`: resolve via `FindStored`, refresh-if-expired with cached-token fallback, `WriteActiveCodexAuth`, compatible-tool sync), after first folding the host's current `auth.json` back into the store — matching `sr switch` semantics. Claude resolves via `MatchProfile` → `SetActiveProfile`.
- **sr CLI**: `sr switch/use/g/gui <selector>` with a remote server selected now calls the endpoint (raw selector; the server resolves it) instead of refusing, still never touching local Codex state. Older servers without the endpoint (404/501) get explicit upgrade guidance.

Routing is unaffected: the scheduler never reads the active flag, so this only changes what the server host's interactive tools use and what `usage-status` reports.

## Tests

- `internal/proxy/switch_account_test.go`: callback dispatch + ok payload, admin-token enforcement off-loopback, method gating, 501 when unwired, body validation (bad JSON / missing fields / unknown provider), callback error → 422.
- `cmd/subrouter`: `TestSRSwitchDoesNotMutateLocalWhenDefaultRemoteServerSelected` now proves the endpoint is called with the right payload while local active auth stays untouched; new `TestSRSwitchExplainsWhenRemoteServerLacksSwitchEndpoint` covers the old-server 404 path.
- `go test ./...` passes; `gofmt`/`go vet` clean.

Consumer side: cmux's Agents panel wires its switch action to this endpoint for remote servers (manaflow-ai/cmux#8206).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787783237&installation_model_id=21920&pr_number=86&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F86&signature=ac28830ce02fb4e8ae307d2ad2035a01eace6e85ca447bae946b900b5733a649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `POST /_subrouter/switch-account` so remote clients can switch the server host’s active Codex or Claude account. `sr switch` now works with a selected remote server without touching local credentials.

- **New Features**
  - Add `POST /_subrouter/switch-account` (admin-token gated, remote-capable). Validates `{provider, account_id}`, runs the server’s switch callback, and invalidates the usage-status cache. Returns 501 if not wired.
  - Server wiring: Codex uses `switchActiveCodexAccount` (refresh with fallback, write active auth, sync compatible tools, fold current `auth.json` into the store). Claude resolves via `MatchProfile` → `SetActiveProfile`.
  - CLI: `sr switch/use/g/gui <selector>` POSTs the raw selector to the selected server and shows upgrade guidance for 404/501. Local Codex state is not modified. Routing is unchanged (scheduler ignores the active flag).

<sup>Written for commit 8abebefafa2e1323d5fc10e1013f9736cadb7f7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remote account switching for Codex and Claude through the `sr` commands.
  * Added a secure server endpoint for switching active accounts.
  * Active account and related authentication state now update after a successful switch.
* **Bug Fixes**
  * Remote servers without account-switch support now provide a clear error message.
  * Account-switch failures return more specific validation and authorization errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->