### PR TITLE
Preserve WebSocket close handshakes and log dial failures

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2118,6 +2118,7 @@ func (s Server) copyWebSocketMessages(ctx context.Context, agentType, sessionID,
 	for {
 		messageType, body, err := src.ReadMessage()
 		if err != nil {
+			forwardWebSocketClose(dst, err)
 			return
 		}
 		if s.Transcripts != nil {
@@ -2144,6 +2145,36 @@ func (s Server) copyWebSocketMessages(ctx context.Context, agentType, sessionID,
 		if err := dst.WriteMessage(messageType, body); err != nil {
 			return
 		}
+	}
+}
+
+const webSocketCloseWriteTimeout = time.Second
+
+// forwardWebSocketClose preserves the close handshake across the proxy. A raw
+// TCP close makes the other peer report abnormal closure 1006 even when the
+// first peer sent a valid WebSocket close frame. Unexpected transport loss is
+// translated to 1011 so the proxy still terminates with a valid close frame.
+func forwardWebSocketClose(dst *websocket.Conn, readErr error) {
+	code := websocket.CloseInternalServerErr
+	reason := "peer connection closed unexpectedly"
+	var closeErr *websocket.CloseError
+	if errors.As(readErr, &closeErr) && webSocketCloseCodeCanBeForwarded(closeErr.Code) {
+		code = closeErr.Code
+		reason = closeErr.Text
+	}
+	_ = dst.WriteControl(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(code, reason),
+		time.Now().Add(webSocketCloseWriteTimeout),
+	)
+}
+
+func webSocketCloseCodeCanBeForwarded(code int) bool {
+	switch code {
+	case websocket.CloseNoStatusReceived, websocket.CloseAbnormalClosure, websocket.CloseTLSHandshake:
+		return false
+	default:
+		return true
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -28,9 +28,9 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
+	"github.com/manaflow-ai/subrouter/internal/transcript"
 	"github.com/manaflow-ai/subrouter/selectacct"
 	"github.com/manaflow-ai/subrouter/session"
-	"github.com/manaflow-ai/subrouter/internal/transcript"
 )
 
 type Server struct {
@@ -55,12 +55,12 @@ type Server struct {
 	ActiveSessions   *ActiveSessions
 	// StreamDrops counts dropped response streams by which side ended them,
 	// so the expected client-hangup case is countable without a log line each.
-	StreamDrops *StreamDropStats
-	Lifecycle        *Lifecycle
-	AdminToken       string
-	MaxBodyBytes     int64
-	Transcripts      *transcript.Recorder
-	ReadCache        *readCache
+	StreamDrops  *StreamDropStats
+	Lifecycle    *Lifecycle
+	AdminToken   string
+	MaxBodyBytes int64
+	Transcripts  *transcript.Recorder
+	ReadCache    *readCache
 	// Bedrock, when set, enables the /bedrock/* SigV4 signing gateway.
 	Bedrock *BedrockConfig
 	// ClaudeFableAPIKey, when set, serves Claude Fable requests via this Anthropic
@@ -1958,6 +1958,27 @@ func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account a
 		status := 502
 		if response != nil {
 			status = response.StatusCode
+		}
+		// Log it. A failed dial previously produced no log line at all, so a
+		// client seeing "Connection reset without closing handshake" left
+		// nothing behind to explain it: the whole log had zero websocket
+		// entries despite every attempt failing. The upstream's status and the
+		// first bytes of its body are what distinguish an edge challenge from
+		// an origin rejection, and they are discarded once this returns.
+		if s.Logger != nil {
+			s.Logger.Error("websocket upstream dial failed",
+				"agent", agentType,
+				"session", sessionID,
+				"account", account.ID,
+				"upstream", upstreamURL.Host,
+				"path", upstreamURL.Path,
+				"status", status,
+				"error", err,
+				"upstream_server", websocketResponseHeader(response, "Server"),
+				"cf_mitigated", websocketResponseHeader(response, "Cf-Mitigated"),
+				"cf_ray", websocketResponseHeader(response, "Cf-Ray"),
+				"content_type", websocketResponseHeader(response, "Content-Type"),
+				"body", websocketDialFailureBody(response))
 		}
 		http.Error(w, err.Error(), status)
 		return
@@ -4241,4 +4262,30 @@ func writeJSON(w http.ResponseWriter, value any) {
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")
 	_ = encoder.Encode(value)
+}
+
+// websocketDialFailureBodyMax bounds how much of a failed websocket dial's
+// response body is logged. Edge challenge pages are large HTML documents, and
+// only the opening bytes are needed to tell them apart from an origin error.
+const websocketDialFailureBodyMax = 240
+
+func websocketResponseHeader(response *http.Response, key string) string {
+	if response == nil {
+		return ""
+	}
+	return response.Header.Get(key)
+}
+
+// websocketDialFailureBody returns a bounded, single-line excerpt of the
+// upstream's response body so the reason survives in the log.
+func websocketDialFailureBody(response *http.Response) string {
+	if response == nil || response.Body == nil {
+		return ""
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, websocketDialFailureBodyMax))
+	if err != nil && len(body) == 0 {
+		return ""
+	}
+	return strings.Join(strings.Fields(string(body)), " ")
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1977,8 +1977,7 @@ func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account a
 				"upstream_server", websocketResponseHeader(response, "Server"),
 				"cf_mitigated", websocketResponseHeader(response, "Cf-Mitigated"),
 				"cf_ray", websocketResponseHeader(response, "Cf-Ray"),
-				"content_type", websocketResponseHeader(response, "Content-Type"),
-				"body", websocketDialFailureBody(response))
+				"content_type", websocketResponseHeader(response, "Content-Type"))
 		}
 		http.Error(w, err.Error(), status)
 		return
@@ -4295,28 +4294,9 @@ func writeJSON(w http.ResponseWriter, value any) {
 	_ = encoder.Encode(value)
 }
 
-// websocketDialFailureBodyMax bounds how much of a failed websocket dial's
-// response body is logged. Edge challenge pages are large HTML documents, and
-// only the opening bytes are needed to tell them apart from an origin error.
-const websocketDialFailureBodyMax = 240
-
 func websocketResponseHeader(response *http.Response, key string) string {
 	if response == nil {
 		return ""
 	}
 	return response.Header.Get(key)
-}
-
-// websocketDialFailureBody returns a bounded, single-line excerpt of the
-// upstream's response body so the reason survives in the log.
-func websocketDialFailureBody(response *http.Response) string {
-	if response == nil || response.Body == nil {
-		return ""
-	}
-	defer response.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(response.Body, websocketDialFailureBodyMax))
-	if err != nil && len(body) == 0 {
-		return ""
-	}
-	return strings.Join(strings.Fields(string(body)), " ")
 }

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -100,6 +100,64 @@ func TestHandlerProxiesWebSocketWithSelectedAccountAuth(t *testing.T) {
 	}
 }
 
