### PR TITLE
Dial websockets with the same TLS and address family as HTTP

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1953,7 +1953,7 @@ func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account a
 	setAccountAuthHeaders(headers, account)
 	s.recordWebSocketMeta(r, upstreamURL, headers, agentType, sessionID, userEmail, account, upstream)
 
-	upstreamConn, response, err := websocket.DefaultDialer.Dial(upstreamURL.String(), headers)
+	upstreamConn, response, err := outboundWebSocketDialer().Dial(upstreamURL.String(), headers)
 	if err != nil {
 		status := 502
 		if response != nil {
@@ -4300,3 +4300,44 @@ func websocketResponseHeader(response *http.Response, key string) string {
 	}
 	return response.Header.Get(key)
 }
+
+// outboundWebSocketDialer matches the TLS and dial behavior of
+// NewOutboundTransport, which is the configuration our upstreams actually
+// accept.
+//
+// websocket.DefaultDialer offers no ALPN and dials dual-stack. The plain HTTP
+// path deliberately does neither: it pins http/1.1 and dials IPv4, because the
+// upstream edge treats protocols differently. Probing the same URL showed a
+// bot challenge over HTTP/2 versus a real origin response over HTTP/1.1.
+//
+// Left on the default dialer, a websocket upgrade to
+// chatgpt.com/backend-api/codex/responses closed with EOF before any response
+// headers arrived (no status, no Server, no Cf-Ray), which reached clients as
+// "Connection reset without closing handshake".
+func outboundWebSocketDialer() *websocket.Dialer {
+	outboundWebSocketDialerOnce.Do(func() {
+		dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+		outboundWebSocketDialerValue = &websocket.Dialer{
+			Proxy:            http.ProxyFromEnvironment,
+			HandshakeTimeout: websocketHandshakeTimeout,
+			NetDialContext: func(ctx context.Context, _, addr string) (net.Conn, error) {
+				return dialer.DialContext(ctx, "tcp4", addr)
+			},
+			// Pin http/1.1. A websocket upgrade cannot proceed over h2, and
+			// advertising nothing lets the edge choose, which is what differs
+			// from the working HTTP path.
+			TLSClientConfig:   &tls.Config{NextProtos: []string{"http/1.1"}},
+			EnableCompression: true,
+		}
+	})
+	return outboundWebSocketDialerValue
+}
+
+// websocketHandshakeTimeout bounds the upgrade itself. The default dialer has
+// no timeout, so a silent upstream could hang the handshake indefinitely.
+const websocketHandshakeTimeout = 30 * time.Second
+
+var (
+	outboundWebSocketDialerOnce  sync.Once
+	outboundWebSocketDialerValue *websocket.Dialer
+)

--- a/internal/proxy/websocket_dialer_test.go
+++ b/internal/proxy/websocket_dialer_test.go
@@ -1,0 +1,97 @@
+package proxy
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+// The plain HTTP path pins http/1.1 and IPv4 because that is what the upstream
+// edge accepts; probing the same URL returned a bot challenge over HTTP/2 and a
+// real origin response over HTTP/1.1. The websocket dialer has to match, or the
+// upgrade closes with EOF before any response headers arrive.
+func TestOutboundWebSocketDialerPinsHTTP11(t *testing.T) {
+	dialer := outboundWebSocketDialer()
+
+	if dialer == websocket.DefaultDialer {
+		t.Fatal("websocket dials use DefaultDialer, which offers no ALPN and dials dual-stack")
+	}
+	if dialer.TLSClientConfig == nil {
+		t.Fatal("dialer has no TLS config, so ALPN is left to the default")
+	}
+	if !slices.Contains(dialer.TLSClientConfig.NextProtos, "http/1.1") {
+		t.Fatalf("NextProtos = %v, want it to advertise http/1.1; a websocket upgrade cannot proceed over h2",
+			dialer.TLSClientConfig.NextProtos)
+	}
+	if slices.Contains(dialer.TLSClientConfig.NextProtos, "h2") {
+		t.Fatalf("NextProtos = %v, must not offer h2 for an upgrade", dialer.TLSClientConfig.NextProtos)
+	}
+	if dialer.NetDialContext == nil {
+		t.Fatal("dialer has no NetDialContext, so it will not pin IPv4 like the HTTP transport does")
+	}
+	if dialer.HandshakeTimeout <= 0 {
+		t.Fatal("HandshakeTimeout is unset; a silent upstream would hang the upgrade indefinitely")
+	}
+}
+
+// The negotiated protocol is what actually matters, so assert it end to end
+// against a TLS server that records ALPN.
+func TestOutboundWebSocketDialerNegotiatesHTTP11(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
+
+	var mu sync.Mutex
+	var negotiated string
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.TLS != nil {
+			mu.Lock()
+			negotiated = r.TLS.NegotiatedProtocol
+			mu.Unlock()
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = conn.WriteMessage(websocket.TextMessage, []byte("ok"))
+	}))
+	// Offer both, so the client's advertisement decides.
+	server.TLS = &tls.Config{NextProtos: []string{"h2", "http/1.1"}}
+	server.StartTLS()
+	defer server.Close()
+
+	dialer := *outboundWebSocketDialer()
+	// Trust the test server's cert while keeping the ALPN pin under test.
+	dialer.TLSClientConfig = &tls.Config{
+		NextProtos:         outboundWebSocketDialer().TLSClientConfig.NextProtos,
+		InsecureSkipVerify: true,
+	}
+	// httptest listens on IPv4 loopback, matching the pinned dial family.
+
+	url := "wss" + server.URL[len("https"):]
+	conn, response, err := dialer.Dial(url, nil)
+	if err != nil {
+		status := 0
+		if response != nil {
+			status = response.StatusCode
+		}
+		t.Fatalf("websocket dial failed: %v (status %d)", err, status)
+	}
+	defer conn.Close()
+
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("read after upgrade: %v", err)
+	}
+
+	mu.Lock()
+	got := negotiated
+	mu.Unlock()
+	if got != "http/1.1" {
+		t.Fatalf("negotiated ALPN = %q, want http/1.1; the upgrade must not land on h2", got)
+	}
+}


