### PR TITLE
Fix local proxy nil broker panic

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -282,7 +282,7 @@ func serve(args []string) error {
 			"team credential storage cannot use local Bedrock or personal Fable credential fallback; remove the Bedrock/Fable options or run 'sr storage local'",
 		)
 	}
-	var credentialBroker *broker.Client
+	var credentialBroker proxy.CredentialBroker
 	if cloudConfig.TeamModeReady() {
 		credentialBroker = broker.NewClient(cloudConfig)
 	}

--- a/internal/proxy/credential_broker_test.go
+++ b/internal/proxy/credential_broker_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/manaflow-ai/subrouter/account"
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 	"github.com/manaflow-ai/subrouter/internal/broker"
+	"github.com/manaflow-ai/subrouter/selectacct"
 )
 
 type fakeCredentialBroker struct {
@@ -156,6 +157,49 @@ func TestCredentialBrokerKeepsProviderTrafficOnLocalProxy(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("lease outcome was not reported")
+	}
+}
+
+func TestTypedNilCredentialBrokerUsesLocalAccounts(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer local-access" {
+			t.Fatalf("Authorization = %q, want local account token", got)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var nilBroker *broker.Client
+	handler := Server{
+		CodexUpstream: upstreamURL,
+		Accounts: []accounts.Account{{
+			ID:       "local-account",
+			Provider: accounts.ProviderCodex,
+			AuthMode: accounts.AuthModeOAuth,
+			Token:    "local-access",
+		}},
+		CredentialBroker: nilBroker,
+		Scheduler:        selectacct.NewScheduler(nil),
+		MaxBodyBytes:     1 << 20,
+	}.Handler()
+	subrouter := httptest.NewServer(handler)
+	defer subrouter.Close()
+
+	response, err := http.Post(
+		subrouter.URL+"/v1/responses",
+		"application/json",
+		strings.NewReader(`{"model":"gpt-5.6-sol","input":"hello"}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusNoContent)
 	}
 }
 

--- a/internal/proxy/credential_broker_test.go
+++ b/internal/proxy/credential_broker_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -19,6 +20,7 @@ import (
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 	"github.com/manaflow-ai/subrouter/internal/broker"
 	"github.com/manaflow-ai/subrouter/selectacct"
+	"github.com/manaflow-ai/subrouter/session"
 )
 
 type fakeCredentialBroker struct {
@@ -174,6 +176,10 @@ func TestTypedNilCredentialBrokerUsesLocalAccounts(t *testing.T) {
 		t.Fatal(err)
 	}
 	var nilBroker *broker.Client
+	sessionStore, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	handler := Server{
 		CodexUpstream: upstreamURL,
 		Accounts: []accounts.Account{{
@@ -183,6 +189,7 @@ func TestTypedNilCredentialBrokerUsesLocalAccounts(t *testing.T) {
 			Token:    "local-access",
 		}},
 		CredentialBroker: nilBroker,
+		Sessions:         sessionStore,
 		Scheduler:        selectacct.NewScheduler(nil),
 		MaxBodyBytes:     1 << 20,
 	}.Handler()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -34,6 +34,11 @@ import (
 	"github.com/manaflow-ai/subrouter/session"
 )
 
+type CredentialBroker interface {
+	Lease(context.Context, broker.LeaseRequest) (broker.Lease, error)
+	Report(context.Context, string, broker.LeaseReport) error
+}
+
 type Server struct {
 	Upstream       *url.URL
 	CodexUpstream  *url.URL
@@ -54,13 +59,10 @@ type Server struct {
 	// CredentialBroker selects a team account and returns an access-only,
 	// short-lived lease. When configured, local refresh-token stores and the
 	// local scheduler are bypassed entirely.
-	CredentialBroker interface {
-		Lease(context.Context, broker.LeaseRequest) (broker.Lease, error)
-		Report(context.Context, string, broker.LeaseReport) error
-	}
-	Transport      http.RoundTripper
-	Logger         *slog.Logger
-	ActiveSessions *ActiveSessions
+	CredentialBroker CredentialBroker
+	Transport        http.RoundTripper
+	Logger           *slog.Logger
+	ActiveSessions   *ActiveSessions
 	// StreamDrops counts dropped response streams by which side ended them,
 	// so the expected client-hangup case is countable without a log line each.
 	StreamDrops *StreamDropStats
@@ -904,6 +906,7 @@ func (r *AccountRef) replace(account accounts.Account) {
 }
 
 func (s Server) Handler() http.Handler {
+	s.CredentialBroker = normalizedCredentialBroker(s.CredentialBroker)
 	if s.ActiveSessions == nil {
 		s.ActiveSessions = NewActiveSessions()
 	}
@@ -936,6 +939,13 @@ func (s Server) Handler() http.Handler {
 	}
 	mux.Handle("/", s.proxyHandler())
 	return mux
+}
+
+func normalizedCredentialBroker(value CredentialBroker) CredentialBroker {
+	if client, ok := value.(*broker.Client); ok && client == nil {
+		return nil
+	}
+	return value
 }
 
 func (s Server) handleHealth(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
Local credential mode stored a nil `*broker.Client` in an interface field. The interface compared non-nil, so real `/v1/responses` and `/v1/messages` requests called `Lease` on a nil receiver and disconnected the client.

This names the broker interface, constructs a genuinely nil interface outside team mode, and normalizes typed-nil production clients at the proxy boundary.

Regression structure:
1. `test: reproduce local proxy nil broker panic`
2. `fix: keep local proxy out of team broker mode`

Verified with focused tests, race tests, `go vet ./...`, `go build ./...`, serial `go test -p 1 ./...`, and real `sr codex exec` plus `sr claude -p` requests through the installed local daemon.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787909046&installation_model_id=21920&pr_number=104&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F104&signature=b254d694fc5fbad186076dd0dcb05d04800da695943de89d87b85edf3e477ce6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a panic in local credential mode where a typed-nil `*broker.Client` in an interface was treated as non-nil, causing unintended broker calls. We now define a named `CredentialBroker` and normalize typed-nil clients to real nil so local proxies stay in local-account mode.

- **Bug Fixes**
  - Introduced `CredentialBroker` in `internal/proxy` and updated `cmd/subrouter` to use it.
  - Added `normalizedCredentialBroker` and applied it in `Server.Handler` to convert typed-nil `*broker.Client` to `nil`.
  - Ensured local mode uses local accounts when the broker is nil; added `TestTypedNilCredentialBrokerUsesLocalAccounts`.

<sup>Written for commit 3d60075fa304f70b2e667a4a273874916626f3b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed proxy authentication when no credential broker is available.
  - Requests now correctly fall back to locally configured account credentials instead of treating an empty broker as configured.
  - Improved reliability for requests requiring local account authorization, including response-generation endpoints.
- **Tests**
  - Added coverage to verify local account credentials are used in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->