### PR TITLE
Retire old workers by ending connection reuse (so deployed fixes actually take effect)

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -553,34 +553,59 @@ func listenAndServeWithSignals(server *http.Server, lifecycle *proxy.Lifecycle, 
 		errCh <- err
 	}()
 
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	sigCh := make(chan os.Signal, 2)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM, syscall.SIGUSR1)
 	defer signal.Stop(sigCh)
 
-	select {
-	case err := <-errCh:
-		return err
-	case sig := <-sigCh:
-		if lifecycle != nil {
-			lifecycle.Drain()
-		}
-		if logger != nil {
-			logger.Info("subrouter shutdown signal received", "signal", sig.String(), "timeout", shutdownTimeout.String())
-		}
-		if shutdownTimeout < 0 {
-			shutdownTimeout = 0
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
-		defer cancel()
-		if err := server.Shutdown(ctx); err != nil {
-			if logger != nil {
-				logger.Error("subrouter graceful shutdown failed", "error", err)
-			}
-			_ = server.Close()
+	for {
+		select {
+		case err := <-errCh:
 			return err
+		case sig := <-sigCh:
+			if sig == syscall.SIGUSR1 {
+				// Retired by the supervisor: a newer generation now owns new
+				// connections, but clients holding keep-alive connections would
+				// otherwise stay pinned to this worker indefinitely, since the
+				// drain has no timeout. Disabling keep-alives makes every
+				// response carry "Connection: close", so each client finishes
+				// its current request and reconnects onto the new generation.
+				// In-flight requests and streams are unaffected.
+				retireServer(server, logger)
+				continue
+			}
+			return shutdownOnSignal(server, lifecycle, sig, shutdownTimeout, logger, errCh)
 		}
-		return <-errCh
 	}
+}
+
+// retireServer stops connection reuse without interrupting anything in flight.
+func retireServer(server *http.Server, logger *slog.Logger) {
+	server.SetKeepAlivesEnabled(false)
+	if logger != nil {
+		logger.Info("subrouter worker retired; closing idle connections and asking clients to reconnect")
+	}
+}
+
+func shutdownOnSignal(server *http.Server, lifecycle *proxy.Lifecycle, sig os.Signal, shutdownTimeout time.Duration, logger *slog.Logger, errCh chan error) error {
+	if lifecycle != nil {
+		lifecycle.Drain()
+	}
+	if logger != nil {
+		logger.Info("subrouter shutdown signal received", "signal", sig.String(), "timeout", shutdownTimeout.String())
+	}
+	if shutdownTimeout < 0 {
+		shutdownTimeout = 0
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		if logger != nil {
+			logger.Error("subrouter graceful shutdown failed", "error", err)
+		}
+		_ = server.Close()
+		return err
+	}
+	return <-errCh
 }
 
 func listenAndServeHTTP(server *http.Server, logger *slog.Logger) error {

--- a/cmd/subrouter/retire_worker_test.go
+++ b/cmd/subrouter/retire_worker_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// A retired worker must stop connection reuse so clients migrate to the new
+// generation. Without this, the supervisor's drain never completes (WaitIdle
+// has no timeout) and a keep-alive client pins an obsolete worker forever.
+func TestRetireServerStopsConnectionReuse(t *testing.T) {
+	var mu sync.Mutex
+	conns := map[string]struct{}{}
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, "ok")
+	}))
+	server.Config.ConnState = func(c net.Conn, state http.ConnState) {
+		if state != http.StateNew {
+			return
+		}
+		mu.Lock()
+		conns[c.RemoteAddr().String()] = struct{}{}
+		mu.Unlock()
+	}
+	server.Start()
+	defer server.Close()
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	get := func() *http.Response {
+		t.Helper()
+		response, err := client.Get(server.URL)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		_, _ = io.Copy(io.Discard, response.Body)
+		_ = response.Body.Close()
+		return response
+	}
+
+	// Before retirement, a second request reuses the first connection.
+	first := get()
+	if first.Close {
+		t.Fatal("server asked the client to close before retirement")
+	}
+	get()
+	mu.Lock()
+	beforeRetire := len(conns)
+	mu.Unlock()
+	if beforeRetire != 1 {
+		t.Fatalf("opened %d connections for two sequential requests, want 1; keep-alive is not working", beforeRetire)
+	}
+
+	retireServer(server.Config, nil)
+
+	// After retirement the response tells the client to close, and the next
+	// request must therefore land on a new connection.
+	afterFirst := get()
+	if !afterFirst.Close {
+		t.Fatal("retired server did not send Connection: close, so clients would stay pinned to it")
+	}
+	get()
+
+	mu.Lock()
+	afterRetire := len(conns)
+	mu.Unlock()
+	if afterRetire <= beforeRetire {
+		t.Fatalf("connection count stayed at %d after retirement; clients are still reusing the retired worker", afterRetire)
+	}
+}
+
+// Retirement must not disturb a request that is already streaming.
+func TestRetireServerDoesNotInterruptInFlightRequest(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		close(started)
+		<-release
+		fmt.Fprint(w, "tail")
+	}))
+	server.Start()
+	defer server.Close()
+
+	type result struct {
+		body string
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		response, err := (&http.Client{Timeout: 15 * time.Second}).Get(server.URL)
+		if err != nil {
+			done <- result{err: err}
+			return
+		}
+		defer response.Body.Close()
+		body, err := io.ReadAll(response.Body)
+		done <- result{body: string(body), err: err}
+	}()
+
+	<-started
+	retireServer(server.Config, nil) // retire mid-stream
+	close(release)
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("in-flight request failed after retirement: %v", got.err)
+		}
+		if got.body != "tail" {
+			t.Fatalf("in-flight response body = %q, want %q; retirement truncated it", got.body, "tail")
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("in-flight request never completed after retirement")
+	}
+}

