### PR TITLE
Record why a replayable POST upload failed

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4067,10 +4067,20 @@ func (t replayablePostRetryTransport) RoundTrip(req *http.Request) (*http.Respon
 	}
 	attemptReq := req
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		response, err := t.roundTrip(attemptReq)
+		trace := newUploadAttemptTrace(attemptReq.ContentLength)
+		response, err := t.roundTrip(trace.attach(attemptReq))
 		retryStatus := err == nil && retryablePostUpstreamStatus(response)
 		retryTransportErr := err != nil && retryablePostTransportError(err)
 		if (!retryStatus && !retryTransportErr) || req.GetBody == nil || req.Context().Err() != nil || attempt == maxAttempts {
+			// The last attempt's failure is what the client sees as a 502, so
+			// record how the transport got there before giving up.
+			if err != nil && t.logger != nil {
+				t.logger.Error("replayable upstream request exhausted",
+					append([]any{"agent", t.agent, "session", t.session, "account", t.account,
+						"method", t.method, "path", t.path, "upstream", t.upstream,
+						"attempts", attempt, "max_attempts", maxAttempts, "error", err},
+						trace.attrs()...)...)
+			}
 			return response, err
 		}
 		body, bodyErr := req.GetBody()
@@ -4105,7 +4115,11 @@ func (t replayablePostRetryTransport) RoundTrip(req *http.Request) (*http.Respon
 			if retryStatus {
 				t.logger.Warn("retrying replayable upstream request after upstream timeout status", "agent", t.agent, "session", t.session, "account", t.account, "method", t.method, "path", t.path, "upstream", t.upstream, "attempt", attempt+1, "max_attempts", maxAttempts, "status", response.StatusCode, "cf_ray", response.Header.Get("Cf-Ray"), "request_id", response.Header.Get("X-Request-ID"))
 			} else {
-				t.logger.Warn("retrying replayable upstream request after transport failure", "agent", t.agent, "session", t.session, "account", t.account, "method", t.method, "path", t.path, "upstream", t.upstream, "attempt", attempt+1, "max_attempts", maxAttempts, "error", err)
+				t.logger.Warn("retrying replayable upstream request after transport failure",
+					append([]any{"agent", t.agent, "session", t.session, "account", t.account,
+						"method", t.method, "path", t.path, "upstream", t.upstream,
+						"attempt", attempt + 1, "max_attempts", maxAttempts, "error", err},
+						trace.attrs()...)...)
 			}
 		}
 		if !sleepForRetry(req.Context(), retryBackoff(attempt)) {

--- a/internal/proxy/upload_trace.go
+++ b/internal/proxy/upload_trace.go
@@ -1,0 +1,93 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptrace"
+	"sync/atomic"
+	"time"
+)
+
+// uploadAttemptTrace records what the transport actually did for one attempt at
+// a replayable POST. It exists because the failure wording alone cannot tell
+// these apart:
+//
+//   - "use of closed network connection" on a reused pooled connection means we
+//     handed the attempt a connection the peer had already closed, which is our
+//     bug to fix in pooling.
+//   - the same wording on a freshly dialed connection means the upstream hung up
+//     mid-upload, which is not something pooling can fix.
+//
+// Every field is written from httptrace callbacks that run on other goroutines,
+// so they are all atomics.
+type uploadAttemptTrace struct {
+	reused        atomic.Bool
+	gotConn       atomic.Bool
+	idleMillis    atomic.Int64
+	wroteRequest  atomic.Bool
+	wroteErr      atomic.Value // string
+	firstByte     atomic.Bool
+	connectErr    atomic.Value // string
+	requestStart  time.Time
+	bytesExpected int64
+}
+
+func newUploadAttemptTrace(contentLength int64) *uploadAttemptTrace {
+	return &uploadAttemptTrace{bytesExpected: contentLength}
+}
+
+// attach returns a request carrying the trace. The caller must use the returned
+// request; the original is left untouched.
+func (t *uploadAttemptTrace) attach(req *http.Request) *http.Request {
+	if t == nil || req == nil {
+		return req
+	}
+	t.requestStart = time.Now()
+	trace := &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			t.gotConn.Store(true)
+			t.reused.Store(info.Reused)
+			t.idleMillis.Store(info.IdleTime.Milliseconds())
+		},
+		WroteRequest: func(info httptrace.WroteRequestInfo) {
+			t.wroteRequest.Store(true)
+			if info.Err != nil {
+				t.wroteErr.Store(info.Err.Error())
+			}
+		},
+		GotFirstResponseByte: func() {
+			t.firstByte.Store(true)
+		},
+		ConnectDone: func(_, _ string, err error) {
+			if err != nil {
+				t.connectErr.Store(err.Error())
+			}
+		},
+	}
+	return req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+}
+
+// attrs returns slog key/value pairs describing the attempt. Only emitted on
+// failure paths, so this adds no steady-state log volume.
+func (t *uploadAttemptTrace) attrs() []any {
+	if t == nil {
+		return nil
+	}
+	attrs := []any{
+		"conn_reused", t.reused.Load(),
+		"got_conn", t.gotConn.Load(),
+		"conn_idle_ms", t.idleMillis.Load(),
+		"wrote_request", t.wroteRequest.Load(),
+		// Whether any response byte arrived before the failure separates an
+		// upstream that rejected the upload early from one that never answered.
+		"got_first_byte", t.firstByte.Load(),
+		"content_length", t.bytesExpected,
+		"attempt_ms", time.Since(t.requestStart).Milliseconds(),
+	}
+	if wrote, ok := t.wroteErr.Load().(string); ok && wrote != "" {
+		attrs = append(attrs, "wrote_request_err", wrote)
+	}
+	if connect, ok := t.connectErr.Load().(string); ok && connect != "" {
+		attrs = append(attrs, "connect_err", connect)
+	}
+	return attrs
+}

