### PR TITLE
Attribute and count dropped response streams

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -312,6 +312,7 @@ func serve(args []string) error {
 	})
 
 	server := proxy.Server{
+		StreamDrops:         &proxy.StreamDropStats{},
 		Upstream:            upstream,
 		CodexUpstream:       codexUpstream,
 		APIUpstream:         apiUpstream,

--- a/internal/proxy/claude_failover_test.go
+++ b/internal/proxy/claude_failover_test.go
@@ -307,7 +307,7 @@ func TestCaptureResponseBodyClaude401MarksExhausted(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"authentication_error"}}`)),
 		Header:     http.Header{},
 	}
-	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "", "", "/v1/messages")
+	server.captureResponseBody(response, context.Background(), "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "", "", "/v1/messages")
 	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
 		t.Fatal("claude 401 should mark the account exhausted via passive inspection")
 	}
@@ -341,7 +341,7 @@ func TestCaptureResponseBodyClaude429MarksExhausted(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error"}}`)),
 		Header:     h,
 	}
-	server.captureResponseBody(response, "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "", "", "/v1/messages")
+	server.captureResponseBody(response, context.Background(), "claude", "session-1", "cooked@example.com", accounts.ProviderClaude, "", "", "/v1/messages")
 	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "cooked@example.com") {
 		t.Fatal("claude rejected-header 429 should mark the account exhausted via passive inspection")
 	}
@@ -357,7 +357,7 @@ func TestCaptureResponseBodyClaudeBare429DoesNotPoison(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}`)),
 		Header:     http.Header{},
 	}
-	server.captureResponseBody(response, "claude", "session-1", "healthy@example.com", accounts.ProviderClaude, "", "", "/v1/messages")
+	server.captureResponseBody(response, context.Background(), "claude", "session-1", "healthy@example.com", accounts.ProviderClaude, "", "", "/v1/messages")
 	if server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, "healthy@example.com") {
 		t.Fatal("a bare (headerless) 429 must NOT mark a healthy account exhausted")
 	}

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -1091,7 +1091,7 @@ func TestClaudeUpstreamServerErrorLoggedNotExhausted(t *testing.T) {
 		Header:     http.Header{},
 		Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"overloaded_error"}}`)),
 	}
