### PR TITLE
Back off between replayable POST retries (fixes the residual 502s)

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4037,8 +4037,52 @@ func (t replayablePostRetryTransport) RoundTrip(req *http.Request) (*http.Respon
 				t.logger.Warn("retrying replayable upstream request after transport failure", "agent", t.agent, "session", t.session, "account", t.account, "method", t.method, "path", t.path, "upstream", t.upstream, "attempt", attempt+1, "max_attempts", maxAttempts, "error", err)
 			}
 		}
+		if !sleepForRetry(req.Context(), retryBackoff(attempt)) {
+			return response, err
+		}
 	}
 	return t.roundTrip(req)
+}
+
+// retryBackoff returns how long to wait before the attempt after n.
+//
+// Retries used to fire back to back, so all six attempts completed within
+// microseconds. That is the worst possible strategy against an upstream that is
+// briefly refusing connections: the whole retry budget burns before the far end
+// recovers, and the client gets a 502. Backing off gives it time to come back,
+// while the cap keeps the added latency bounded on a genuinely dead upstream.
+func retryBackoff(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	backoff := retryBaseBackoff << (attempt - 1)
+	if backoff > retryMaxBackoff {
+		backoff = retryMaxBackoff
+	}
+	return backoff
+}
+
+const (
+	retryBaseBackoff = 100 * time.Millisecond
+	// Bounds the worst case: with six attempts the added latency stays near a
+	// couple of seconds, far better than surfacing a 502 to the caller.
+	retryMaxBackoff = 800 * time.Millisecond
+)
+
+// sleepForRetry waits for the backoff, reporting false if the caller gave up
+// first so a client that has already hung up is not kept waiting.
+func sleepForRetry(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return true
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 func (t replayablePostRetryTransport) roundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/proxy/retry_backoff_test.go
+++ b/internal/proxy/retry_backoff_test.go
@@ -1,0 +1,113 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRetryBackoffGrowsAndIsCapped(t *testing.T) {
+	first := retryBackoff(1)
+	if first != retryBaseBackoff {
+		t.Fatalf("retryBackoff(1) = %s, want %s", first, retryBaseBackoff)
+	}
+	if second := retryBackoff(2); second <= first {
+		t.Fatalf("retryBackoff(2) = %s, want more than attempt 1's %s; retries must space out", second, first)
+	}
+	// Every attempt must be waited on, and the total must stay bounded.
+	var total time.Duration
+	for attempt := 1; attempt <= replayablePostMaxAttempts; attempt++ {
+		wait := retryBackoff(attempt)
+		if wait <= 0 {
+			t.Fatalf("retryBackoff(%d) = %s, want a positive wait; back-to-back retries burn the budget instantly", attempt, wait)
+		}
+		if wait > retryMaxBackoff {
+			t.Fatalf("retryBackoff(%d) = %s, exceeds the cap %s", attempt, wait, retryMaxBackoff)
+		}
+		total += wait
+	}
+	if total > 5*time.Second {
+		t.Fatalf("total backoff across %d attempts = %s, too slow to sit in a request path", replayablePostMaxAttempts, total)
+	}
+}
+
+func TestSleepForRetryWaitsThenReportsTrue(t *testing.T) {
+	start := time.Now()
+	if !sleepForRetry(context.Background(), 40*time.Millisecond) {
+		t.Fatal("sleepForRetry reported the caller gave up, want true")
+	}
+	if elapsed := time.Since(start); elapsed < 30*time.Millisecond {
+		t.Fatalf("returned after %s, want it to actually wait ~40ms", elapsed)
+	}
+}
+
+// A client that has already hung up must not be kept waiting through the
+// remaining backoff.
+func TestSleepForRetryAbortsWhenClientGivesUp(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	if sleepForRetry(ctx, 5*time.Second) {
+		t.Fatal("sleepForRetry waited out a canceled context, want an immediate abort")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("took %s to notice cancellation, want near-immediate", elapsed)
+	}
+}
+
+func TestSleepForRetryZeroIsImmediate(t *testing.T) {
+	if !sleepForRetry(context.Background(), 0) {
+		t.Fatal("zero backoff should return true immediately")
+	}
+}
+
+type alwaysResetTransport struct{ attempts int }
+
+func (t *alwaysResetTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	t.attempts++
+	return nil, errors.New("write tcp4 10.0.0.1:1->10.0.0.2:443: use of closed network connection")
+}
+
+// The whole point of the retry budget is to span a brief upstream refusal.
+// Firing every attempt in the same microsecond spends it for nothing, which is
+// how six retries still produced a 502.
+func TestReplayablePostRetrySpacesOutAttempts(t *testing.T) {
+	base := &alwaysResetTransport{}
+	transport := replayablePostRetryTransport{
+		base:        base,
+		maxAttempts: 4,
+		method:      http.MethodPost,
+		path:        "/responses",
+	}
+
+	request, err := http.NewRequest(http.MethodPost, "https://example.invalid/responses", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	request.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader("{}")), nil
+	}
+
+	start := time.Now()
+	if _, err := transport.RoundTrip(request); err == nil {
+		t.Fatal("expected the retryable transport error to surface after the budget is spent")
+	}
+	elapsed := time.Since(start)
+
+	if base.attempts != 4 {
+		t.Fatalf("made %d attempts, want 4", base.attempts)
+	}
+	// Three gaps between four attempts.
+	var want time.Duration
+	for attempt := 1; attempt <= 3; attempt++ {
+		want += retryBackoff(attempt)
+	}
+	if elapsed < want {
+		t.Fatalf("four attempts took %s, want at least %s of backoff between them; retries are firing back to back", elapsed, want)
+	}
+}


