### PR TITLE
Stop discarding the shared idle pool on every retry (second port exhaustion)

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4023,9 +4023,23 @@ func (t replayablePostRetryTransport) RoundTrip(req *http.Request) (*http.Respon
 		if response != nil && response.Body != nil {
 			_ = response.Body.Close()
 		}
-		if closer, ok := t.base.(interface{ CloseIdleConnections() }); ok {
-			closer.CloseIdleConnections()
-		}
+		// Deliberately do NOT call CloseIdleConnections here.
+		//
+		// It used to run on every retry, to avoid handing the next attempt
+		// another connection the peer had already closed. But t.base is the one
+		// transport shared by every session, so a single retry discarded the
+		// entire pool for every host and every caller. Under failure that is a
+		// feedback loop: failures cause retries, retries empty the pool, every
+		// subsequent request has to dial, the extra dials exhaust the machine's
+		// ephemeral ports, and the resulting dial failures cause more retries.
+		// That is how cmux-mac-mini ran out of ports a second time, with
+		// 33k sockets in TIME_WAIT against a 32k range.
+		//
+		// The staleness this guarded against is now prevented at the source:
+		// IdleConnTimeout is held below the upstream's measured 15s idle close,
+		// so a pooled connection is dropped by us before the peer drops it. Go's
+		// transport also retires the specific connection that just errored, so
+		// the next attempt will not reuse it.
 		attemptReq = req.Clone(req.Context())
 		attemptReq.Body = body
 		attemptReq.GetBody = req.GetBody

--- a/internal/proxy/retry_pool_test.go
+++ b/internal/proxy/retry_pool_test.go
@@ -1,0 +1,91 @@
+package proxy
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countingCloseTransport records how often the retry path discards the shared
+// idle-connection pool.
+type countingCloseTransport struct {
+	attempts atomic.Int64
+	closes   atomic.Int64
+	failFor  int64
+}
+
+func (t *countingCloseTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	n := t.attempts.Add(1)
+	if n <= t.failFor {
+		return nil, errors.New("write tcp4 10.0.0.1:1->10.0.0.2:443: use of closed network connection")
+	}
+	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok")), Header: http.Header{}}, nil
+}
+
+func (t *countingCloseTransport) CloseIdleConnections() { t.closes.Add(1) }
+
+func newReplayableRequest(t *testing.T) *http.Request {
+	t.Helper()
+	request, err := http.NewRequest(http.MethodPost, "https://example.invalid/responses", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	request.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader("{}")), nil }
+	return request
+}
+
+// A retry must not discard the pool shared by every other session. Doing so
+// forces unrelated in-flight work to re-dial, and under sustained failure the
+// extra dials exhaust the machine's ephemeral ports, which causes more
+// failures.
+func TestRetryDoesNotDiscardSharedIdlePool(t *testing.T) {
+	base := &countingCloseTransport{failFor: 3}
+	transport := replayablePostRetryTransport{
+		base:        base,
+		maxAttempts: 6,
+		method:      http.MethodPost,
+		path:        "/responses",
+	}
+
+	response, err := transport.RoundTrip(newReplayableRequest(t))
+	if err != nil {
+		t.Fatalf("expected the retry to eventually succeed, got %v", err)
+	}
+	defer response.Body.Close()
+
+	if got := base.attempts.Load(); got != 4 {
+		t.Fatalf("made %d attempts, want 4 (3 failures then success)", got)
+	}
+	if got := base.closes.Load(); got != 0 {
+		t.Fatalf("retry discarded the shared idle pool %d times; that forces every other session to re-dial and is how the port range was exhausted", got)
+	}
+}
+
+// Retries must still actually retry, and still back off between attempts.
+func TestRetryStillRetriesAndBacksOff(t *testing.T) {
+	base := &countingCloseTransport{failFor: 2}
+	transport := replayablePostRetryTransport{
+		base:        base,
+		maxAttempts: 6,
+		method:      http.MethodPost,
+		path:        "/responses",
+	}
+
+	start := time.Now()
+	response, err := transport.RoundTrip(newReplayableRequest(t))
+	if err != nil {
+		t.Fatalf("retry should have recovered: %v", err)
+	}
+	defer response.Body.Close()
+
+	if got := base.attempts.Load(); got != 3 {
+		t.Fatalf("made %d attempts, want 3", got)
+	}
+	if elapsed := time.Since(start); elapsed < retryBackoff(1) {
+		t.Fatalf("recovered in %s, want at least one backoff interval of %s", elapsed, retryBackoff(1))
+	}
+}


### PR DESCRIPTION
## What happened

cmux-mac-mini exhausted its ephemeral ports a **second** time tonight, hours after connection pooling (#89) was deployed and with only two workers alive:

```
TIME_WAIT: 32,883   against a 32,768-port range
dial failures: 516  502s: 49
```

Widening the range stopped it immediately (last failure at 23:36:41, the second the sysctl landed), but that is a mitigation, not the cause.

## Cause

Measured after the fact, the connection creation rate was **~0.1/sec** and request volume was ordinary (~120/min, briefly 245/min). Nothing was steadily churning connections. The 33k TIME_WAIT was produced by a burst.

The amplifier is in the retry path:

```go
if closer, ok := t.base.(interface{ CloseIdleConnections() }); ok {
    closer.CloseIdleConnections()
}
```

`t.base` is the single outbound transport shared by every session. So **one retry discards the idle pool for every host and every caller**, not just the failing connection.

That closes a feedback loop:

1. some requests fail
2. each failure retries up to 6 times
3. every retry empties the shared pool
4. every other in-flight session must now dial fresh
5. the extra dials consume ephemeral ports
6. port exhaustion produces `can't assign requested address`
7. those are retryable transport errors, so go to 2

A modest traffic burst is enough to enter it, which is exactly the shape observed.

## Why it is safe to remove

The staleness this guarded against is now prevented at the source. #90 holds `IdleConnTimeout` (10s) below the upstream's measured idle close (15s), so a pooled connection is dropped by us before the peer drops it. Go's transport also retires the specific connection that just errored, so the next attempt will not reuse it.

## Verification

`TestRetryDoesNotDiscardSharedIdlePool` drives the real retry loop with a transport that fails 3 times then succeeds, and counts pool discards:

- with the old code: **3 discards for a single request**
- with this change: **0**, and the request still recovers on attempt 4

`TestRetryStillRetriesAndBacksOff` confirms retries and backoff are unaffected. `go vet ./...`, the full `./internal/proxy/` suite, and windows/linux cross-compiles pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787812958&installation_model_id=21920&pr_number=96&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F96&signature=6012b5548e5a7fa6273d88455496f1c1bd6cc29687e4fa630db850f71ba7f515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop discarding the shared idle connection pool on each retry for replayable POSTs. This prevents port exhaustion under failure bursts while keeping retry and backoff behavior unchanged.

- **Bug Fixes**
  - Removed `CloseIdleConnections` from the retry path in `replayablePostRetryTransport`, so a single retry no longer clears the pool shared across hosts and sessions.
  - Safe by design: `IdleConnTimeout` is below the upstream’s idle close, and Go retires the specific errored connection, so stale conns aren’t reused.
  - Added tests to confirm no pool discards and that retries/backoff still work.

<sup>Written for commit 32c4ef3c337d5412c8fa79b8b868eae157e66889. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