-	server.captureResponseBody(response, "claude", "session-1", "acct@example.com", accounts.ProviderClaude, "", "", "/v1/messages")
+	server.captureResponseBody(response, context.Background(), "claude", "session-1", "acct@example.com", accounts.ProviderClaude, "", "", "/v1/messages")
 	logs := logBuf.String()
 	if !strings.Contains(logs, "claude upstream server error") || !strings.Contains(logs, "status=529") {
 		t.Fatalf("expected a 529 upstream-server-error log; logs=\n%s", logs)

--- a/internal/proxy/outbound_transport_test.go
+++ b/internal/proxy/outbound_transport_test.go
@@ -10,23 +10,62 @@ import (
 	"time"
 )
 
-// newTestServerCountingConns records every distinct client connection the
-// server accepts, so a test can tell reuse from per-request dialing.
-func newTestServerCountingConns(t *testing.T, mu *sync.Mutex, conns map[string]struct{}) *httptest.Server {
+// barrierServer holds every request open until `want` of them are in flight,
+// then releases them together. Without this, requests finish fast enough to be
+// recycled mid-burst, so the number of connections opened depends on goroutine
+// scheduling and any assertion about it flakes. Holding them simultaneously
+// forces exactly one connection per concurrent request, deterministically.
+type barrierServer struct {
+	*httptest.Server
+	mu       sync.Mutex
+	conns    map[string]struct{}
+	want     int
+	inFlight int
+	release  chan struct{}
+}
+
+func newBarrierServer(t *testing.T, want int) *barrierServer {
 	t.Helper()
-	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	b := &barrierServer{conns: make(map[string]struct{}), want: want, release: make(chan struct{})}
+	b.Server = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		b.mu.Lock()
+		b.inFlight++
+		if b.inFlight == b.want {
+			close(b.release)
+		}
+		gate := b.release
+		b.mu.Unlock()
+
+		select {
+		case <-gate:
+		case <-time.After(10 * time.Second):
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
-	server.Config.ConnState = func(c net.Conn, state http.ConnState) {
+	b.Server.Config.ConnState = func(c net.Conn, state http.ConnState) {
 		if state != http.StateNew {
 			return
 		}
-		mu.Lock()
-		conns[c.RemoteAddr().String()] = struct{}{}
-		mu.Unlock()
+		b.mu.Lock()
+		b.conns[c.RemoteAddr().String()] = struct{}{}
+		b.mu.Unlock()
 	}
-	server.Start()
-	return server
+	b.Server.Start()
+	return b
+}
+
+// resetBarrier arms the server for another synchronized burst.
+func (b *barrierServer) resetBarrier() {
+	b.mu.Lock()
+	b.inFlight = 0
+	b.release = make(chan struct{})
+	b.mu.Unlock()
+}
+
+func (b *barrierServer) distinctConns() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.conns)
 }
 
 // The proxy speaks HTTP/1.1 only (see NewOutboundTransport), so concurrency is
@@ -55,24 +94,20 @@ func TestNewOutboundTransportPoolsConnectionsPerHost(t *testing.T) {
 // Concurrent requests to one host must reuse connections rather than dial per
 // request. This is the behavior whose absence exhausted the port range.
 //
-// Asserting on a total connection count is racy: the pool only gets a
-// connection back once its body is closed, so a burst can legitimately dial an
-// extra one or two. Instead, drive one warm-up burst, then repeat it and
-// require that the second burst dials nothing. With a pool large enough for the
-// concurrency, every connection is idle and reusable by then. With the default
-// pool of 2, the other connections were discarded and must be re-dialed.
+// Both bursts are synchronized by barrierServer so the connection counts are
+// deterministic rather than a function of goroutine scheduling. The first burst
+// necessarily opens one connection per concurrent request and leaves them all
+// idle; the second needs exactly the same number and must therefore dial none.
 func TestOutboundTransportReusesConnectionsUnderConcurrency(t *testing.T) {
 	const concurrency = 8
 
-	var mu sync.Mutex
-	conns := make(map[string]struct{})
-
-	server := newTestServerCountingConns(t, &mu, conns)
+	server := newBarrierServer(t, concurrency)
 	defer server.Close()
 
-	client := &http.Client{Transport: NewOutboundTransport(), Timeout: 10 * time.Second}
+	client := &http.Client{Transport: NewOutboundTransport(), Timeout: 30 * time.Second}
 
 	burst := func(round int) {
+		server.resetBarrier()
 		var wg sync.WaitGroup
 		for range concurrency {
 			wg.Add(1)
@@ -91,18 +126,20 @@ func TestOutboundTransportReusesConnectionsUnderConcurrency(t *testing.T) {
 		wg.Wait()
 	}
 
+	// All `concurrency` requests are held open together, so this opens exactly
+	// one connection each and leaves them all idle in the pool afterwards.
 	burst(1)
-	mu.Lock()
-	afterWarmup := len(conns)
-	mu.Unlock()
+	afterWarmup := server.distinctConns()
+	if afterWarmup != concurrency {
+		t.Fatalf("warm-up opened %d connections, want exactly %d; the barrier should hold every request open simultaneously", afterWarmup, concurrency)
+	}
 
+	// The same synchronized burst again. Every connection it needs is already
+	// idle in the pool, so a correctly sized pool dials nothing. With the
+	// default pool of 2, only two survived and the rest must be re-dialed.
 	burst(2)
-	mu.Lock()
-	afterReuse := len(conns)
-	mu.Unlock()
-
-	if afterReuse != afterWarmup {
-		t.Fatalf("second burst opened %d new connections (%d -> %d); a warm pool should have served all %d requests without dialing",
-			afterReuse-afterWarmup, afterWarmup, afterReuse, concurrency)
+	if dialed := server.distinctConns() - afterWarmup; dialed != 0 {
+		t.Fatalf("second burst dialed %d new connections despite %d idle in the pool; connections are not being reused",
+			dialed, afterWarmup)
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1866,7 +1866,7 @@ func (s Server) proxyHandler() http.Handler {
 		}
 		rp.Transport = transport
 		rp.ModifyResponse = func(response *http.Response) error {
-			s.captureResponseBody(response, sessionAgentType, sessionID, account.ID, account.Provider, requestPoolModel, retryPoolModel, proxyRequest.URL.Path)
+			s.captureResponseBody(response, r.Context(), sessionAgentType, sessionID, account.ID, account.Provider, requestPoolModel, retryPoolModel, proxyRequest.URL.Path)
 			return nil
 		}
 		if s.Logger != nil {
@@ -2374,7 +2374,26 @@ func (s Server) recordReplayableRequestBody(r *http.Request, agentType, sessionI
 	s.Transcripts.RecordPayloadSummary(agentType, sessionID, "http_body", "client_to_upstream", streamID, bytesRead, hex.EncodeToString(hasher.Sum(nil)), chunks, nil)
 }
 
-func (s Server) captureResponseBody(response *http.Response, agentType, sessionID, accountID string, provider accounts.Provider, poolModel, compatibilityModel, path string) {
+// streamCancelAttribution reports which side ended a response stream. A read
+// error is only meaningful once you know whether the downstream client hung up
+// or the cancellation came from inside the proxy: both surface as
+// "context canceled" on the upstream body, but only the second is our bug.
+func streamCancelAttribution(clientCtx context.Context, err error) (string, error) {
+	if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		return "upstream", nil
+	}
+	if clientCtx == nil {
+		return "unknown", nil
+	}
+	if clientErr := clientCtx.Err(); clientErr != nil {
+		return "client", clientErr
+	}
+	// The upstream read was canceled while the client was still connected, so
+	// something on our side dropped a live stream.
+	return "proxy", nil
+}
+
+func (s Server) captureResponseBody(response *http.Response, clientCtx context.Context, agentType, sessionID, accountID string, provider accounts.Provider, poolModel, compatibilityModel, path string) {
 	if provider == "" {
 		provider = accounts.ProviderCodex
 	}
@@ -2467,6 +2486,7 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 			}
 		}
 	}
+	streamStarted := time.Now()
 	response.Body = newStreamingTranscriptReadCloser(streamingTranscriptConfig{
 		ReadCloser: response.Body,
 		Recorder:   s.Transcripts,
@@ -2480,7 +2500,8 @@ func (s Server) captureResponseBody(response *http.Response, agentType, sessionI
 		OnInspect:  inspect,
 		onReadError: func(err error, bytesRead int) {
 			if s.Logger != nil {
-				s.Logger.Error("proxy response stream read failed", "agent", agentType, "session", sessionID, "account", accountID, "path", path, "status", response.StatusCode, "bytes", bytesRead, "error", err)
+				canceledBy, clientErr := streamCancelAttribution(clientCtx, err)
+				s.Logger.Error("proxy response stream read failed", "agent", agentType, "session", sessionID, "account", accountID, "path", path, "status", response.StatusCode, "bytes", bytesRead, "error", err, "canceled_by", canceledBy, "client_ctx_err", clientErr, "stream_age_ms", time.Since(streamStarted).Milliseconds())
 			}
 		},
 	})

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -53,6 +53,9 @@ type Server struct {
 	Transport        http.RoundTripper
 	Logger           *slog.Logger
 	ActiveSessions   *ActiveSessions
+	// StreamDrops counts dropped response streams by which side ended them,
+	// so the expected client-hangup case is countable without a log line each.
+	StreamDrops *StreamDropStats
 	Lifecycle        *Lifecycle
 	AdminToken       string
 	MaxBodyBytes     int64
@@ -902,6 +905,7 @@ func (s Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/_subrouter/health", s.handleHealth)
 	mux.HandleFunc("/_subrouter/ready", s.handleReady)
+	mux.HandleFunc("/_subrouter/stream-stats", s.handleStreamStats)
 	mux.HandleFunc("/_subrouter/drain", s.requireAdmin(s.handleDrain))
 	mux.HandleFunc("/_subrouter/drain-status", s.requireAdmin(s.handleDrainStatus))
 	mux.HandleFunc("/_subrouter/accounts", s.requireAdmin(s.handleAccounts))
@@ -925,6 +929,13 @@ func (s Server) Handler() http.Handler {
 
 func (s Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, map[string]any{"ok": true})
+}
+
+// handleStreamStats reports dropped response streams grouped by which side
+// ended them. A non-zero "proxy" count is the signal that subrouter dropped a
+// stream while the client was still connected.
+func (s Server) handleStreamStats(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, s.StreamDrops.Snapshot())
 }
 
 func (s Server) handleReady(w http.ResponseWriter, _ *http.Request) {
@@ -2499,10 +2510,20 @@ func (s Server) captureResponseBody(response *http.Response, clientCtx context.C
 		InspectMax: usageLimitInspectMaxBytes,
 		OnInspect:  inspect,
 		onReadError: func(err error, bytesRead int) {
-			if s.Logger != nil {
-				canceledBy, clientErr := streamCancelAttribution(clientCtx, err)
-				s.Logger.Error("proxy response stream read failed", "agent", agentType, "session", sessionID, "account", accountID, "path", path, "status", response.StatusCode, "bytes", bytesRead, "error", err, "canceled_by", canceledBy, "client_ctx_err", clientErr, "stream_age_ms", time.Since(streamStarted).Milliseconds())
+			canceledBy, clientErr := streamCancelAttribution(clientCtx, err)
+			s.StreamDrops.Observe(canceledBy, time.Now())
+			if s.Logger == nil {
+				return
 			}
+			// A client hanging up and retrying is expected and happens ~1000
+			// times a day; it is counted, not written, so the log stays
+			// bounded. Everything else is rare and actionable, so it keeps a
+			// full line.
+			if canceledBy == "client" {
+				s.Logger.Debug("proxy response stream ended by client", "agent", agentType, "session", sessionID, "account", accountID, "path", path, "bytes", bytesRead, "stream_age_ms", time.Since(streamStarted).Milliseconds())
+				return
+			}
+			s.Logger.Error("proxy response stream read failed", "agent", agentType, "session", sessionID, "account", accountID, "path", path, "status", response.StatusCode, "bytes", bytesRead, "error", err, "canceled_by", canceledBy, "client_ctx_err", clientErr, "stream_age_ms", time.Since(streamStarted).Milliseconds())
 		},
 	})
 }

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -3249,7 +3249,7 @@ func TestCaptureResponseBodyMarksCodexModelCompatibility(t *testing.T) {
 		Header:     http.Header{},
 		Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}}`)),
 	}
-	server.captureResponseBody(response, "codex", "session-1", "incompatible@example.com", "", "", "gpt-5.6-sol", "/v1/responses")
+	server.captureResponseBody(response, context.Background(), "codex", "session-1", "incompatible@example.com", "", "", "gpt-5.6-sol", "/v1/responses")
 	if _, err := io.Copy(io.Discard, response.Body); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/proxy/stream_cancel_attribution_test.go
+++ b/internal/proxy/stream_cancel_attribution_test.go
@@ -1,0 +1,74 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+)
+
+func TestStreamCancelAttribution(t *testing.T) {
+	canceledClient, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name       string
+		clientCtx  context.Context
+		err        error
+		want       string
+		wantClient bool
+	}{
+		{
+			// The upstream died on its own; the client is still waiting.
+			name:      "upstream failure",
+			clientCtx: context.Background(),
+			err:       io.ErrUnexpectedEOF,
+			want:      "upstream",
+		},
+		{
+			// The downstream client hung up, which cancels the outbound
+			// request. Expected, not a proxy defect.
+			name:       "client disconnected",
+			clientCtx:  canceledClient,
+			err:        context.Canceled,
+			want:       "client",
+			wantClient: true,
+		},
+		{
+			// The upstream read was canceled while the client was still
+			// connected. This is the case worth alerting on.
+			name:      "proxy dropped a live stream",
+			clientCtx: context.Background(),
+			err:       context.Canceled,
+			want:      "proxy",
+		},
+		{
+			name:      "wrapped cancellation is still attributed",
+			clientCtx: context.Background(),
+			err:       fmt.Errorf("reading body: %w", context.Canceled),
+			want:      "proxy",
+		},
+		{
+			name:      "missing client context",
+			clientCtx: nil,
+			err:       context.Canceled,
+			want:      "unknown",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, clientErr := streamCancelAttribution(test.clientCtx, test.err)
+			if got != test.want {
+				t.Fatalf("canceled_by = %q, want %q", got, test.want)
+			}
+			if test.wantClient && !errors.Is(clientErr, context.Canceled) {
+				t.Fatalf("client_ctx_err = %v, want context.Canceled", clientErr)
+			}
+			if !test.wantClient && clientErr != nil {
+				t.Fatalf("client_ctx_err = %v, want nil", clientErr)
+			}
+		})
+	}
+}

--- a/internal/proxy/stream_drop_stats.go
+++ b/internal/proxy/stream_drop_stats.go
@@ -1,0 +1,76 @@
+package proxy
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// StreamDropStats counts response-stream terminations by which side ended them.
+//
+// Storage is the constraint this type exists to solve. A dropped stream happens
+// roughly 1000 times a day at current volume, and ~94% of those are the client
+// hanging up and immediately retrying, which is expected behavior rather than a
+// defect. Writing an ERROR line for each one buys nothing and is a large share
+// of an unrotated log. Counting them costs a few atomic adds and stays flat
+// forever, while the rare canceled_by=proxy case still gets a full line each.
+type StreamDropStats struct {
+	client   atomic.Uint64
+	proxy    atomic.Uint64
+	upstream atomic.Uint64
+	unknown  atomic.Uint64
+
+	lastProxyUnix atomic.Int64
+	sinceUnix     atomic.Int64
+}
+
+// StreamDropSnapshot is a point-in-time read of the counters.
+type StreamDropSnapshot struct {
+	Client    uint64 `json:"client"`
+	Proxy     uint64 `json:"proxy"`
+	Upstream  uint64 `json:"upstream"`
+	Unknown   uint64 `json:"unknown"`
+	Total     uint64 `json:"total"`
+	Since     string `json:"since,omitempty"`
+	LastProxy string `json:"last_proxy_drop,omitempty"`
+}
+
+// Observe records one dropped stream. Safe on a nil receiver so the counters
+// stay optional for callers that do not wire them up.
+func (s *StreamDropStats) Observe(canceledBy string, now time.Time) {
+	if s == nil {
+		return
+	}
+	s.sinceUnix.CompareAndSwap(0, now.Unix())
+	switch canceledBy {
+	case "client":
+		s.client.Add(1)
+	case "proxy":
+		s.proxy.Add(1)
+		s.lastProxyUnix.Store(now.Unix())
+	case "upstream":
+		s.upstream.Add(1)
+	default:
+		s.unknown.Add(1)
+	}
+}
+
+// Snapshot reads the counters without resetting them.
+func (s *StreamDropStats) Snapshot() StreamDropSnapshot {
+	if s == nil {
+		return StreamDropSnapshot{}
+	}
+	snapshot := StreamDropSnapshot{
+		Client:   s.client.Load(),
+		Proxy:    s.proxy.Load(),
+		Upstream: s.upstream.Load(),
+		Unknown:  s.unknown.Load(),
+	}
+	snapshot.Total = snapshot.Client + snapshot.Proxy + snapshot.Upstream + snapshot.Unknown
+	if since := s.sinceUnix.Load(); since != 0 {
+		snapshot.Since = time.Unix(since, 0).UTC().Format(time.RFC3339)
+	}
+	if last := s.lastProxyUnix.Load(); last != 0 {
+		snapshot.LastProxy = time.Unix(last, 0).UTC().Format(time.RFC3339)
+	}
+	return snapshot
+}

--- a/internal/proxy/stream_drop_stats_test.go
+++ b/internal/proxy/stream_drop_stats_test.go
@@ -1,0 +1,63 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestStreamDropStatsCountsByAttribution(t *testing.T) {
+	stats := &StreamDropStats{}
+	now := time.Unix(1770000000, 0)
+
+	for range 940 {
+		stats.Observe("client", now)
+	}
+	stats.Observe("proxy", now.Add(time.Minute))
+	stats.Observe("upstream", now)
+	stats.Observe("", now)
+
+	got := stats.Snapshot()
+	if got.Client != 940 || got.Proxy != 1 || got.Upstream != 1 || got.Unknown != 1 {
+		t.Fatalf("unexpected counts: %+v", got)
+	}
+	if got.Total != 943 {
+		t.Fatalf("Total = %d, want 943", got.Total)
+	}
+	if got.Since != now.UTC().Format(time.RFC3339) {
+		t.Fatalf("Since = %q, want first observation time", got.Since)
+	}
+	if got.LastProxy != now.Add(time.Minute).UTC().Format(time.RFC3339) {
+		t.Fatalf("LastProxy = %q, want the proxy drop time", got.LastProxy)
+	}
+}
+
+func TestStreamDropStatsNilSafe(t *testing.T) {
+	var stats *StreamDropStats
+	stats.Observe("client", time.Now()) // must not panic
+	if got := stats.Snapshot(); got.Total != 0 {
+		t.Fatalf("nil snapshot Total = %d, want 0", got.Total)
+	}
+}
+
+func TestHandleStreamStatsServesSnapshot(t *testing.T) {
+	stats := &StreamDropStats{}
+	stats.Observe("proxy", time.Unix(1770000000, 0))
+	server := Server{StreamDrops: stats}
+
+	recorder := httptest.NewRecorder()
+	server.handleStreamStats(recorder, httptest.NewRequest(http.MethodGet, "/_subrouter/stream-stats", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var got StreamDropSnapshot
+	if err := json.Unmarshal(recorder.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Proxy != 1 || got.Total != 1 {
+		t.Fatalf("unexpected snapshot: %+v", got)
+	}
+}


### PR DESCRIPTION
## Why

Codex clients hitting the mac mini see `stream disconnected before completion`, and the server logs the matching failure:

```
ERROR proxy response stream read failed session=019f9e5b-… path=/responses status=200 bytes=108414 error="context canceled"
```

That line cannot be acted on. A downstream client hanging up and the proxy dropping a live stream produce the identical message, because `onReadError` only sees the upstream body read error. Both render as `context canceled`.

## Evidence

From 120 MB of `subrouter.err.log` on cmux-mac-mini:

- 1093 dropped streams; **1085 are `context canceled`**, 2 are real network errors.
- **All 1093 are `status=200`**, so the upstream had accepted and was streaming.
- Median **143 KB** streamed before the cut (p90 216 KB, max 1.07 MB).
- Median lifetime **7s** (p75 11s, p90 21s), with no clustering at a timeout boundary.
- **94%** of killed sessions issue another request within 60s, so the client is alive and retrying.
- Flat **4-10 per 1000 requests every hour**, tracking volume rather than any periodic event.

Ruled out along the way: account rotation (auto-switch appears near only 3 of 1093), the supervisor (`proxyBidirectional` waits on both directions before teardown and never parses HTTP), network path instability (the client's path to the mini changed once in 60 minutes), and idle timeouts (no clustering in stream lifetimes).

Every one of those observations is consistent with either explanation, which is the point: the current log line cannot separate them.

## Change

**1. Attribution.** Pass the inbound request context into `captureResponseBody` and classify each drop:

| `canceled_by` | meaning |
|---|---|
| `client` | downstream client hung up (expected) |
| `proxy` | upstream read canceled while the client was still connected (**our defect**) |
| `upstream` | non-cancellation read error |
| `unknown` | no client context available |

Also logs `client_ctx_err` and `stream_age_ms`.

**2. Counters instead of volume.** Attribution alone does not help if getting the answer means grepping 120 MB. Since ~94% of drops are the expected client hangup at ~1000/day, those now increment an atomic counter and log at Debug (off by default) rather than writing an ERROR each. `canceled_by=proxy` still writes a full line every time.

New endpoint `/_subrouter/stream-stats` serves the snapshot:

```json
{"client":940,"proxy":0,"upstream":1,"unknown":0,"total":941,"since":"...","last_proxy_drop":"..."}
```

So "is subrouter dropping live streams" becomes one curl, and steady-state log growth from this path goes to zero.

Diagnostic only. No routing, failover, or streaming behavior changes.

## Verification

`go build ./...`, `go vet ./internal/proxy/ ./cmd/subrouter/`, and `go test ./internal/proxy/` all pass, with new table tests covering all four attributions, a wrapped-error case, nil-receiver safety, and the endpoint.

`internal/transcript` has one pre-existing environmental failure (`TestGCSSyncOnceUsesGsutilRsync`, gsutil `exit status 7` against `gs://example-bucket/`); this branch touches no transcript files.

## Deploying

`subrouter-autoupdate.sh` on the mini polls GitHub every 120s and upgrades through the supervisor's control socket, keeping port 31415 open. It tracks **release assets, not `main`**, so this needs a tagged release before it reaches the mini.