--- a/internal/proxy/upload_trace_test.go
+++ b/internal/proxy/upload_trace_test.go
@@ -1,0 +1,154 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// The whole point of the trace is to answer one question from the log alone:
+// did the failing attempt run on a pooled connection we handed it, or on a
+// connection we had just dialed? Without that, "use of closed network
+// connection" is unattributable.
+func TestUploadTraceDistinguishesReusedFromFreshConnections(t *testing.T) {
+	var requests atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer upstream.Close()
+
+	client := &http.Client{Transport: &http.Transport{}}
+
+	first := newUploadAttemptTrace(0)
+	request, err := http.NewRequest(http.MethodGet, upstream.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := client.Do(first.attach(request))
+	if err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, response.Body)
+	response.Body.Close()
+
+	if got := attrValue(first.attrs(), "conn_reused"); got != false {
+		t.Errorf("first request conn_reused = %v, want false", got)
+	}
+	if got := attrValue(first.attrs(), "got_first_byte"); got != true {
+		t.Errorf("first request got_first_byte = %v, want true", got)
+	}
+
+	second := newUploadAttemptTrace(0)
+	request, err = http.NewRequest(http.MethodGet, upstream.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err = client.Do(second.attach(request))
+	if err != nil {
+		t.Fatalf("second request: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, response.Body)
+	response.Body.Close()
+
+	if got := attrValue(second.attrs(), "conn_reused"); got != true {
+		t.Errorf("second request conn_reused = %v, want true; a pooled reuse must be visible in the log", got)
+	}
+}
+
+// A failure with no response byte is the case that has to be distinguishable
+// from an upstream that answered and then hung up.
+func TestUploadTraceRecordsFailureWithoutResponse(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		if tcp, ok := conn.(*net.TCPConn); ok {
+			_ = tcp.SetLinger(0)
+		}
+		_ = conn.Close()
+	}()
+
+	trace := newUploadAttemptTrace(11)
+	request, err := http.NewRequest(http.MethodPost, "http://"+listener.Addr().String(), strings.NewReader("hello world"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{Transport: &http.Transport{}}
+	if response, doErr := client.Do(trace.attach(request)); doErr == nil {
+		response.Body.Close()
+		t.Fatal("request unexpectedly succeeded against a socket that resets")
+	}
+	<-done
+	listener.Close()
+
+	attrs := trace.attrs()
+	if got := attrValue(attrs, "got_first_byte"); got != false {
+		t.Errorf("got_first_byte = %v, want false; the upstream never answered", got)
+	}
+	if got := attrValue(attrs, "content_length"); got != int64(11) {
+		t.Errorf("content_length = %v, want 11; upload size is what correlates these failures", got)
+	}
+}
+
+// Failures are logged with the trace attached, so an operator reading the log
+// can attribute them without reproducing anything.
+func TestExhaustedRequestLogsTraceAttributes(t *testing.T) {
+	var logs bytes.Buffer
+	transport := replayablePostRetryTransport{
+		base:        &http.Transport{},
+		logger:      slog.New(slog.NewTextHandler(&logs, nil)),
+		method:      http.MethodPost,
+		path:        "/responses",
+		maxAttempts: 1,
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := listener.Addr().String()
+	listener.Close() // nothing is listening, so the dial fails
+
+	request, err := http.NewRequest(http.MethodPost, "http://"+addr, strings.NewReader("body"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response, roundTripErr := transport.RoundTrip(request); roundTripErr == nil {
+		response.Body.Close()
+		t.Fatal("request unexpectedly succeeded")
+	}
+
+	got := logs.String()
+	if !strings.Contains(got, "replayable upstream request exhausted") {
+		t.Fatalf("no exhaustion log line; the client-visible 502 would leave no record.\nlogs:\n%s", got)
+	}
+	for _, want := range []string{"conn_reused=", "got_first_byte=", "content_length=", "attempt_ms="} {
+		if !strings.Contains(got, want) {
+			t.Errorf("exhaustion log missing %q.\nlogs:\n%s", want, got)
+		}
+	}
+}
+
+func attrValue(attrs []any, key string) any {
+	for i := 0; i+1 < len(attrs); i += 2 {
+		if name, ok := attrs[i].(string); ok && name == key {
+			return attrs[i+1]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Between 16:10 and 17:22 PDT `cmux-mac-mini` surfaced 33 `/responses` 502s across many sessions and 10+ accounts. Every one exhausted all 6 retry attempts, and every attempt failed on the **write** side: 27 `use of closed network connection`, 4 `write: broken pipe`. They span both Cloudflare edge IPs we resolve, so this is not one bad edge or one bad account.

The wording alone cannot attribute it, and the two candidates need opposite fixes:

- a **reused pooled connection** the peer had already closed means our pooling is handing out dead connections
- a **freshly dialed** connection means the upstream is hanging up mid-upload, which pooling cannot fix

So this adds an `httptrace` per attempt and logs `conn_reused`, `conn_idle_ms`, `got_first_byte`, `content_length`, `attempt_ms` (plus `wrote_request_err` / `connect_err` when set) on the retry warning, and on a new `replayable upstream request exhausted` error line that fires for exactly the failures a client sees as a 502.

Diagnostic only, no behavior change. Nothing is logged on the success path, so steady-state volume is unchanged.

Tests cover both directions the trace has to separate: a fresh connection vs a pooled reuse, and a failure where no response byte ever arrived. The exhaustion log test fails without the `proxy.go` change and passes with it; verified 25x under `-race`, and the full `internal/proxy` suite passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787876864&installation_model_id=21920&pr_number=101&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F101&signature=08726322efe132484bf52b1ae2f8089f6ab2ca8de02c8002e115453bf1f57b14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-attempt `httptrace` to replayable POST uploads and log connection details so we can attribute `/responses` 502s to either pooled dead-connection reuse or fresh-dial hang-ups. No behavior change; only failure-path logs.

- **New Features**
  - Capture and emit trace attrs: conn_reused, got_conn, conn_idle_ms, wrote_request, wrote_request_err, got_first_byte, connect_err, content_length, attempt_ms.
  - Include these attrs on transport-failure retry warnings and on a new “replayable upstream request exhausted” error line; success path stays silent.
  - Tests cover fresh vs pooled reuse, failures with no response byte, and the exhaustion log contents.

<sup>Written for commit 06b6fdc434e04ee098440b8da6412470f8c0f3cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

