### PR TITLE
Spread clients across accounts with rendezvous affinity

### DIFF
--- a/selectacct/affinity_test.go
+++ b/selectacct/affinity_test.go
@@ -1,0 +1,172 @@
+package selectacct
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/account"
+)
+
+func accounts(n int) []account.Account {
+	out := make([]account.Account, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, account.Account{ID: fmt.Sprintf("acct-%d", i), Provider: account.ProviderCodex})
+	}
+	return out
+}
+
+// evenScheduler gives every account identical headroom, so ordering is decided
+// purely by the tiebreaks under test.
+func evenScheduler(n int, headroom float64) Scheduler {
+	scores := make([]Score, 0, n)
+	for i := 0; i < n; i++ {
+		scores = append(scores, Score{
+			AccountID: fmt.Sprintf("acct-%d", i),
+			Provider:  account.ProviderCodex,
+			Headroom:  headroom,
+			Fresh:     true,
+		})
+	}
+	return NewScheduler(scores)
+}
+
+func TestArgmaxHerdsWithoutAffinity(t *testing.T) {
+	// The behaviour this change exists to fix: with no affinity key, every
+	// client picks the same account.
+	s := evenScheduler(5, 0.9)
+	// Give one account a hair more headroom, as a real usage fetch would.
+	s = s.WithScore(Score{AccountID: "acct-3", Provider: account.ProviderCodex, Headroom: 0.91, Fresh: true})
+
+	for i := 0; i < 50; i++ {
+		got, err := s.Pick(accounts(5))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.ID != "acct-3" {
+			t.Fatalf("client %d picked %s, expected every client to herd onto acct-3", i, got.ID)
+		}
+	}
+}
+
+func TestAffinitySpreadsClientsAcrossAccounts(t *testing.T) {
+	const clients, numAccounts = 600, 6
+	s := evenScheduler(numAccounts, 0.9)
+
+	counts := map[string]int{}
+	for i := 0; i < clients; i++ {
+		picked, err := s.WithAffinity(fmt.Sprintf("client-%d", i)).Pick(accounts(numAccounts))
+		if err != nil {
+			t.Fatal(err)
+		}
+		counts[picked.ID]++
+	}
+
+	if len(counts) != numAccounts {
+		t.Fatalf("expected all %d accounts used, got %d: %v", numAccounts, len(counts), counts)
+	}
+	// Rendezvous hashing is uniform in expectation; allow a generous band so
+	// this never flakes while still catching a collapse onto one account.
+	expected := clients / numAccounts
+	for id, n := range counts {
+		if n < expected/2 || n > expected*2 {
+			t.Errorf("account %s got %d picks, expected near %d (%v)", id, n, expected, counts)
+		}
+	}
+}
+
+func TestAffinityIsStableForOneClient(t *testing.T) {
+	s := evenScheduler(6, 0.9).WithAffinity("client-stable")
+	first, err := s.Pick(accounts(6))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 20; i++ {
+		got, err := s.Pick(accounts(6))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.ID != first.ID {
+			t.Fatalf("affinity unstable: %s then %s", first.ID, got.ID)
+		}
+	}
+}
+
+func TestAffinityReassignsOnlyDisplacedClientsWhenAccountRemoved(t *testing.T) {
+	const clients = 600
+	before := evenScheduler(6, 0.9)
+	after := evenScheduler(6, 0.9)
+
+	full := accounts(6)
+	reduced := accounts(6)[:5] // drop acct-5
+
+	moved, boundToDropped := 0, 0
+	for i := 0; i < clients; i++ {
+		key := fmt.Sprintf("client-%d", i)
+		a, err := before.WithAffinity(key).Pick(full)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := after.WithAffinity(key).Pick(reduced)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if a.ID == "acct-5" {
+			boundToDropped++
+		}
+		if a.ID != b.ID {
+			moved++
+		}
+	}
+	// Only clients bound to the removed account should move. That is the
+	// property that makes adding capacity cheap.
+	if moved != boundToDropped {
+		t.Fatalf("removing one account moved %d clients but only %d were bound to it", moved, boundToDropped)
+	}
+}
+
+func TestAffinityNeverPrefersAMateriallyEmptierAccount(t *testing.T) {
+	// acct-0 is nearly full, the rest are nearly empty. Affinity must not pull
+	// a client onto an empty account just because the hash likes it.
+	scores := []Score{{AccountID: "acct-0", Provider: account.ProviderCodex, Headroom: 0.95, Fresh: true}}
+	for i := 1; i < 6; i++ {
+		scores = append(scores, Score{
+			AccountID: fmt.Sprintf("acct-%d", i), Provider: account.ProviderCodex,
+			Headroom: 0.45, Fresh: true,
+		})
+	}
+	s := NewScheduler(scores)
+	for i := 0; i < 200; i++ {
+		got, err := s.WithAffinity(fmt.Sprintf("client-%d", i)).Pick(accounts(6))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.ID != "acct-0" {
+			t.Fatalf("client %d picked %s over the much fuller acct-0", i, got.ID)
+		}
+	}
+}
+
+func TestHeadroomBandBucketsContinuousValues(t *testing.T) {
+	if headroomBand(0.91) != headroomBand(0.95) {
+		t.Fatal("0.91 and 0.95 should share a band")
+	}
+	if headroomBand(0.95) == headroomBand(0.45) {
+		t.Fatal("0.95 and 0.45 must not share a band")
+	}
+	if headroomBand(-1) != 0 {
+		t.Fatal("negative headroom should clamp to the lowest band")
+	}
+}
+
+func TestEmptyAffinityKeyPreservesArgmax(t *testing.T) {
+	s := evenScheduler(4, 0.5).WithScore(Score{
+		AccountID: "acct-2", Provider: account.ProviderCodex, Headroom: 0.99, Fresh: true,
+	})
+	got, err := s.WithAffinity("").Pick(accounts(4))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "acct-2" {
+		t.Fatalf("empty affinity key should keep plain argmax, got %s", got.ID)
+	}
+}