+func TestHandlerForwardsUpstreamWebSocketCloseHandshake(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade: %v", err)
+		}
+		defer conn.Close()
+		if err := conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, "complete"),
+			time.Now().Add(time.Second),
+		); err != nil {
+			t.Fatalf("write close: %v", err)
+		}
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := Server{
+		Upstream: upstreamURL,
+		Accounts: []accounts.Account{{
+			ID:       "a@example.com",
+			AuthMode: accounts.AuthModeOAuth,
+			Token:    "selected-token",
+		}},
+		Sessions:     store,
+		Scheduler:    selectacct.NewScheduler(nil),
+		MaxBodyBytes: 1024,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(subrouter.URL, "http") + "/v1/responses"
+	conn, response, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer response.Body.Close()
+	defer conn.Close()
+
+	_, _, err = conn.ReadMessage()
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("read error = %v, want WebSocket close frame", err)
+	}
+	if closeErr.Code != websocket.CloseNormalClosure || closeErr.Text != "complete" {
+		t.Fatalf("close = (%d, %q), want (%d, %q)", closeErr.Code, closeErr.Text, websocket.CloseNormalClosure, "complete")
+	}
+}
+
 func TestHandlerProxiesWebSocketWhenAllOAuthAccountsBelowProtectedHeadroom(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -158,6 +158,36 @@ func TestHandlerForwardsUpstreamWebSocketCloseHandshake(t *testing.T) {
 	}
 }
 
