### PR TITLE
Keep pooled connections shorter than the upstream idle close (fixes residual 502s)

### DIFF
--- a/internal/proxy/outbound_transport_test.go
+++ b/internal/proxy/outbound_transport_test.go
@@ -143,3 +143,20 @@ func TestOutboundTransportReusesConnectionsUnderConcurrency(t *testing.T) {
 			dialed, afterWarmup)
 	}
 }
+
+// Pooling a connection for longer than the upstream keeps it alive guarantees
+// checking out a connection the peer already closed. The next write then fails
+// with "use of closed network connection" and the client sees a 502. Go's
+// default of 90s is 6x the measured upstream idle close, so this must be set
+// explicitly rather than inherited from DefaultTransport.
+func TestOutboundIdleTimeoutStaysUnderUpstreamIdleClose(t *testing.T) {
+	transport := NewOutboundTransport()
+
+	if transport.IdleConnTimeout >= upstreamIdleCloseAfter {
+		t.Fatalf("IdleConnTimeout = %s, must be below the measured upstream idle close of %s; otherwise pooled connections are handed out already closed",
+			transport.IdleConnTimeout, upstreamIdleCloseAfter)
+	}
+	if transport.IdleConnTimeout <= 0 {
+		t.Fatalf("IdleConnTimeout = %s, want a positive value", transport.IdleConnTimeout)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4115,9 +4115,21 @@ const (
 	// upstream hosts, which is the shape of this proxy's traffic.
 	outboundMaxIdleConnsPerHost = 256
 	outboundMaxIdleConns        = 1024
-	// Long enough to span a user's think time between turns so the next
-	// request reuses a warm connection instead of dialing again.
-	outboundIdleConnTimeout = 120 * time.Second
+	// upstreamIdleCloseAfter is how long our upstreams keep an idle connection
+	// before closing it. Measured 2026-07-27 from the mac mini by opening a TLS
+	// connection and waiting for EOF:
+	//
+	//	chatgpt.com:443       peer closed after 15s
+	//	api.anthropic.com:443 peer closed after 15s
+	//
+	// Pooling a connection past this point guarantees handing out one the peer
+	// already closed, which fails the next write with "use of closed network
+	// connection" and surfaces to clients as 502 upstream request failed.
+	upstreamIdleCloseAfter = 15 * time.Second
+	// Comfortably below upstreamIdleCloseAfter so a pooled connection is always
+	// dropped by us before the peer drops it. Still long enough to absorb the
+	// bursts of concurrent requests that pooling exists to serve.
+	outboundIdleConnTimeout = 10 * time.Second
 )
 
 func (s Server) scheduler() selectacct.Scheduler {


### PR DESCRIPTION
## Symptom

`502 Bad Gateway: upstream request failed` on `POST /v1/responses`, still reaching clients after the connection-pooling fix in #89:

```
ERROR proxy request failed ... method=POST path=/responses upstream=chatgpt.com
  error="write tcp4 10.0.0.222:36827->104.18.32.47:443: use of closed network connection"
```

## Cause, measured

Opened a TLS connection from the mini to each upstream and waited for EOF:

```
chatgpt.com:443        peer closed after 15s
api.anthropic.com:443  peer closed after 15s
```

`IdleConnTimeout` was **120s**. Anything pooled longer than 15s is handed out already closed by the peer, and the next write fails. Go's `DefaultTransport` default is 90s, still 6x the upstream bound, so this was broken before #89 widened the pool: the pre-#89 log archive has 1,326 of these.

## Change

```go
upstreamIdleCloseAfter  = 15 * time.Second  // measured, documented in-code
outboundIdleConnTimeout = 10 * time.Second  // was 120s
```

10s stays comfortably under the measured bound while still absorbing the concurrent bursts that pooling exists to serve (those reuse within milliseconds; the port exhaustion in #89 came from concurrency, not from long idle gaps).

## Why not just retry

Subrouter already retries this error class, and it works: 472 `retrying replayable upstream request after transport failure` against 10 hard failures in two hours, with zero retry exhaustions. That is a ~98% recovery rate, and the residual 2% is what users see. This removes the cause rather than papering over it.

## Verification

New test fails at the old value and passes at the new one:

```
IdleConnTimeout = 2m0s, must be below the measured upstream idle close of 15s;
otherwise pooled connections are handed out already closed
```

`go build ./...`, `go vet`, and `go test ./internal/proxy/` all pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787800984&installation_model_id=21920&pr_number=90&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F90&signature=335d8444952a509964c7b3e9b8a81ebdda4cec6c1f348ad7e3ed81cca566b699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce outbound idle connection timeout to 10s (below the upstream 15s idle close) so pooled connections aren’t handed out after peers close them. This removes residual 502s on POST /v1/responses from “use of closed network connection” failures.

- **Bug Fixes**
  - Set `outboundIdleConnTimeout` to 10s and documented `upstreamIdleCloseAfter = 15s` based on measurements.
  - Added `TestOutboundIdleTimeoutStaysUnderUpstreamIdleClose` to enforce the bound; build, vet, and tests pass.

<sup>Written for commit 16ef59c13f9a2f6acd24fd3f9579744a754f7642. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling to prevent reuse of connections that have already been closed by upstream services.
  * Reduced the likelihood of intermittent 502 errors caused by stale pooled connections.

* **Tests**
  * Added coverage to verify outbound connection timeouts remain positive and below the upstream connection-close threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->