### PR TITLE
Pool outbound connections per host (fixes 502 ephemeral port exhaustion)

### DIFF
--- a/internal/proxy/outbound_transport_test.go
+++ b/internal/proxy/outbound_transport_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -53,20 +54,27 @@ func TestNewOutboundTransportPoolsConnectionsPerHost(t *testing.T) {
 
 // Concurrent requests to one host must reuse connections rather than dial per
 // request. This is the behavior whose absence exhausted the port range.
+//
+// Asserting on a total connection count is racy: the pool only gets a
+// connection back once its body is closed, so a burst can legitimately dial an
+// extra one or two. Instead, drive one warm-up burst, then repeat it and
+// require that the second burst dials nothing. With a pool large enough for the
+// concurrency, every connection is idle and reusable by then. With the default
+// pool of 2, the other connections were discarded and must be re-dialed.
 func TestOutboundTransportReusesConnectionsUnderConcurrency(t *testing.T) {
+	const concurrency = 8
+
 	var mu sync.Mutex
 	conns := make(map[string]struct{})
 
 	server := newTestServerCountingConns(t, &mu, conns)
 	defer server.Close()
 
-	transport := NewOutboundTransport()
-	client := &http.Client{Transport: transport, Timeout: 10 * time.Second}
+	client := &http.Client{Transport: NewOutboundTransport(), Timeout: 10 * time.Second}
 
-	// Two sequential rounds: the second must reuse the first round's pool.
-	for round := range 2 {
+	burst := func(round int) {
 		var wg sync.WaitGroup
-		for range 8 {
+		for range concurrency {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -75,18 +83,26 @@ func TestOutboundTransportReusesConnectionsUnderConcurrency(t *testing.T) {
 					t.Errorf("round %d: %v", round, err)
 					return
 				}
+				// Drain and close so the connection returns to the pool.
+				_, _ = io.Copy(io.Discard, response.Body)
 				_ = response.Body.Close()
 			}()
 		}
 		wg.Wait()
 	}
 
+	burst(1)
 	mu.Lock()
-	distinct := len(conns)
+	afterWarmup := len(conns)
 	mu.Unlock()
 
-	// 16 requests over 8-way concurrency should not open 16 connections.
-	if distinct > 8 {
-		t.Fatalf("opened %d distinct connections for 16 requests; connections are not being reused", distinct)
+	burst(2)
+	mu.Lock()
+	afterReuse := len(conns)
+	mu.Unlock()
+
+	if afterReuse != afterWarmup {
+		t.Fatalf("second burst opened %d new connections (%d -> %d); a warm pool should have served all %d requests without dialing",
+			afterReuse-afterWarmup, afterWarmup, afterReuse, concurrency)
 	}
 }

--- a/internal/proxy/outbound_transport_test.go
+++ b/internal/proxy/outbound_transport_test.go
@@ -1,0 +1,92 @@
+package proxy
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newTestServerCountingConns records every distinct client connection the
+// server accepts, so a test can tell reuse from per-request dialing.
+func newTestServerCountingConns(t *testing.T, mu *sync.Mutex, conns map[string]struct{}) *httptest.Server {
+	t.Helper()
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	server.Config.ConnState = func(c net.Conn, state http.ConnState) {
+		if state != http.StateNew {
+			return
+		}
+		mu.Lock()
+		conns[c.RemoteAddr().String()] = struct{}{}
+		mu.Unlock()
+	}
+	server.Start()
+	return server
+}
+
+// The proxy speaks HTTP/1.1 only (see NewOutboundTransport), so concurrency is
+// bounded by connection count rather than stream multiplexing. If the idle pool
+// is left at Go's default of 2, concurrent requests to one host burn a fresh
+// connection each and strand it in TIME_WAIT, exhausting ephemeral ports.
+func TestNewOutboundTransportPoolsConnectionsPerHost(t *testing.T) {
+	transport := NewOutboundTransport()
+
+	if transport.MaxIdleConnsPerHost <= http.DefaultMaxIdleConnsPerHost {
+		t.Fatalf("MaxIdleConnsPerHost = %d, want more than the default %d; HTTP/1.1 cannot multiplex so a small pool forces one dial per concurrent request",
+			transport.MaxIdleConnsPerHost, http.DefaultMaxIdleConnsPerHost)
+	}
+	if transport.MaxIdleConns < transport.MaxIdleConnsPerHost {
+		t.Fatalf("MaxIdleConns = %d, want >= MaxIdleConnsPerHost %d, otherwise the global cap silently defeats the per-host pool",
+			transport.MaxIdleConns, transport.MaxIdleConnsPerHost)
+	}
+	if transport.IdleConnTimeout <= 0 {
+		t.Fatal("IdleConnTimeout must be positive so idle connections are eventually reclaimed")
+	}
+	if transport.ForceAttemptHTTP2 {
+		t.Fatal("ForceAttemptHTTP2 must stay false; the pool sizing above assumes one request per connection")
+	}
+}
+
+// Concurrent requests to one host must reuse connections rather than dial per
+// request. This is the behavior whose absence exhausted the port range.
+func TestOutboundTransportReusesConnectionsUnderConcurrency(t *testing.T) {
+	var mu sync.Mutex
+	conns := make(map[string]struct{})
+
+	server := newTestServerCountingConns(t, &mu, conns)
+	defer server.Close()
+
+	transport := NewOutboundTransport()
+	client := &http.Client{Transport: transport, Timeout: 10 * time.Second}
+
+	// Two sequential rounds: the second must reuse the first round's pool.
+	for round := range 2 {
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				response, err := client.Get(server.URL)
+				if err != nil {
+					t.Errorf("round %d: %v", round, err)
+					return
+				}
+				_ = response.Body.Close()
+			}()
+		}
+		wg.Wait()
+	}
+
+	mu.Lock()
+	distinct := len(conns)
+	mu.Unlock()
+
+	// 16 requests over 8-way concurrency should not open 16 connections.
+	if distinct > 8 {
+		t.Fatalf("opened %d distinct connections for 16 requests; connections are not being reused", distinct)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4054,8 +4054,29 @@ func NewOutboundTransport() *http.Transport {
 		transport.TLSClientConfig = transport.TLSClientConfig.Clone()
 	}
 	transport.TLSClientConfig.NextProtos = []string{"http/1.1"}
+	// Pool aggressively per host. HTTP/1.1 cannot multiplex, so each in-flight
+	// request needs its own connection, and DefaultTransport only keeps
+	// MaxIdleConnsPerHost (2) for reuse. Every concurrent request past the
+	// second one therefore built a fresh TCP+TLS connection and discarded it,
+	// leaving a socket in TIME_WAIT for 2*MSL. Because nearly all traffic goes
+	// to a handful of hosts, that churn exhausted the machine's ephemeral port
+	// range and upstream dials began failing with EADDRNOTAVAIL
+	// ("can't assign requested address"), which surfaced to clients as 502.
+	transport.MaxIdleConnsPerHost = outboundMaxIdleConnsPerHost
+	transport.MaxIdleConns = outboundMaxIdleConns
+	transport.IdleConnTimeout = outboundIdleConnTimeout
 	return transport
 }
+
+const (
+	// Sized for many concurrent streaming requests against a small number of
+	// upstream hosts, which is the shape of this proxy's traffic.
+	outboundMaxIdleConnsPerHost = 256
+	outboundMaxIdleConns        = 1024
+	// Long enough to span a user's think time between turns so the next
+	// request reuses a warm connection instead of dialing again.
+	outboundIdleConnTimeout = 120 * time.Second
+)
 
 func (s Server) scheduler() selectacct.Scheduler {
 	if s.SchedulerRef != nil {


### PR DESCRIPTION
## Symptom

Codex clients hitting cmux-mac-mini started getting:

```
unexpected status 502 Bad Gateway: upstream request failed, url: http://cmux-mac-mini:31415/v1/responses
```

Server side:

```
ERROR proxy request failed agent=codex account=aw11@manaflow.com method=POST path=/responses
  upstream=chatgpt.com error="dial tcp4 172.64.155.209:443: connect: can't assign requested address"
```

`EADDRNOTAVAIL` on connect means the machine had no ephemeral port left to source an outbound connection from. It peaked at **240 failures/minute**.

## Measured on the mini

```
net.inet.ip.portrange.first: 49152      # 16,384 ports total
distinct ephemeral ports in use: 16,383 # all of them
TIME_WAIT sockets:              16,497
  ...of those, to :443:         14,976  (7,521 + 6,747 to two Cloudflare IPs)
net.inet.tcp.msl:               15000   # TIME_WAIT = 2*MSL = 30s
```

Sustaining ~14k TIME_WAIT entries over a 30s window implies roughly **470 new connections/second**, against only ~4 proxied requests/second of real traffic. A ~100:1 connection-to-request ratio means connections were not being reused at all.

## Cause

`NewOutboundTransport` disables HTTP/2 on purpose, and the reason is good (one upstream TLS failure shouldn't tear down unrelated multiplexed streams). But it clones `http.DefaultTransport`, which leaves `MaxIdleConnsPerHost` at Go's default of **2**.

Without multiplexing, one connection carries one in-flight request. So every concurrent request past the second one dialed a fresh TCP+TLS connection and threw it away on completion, leaving a socket in TIME_WAIT for 30s. Because essentially all traffic goes to a handful of hosts, that churn drained the entire ephemeral port range.

The HTTP/2 decision is kept. What was missing is the pool sizing that decision requires.

## Change

```go
transport.MaxIdleConnsPerHost = 256
transport.MaxIdleConns        = 1024
transport.IdleConnTimeout     = 120 * time.Second
```

The 120s idle timeout spans a user's think time between turns so the next request reuses a warm connection instead of dialing again.

## Verification

Two commits, so CI shows red then green:

1. `Add regression test for outbound connection reuse` - fails on main with `opened 14 distinct connections for 16 requests; connections are not being reused`, and `MaxIdleConnsPerHost = 0, want more than the default 2`.
2. `Pool outbound connections per host` - both pass; 16 requests over 8-way concurrency now reuse <= 8 connections.

Full `go test ./internal/proxy/` and `go vet` pass, including the pre-existing IPv4/HTTP1 transport tests, which this does not change.

## Deploying

The live outage is already mitigated on the mini by widening the port range and shortening TIME_WAIT:

```
sysctl -w net.inet.ip.portrange.first=32768   # 16,384 -> 32,768 ports
sysctl -w net.inet.tcp.msl=5000               # TIME_WAIT 30s -> 10s
```

Dial failures stopped immediately (last one 18:58:16, applied 18:58). **Those are runtime-only and revert on reboot**, so they are a stopgap until this ships. Needs a tagged release, since `subrouter-autoupdate` tracks release assets rather than `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787796143&installation_model_id=21920&pr_number=89&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F89&signature=352641d74926a93d6664328a3d8f93848cc8e6efaa243345d5c7d3da8141c6c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pools outbound HTTP/1.1 connections per host to stop 502 errors from ephemeral port exhaustion. HTTP/2 stays off, and the regression test is now deterministic to verify connection reuse under concurrency.

- **Bug Fixes**
  - In `NewOutboundTransport`, set `MaxIdleConnsPerHost=256`, `MaxIdleConns=1024`, and `IdleConnTimeout=120s` to reuse connections instead of dialing per request.
  - Added `internal/proxy/outbound_transport_test.go` with a two-burst test that requires zero new connections on the second burst to prove reuse without flaky counts.

- **Migration**
  - Tag a release so `subrouter-autoupdate` picks up the fix; this replaces the temporary sysctl mitigation on the mini.

<sup>Written for commit f6fef7809b09502f7e744550b4da9eb8d6f45e54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outbound HTTP connection reuse to reduce connection churn.
  * Increased connection-pooling capacity and idle timeout for more reliable HTTP/1.1 request handling.
  * Added coverage to verify connection pooling and reuse under concurrent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->