+func TestForwardWebSocketCloseTranslatesTransportReset(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade: %v", err)
+		}
+		defer conn.Close()
+		forwardWebSocketClose(conn, io.ErrUnexpectedEOF)
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, response, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer response.Body.Close()
+	defer conn.Close()
+
+	_, _, err = conn.ReadMessage()
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("read error = %v, want WebSocket close frame", err)
+	}
+	if closeErr.Code != websocket.CloseInternalServerErr {
+		t.Fatalf("close code = %d, want %d", closeErr.Code, websocket.CloseInternalServerErr)
+	}
+}
+
 func TestHandlerProxiesWebSocketWhenAllOAuthAccountsBelowProtectedHeadroom(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
+	"github.com/manaflow-ai/subrouter/internal/transcript"
 	"github.com/manaflow-ai/subrouter/selectacct"
 	"github.com/manaflow-ai/subrouter/session"
-	"github.com/manaflow-ai/subrouter/internal/transcript"
 )
 
 func TestHandlerProxiesWebSocketWithSelectedAccountAuth(t *testing.T) {

--- a/internal/proxy/websocket_dial_failure_test.go
+++ b/internal/proxy/websocket_dial_failure_test.go
@@ -1,0 +1,113 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/selectacct"
+	"github.com/manaflow-ai/subrouter/session"
+)
+
+// A websocket dial that the upstream rejects used to produce no log line at
+// all, so a client reporting "Connection reset without closing handshake" left
+// nothing behind to diagnose. The upstream's status and body are the only
+// things that distinguish an edge challenge from an origin rejection, and they
+// are discarded once the handler returns.
+func TestWebSocketDialFailureIsLoggedWithUpstreamDetail(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Server", "cloudflare")
+		w.Header().Set("Cf-Mitigated", "challenge")
+		w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, "<html>\n  <head>\n    <title>Just a moment...</title>\n  </head>\n</html>")
+	}))
+	defer upstream.Close()
+
+	codexUpstream, err := url.Parse(upstream.URL + "/backend-api/codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	handler := Server{
+		CodexUpstream: codexUpstream,
+		Accounts: []accounts.Account{{
+			ID:       "codex-account",
+			AuthMode: accounts.AuthModeOAuth,
+			Token:    "oauth-token",
+		}},
+		Sessions:     store,
+		Scheduler:    selectacct.NewScheduler(nil),
+		MaxBodyBytes: 1024,
+		Logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+	}.Handler()
+
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	request, err := http.NewRequest(http.MethodGet, proxy.URL+"/v1/realtime?intent=quicksilver", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Connection", "Upgrade")
+	request.Header.Set("Upgrade", "websocket")
+	request.Header.Set("Sec-WebSocket-Version", "13")
+	request.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, response.Body)
+
+	got := logs.String()
+	if !strings.Contains(got, "websocket upstream dial failed") {
+		t.Fatalf("no dial-failure log line emitted; the failure would be invisible.\nlogs:\n%s", got)
+	}
+	for _, want := range []string{"status=403", "cf_mitigated=challenge", "upstream_server=cloudflare"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("log missing %q, which is what identifies the rejecting layer.\nlogs:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, "Just a moment") {
+		t.Errorf("log missing the upstream body excerpt.\nlogs:\n%s", got)
+	}
+}
+
+func TestWebSocketDialFailureBodyIsBoundedAndSingleLine(t *testing.T) {
+	huge := strings.Repeat("<html>challenge page\n", 500)
+	response := &http.Response{Body: io.NopCloser(strings.NewReader(huge))}
+
+	got := websocketDialFailureBody(response)
+	if len(got) > websocketDialFailureBodyMax {
+		t.Fatalf("body excerpt is %d bytes, want at most %d; challenge pages must not flood the log", len(got), websocketDialFailureBodyMax)
+	}
+	if strings.ContainsAny(got, "\n\r") {
+		t.Fatalf("body excerpt contains newlines, which would break one-line-per-event parsing: %q", got)
+	}
+	if got == "" {
+		t.Fatal("body excerpt is empty, want the opening bytes of the response")
+	}
+}
+
+func TestWebSocketDialFailureHelpersHandleNilResponse(t *testing.T) {
+	if got := websocketDialFailureBody(nil); got != "" {
+		t.Fatalf("nil response body = %q, want empty", got)
+	}
+	if got := websocketResponseHeader(nil, "Server"); got != "" {
+		t.Fatalf("nil response header = %q, want empty", got)
+	}
+}

--- a/internal/proxy/websocket_dial_failure_test.go
+++ b/internal/proxy/websocket_dial_failure_test.go
@@ -18,16 +18,16 @@ import (
 
 // A websocket dial that the upstream rejects used to produce no log line at
 // all, so a client reporting "Connection reset without closing handshake" left
-// nothing behind to diagnose. The upstream's status and body are the only
-// things that distinguish an edge challenge from an origin rejection, and they
-// are discarded once the handler returns.
+// nothing behind to diagnose. The upstream's status and headers identify the
+// rejecting layer without logging an arbitrary response body that could reflect
+// request credentials.
 func TestWebSocketDialFailureIsLoggedWithUpstreamDetail(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Server", "cloudflare")
 		w.Header().Set("Cf-Mitigated", "challenge")
 		w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 		w.WriteHeader(http.StatusForbidden)
-		_, _ = io.WriteString(w, "<html>\n  <head>\n    <title>Just a moment...</title>\n  </head>\n</html>")
+		_, _ = io.WriteString(w, "<html>reflected Authorization: Bearer secret-token</html>")
 	}))
 	defer upstream.Close()
 