### PR DESCRIPTION
## Evidence

The dial-failure logging from #97 caught the first real failure:

```
websocket upstream dial failed  upstream=chatgpt.com
  path=/backend-api/codex/responses  status=502  error=EOF
  upstream_server=""  cf_mitigated=""  cf_ray=""  content_type=""
```

Three things follow. It is the `responses_websockets` feature (codex sending `/responses` over a websocket), not realtime. Every upstream header is empty and the error is `EOF`, so **no HTTP response arrived at all** — the connection closed before headers, meaning neither the Cloudflare edge nor the origin answered. And that is exactly what clients report as `Connection reset without closing handshake`.

## Cause

`websocket.DefaultDialer` advertises **no ALPN** and dials dual-stack.

`NewOutboundTransport`, the transport whose requests succeed by the thousand against this same host, deliberately does neither:

```go
transport.ForceAttemptHTTP2 = false
transport.TLSClientConfig.NextProtos = []string{"http/1.1"}
transport.DialContext = ... dialer.DialContext(ctx, "tcp4", addr)
```

That difference is not cosmetic at this edge. Probing one URL two ways:

| protocol | result |
|---|---|
| HTTP/2 (curl default) | `403`, `cf-mitigated: challenge`, HTML |
| forced `--http1.1` | real origin response |

A websocket upgrade cannot proceed over h2 at all, so leaving ALPN unset lets the edge pick and the upgrade dies before it starts.

## Change

Dial websockets through a dialer that matches the HTTP transport: `http/1.1` ALPN, IPv4, `ProxyFromEnvironment`, compression, plus a 30s `HandshakeTimeout` (the default dialer has none, so a silent upstream could hang the upgrade indefinitely).

## Verification

`TestOutboundWebSocketDialerNegotiatesHTTP11` stands up a TLS server offering **both** `h2` and `http/1.1`, so the client's advertisement decides, dials a real websocket through it, and asserts the negotiated protocol.

- with `DefaultDialer`: fails with `negotiated ALPN = "", want http/1.1`
- with this change: negotiates `http/1.1` and the upgrade completes

Plus a configuration test covering the ALPN pin, absence of `h2`, the IPv4 dial hook, and a positive handshake timeout. `go vet`, the full `./internal/proxy/` suite, and windows/linux cross-compiles pass.

## Honest scope

This removes a real and specific difference between the websocket path and the HTTP path that works. Whether it is sufficient to make `responses_websockets` succeed end to end will be visible immediately: the same log line from #97 either stops appearing or comes back with upstream headers attached, which would then point at the edge or the origin rather than at our client setup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787829438&installation_model_id=21920&pr_number=98&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F98&signature=345e14abdd2e46080418c891d20591b73cf22e2238224c6ac69286f40e46a6be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dial websockets with the same TLS and network settings as our HTTP transport to keep upgrades on http/1.1 and stop EOFs before headers. This fixes websocket upgrades to upstreams like chatgpt.com `/backend-api/codex/responses` that were closing with “Connection reset without closing handshake”.

- **Bug Fixes**
  - Route websocket dials through an outbound dialer that matches `NewOutboundTransport`: ALPN `http/1.1`, IPv4, `ProxyFromEnvironment`, compression, and a 30s handshake timeout (prevents h2 selection at the edge and 502/EOFs on `responses_websockets`).
  - Add tests to assert ALPN negotiation to `http/1.1` and verify dialer config (no `h2`, IPv4 dial, positive timeout).

<sup>Written for commit b1299d4b62320bfc7193679b54f7367d337959de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