### PR DESCRIPTION
## What is still failing

Clients keep seeing this despite the pooling and idle-timeout fixes:

```
Unexpected status 502 Bad Gateway: upstream request failed, url: http://cmux-mac-mini:31415/v1/responses
```

## Measurement

Across 439 failing `POST /responses` in the live log, split by error class and whether a retry ran for that session:

| error | retried | not retried |
|---|---|---|
| connection reset by peer | 55 | 0 |
| broken pipe | 11 | 0 |
| use of closed network | 10 | 0 |
| bad record MAC | 1 | 0 |
| can't assign requested address | 0 | 355 |
| context canceled (client gone) | 2 | 5 |

Two conclusions. The retry path is correct: every transport error already goes through it. And the 355 unretried failures are all `can't assign requested address`, the ephemeral-port exhaustion fixed by #89, not a retry gap.

So the surviving 502s are requests that **exhausted all six attempts**. The reason is that the attempts are instantaneous:

```
four attempts took 37.166µs, want at least 700ms of backoff between them
```

Six retries inside 37 microseconds is the worst possible strategy against an upstream that is briefly refusing connections. The entire budget is gone long before the far end recovers.

## Change

Exponential backoff between attempts, 100ms doubling to a 800ms cap, so six attempts span roughly two seconds instead of microseconds. `sleepForRetry` aborts the moment the request context is done, so a client that has already hung up is never kept waiting.

## Verification

`TestReplayablePostRetrySpacesOutAttempts` drives the real retry loop with a transport that always returns a retryable error, then asserts both the attempt count and that the elapsed time covers the expected backoff. Without the change it fails with the 37µs line above.

Plus unit tests for growth, the cap, total bounded latency, immediate abort on a canceled context, and the zero case. `go vet ./...`, the full `./internal/proxy/` suite, and windows/linux cross-compiles pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787806732&installation_model_id=21920&pr_number=94&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F94&signature=7acb99197cbd038e78c6a25f7c68dd069adde93aeb8862dc7bce27a3c842f4e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds exponential backoff between replayable POST retries to prevent rapid-fire attempts that led to residual 502s during brief upstream refusals. Retries now space out and abort immediately if the request context is canceled.

- Bug Fixes
  - Exponential backoff: 100ms → 200ms → 400ms → 800ms cap; six attempts span ~2s.
  - Respect context: aborts immediately on cancellation (no waiting after client disconnect).
  - Tests cover growth, cap, bounded total latency, cancellation, and spaced attempts.

<sup>Written for commit b4bc83359ce05f299637dd643e78646b79d800fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added increasing delays between retry attempts for failed POST requests.
  * Capped retry delays to keep request recovery times within reasonable limits.
  * Retries now stop promptly when the request is canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->