### PR TITLE
Run the sr auto-switch sweep once per interval, not once per worker

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -353,6 +353,7 @@ func serve(args []string) error {
 			Sessions:     store,
 			SchedulerRef: schedulerRef,
 			Logger:       slog.Default(),
+			Lease:        newSRAutoSwitchLease(storepath.StateDir()),
 		})
 	} else if srSwitchInterval > 0 {
 		slog.Info("sr auto-switch disabled because usage fetching is disabled", "interval", srSwitchInterval.String())

--- a/cmd/subrouter/sr_auto_switch.go
+++ b/cmd/subrouter/sr_auto_switch.go
@@ -22,6 +22,8 @@ type srAutoSwitchConfig struct {
 	Logger       *slog.Logger
 	FetchScores  func(context.Context, []accounts.Account) ([]selectacct.Score, int)
 	SwitchActive func(context.Context, string) error
+	// Lease keeps the sweep singleton across concurrently live workers.
+	Lease srAutoSwitchLease
 }
 
 func runSRAutoSwitch(ctx context.Context, cfg srAutoSwitchConfig) {
@@ -35,6 +37,15 @@ func runSRAutoSwitch(ctx context.Context, cfg srAutoSwitchConfig) {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
+			claimed, leaseErr := cfg.Lease.acquire(cfg.Interval)
+			if leaseErr != nil {
+				logSRAutoSwitch(cfg.Logger, slog.LevelWarn, "sr auto-switch lease unavailable, sweeping anyway", "error", leaseErr)
+			}
+			if !claimed {
+				// Another live worker already swept within this interval.
+				timer.Reset(cfg.Interval)
+				continue
+			}
 			picked, err := srAutoSwitchOnce(ctx, cfg)
 			if err != nil {
 				logSRAutoSwitch(cfg.Logger, slog.LevelWarn, "sr auto-switch failed", "error", err)

--- a/cmd/subrouter/sr_auto_switch_lease.go
+++ b/cmd/subrouter/sr_auto_switch_lease.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// The auto-switch sweep is a singleton operation even though every worker runs
+// its own timer for it. Each sweep fetches usage for every OAuth account and
+// then rewrites the shared active-account file, so N live workers means N times
+// the upstream usage traffic and N times the churn on one file.
+//
+// This is not hypothetical. The supervisor's drain has no timeout, so upgraded
+// -away workers survive as long as a client holds a connection. On the mac mini
+// six generations were live at once and `sr auto-switch selected account` was
+// firing about seven times per ten minutes instead of once, thrashing account
+// selection roughly every 90 seconds.
+//
+// A filesystem lease makes the sweep cooperative: whichever worker claims it
+// performs the sweep, and the rest skip until the interval has elapsed. The
+// cadence then depends on the configured interval rather than on how many
+// workers happen to be draining.
+type srAutoSwitchLease struct {
+	path string
+	now  func() time.Time
+}
+
+func newSRAutoSwitchLease(stateDir string) srAutoSwitchLease {
+	return srAutoSwitchLease{path: filepath.Join(stateDir, "sr-auto-switch.lease")}
+}
+
+func (l srAutoSwitchLease) clock() time.Time {
+	if l.now != nil {
+		return l.now()
+	}
+	return time.Now()
+}
+
+// acquire reports whether this worker should run the sweep now. It claims the
+// lease by stamping the file, so a concurrent worker checking within the same
+// interval declines.
+func (l srAutoSwitchLease) acquire(interval time.Duration) (bool, error) {
+	if l.path == "" || interval <= 0 {
+		return true, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(l.path), 0o700); err != nil {
+		// Never let a lease problem stop the sweep entirely; degrading to the
+		// old per-worker behavior is better than never switching accounts.
+		return true, fmt.Errorf("prepare auto-switch lease dir: %w", err)
+	}
+
+	// Checking the stamp and claiming it must be one atomic step. Doing them
+	// separately lets simultaneous workers all observe the same stale stamp and
+	// every one of them sweep, which is the exact behavior this exists to stop.
+	// O_EXCL create is the portable cross-process mutex for that.
+	unlock, held := l.lock()
+	if !held {
+		// Another worker is deciding right now; it will do the sweep if one is
+		// due, so this tick has nothing to do.
+		return false, nil
+	}
+	defer unlock()
+
+	info, err := os.Stat(l.path)
+	switch {
+	case err == nil:
+		// Another worker swept recently, so stand down. A small tolerance keeps
+		// timers that drift slightly from both firing.
+		if elapsed := l.clock().Sub(info.ModTime()); elapsed < interval-interval/10 {
+			return false, nil
+		}
+	case !errors.Is(err, os.ErrNotExist):
+		return true, fmt.Errorf("stat auto-switch lease: %w", err)
+	}
+
+	// Claim before sweeping, not after, so a slow sweep does not let every other
+	// worker in behind it.
+	if err := l.stamp(); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+// lockStaleAfter bounds how long a crashed or killed worker can block the
+// sweep. Workers are terminated routinely during upgrades, so an abandoned lock
+// must not freeze account selection.
+const lockStaleAfter = 2 * time.Minute
+
+// lock takes a short cross-process mutex around the check-and-claim.
+func (l srAutoSwitchLease) lock() (func(), bool) {
+	path := l.path + ".lock"
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err == nil {
+		_ = file.Close()
+		return func() { _ = os.Remove(path) }, true
+	}
+	if !errors.Is(err, os.ErrExist) {
+		return nil, false
+	}
+	// Reclaim a lock abandoned by a worker that died holding it.
+	if info, statErr := os.Stat(path); statErr == nil && l.clock().Sub(info.ModTime()) > lockStaleAfter {
+		if os.Remove(path) == nil {
+			if file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600); err == nil {
+				_ = file.Close()
+				return func() { _ = os.Remove(path) }, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func (l srAutoSwitchLease) stamp() error {
+	file, err := os.OpenFile(l.path, os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("claim auto-switch lease: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close auto-switch lease: %w", err)
+	}
+	now := l.clock()
+	if err := os.Chtimes(l.path, now, now); err != nil {
+		return fmt.Errorf("stamp auto-switch lease: %w", err)
+	}
+	return nil
+}

--- a/cmd/subrouter/sr_auto_switch_lease_test.go
+++ b/cmd/subrouter/sr_auto_switch_lease_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/selectacct"
+)
+
+// Several workers are alive at once whenever an upgraded-away generation is
+// still draining. Only one of them may run the sweep per interval, because each
+// sweep rewrites the shared active-account file.
+func TestAutoSwitchLeaseAdmitsOneWorkerPerInterval(t *testing.T) {
+	lease := newSRAutoSwitchLease(t.TempDir())
+	const interval = 10 * time.Minute
+
+	admitted := 0
+	for worker := 0; worker < 6; worker++ {
+		ok, err := lease.acquire(interval)
+		if err != nil {
+			t.Fatalf("worker %d: %v", worker, err)
+		}
+		if ok {
+			admitted++
+		}
+	}
+	if admitted != 1 {
+		t.Fatalf("%d of 6 concurrent workers ran the sweep, want exactly 1", admitted)
+	}
+}
+
+// Once the interval has genuinely elapsed the sweep must run again, otherwise
+// account selection freezes.
+func TestAutoSwitchLeaseAdmitsAgainAfterInterval(t *testing.T) {
+	now := time.Unix(1770000000, 0)
+	lease := newSRAutoSwitchLease(t.TempDir())
+	lease.now = func() time.Time { return now }
+	const interval = 10 * time.Minute
+
+	if ok, err := lease.acquire(interval); err != nil || !ok {
+		t.Fatalf("first acquire ok=%v err=%v, want true/nil", ok, err)
+	}
+	if ok, _ := lease.acquire(interval); ok {
+		t.Fatal("second acquire in the same interval was admitted, want it to stand down")
+	}
+
+	now = now.Add(interval)
+	if ok, err := lease.acquire(interval); err != nil || !ok {
+		t.Fatalf("acquire after the interval ok=%v err=%v, want true/nil", ok, err)
+	}
+}
+
+func TestAutoSwitchLeaseIsRaceFree(t *testing.T) {
+	lease := newSRAutoSwitchLease(t.TempDir())
+	const interval = time.Hour
+
+	var mu sync.Mutex
+	admitted := 0
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if ok, _ := lease.acquire(interval); ok {
+				mu.Lock()
+				admitted++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	if admitted == 0 {
+		t.Fatal("no worker was admitted, the sweep would never run")
+	}
+	if admitted > 2 {
+		t.Fatalf("%d workers admitted concurrently, want at most a small race window", admitted)
+	}
+}
+
+// A zero lease (unset, as in tests and one-shot CLI paths) must not block the
+// sweep.
+func TestZeroLeaseAlwaysAdmits(t *testing.T) {
+	var lease srAutoSwitchLease
+	for range 3 {
+		if ok, err := lease.acquire(time.Minute); err != nil || !ok {
+			t.Fatalf("zero lease ok=%v err=%v, want true/nil", ok, err)
+		}
+	}
+}
+
+// End to end through the loop: with a shared lease, a second worker firing in
+// the same interval must not perform a sweep.
+func TestRunSRAutoSwitchHonoursLease(t *testing.T) {
+	lease := newSRAutoSwitchLease(t.TempDir())
+	var mu sync.Mutex
+	sweeps := 0
+
+	cfg := srAutoSwitchConfig{
+		Interval: 50 * time.Millisecond,
+		Accounts: []accounts.Account{{ID: "a@example.com", AuthMode: accounts.AuthModeOAuth}},
+		Logger:   slog.New(slog.NewTextHandler(discardWriter{}, nil)),
+		Lease:    lease,
+		FetchScores: func(context.Context, []accounts.Account) ([]selectacct.Score, int) {
+			return []selectacct.Score{{AccountID: "a@example.com", Headroom: 1, ShortHeadroom: 1, Fresh: true}}, 1
+		},
+		SwitchActive: func(context.Context, string) error {
+			mu.Lock()
+			sweeps++
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 220*time.Millisecond)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runSRAutoSwitch(ctx, cfg)
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	got := sweeps
+	mu.Unlock()
+
+	// Four workers over ~4 intervals would be ~16 sweeps unleased. With the
+	// lease it tracks the interval, not the worker count.
+	if got == 0 {
+		t.Fatal("no sweeps ran at all")
+	}
+	if got > 8 {
+		t.Fatalf("%d sweeps across 4 workers, want the lease to hold it near the per-interval count", got)
+	}
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }


### PR DESCRIPTION
## Problem

Every worker runs its own `runSRAutoSwitch` timer. Each sweep fetches usage for every OAuth account **and rewrites the shared active-account file** via `WriteActiveCodexAuth`. That is inherently a singleton operation, but nothing enforces it.

The supervisor's drain deliberately has no timeout, so an upgraded-away worker lives until its last client connection closes. Measured on cmux-mac-mini with six generations alive at once:

```
sr auto-switch selected account
  22:35:40  22:36:43  22:41:30  22:42:46  22:43:10  22:43:16  22:45:50  22:46:46
```

That is roughly **seven sweeps per ten minutes instead of one**. Two consequences: usage-endpoint traffic to chatgpt.com is multiplied by the number of live workers, and the active account is switched about every 90 seconds instead of every 10 minutes, churning selection underneath running sessions.

## Change

Gate the sweep on a filesystem lease in the state dir. Whichever worker claims it sweeps; the rest stand down until the interval has elapsed. The cadence now follows `--sr-switch-interval` rather than the number of draining workers.

The check-and-claim runs under an `O_EXCL` lock. My first version checked the stamp and then wrote it as two steps, and the end-to-end test caught the race immediately: simultaneous workers all observed the same stale stamp and swept anyway (9-11 sweeps instead of ~4), which is precisely the bug being fixed. The lock is reclaimed after `lockStaleAfter` so a worker killed mid-upgrade cannot freeze account selection, and a zero-value lease always admits so tests and one-shot CLI paths are unaffected.

## Verification

`TestRunSRAutoSwitchHonoursLease` runs four concurrent workers through the real loop:

- without the lease: **20 sweeps**
- with the lease: **<= 8**, tracking the interval rather than the worker count

Plus unit tests for one-admit-per-interval across six workers, re-admission after the interval elapses, a 16-goroutine race check, and the zero-lease case. Clean under `-race`, 8 consecutive runs, `go vet ./...`, full `./cmd/subrouter/` suite, and windows/linux cross-compiles all pass.

## Related

The underlying worker accumulation is bounded separately by #93 (`IdleTimeout` on the worker), which stops new generations from piling up. This fix makes the sweep correct even when several are legitimately alive mid-drain.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787810418&installation_model_id=21920&pr_number=95&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F95&signature=c296c69a9af1c85356ef28861052bc1d03aba4f26acf1d875afa7268b8f40ff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the SR auto-switch sweep a singleton so it runs once per interval instead of once per worker, reducing usage calls and stopping account churn during upgrades.

- **Bug Fixes**
  - Added a filesystem lease in the state dir so only one worker sweeps per interval.
  - Used an `O_EXCL` lock for atomic check-and-claim; reclaim stale locks after 2 minutes.
  - If the lease is unavailable due to errors, proceed with a sweep to avoid freezing selection.
  - Integrated the lease in `serve` so all workers share it, and reset the timer when not claimed.

<sup>Written for commit 4a6c43d9befbb9da678e8a0d951957a514c98095. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic account switching when multiple workers run concurrently.
  * Prevented duplicate account sweeps within the same configured interval.
  * Added fallback behavior so automatic switching continues if coordination is unavailable.

* **Tests**
  * Added coverage for concurrent workers, lease timing, contention, and automatic switching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->