### PR TITLE
Fix Windows build broken by the retire signal, and cross-compile in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,22 @@ jobs:
 
       - name: Test
         run: CGO_ENABLED=0 go test ./...
+
+      # CI only builds for linux/amd64, but releases cross-compile for every
+      # platform below. A platform-specific symbol (syscall.SIGUSR1 does not
+      # exist on Windows) therefore passed CI, merged, and only broke at
+      # release tag time. Catch it on the PR instead.
+      - name: Cross-compile release targets
+        run: |
+          set -euo pipefail
+          for target in \
+            darwin/amd64 darwin/arm64 \
+            linux/386 linux/amd64 linux/arm linux/arm64 \
+            windows/386 windows/amd64 windows/arm64 \
+            freebsd/386 freebsd/amd64 freebsd/arm64 \
+            netbsd/amd64 netbsd/arm64 \
+            openbsd/amd64 openbsd/arm64
+          do
+            echo "building ${target}"
+            GOOS="${target%/*}" GOARCH="${target#*/}" go build -o /dev/null ./...
+          done

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -554,7 +554,11 @@ func listenAndServeWithSignals(server *http.Server, lifecycle *proxy.Lifecycle, 
 	}()
 
 	sigCh := make(chan os.Signal, 2)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM, syscall.SIGUSR1)
+	watched := []os.Signal{os.Interrupt, syscall.SIGTERM}
+	if retireSignal != nil {
+		watched = append(watched, retireSignal)
+	}
+	signal.Notify(sigCh, watched...)
 	defer signal.Stop(sigCh)
 
 	for {
@@ -562,7 +566,7 @@ func listenAndServeWithSignals(server *http.Server, lifecycle *proxy.Lifecycle, 
 		case err := <-errCh:
 			return err
 		case sig := <-sigCh:
-			if sig == syscall.SIGUSR1 {
+			if retireSignal != nil && sig == retireSignal {
 				// Retired by the supervisor: a newer generation now owns new
 				// connections, but clients holding keep-alive connections would
 				// otherwise stay pinned to this worker indefinitely, since the

--- a/cmd/subrouter/retire_signal_unix.go
+++ b/cmd/subrouter/retire_signal_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+// retireSignal tells a worker that a newer generation has taken over new
+// connections, so it should stop reusing the ones it still holds. SIGUSR1 is
+// chosen because the supervisor already uses SIGTERM for shutdown and SIGHUP
+// for upgrade, and retirement must not mean either.
+var retireSignal os.Signal = syscall.SIGUSR1

--- a/cmd/subrouter/retire_signal_windows.go
+++ b/cmd/subrouter/retire_signal_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package main
+
+import "os"
+
+// Windows has no SIGUSR1, so there is no signal that means "retired" without
+// also meaning "shut down". The supervisor runs under launchd/systemd on unix
+// in practice; on Windows a retired worker simply keeps serving its existing
+// connections as it did before, and callers skip the retire step when this is
+// nil. Release builds cross-compile for Windows, so this has to compile.
+var retireSignal os.Signal = nil

--- a/cmd/subrouter/supervisor.go
+++ b/cmd/subrouter/supervisor.go
@@ -434,8 +434,8 @@ func (s *supervisor) reapWhenIdle(id string) {
 	s.workersMu.Lock()
 	retiring := s.workers[id]
 	s.workersMu.Unlock()
-	if retiring != nil && retiring.command != nil && retiring.command.Process != nil {
-		if err := retiring.command.Process.Signal(syscall.SIGUSR1); err != nil {
+	if retireSignal != nil && retiring != nil && retiring.command != nil && retiring.command.Process != nil {
+		if err := retiring.command.Process.Signal(retireSignal); err != nil {
 			slog.Warn("subrouter worker retire signal failed", "generation", id, "error", err)
 		}
 	}


### PR DESCRIPTION
## What broke

#91 added `syscall.SIGUSR1` to retire old workers. That symbol does not exist on Windows.

CI compiles only for linux/amd64. Releases cross-compile for 16 targets. So the change passed CI, merged cleanly, and then failed at tag time:

```
cmd/subrouter/main.go:557:62: undefined: syscall.SIGUSR1
cmd/subrouter/main.go:565:22: undefined: syscall.SIGUSR1
cmd/subrouter/supervisor.go:438:53: undefined: syscall.SIGUSR1
```

`v0.1.40` is tagged but published no artifacts, so nothing could deploy it.

## Fix

Move the signal behind build tags:

- `retire_signal_unix.go` (`!windows`): `retireSignal = syscall.SIGUSR1`
- `retire_signal_windows.go` (`windows`): `retireSignal = nil`

Both the signal registration in `listenAndServeWithSignals` and the send in `reapWhenIdle` skip retirement when it is nil, so Windows keeps the pre-#91 behavior instead of failing to build. The supervisor runs under launchd/systemd on unix in practice; Windows only has to compile.

## Guard

CI now cross-compiles all 16 release targets, so a platform-specific symbol fails on the PR rather than after a tag is cut. Verified locally that every target in that list builds.

`go test ./cmd/subrouter/` still passes, including the two retirement tests from #91.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787802508&installation_model_id=21920&pr_number=92&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F92&signature=5d9eaa2fb8a741a5ebf4bf86b03a9bdbb8c91b2b49f83cc1bf3dab71890dd844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows build by build‑tagging the retire signal (`SIGUSR1` on Unix, disabled on Windows) and update CI to cross‑compile all release targets so platform issues fail in PRs, not at release time.

- **Bug Fixes**
  - Add `retire_signal_unix.go` (`retireSignal = syscall.SIGUSR1`) and `retire_signal_windows.go` (`retireSignal = nil`).
  - Only register/send the retire signal when `retireSignal` is not nil, preserving pre-#91 behavior on Windows.

- **Refactors**
  - CI cross-compiles the 16 release targets during PRs to catch platform-specific symbol errors early.

<sup>Written for commit 726931ab937f6ca53e7419ed3293daa5bc28c24e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