--- a/cmd/subrouter/supervisor.go
+++ b/cmd/subrouter/supervisor.go
@@ -423,6 +423,23 @@ func (s *supervisor) monitorWorker(worker *workerGeneration) {
 }
 
 func (s *supervisor) reapWhenIdle(id string) {
+	// Tell the retired worker to stop reusing connections before waiting on it.
+	// WaitIdle has no timeout, so without this a client holding a keep-alive
+	// connection pins an obsolete generation indefinitely: a worker from four
+	// hours and two upgrades ago was still serving 64 connections, which meant
+	// deployed fixes never took effect for those clients. SIGUSR1 makes the
+	// worker answer with "Connection: close", so each client finishes its
+	// current request and reconnects onto the current generation. Nothing in
+	// flight is interrupted.
+	s.workersMu.Lock()
+	retiring := s.workers[id]
+	s.workersMu.Unlock()
+	if retiring != nil && retiring.command != nil && retiring.command.Process != nil {
+		if err := retiring.command.Process.Signal(syscall.SIGUSR1); err != nil {
+			slog.Warn("subrouter worker retire signal failed", "generation", id, "error", err)
+		}
+	}
+
 	s.router.WaitIdle(id)
 	s.workersMu.Lock()
 	worker := s.workers[id]


### PR DESCRIPTION
## Problem

The supervisor's drain has no timeout by design: `reapWhenIdle` blocks in `WaitIdle` until the retired worker's connection count reaches zero, and only then terminates it. That is what makes upgrades lossless, and it should stay.

But nothing ever tells clients to let go. They hold HTTP keep-alive connections, so an obsolete generation can live forever. Observed on cmux-mac-mini after two upgrades:

| pid | version | age | connections |
|---|---|---|---|
| 4653 | v0.1.37 (pre-fix) | **4h30m** | 64 |
| 29779 | v0.1.38 | 1h13m | 24 |
| 38833 | v0.1.39 | 4m | 34 |

The consequences are not cosmetic. That 4.5-hour-old worker still had the **pre-#89 connection pool of 2**, so it kept dialing a fresh connection per concurrent request and burning ephemeral ports, which is the exact bug #89 fixed. It also still had the 120s `IdleConnTimeout` that #90 fixed. Both deployments were live, and both were being ignored by every client pinned to that worker.

## Change

When the supervisor retires a generation, it now sends `SIGUSR1` before waiting. The worker responds by calling `SetKeepAlivesEnabled(false)`, so every response carries `Connection: close`. Each client finishes its current request, closes, and reconnects onto the current generation.

Requests and streams already in flight are untouched, so the no-dropped-connection guarantee holds. The difference is that the drain now terminates in seconds instead of never.

## Verification

Two behavioral tests in `cmd/subrouter`:

- `TestRetireServerStopsConnectionReuse` - two sequential requests share one connection before retirement; after retirement the response sets `Connection: close` and the next request lands on a new connection. Fails without the change: `retired server did not send Connection: close, so clients would stay pinned to it`.
- `TestRetireServerDoesNotInterruptInFlightRequest` - retires the server mid-stream and asserts the in-flight response still completes with its full body, proving retirement does not truncate live work.

15 consecutive runs pass. `go build ./...`, `go vet ./...`, and the full `./internal/...` and `./cmd/subrouter/` suites pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787801943&installation_model_id=21920&pr_number=91&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F91&signature=832b86874188e9551109864fd7894b83ffd704929712be0e0ed1db4e29914942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retired workers now stop keep-alive reuse so clients reconnect to the current generation, making upgrades take effect quickly. Drains remain lossless and complete in seconds.

- **Bug Fixes**
  - Supervisor sends `SIGUSR1` to retired workers; they call `SetKeepAlivesEnabled(false)` so responses include `Connection: close` and clients reconnect to the new generation.
  - In-flight requests/streams are untouched; only reuse is disabled.
  - Added tests in `cmd/subrouter` to verify connection reuse stops and active streams finish; `listenAndServeWithSignals` now handles `SIGUSR1` via `retireServer()`.

<sup>Written for commit f9eec9f4ee48776484f7dc159e1b5261e9d3aaf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