--- a/selectacct/scheduler.go
+++ b/selectacct/scheduler.go
@@ -2,6 +2,7 @@ package selectacct
 
 import (
 	"errors"
+	"hash/fnv"
 	"math"
 	"sort"
 
@@ -31,6 +32,37 @@ type Scheduler struct {
 	scores        map[string]Score
 	sessionCounts map[string]int
 	liveDebits    map[string]int
+	affinityKey   string
+}
+
+// headroomBandWidth buckets headroom so affinity can break ties inside a band.
+//
+// Without bucketing, Headroom is a continuous float that is essentially never
+// equal between two accounts, so every tiebreak below it (including Sessions)
+// is unreachable and selection collapses to a deterministic argmax. Every
+// client then computes the same maximum over the same periodically-refreshed
+// snapshot and stampedes the same account until the next usage fetch.
+const headroomBandWidth = 0.10
+
+// headroomBand returns the descending-preference bucket for a headroom value.
+func headroomBand(headroom float64) int {
+	if headroom <= 0 {
+		return 0
+	}
+	return int(headroom / headroomBandWidth)
+}
+
+// affinityWeight implements rendezvous (highest-random-weight) hashing.
+//
+// Each client independently prefers a different account with no coordination,
+// and because the weight depends on both sides, adding or removing an account
+// only reassigns the clients bound to it rather than reshuffling everyone.
+func affinityWeight(key, accountID string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(accountID))
+	return h.Sum64()
 }
 
 const MinNewSessionHeadroom = 0.40
