### PR TITLE
Fix Claude auto classifier routing for Fable

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -79,6 +79,7 @@ func (s Server) bedrockHandler() http.Handler {
 		if !strings.HasPrefix(upstreamPath, "/") {
 			upstreamPath = "/" + upstreamPath
 		}
+		upstreamPath = rewriteClaudeCodeAutoClassifierPath(upstreamPath)
 
 		body, err := io.ReadAll(io.LimitReader(r.Body, replayablePostMaxBodyBytes))
 		if err != nil {
@@ -135,6 +136,19 @@ func (s Server) bedrockHandler() http.Handler {
 }
 
 const bedrockFableModelID = "us.anthropic.claude-fable-5"
+const claudeCodeAutoClassifierModelID = "us.anthropic.claude-opus-5[1m]"
+
+// rewriteClaudeCodeAutoClassifierPath maps Claude Code's selector-shaped auto
+// mode model to the Fable inference profile exposed by this gateway. The [1m]
+// suffix is a Claude Code selector, not a valid Bedrock model identifier, so
+// valid intentional Opus requests remain untouched.
+func rewriteClaudeCodeAutoClassifierPath(path string) string {
+	const prefix = "/model/" + claudeCodeAutoClassifierModelID + "/"
+	if !strings.HasPrefix(path, prefix) {
+		return path
+	}
+	return "/model/" + bedrockFableModelID + "/" + strings.TrimPrefix(path, prefix)
+}
 
 // claudeFableBedrockResponse forwards a Fable Messages request to Bedrock and
 // returns a native Anthropic-shaped response: SSE (transcoded from AWS

--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -86,6 +86,7 @@ func (s Server) bedrockHandler() http.Handler {
 			http.Error(w, "failed to read request body", http.StatusBadRequest)
 			return
 		}
+		upstreamPath, body = rewriteResolvedClaudeCodeAutoClassifierRequest(upstreamPath, body)
 
 		headers := http.Header{}
 		copyBedrockRequestHeaders(headers, r.Header)
@@ -148,6 +149,41 @@ func rewriteClaudeCodeAutoClassifierPath(path string) string {
 		return path
 	}
 	return "/model/" + bedrockFableModelID + "/" + strings.TrimPrefix(path, prefix)
+}
+
+const claudeCodeAutoClassifierSystemMarker = "You are a security monitor for autonomous AI coding agents."
+
+// Claude Code resolves its opus-5[1m] auto-mode selector before sending the
+// Bedrock request, so the wire path looks like an ordinary Opus invocation.
+// Match the classifier's system prompt before rerouting it, preserving genuine
+// Opus requests. Fable defaults to adaptive thinking and rejects the disabled
+// thinking shape emitted for Opus, so remove only that incompatible field.
+func rewriteResolvedClaudeCodeAutoClassifierRequest(path string, body []byte) (string, []byte) {
+	const resolvedPath = "/model/us.anthropic.claude-opus-5/invoke"
+	if path != resolvedPath {
+		return path, body
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil ||
+		!bytes.Contains(payload["system"], []byte(claudeCodeAutoClassifierSystemMarker)) {
+		return path, body
+	}
+
+	if rawThinking, ok := payload["thinking"]; ok {
+		var thinking struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(rawThinking, &thinking) == nil && thinking.Type == "disabled" {
+			delete(payload, "thinking")
+			rewritten, err := json.Marshal(payload)
+			if err != nil {
+				return path, body
+			}
+			body = rewritten
+		}
+	}
+	return "/model/" + bedrockFableModelID + "/invoke", body
 }
 
 // claudeFableBedrockResponse forwards a Fable Messages request to Bedrock and

--- a/internal/proxy/bedrock_test.go
+++ b/internal/proxy/bedrock_test.go
@@ -82,9 +82,9 @@ func TestBedrockHandlerSignsAndForwards(t *testing.T) {
 }
 
 func TestBedrockHandlerRoutesClaudeCodeAutoClassifierToFable(t *testing.T) {
-	var captured *http.Request
+	var capturedPaths []string
 	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		captured = req
+		capturedPaths = append(capturedPaths, req.URL.Path)
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
@@ -104,11 +104,25 @@ func TestBedrockHandlerRoutesClaudeCodeAutoClassifierToFable(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (body %q)", rec.Code, rec.Body.String())
 	}
-	if captured == nil {
+	if len(capturedPaths) != 1 {
 		t.Fatal("no upstream request captured")
 	}
-	if got := captured.URL.Path; got != "/model/us.anthropic.claude-fable-5/invoke" {
+	if got := capturedPaths[0]; got != "/model/us.anthropic.claude-fable-5/invoke" {
 		t.Fatalf("upstream path = %q, want Fable classifier path", got)
+	}
+
+	req = httptest.NewRequest(
+		http.MethodPost,
+		"/bedrock/model/us.anthropic.claude-opus-5/invoke",
+		strings.NewReader(`{"anthropic_version":"bedrock-2023-05-31"}`),
+	)
+	rec = httptest.NewRecorder()
+	s.bedrockHandler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("valid Opus status = %d, want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+	if got := capturedPaths[1]; got != "/model/us.anthropic.claude-opus-5/invoke" {
+		t.Fatalf("valid Opus upstream path = %q, want unchanged", got)
 	}
 }
 

--- a/internal/proxy/bedrock_test.go
+++ b/internal/proxy/bedrock_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
@@ -123,6 +124,49 @@ func TestBedrockHandlerRoutesClaudeCodeAutoClassifierToFable(t *testing.T) {
 	}
 	if got := capturedPaths[1]; got != "/model/us.anthropic.claude-opus-5/invoke" {
 		t.Fatalf("valid Opus upstream path = %q, want unchanged", got)
+	}
+}
+
+func TestBedrockHandlerRoutesResolvedClaudeCodeAutoClassifierToFable(t *testing.T) {
+	var capturedPath string
+	var capturedBody []byte
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		capturedPath = req.URL.Path
+		capturedBody, _ = io.ReadAll(req.Body)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+	s := Server{Bedrock: &BedrockConfig{Regions: []string{"us-east-1"}, Credentials: staticBedrockCreds(), Transport: rt}}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/bedrock/model/us.anthropic.claude-opus-5/invoke",
+		strings.NewReader(`{
+			"anthropic_version":"bedrock-2023-05-31",
+			"max_tokens":64,
+			"system":[{"type":"text","text":"You are a security monitor for autonomous AI coding agents."}],
+			"messages":[{"role":"user","content":"Classify this Bash command."}],
+			"thinking":{"type":"disabled"}
+		}`),
+	)
+	rec := httptest.NewRecorder()
+	s.bedrockHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+	if capturedPath != "/model/us.anthropic.claude-fable-5/invoke" {
+		t.Fatalf("upstream path = %q, want Fable classifier path", capturedPath)
+	}
+	var capturedPayload map[string]json.RawMessage
+	if err := json.Unmarshal(capturedBody, &capturedPayload); err != nil {
+		t.Fatalf("decode captured body: %v", err)
+	}
+	if _, ok := capturedPayload["thinking"]; ok {
+		t.Fatalf("captured body still contains Fable-incompatible thinking: %s", capturedBody)
 	}
 }
 

--- a/internal/proxy/bedrock_test.go
+++ b/internal/proxy/bedrock_test.go
@@ -81,6 +81,37 @@ func TestBedrockHandlerSignsAndForwards(t *testing.T) {
 	}
 }
 
+func TestBedrockHandlerRoutesClaudeCodeAutoClassifierToFable(t *testing.T) {
+	var captured *http.Request
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		captured = req
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+	s := Server{Bedrock: &BedrockConfig{Regions: []string{"us-east-1"}, Credentials: staticBedrockCreds(), Transport: rt}}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/bedrock/model/us.anthropic.claude-opus-5%5B1m%5D/invoke",
+		strings.NewReader(`{"anthropic_version":"bedrock-2023-05-31"}`),
+	)
+	rec := httptest.NewRecorder()
+	s.bedrockHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+	if captured == nil {
+		t.Fatal("no upstream request captured")
+	}
+	if got := captured.URL.Path; got != "/model/us.anthropic.claude-fable-5/invoke" {
+		t.Fatalf("upstream path = %q, want Fable classifier path", got)
+	}
+}
+
 func TestBedrockHandlerRequiresGatewayToken(t *testing.T) {
 	forwarded := false
 	rt := bedrockRoundTripFunc(func(*http.Request) (*http.Response, error) {


### PR DESCRIPTION
Claude Code labels its auto-mode classifier as `us.anthropic.claude-opus-5[1m]`, then resolves it to `/model/us.anthropic.claude-opus-5/invoke` on the wire. Bedrock rejects Opus on the team route. Fable also rejects the classifier payload's `thinking: disabled` field.

Recognize the classifier by its security-monitor system prompt, route only that request to `us.anthropic.claude-fable-5`, and remove the incompatible thinking field. Ordinary Opus requests remain unchanged.

Verification: `go test ./...` plus a live Claude auto-mode `gh release list --repo manaflow-ai/iroh-ffi --limit 3` reproduction through the compatibility route.