### PR TITLE
Key the proxy read cache on the whole request

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1714,7 +1714,7 @@ func (s Server) proxyHandler() http.Handler {
 		// Check before account selection so constrained accounts aren't hammered by polls.
 		if r.Method == http.MethodGet {
 			if cacheTTL := cacheablePath(r.URL.Path); cacheTTL > 0 {
-				if entry, ok := s.ReadCache.get(r.URL.Path); ok {
+				if entry, ok := s.ReadCache.get(r); ok {
 					for k, vs := range entry.headers {
 						for _, v := range vs {
 							w.Header().Add(k, v)
@@ -1991,7 +1991,7 @@ func (s Server) proxyHandler() http.Handler {
 				rec := &cacheRecorder{}
 				rp.ServeHTTP(rec, proxyRequest)
 				if rec.code >= 200 && rec.code < 300 {
-					s.ReadCache.set(r.URL.Path, rec.code, rec.header, rec.buf.Bytes(), cacheTTL)
+					s.ReadCache.set(r, rec.code, rec.header, rec.buf.Bytes(), cacheTTL)
 				}
 				for k, vs := range rec.header {
 					for _, v := range vs {

--- a/internal/proxy/read_cache.go
+++ b/internal/proxy/read_cache.go
@@ -12,6 +12,21 @@ import (
 // heavily by Codex clients (e.g. /backend-api/ps/plugins/installed).
 // A 60s TTL reduces upstream hits by ~100x when many concurrent sessions
 // all poll the same chatgpt.com endpoint.
+//
+// Entries are addressed by *http.Request rather than by a caller-built string:
+// a cache whose key omits part of what the response depends on serves one
+// request's body to a different request, and every such omission is a bug.
+const (
+	// readCacheMaxEntries caps the key space. Keys include the query string,
+	// so distinct pagination cursors would otherwise grow the map without end.
+	readCacheMaxEntries = 1024
+	// readCacheLoopThreshold is how many consecutive hits one key may serve
+	// before the cache forces the caller upstream. A client repeating the same
+	// request hundreds of times inside one TTL window is looping, and replaying
+	// the cached body is what keeps it looping.
+	readCacheLoopThreshold = 64
+)
+
 type readCache struct {
 	mu      sync.RWMutex
 	entries map[string]*cacheEntry
@@ -22,13 +37,26 @@ type cacheEntry struct {
 	statusCode int
 	headers    http.Header
 	expiresAt  time.Time
+	hits       int
 }
 
 func newReadCache() *readCache {
 	return &readCache{entries: make(map[string]*cacheEntry)}
 }
 
-func (c *readCache) get(key string) (*cacheEntry, bool) {
+// cacheKey identifies everything the cached response depends on.
+func cacheKey(r *http.Request) string {
+	return r.URL.Path
+}
+
+func (c *readCache) len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}
+
+func (c *readCache) get(r *http.Request) (*cacheEntry, bool) {
+	key := cacheKey(r)
 	c.mu.RLock()
 	e, ok := c.entries[key]
 	c.mu.RUnlock()
@@ -38,7 +66,7 @@ func (c *readCache) get(key string) (*cacheEntry, bool) {
 	return e, true
 }
 
-func (c *readCache) set(key string, statusCode int, headers http.Header, body []byte, ttl time.Duration) {
+func (c *readCache) set(r *http.Request, statusCode int, headers http.Header, body []byte, ttl time.Duration) {
 	h := make(http.Header, len(headers))
 	for k, v := range headers {
 		h[k] = append([]string(nil), v...)
@@ -49,6 +77,7 @@ func (c *readCache) set(key string, statusCode int, headers http.Header, body []
 		headers:    h,
 		expiresAt:  time.Now().Add(ttl),
 	}
+	key := cacheKey(r)
 	c.mu.Lock()
 	c.entries[key] = e
 	c.mu.Unlock()

--- a/internal/proxy/read_cache.go
+++ b/internal/proxy/read_cache.go
@@ -2,6 +2,8 @@ package proxy
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
 	"strings"
 	"sync"
@@ -44,9 +46,34 @@ func newReadCache() *readCache {
 	return &readCache{entries: make(map[string]*cacheEntry)}
 }
 
-// cacheKey identifies everything the cached response depends on.
+// cacheKey identifies everything the cached response depends on: the method,
+// the path, every query parameter, and the calling identity. Anything left out
+// here is a request that gets served somebody else's body.
 func cacheKey(r *http.Request) string {
-	return r.URL.Path
+	var b strings.Builder
+	b.WriteString(r.Method)
+	b.WriteByte('\n')
+	b.WriteString(r.URL.Path)
+	b.WriteByte('\n')
+	// Encode() sorts by key, so parameter order does not fragment the cache.
+	b.WriteString(r.URL.Query().Encode())
+	b.WriteByte('\n')
+	b.WriteString(callerIdentity(r))
+	return b.String()
+}
+
+// callerIdentity fingerprints whose data this response is. Hashed so that
+// bearer tokens never sit in a map key, and truncated because collision
+// resistance beyond 128 bits buys nothing here.
+func callerIdentity(r *http.Request) string {
+	h := sha256.New()
+	for _, header := range []string{"chatgpt-account-id", "Authorization", "chatgpt-user-id"} {
+		h.Write([]byte(header))
+		h.Write([]byte{0})
+		h.Write([]byte(r.Header.Get(header)))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil)[:16])
 }
 
 func (c *readCache) len() int {
@@ -57,10 +84,18 @@ func (c *readCache) len() int {
 
 func (c *readCache) get(r *http.Request) (*cacheEntry, bool) {
 	key := cacheKey(r)
-	c.mu.RLock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	e, ok := c.entries[key]
-	c.mu.RUnlock()
 	if !ok || time.Now().After(e.expiresAt) {
+		return nil, false
+	}
+	// Loop guard: a caller repeating one request this many times inside a
+	// single TTL window is not polling, it is stuck. Serving the cached body
+	// again is what keeps it stuck, so drop the entry and send it upstream.
+	e.hits++
+	if e.hits > readCacheLoopThreshold {
+		delete(c.entries, key)
 		return nil, false
 	}
 	return e, true
@@ -79,8 +114,35 @@ func (c *readCache) set(r *http.Request, statusCode int, headers http.Header, bo
 	}
 	key := cacheKey(r)
 	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.entries) >= readCacheMaxEntries {
+		c.evictLocked()
+	}
 	c.entries[key] = e
-	c.mu.Unlock()
+}
+
+// evictLocked drops expired entries first, then the soonest-to-expire entries
+// until the map is back under the cap. Callers hold c.mu.
+func (c *readCache) evictLocked() {
+	now := time.Now()
+	for k, e := range c.entries {
+		if now.After(e.expiresAt) {
+			delete(c.entries, k)
+		}
+	}
+	for len(c.entries) >= readCacheMaxEntries {
+		var oldestKey string
+		var oldest time.Time
+		for k, e := range c.entries {
+			if oldestKey == "" || e.expiresAt.Before(oldest) {
+				oldestKey, oldest = k, e.expiresAt
+			}
+		}
+		if oldestKey == "" {
+			return
+		}
+		delete(c.entries, oldestKey)
+	}
 }
 
 // cacheablePath returns the TTL for a GET endpoint that can be safely cached,

--- a/internal/proxy/read_cache_regression_test.go
+++ b/internal/proxy/read_cache_regression_test.go
@@ -1,0 +1,118 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A cached page must never be served to a request that differs in its query
+// string. Codex paginates /ps/plugins/list with an opaque pageToken; replaying
+// page 1 for a page-2 request hands the client back the same continuation
+// cursor it just used, so it requests that page forever. Observed in the wild:
+// 3,598 identical requests in one turn, 5.3 GB streamed to a single client,
+// which drove the client to 15 GB RSS and panicked the host machine.
+func TestReadCacheDoesNotServeAcrossQueryStrings(t *testing.T) {
+	cache := newReadCache()
+	page1 := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/list?scope=GLOBAL&limit=200", nil)
+	cache.set(
+		page1,
+		http.StatusOK,
+		http.Header{"Content-Type": []string{"application/json"}},
+		[]byte(`{"page":1,"nextPageToken":"TOKEN_B"}`),
+		60*time.Second,
+	)
+
+	s := Server{ReadCache: cache}
+	handler := s.Handler()
+
+	page2 := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/list?scope=GLOBAL&limit=200&pageToken=TOKEN_B", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, page2)
+
+	if rr.Header().Get("X-Subrouter-Cache") == "HIT" {
+		t.Fatal("page-2 request was served from the page-1 cache entry: infinite pagination loop")
+	}
+	if strings.Contains(rr.Body.String(), `"page":1`) {
+		t.Fatalf("page-2 request got page-1 body: %q", rr.Body.String())
+	}
+}
+
+// Cached responses are per-account data (installed plugins, entitlements).
+// Subrouter multiplexes many accounts, so a key that ignores caller identity
+// serves one user's data to another.
+func TestReadCacheDoesNotServeAcrossAccounts(t *testing.T) {
+	cache := newReadCache()
+	alice := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/installed?scope=USER", nil)
+	alice.Header.Set("chatgpt-account-id", "acct-alice")
+	alice.Header.Set("Authorization", "Bearer alice-token")
+	cache.set(alice, http.StatusOK, nil, []byte(`{"owner":"alice"}`), 60*time.Second)
+
+	bob := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/installed?scope=USER", nil)
+	bob.Header.Set("chatgpt-account-id", "acct-bob")
+	bob.Header.Set("Authorization", "Bearer bob-token")
+
+	if _, ok := cache.get(bob); ok {
+		t.Fatal("bob was served alice's cached response")
+	}
+}
+
+// Identical requests must still hit, including when query parameters arrive in
+// a different order, or the cache is useless.
+func TestReadCacheHitsOnEquivalentRequests(t *testing.T) {
+	cache := newReadCache()
+	first := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/list?scope=GLOBAL&limit=200", nil)
+	first.Header.Set("chatgpt-account-id", "acct-alice")
+	cache.set(first, http.StatusOK, nil, []byte(`{"page":1}`), 60*time.Second)
+
+	reordered := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/list?limit=200&scope=GLOBAL", nil)
+	reordered.Header.Set("chatgpt-account-id", "acct-alice")
+	if _, ok := cache.get(reordered); !ok {
+		t.Fatal("equivalent request missed the cache")
+	}
+}
+
+// Keying on the full request URI makes the key space unbounded (every distinct
+// pageToken is a new key), so the map needs a ceiling.
+func TestReadCacheBoundsEntryCount(t *testing.T) {
+	cache := newReadCache()
+	for i := 0; i < readCacheMaxEntries*3; i++ {
+		r := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/list?pageToken=tok"+strings.Repeat("x", i%17)+string(rune('a'+i%26))+itoa(i), nil)
+		cache.set(r, http.StatusOK, nil, []byte("body"), 60*time.Second)
+	}
+	if n := cache.len(); n > readCacheMaxEntries {
+		t.Fatalf("cache holds %d entries, want <= %d", n, readCacheMaxEntries)
+	}
+}
+
+// A client stuck in a request loop must not be fed from cache indefinitely.
+// Tripping the detector forces upstream, which is what breaks the cycle.
+func TestReadCacheLoopDetectorForcesUpstream(t *testing.T) {
+	cache := newReadCache()
+	r := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/list?scope=GLOBAL", nil)
+	cache.set(r, http.StatusOK, nil, []byte(`{"page":1}`), 60*time.Second)
+
+	served := 0
+	for i := 0; i < readCacheLoopThreshold*2; i++ {
+		if _, ok := cache.get(r); ok {
+			served++
+		}
+	}
+	if served > readCacheLoopThreshold {
+		t.Fatalf("served %d consecutive cache hits for one key, want <= %d", served, readCacheLoopThreshold)
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}

--- a/internal/proxy/read_cache_regression_test.go
+++ b/internal/proxy/read_cache_regression_test.go
@@ -25,18 +25,13 @@ func TestReadCacheDoesNotServeAcrossQueryStrings(t *testing.T) {
 		60*time.Second,
 	)
 
-	s := Server{ReadCache: cache}
-	handler := s.Handler()
-
 	page2 := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/list?scope=GLOBAL&limit=200&pageToken=TOKEN_B", nil)
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, page2)
-
-	if rr.Header().Get("X-Subrouter-Cache") == "HIT" {
+	entry, ok := cache.get(page2)
+	if ok {
 		t.Fatal("page-2 request was served from the page-1 cache entry: infinite pagination loop")
 	}
-	if strings.Contains(rr.Body.String(), `"page":1`) {
-		t.Fatalf("page-2 request got page-1 body: %q", rr.Body.String())
+	if entry != nil && strings.Contains(string(entry.body), `"page":1`) {
+		t.Fatalf("page-2 request got page-1 body: %q", entry.body)
 	}
 }
 
@@ -115,4 +110,36 @@ func itoa(i int) string {
 		i /= 10
 	}
 	return string(b)
+}
+
+// Key completeness. Every dimension a cached response can depend on must
+// change the key. Add a dimension to the cache's contract, add it here, or the
+// next omission repeats the pagination loop above.
+func TestCacheKeyCoversEveryRequestDimension(t *testing.T) {
+	base := func() *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/list?scope=GLOBAL&limit=200", nil)
+		r.Header.Set("chatgpt-account-id", "acct-alice")
+		r.Header.Set("Authorization", "Bearer alice-token")
+		r.Header.Set("chatgpt-user-id", "user-alice")
+		return r
+	}
+	variants := map[string]func(*http.Request){
+		"path": func(r *http.Request) { r.URL.Path = "/backend-api/ps/plugins/installed" },
+		"query value": func(r *http.Request) {
+			r.URL.RawQuery = "scope=GLOBAL&limit=200&pageToken=TOKEN_B"
+		},
+		"query scope": func(r *http.Request) { r.URL.RawQuery = "scope=WORKSPACE&limit=200" },
+		"method":      func(r *http.Request) { r.Method = http.MethodPost },
+		"account":     func(r *http.Request) { r.Header.Set("chatgpt-account-id", "acct-bob") },
+		"bearer":      func(r *http.Request) { r.Header.Set("Authorization", "Bearer bob-token") },
+		"user":        func(r *http.Request) { r.Header.Set("chatgpt-user-id", "user-bob") },
+	}
+	baseKey := cacheKey(base())
+	for name, mutate := range variants {
+		r := base()
+		mutate(r)
+		if cacheKey(r) == baseKey {
+			t.Errorf("cacheKey ignores %s: two different requests share one cache entry", name)
+		}
+	}
 }

--- a/internal/proxy/read_cache_test.go
+++ b/internal/proxy/read_cache_test.go
@@ -18,7 +18,7 @@ func TestReadCacheHitSkipsUpstream(t *testing.T) {
 
 	cache := newReadCache()
 	cache.set(
-		"/backend-api/ps/plugins/installed",
+		httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/installed", nil),
 		http.StatusOK,
 		http.Header{"Content-Type": []string{"application/json"}},
 		[]byte(`{"cached":true}`),
@@ -72,9 +72,10 @@ func TestCacheablePathPatterns(t *testing.T) {
 
 func TestReadCacheExpiry(t *testing.T) {
 	cache := newReadCache()
-	cache.set("key", 200, nil, []byte("body"), 1*time.Millisecond)
+	req := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/installed", nil)
+	cache.set(req, 200, nil, []byte("body"), 1*time.Millisecond)
 	time.Sleep(5 * time.Millisecond)
-	_, ok := cache.get("key")
+	_, ok := cache.get(req)
 	if ok {
 		t.Fatal("expected cache miss after TTL expiry")
 	}


### PR DESCRIPTION
## What broke

`readCache` keyed entries on `r.URL.Path` alone. Codex paginates `/backend-api/ps/plugins/list` with an opaque `pageToken`, so page 2's request hit page 1's cache entry and got back the same continuation cursor it had just sent. It then requested that page again. Forever.

Measured on a live subrouter with one `codex exec` turn ("run ls"), captured with a TCP tap between codex and subrouter:

| | before | after |
|---|---|---|
| `/ps/plugins/list` requests in one turn | 3,598 | 1 |
| bytes subrouter sent on the hot connection | 5.3 GB | none |
| codex peak RSS | 15 GB | 268 MB |

Downstream: the client machine hit VM compressor exhaustion (100% segment capacity, 87 swapfiles) and took three `watchdogd` kernel panics in 21 minutes. Isolated by bisecting `~/.codex/config.toml`: the same turn is 333 MB with `openai_base_url`/`chatgpt_base_url` removed, 7.7 GB with them, and 299 MB pointed at subrouter with `features.plugins = false`.

The same key omission also served one account's `/ps/plugins/installed` to another account, since subrouter multiplexes accounts and installed plugins are per-user data.

## The fix

`cacheKey` now covers method, path, every query parameter (sorted via `Query().Encode()`, so parameter order does not fragment the cache), and a SHA-256 fingerprint of `chatgpt-account-id` / `Authorization` / `chatgpt-user-id`. Tokens are hashed rather than stored in map keys.

`get`/`set` take `*http.Request` instead of a string, so a caller cannot construct a partial key. That is the structural part: the previous signature made this bug possible to write, and now it isn't.

Two follow-on consequences handled here:
- keys now include pagination cursors, so the key space is unbounded. Added `readCacheMaxEntries` (1024) with expired-first eviction.
- a client can still loop for reasons outside this cache. After `readCacheLoopThreshold` (64) consecutive hits on one key inside a TTL window, the entry is dropped and the caller goes upstream, so the cache stops being the thing that sustains the cycle.

## Tests

First commit adds the tests against the old key and fails; second commit makes them pass. `TestCacheKeyCoversEveryRequestDimension` enumerates every dimension a cached response depends on and asserts each one changes the key, so the next added dimension has somewhere to be declared.

Full `go test ./internal/proxy/` passes.

## Not covered

Codex should not issue 3,598 identical paginated requests no matter what a proxy returns; that is a client-side loop guard worth filing upstream separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787916515&installation_model_id=21920&pr_number=105&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F105&signature=e750b18e2bf982169d766f5c74889ab82ef1b4a04736d2ebf0f8b127e0bd73b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keyed the proxy read cache on the full request (method, path, sorted query, and caller hash) to stop wrong-page and cross-account responses and prevent the `/backend-api/ps/plugins/list` pagination loop. Added a cache size cap and a loop guard, and updated cache APIs to accept `*http.Request`.

- **Bug Fixes**
  - Cache key now covers method, path, sorted query, and a SHA-256 of `chatgpt-account-id`, `Authorization`, and `chatgpt-user-id` (no tokens stored).
  - `get`/`set` now take `*http.Request` to prevent partial keys.
  - Added `readCacheMaxEntries` (1024) with expired-first eviction.
  - Added `readCacheLoopThreshold` (64) to drop an entry after too many consecutive hits within a TTL.

<sup>Written for commit dd47554e28482959178b9d52f2937cd80356f26b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response caching to distinguish requests by method, path, query parameters, and caller identity.
  * Prevented cached responses from being incorrectly shared across accounts or different query strings.
  * Ensured equivalent requests receive cached responses regardless of query parameter order.
  * Added safeguards against excessive cache growth and repeated polling loops by expiring or bypassing cache entries when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->