### PR TITLE
Retry Codex web-search POSTs like /responses

### DIFF
--- a/internal/proxy/alpha_search_retry_test.go
+++ b/internal/proxy/alpha_search_retry_test.go
@@ -1,0 +1,130 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/selectacct"
+	"github.com/manaflow-ai/subrouter/session"
+)
+
+// Codex's web-search POST carries a query, not a mutation, so a transport-level
+// failure is safe to replay. It was missing from the allowlist, so every TLS
+// record failure, ephemeral-port exhaustion, and broken pipe on /alpha/search
+// reached the client as a 502 while the identical failure on /responses was
+// absorbed by the retry transport.
+func TestAlphaSearchPostIsRetryable(t *testing.T) {
+	post := func(path string) *http.Request {
+		return &http.Request{Method: http.MethodPost, URL: &url.URL{Path: path}}
+	}
+
+	for _, path := range []string{"/alpha/search", "/v1/alpha/search"} {
+		if !retryableUpstreamPostRequest(accounts.ProviderCodex, post(path)) {
+			t.Errorf("POST %s is not retryable; a transport blip becomes a user-visible 502", path)
+		}
+	}
+	// The allowlist stays an allowlist: unrelated codex POSTs must not replay.
+	for _, path := range []string{"/alpha/search/save", "/codex/analytics-events/events"} {
+		if retryableUpstreamPostRequest(accounts.ProviderCodex, post(path)) {
+			t.Errorf("POST %s became retryable; only known-safe paths may replay", path)
+		}
+	}
+	if retryableUpstreamPostRequest(accounts.ProviderCodex, &http.Request{
+		Method: http.MethodGet,
+		URL:    &url.URL{Path: "/alpha/search"},
+	}) {
+		t.Error("GET /alpha/search took the replayable-POST path")
+	}
+}
+
+// End to end: the first upstream attempt dies at the transport layer, exactly
+// like the "tls: bad record MAC" and "can't assign requested address" failures
+// observed in production. With the path allowlisted the proxy replays the
+// buffered body and the client sees the successful second attempt.
+func TestAlphaSearchTransportFailureIsRetried(t *testing.T) {
+	var attempts atomic.Int32
+	var secondBody atomic.Value
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) == 1 {
+			// Reset the connection so the proxy's transport reports the failure,
+			// matching the "connection reset by peer" / "broken pipe" class seen
+			// in production rather than a clean upstream error response.
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				t.Error("test server does not support hijacking")
+				return
+			}
+			conn, _, err := hijacker.Hijack()
+			if err != nil {
+				t.Errorf("hijack: %v", err)
+				return
+			}
+			if tcp, ok := conn.(*net.TCPConn); ok {
+				_ = tcp.SetLinger(0)
+			}
+			_ = conn.Close()
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		secondBody.Store(string(body))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"results":[]}`)
+	}))
+	defer upstream.Close()
+
+	codexUpstream, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	handler := Server{
+		CodexUpstream: codexUpstream,
+		Accounts: []accounts.Account{{
+			ID:       "codex-account",
+			AuthMode: accounts.AuthModeOAuth,
+			Token:    "oauth-token",
+		}},
+		Sessions:     store,
+		Scheduler:    selectacct.NewScheduler(nil),
+		MaxBodyBytes: 1 << 20,
+		Logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+	}.Handler()
+
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	const query = `{"query":"ephemeral port exhaustion"}`
+	response, err := http.Post(proxy.URL+"/alpha/search", "application/json", strings.NewReader(query))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; the transport failure was surfaced instead of retried.\nbody: %s\nlogs:\n%s",
+			response.StatusCode, body, logs.String())
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("upstream attempts = %d, want 2", got)
+	}
+	if got, _ := secondBody.Load().(string); got != query {
+		t.Fatalf("replayed body = %q, want %q; the retry must resend the original query", got, query)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3294,7 +3294,13 @@ func retryableResponsesPostRequest(r *http.Request) bool {
 	return path == "/responses" ||
 		path == "/v1/responses" ||
 		path == "/responses/compact" ||
-		path == "/v1/responses/compact"
+		path == "/v1/responses/compact" ||
+		// Codex's web-search backend. The body carries a query, so replaying it
+		// is as safe as replaying a GET; without it every transport-level blip
+		// (TLS record failure, port exhaustion, broken pipe) reached the client
+		// as a 502 that the retry layer already absorbs for /responses.
+		path == "/alpha/search" ||
+		path == "/v1/alpha/search"
 }
 
 func retryableUpstreamPostRequest(provider accounts.Provider, r *http.Request) bool {


### PR DESCRIPTION
POST `/alpha/search` was missing from the replayable-POST allowlist, so every transport-level failure on Codex web search reached the client as a 502 while the identical failure on `/responses` was retried away.

`cmux-mac-mini` logged 30 user-visible `/alpha/search` failures in one log rotation, all in the class the retry transport already absorbs:

- 20 `dial tcp4 104.18.32.47:443: connect: can't assign requested address` (ephemeral port exhaustion)
- 9 `remote error: tls: bad record MAC`
- 1 `write: broken pipe`

For comparison, over the same window `/responses` saw 232 `bad record MAC` events and surfaced exactly 1 to a client, because it retries.

The body is a search query, not a mutation, so replaying it is as safe as replaying a GET. The allowlist stays an allowlist: only `/alpha/search` and its API-key-mode `/v1/alpha/search` form are added, and the test asserts neighbours like `/alpha/search/save` stay non-replayable.

Tests: predicate coverage plus an end-to-end case where the first upstream attempt RSTs the connection and the proxy must replay the buffered query. Both fail without the one-line allowlist change and pass with it; verified 30x under `-race`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787871985&installation_model_id=21920&pr_number=100&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F100&signature=615d3b5ec5cef141871aab3512b7d0b8e7ec0aae4145b1bf9c4ca60029ac671e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for web search requests by retrying eligible requests after transient connection failures.
  - Preserved and replayed the original search query when a retry is required.
  - Added support for both standard and versioned web search endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Codex web-search POSTs retryable like `/responses` to stop transient transport errors from surfacing as 502s. Adds `/alpha/search` and `/v1/alpha/search` to the replayable-POST allowlist; safe because the body is a query.

- **Bug Fixes**
  - Allowlisted only `/alpha/search` and `/v1/alpha/search` for retry; neighbors like `/alpha/search/save` remain non-retryable.
  - Retries now cover transient failures (e.g., TLS bad record MAC, ephemeral port exhaustion, broken pipe) that previously returned 502s.
  - Added predicate tests and an end-to-end test that simulates a connection reset and verifies the original query body is replayed successfully.

<sup>Written for commit ecde070d7852275502f746e30b9557defbff506c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