@@ -82,31 +82,12 @@ func TestWebSocketDialFailureIsLoggedWithUpstreamDetail(t *testing.T) {
 			t.Errorf("log missing %q, which is what identifies the rejecting layer.\nlogs:\n%s", want, got)
 		}
 	}
-	if !strings.Contains(got, "Just a moment") {
-		t.Errorf("log missing the upstream body excerpt.\nlogs:\n%s", got)
-	}
-}
-
-func TestWebSocketDialFailureBodyIsBoundedAndSingleLine(t *testing.T) {
-	huge := strings.Repeat("<html>challenge page\n", 500)
-	response := &http.Response{Body: io.NopCloser(strings.NewReader(huge))}
-
-	got := websocketDialFailureBody(response)
-	if len(got) > websocketDialFailureBodyMax {
-		t.Fatalf("body excerpt is %d bytes, want at most %d; challenge pages must not flood the log", len(got), websocketDialFailureBodyMax)
-	}
-	if strings.ContainsAny(got, "\n\r") {
-		t.Fatalf("body excerpt contains newlines, which would break one-line-per-event parsing: %q", got)
-	}
-	if got == "" {
-		t.Fatal("body excerpt is empty, want the opening bytes of the response")
+	if strings.Contains(got, "secret-token") {
+		t.Errorf("log contains a credential reflected in the upstream body.\nlogs:\n%s", got)
 	}
 }
 
 func TestWebSocketDialFailureHelpersHandleNilResponse(t *testing.T) {
-	if got := websocketDialFailureBody(nil); got != "" {
-		t.Fatalf("nil response body = %q, want empty", got)
-	}
 	if got := websocketResponseHeader(nil, "Server"); got != "" {
 		t.Fatalf("nil response header = %q, want empty", got)
 	}


### PR DESCRIPTION
## Problem

Codex realtime sessions fail with:

```
Stream disconnected before completion: WebSocket protocol error:
Connection reset without closing handshake
```

Subrouter's log contains **zero** websocket entries. Not zero failures, zero entries: `grep -ic websocket` over the whole log returns 0, while every realtime attempt has been failing. `proxyWebSocket` reads the upstream response only to extract a status code, passes `err.Error()` to the client, and drops the rest:

```go
upstreamConn, response, err := websocket.DefaultDialer.Dial(upstreamURL.String(), headers)
if err != nil {
    status := 502
    if response != nil { status = response.StatusCode }
    http.Error(w, err.Error(), status)
    return
}
```

The upstream's status and headers, the only things that say *who* rejected the dial, are discarded.

## Why this matters more than it looks

Diagnosing this without the log meant packet captures and hand-built curl probes, and those probes are actively misleading. Cloudflare fingerprints curl and served it a bot challenge (`cf-mitigated: challenge`), so curl and the Go dialer get different verdicts for the same URL. I reached two different wrong conclusions before realising the probe itself was the variable.

One log line from the real dialer settles in seconds what a capture cannot settle at all.

## Change

On dial failure, log the dialed host and path, the upstream status, and `Server` / `Cf-Mitigated` / `Cf-Ray` / `Content-Type`.

`cf_mitigated=challenge` from `server: cloudflare` means the edge blocked it. A status from the origin with a JSON content type means the origin did. Those need different fixes and were previously indistinguishable.

The response **body is deliberately not logged**: an upstream error page can reflect request credentials, and the headers are sufficient to attribute the rejection.

## Verification

`TestWebSocketDialFailureIsLoggedWithUpstreamDetail` stands up an upstream that answers a websocket upgrade with a 403 challenge page whose body reflects a bearer token. It drives a real upgrade through the handler and asserts the log carries `status=403`, `cf_mitigated=challenge`, and `upstream_server=cloudflare`, **and** that the reflected credential never reaches the log. Without the change it fails with `no dial-failure log line emitted; the failure would be invisible`.

Also covers nil-response safety. `go vet ./...`, the full `./internal/proxy/` suite, and windows/linux cross-compiles pass.

## What this does not do

It does not make realtime work. It makes the next attempt diagnosable from one grep instead of a packet capture.