@@ -87,6 +119,15 @@ func (s Scheduler) WithSessionCounts(counts map[string]int) Scheduler {
 // base scheduler is returned unchanged so account-wide quota is used. When a
 // pool exists but a given account lacks it, that account scores zero so it is
 // not picked for a model it cannot serve.
+// WithAffinity binds selection to a stable client identity so different
+// clients prefer different accounts. An empty key restores plain argmax
+// ordering, which is what every existing caller gets.
+func (s Scheduler) WithAffinity(key string) Scheduler {
+	next := s
+	next.affinityKey = key
+	return next
+}
+
 func (s Scheduler) ForModel(model string) Scheduler {
 	key := ModelKey(model)
 	if key == "" || !s.hasModelScore(key) {
@@ -145,7 +186,20 @@ func (s Scheduler) Pick(candidates []account.Account) (account.Account, error) {
 		if leftUsable && rightUsable && left.ExpiryPressure != right.ExpiryPressure {
 			return left.ExpiryPressure > right.ExpiryPressure
 		}
-		if left.Headroom != right.Headroom {
+		if s.affinityKey != "" {
+			// Compare by band, then by affinity, so a client sticks to its own
+			// account while never preferring a materially emptier one.
+			leftBand := headroomBand(left.Headroom)
+			rightBand := headroomBand(right.Headroom)
+			if leftBand != rightBand {
+				return leftBand > rightBand
+			}
+			leftWeight := affinityWeight(s.affinityKey, sorted[i].ID)
+			rightWeight := affinityWeight(s.affinityKey, sorted[j].ID)
+			if leftWeight != rightWeight {
+				return leftWeight > rightWeight
+			}
+		} else if left.Headroom != right.Headroom {
 			return left.Headroom > right.Headroom
 		}
 		if left.Sessions != right.Sessions {
@@ -197,7 +251,7 @@ func (s Scheduler) ScoreFor(provider account.Provider, accountID string) Score {
 // draining the snapshot instead of herding every pick onto the same account.
 // Keys are ScoreKey(provider, accountID).
 func (s Scheduler) WithLiveDebits(debits map[string]int) Scheduler {
-	return Scheduler{scores: s.scores, sessionCounts: s.sessionCounts, liveDebits: debits}
+	return Scheduler{scores: s.scores, sessionCounts: s.sessionCounts, liveDebits: debits, affinityKey: s.affinityKey}
 }
 
 func (s Scheduler) score(provider account.Provider, accountID string) Score {


### PR DESCRIPTION
## Why

`Pick` sorts by `Headroom` (a continuous float) before `Sessions`. Two accounts are essentially never *exactly* equal, so `Sessions` and everything below it is unreachable and selection is a deterministic argmax.

That herds. Every client computes the same maximum over the same periodically-refreshed usage snapshot, so they all pick the same account, hammer it until the next fetch, then stampede together to the next one. `WithLiveDebits` fixes staleness only within one process, so N machines still converge on one account.

## What

Bucket headroom into 10% bands, break ties inside a band with rendezvous (highest-random-weight) hashing over a client key.

- Different clients prefer different accounts with **no coordination**.
- Weight depends on both client and account, so removing an account reassigns only the clients bound to it, not everyone.
- Opt-in: empty affinity key preserves current argmax ordering, so no existing caller changes behaviour.
- Band comparison runs *before* affinity, so a client never prefers a materially emptier account.

## Tests

`TestArgmaxHerdsWithoutAffinity` pins the behaviour being fixed (50/50 clients pick one account). Then: even spread across 6 accounts over 600 clients, per-client stability, minimal reassignment when an account is removed, a nearly-full account still winning over nearly-empty ones regardless of hash, and band bucketing.

Existing `gto_sim`, `velocity_sim` and `saturation` suites pass unchanged.

## Note

`subrouter-cloud` imports `selectacct` (v0.1.38) and calls `routing.Select(..., model="")`, so it will need a version bump plus a client key to benefit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787907952&installation_model_id=21920&pr_number=103&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F103&signature=1f28e9a20caec7c4e50b5ba64803c8ee6f0fd6da3a80eed786685014e668835d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Spread clients across accounts by bucketing headroom into 10% bands and using client-keyed rendezvous hashing to break ties, preventing herd behavior. Opt-in via `WithAffinity(key)`; an empty key keeps current argmax ordering, and fuller accounts still win over emptier ones.

- **Migration**
  - Bump `selectacct` in callers (e.g., `subrouter-cloud`) to the new version.
  - Pass a stable per-client key to `WithAffinity(...)` to enable affinity; leave it empty to keep current behavior.

<sup>Written for commit 068788627c2e601387d7d19e85732bb2be64eb14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

