### PR TITLE
Hold Cloudflare infrastructure cookies for upstream requests

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -74,6 +74,7 @@ type Server struct {
 	MaxBodyBytes    int64
 	Transcripts     *transcript.Recorder
 	ReadCache       *readCache
+	UpstreamCookies *upstreamCookieJar
 	// Bedrock, when set, enables the /bedrock/* SigV4 signing gateway.
 	Bedrock *BedrockConfig
 	// ClaudeFableAPIKey, when set, serves Claude Fable requests via this Anthropic
@@ -915,6 +916,9 @@ func (s Server) Handler() http.Handler {
 	}
 	if s.ReadCache == nil {
 		s.ReadCache = newReadCache()
+	}
+	if s.UpstreamCookies == nil {
+		s.UpstreamCookies = newUpstreamCookieJar()
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/_subrouter/health", s.handleHealth)
@@ -1883,10 +1887,15 @@ func (s Server) proxyHandler() http.Handler {
 			s.captureRequestBody(proxyRequest, sessionAgentType, sessionID)
 		}
 
+		cookieKey := upstreamCookieKey(account.ID, upstream.Host)
 		rp := &httputil.ReverseProxy{
 			Rewrite: func(pr *httputil.ProxyRequest) {
 				pr.SetURL(upstream)
 				stripOutboundForwardingHeaders(pr.Out.Header)
+				// Present the Cloudflare affinity a direct client would present,
+				// so backend-bound upstream state (pagination cursors, challenge
+				// clearance) stays valid across requests.
+				s.UpstreamCookies.apply(cookieKey, pr.Out)
 			},
 		}
 		transport := s.transport()
@@ -1942,6 +1951,7 @@ func (s Server) proxyHandler() http.Handler {
 		}
 		rp.Transport = transport
 		rp.ModifyResponse = func(response *http.Response) error {
+			s.UpstreamCookies.capture(cookieKey, response)
 			s.captureResponseBody(response, r.Context(), sessionAgentType, sessionID, account.ID, account.Provider, requestPoolModel, retryPoolModel, proxyRequest.URL.Path)
 			if credentialLease != nil {
 				s.reportCredentialLease(
@@ -2000,8 +2010,9 @@ func (s Server) proxyHandler() http.Handler {
 			if cacheTTL := cacheablePath(r.URL.Path); cacheTTL > 0 {
 				rec := &cacheRecorder{}
 				rp.ServeHTTP(rec, proxyRequest)
+				payload := rec.buf.Bytes()
 				if rec.code >= 200 && rec.code < 300 {
-					s.ReadCache.set(r, rec.code, rec.header, rec.buf.Bytes(), cacheTTL)
+					s.ReadCache.set(r, rec.code, rec.header, payload, cacheTTL)
 				}
 				for k, vs := range rec.header {
 					for _, v := range vs {
@@ -2011,7 +2022,7 @@ func (s Server) proxyHandler() http.Handler {
 				if rec.code != 0 {
 					w.WriteHeader(rec.code)
 				}
-				_, _ = w.Write(rec.buf.Bytes())
+				_, _ = w.Write(payload)
 				return
 			}
 		}

--- a/internal/proxy/upstream_cookies.go
+++ b/internal/proxy/upstream_cookies.go
@@ -1,0 +1,175 @@
+package proxy
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Cloudflare pins a client to a specific backend with infrastructure cookies
+// (__cflb for load-balancer affinity, __cf_bm for bot management, cf_clearance
+// for challenge clearance). Codex keeps its own jar for these, but only for
+// https://chatgpt.com URLs: see is_chatgpt_cookie_url in
+// codex-rs/http-client/src/chatgpt_cloudflare_cookies.rs, which requires an
+// https scheme and an allowlisted ChatGPT host. Pointed at http://127.0.0.1,
+// the client stores nothing and sends nothing, and it is right not to hand
+// session cookies to an arbitrary local proxy.
+//
+// That leaves subrouter as the only component that can hold them, and it must,
+// because upstream state can be backend-bound. The plugin catalog's pagination
+// cursor is: a continuation token minted by one backend is meaningless to
+// another, which answers by restarting the listing and issuing a fresh cursor.
+// A client that follows cursors until they run out then never terminates. Codex
+// does exactly that (core-plugins/src/remote.rs), so one plugin-list call
+// streamed 5.3 GB and drove the client to 18 GB RSS in two seconds.
+//
+// Stickiness aside, presenting the cookies a normal client would present is
+// what keeps proxied traffic indistinguishable from direct traffic.
+const (
+	// upstreamCookieMaxKeys bounds the jar. Keys are (account, host) pairs, so
+	// this is small in practice; the cap exists so it cannot grow without end.
+	upstreamCookieMaxKeys = 512
+)
+
+type upstreamCookie struct {
+	value     string
+	expiresAt time.Time // zero means session cookie: keep for the process lifetime
+}
+
+type upstreamCookieJar struct {
+	mu      sync.Mutex
+	entries map[string]map[string]upstreamCookie
+}
+
+func newUpstreamCookieJar() *upstreamCookieJar {
+	return &upstreamCookieJar{entries: make(map[string]map[string]upstreamCookie)}
+}
+
+// upstreamCookieKey scopes the jar. Cookies are per upstream host, and per
+// account so two accounts are never correlated by a shared backend affinity.
+func upstreamCookieKey(accountID, upstreamHost string) string {
+	return accountID + "\n" + upstreamHost
+}
+
+// isCloudflareInfraCookie mirrors the allowlist Codex uses. Only Cloudflare
+// infrastructure cookies belong here: never account, session, or auth cookies,
+// which are user-identifying and must not be replayed across requests by an
+// intermediary.
+func isCloudflareInfraCookie(name string) bool {
+	switch name {
+	case "__cf_bm", "__cflb", "__cfruid", "__cfseq", "__cfwaitingroom",
+		"_cfuvid", "cf_clearance", "cf_ob_info", "cf_use_ob":
+		return true
+	}
+	return strings.HasPrefix(name, "cf_chl_")
+}
+
+// capture records allowlisted cookies from an upstream response.
+func (j *upstreamCookieJar) capture(key string, resp *http.Response) {
+	if j == nil || resp == nil {
+		return
+	}
+	cookies := resp.Cookies()
+	if len(cookies) == 0 {
+		return
+	}
+	now := time.Now()
+
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	for _, c := range cookies {
+		if !isCloudflareInfraCookie(c.Name) {
+			continue
+		}
+		if c.MaxAge < 0 || (!c.Expires.IsZero() && c.Expires.Before(now)) {
+			// Upstream is clearing this cookie.
+			if bucket, ok := j.entries[key]; ok {
+				delete(bucket, c.Name)
+			}
+			continue
+		}
+		var expiresAt time.Time
+		switch {
+		case c.MaxAge > 0:
+			expiresAt = now.Add(time.Duration(c.MaxAge) * time.Second)
+		case !c.Expires.IsZero():
+			expiresAt = c.Expires
+		}
+		bucket, ok := j.entries[key]
+		if !ok {
+			if len(j.entries) >= upstreamCookieMaxKeys {
+				j.evictLocked(now)
+			}
+			bucket = make(map[string]upstreamCookie)
+			j.entries[key] = bucket
+		}
+		bucket[c.Name] = upstreamCookie{value: c.Value, expiresAt: expiresAt}
+	}
+}
+
+// apply attaches stored cookies to an outbound upstream request without
+// disturbing cookies the client sent itself.
+func (j *upstreamCookieJar) apply(key string, r *http.Request) {
+	if j == nil || r == nil {
+		return
+	}
+	now := time.Now()
+
+	j.mu.Lock()
+	bucket := j.entries[key]
+	stored := make([]*http.Cookie, 0, len(bucket))
+	for name, c := range bucket {
+		if !c.expiresAt.IsZero() && now.After(c.expiresAt) {
+			delete(bucket, name)
+			continue
+		}
+		stored = append(stored, &http.Cookie{Name: name, Value: c.value})
+	}
+	j.mu.Unlock()
+	if len(stored) == 0 {
+		return
+	}
+
+	existing := make(map[string]struct{})
+	for _, c := range r.Cookies() {
+		existing[c.Name] = struct{}{}
+	}
+	for _, c := range stored {
+		if _, ok := existing[c.Name]; ok {
+			// The client's own cookie wins; it knows its session, we do not.
+			continue
+		}
+		r.AddCookie(c)
+	}
+}
+
+// evictLocked drops expired buckets, then arbitrary ones if still at the cap.
+// Callers hold j.mu.
+func (j *upstreamCookieJar) evictLocked(now time.Time) {
+	for key, bucket := range j.entries {
+		live := false
+		for name, c := range bucket {
+			if !c.expiresAt.IsZero() && now.After(c.expiresAt) {
+				delete(bucket, name)
+				continue
+			}
+			live = true
+		}
+		if !live {
+			delete(j.entries, key)
+		}
+	}
+	for key := range j.entries {
+		if len(j.entries) < upstreamCookieMaxKeys {
+			break
+		}
+		delete(j.entries, key)
+	}
+}
+
+func (j *upstreamCookieJar) len() int {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return len(j.entries)
+}

--- a/internal/proxy/upstream_cookies_test.go
+++ b/internal/proxy/upstream_cookies_test.go
@@ -1,0 +1,244 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func respWithCookies(values ...string) *http.Response {
+	h := http.Header{}
+	for _, v := range values {
+		h.Add("Set-Cookie", v)
+	}
+	return &http.Response{Header: h}
+}
+
+func cookieHeader(t *testing.T, jar *upstreamCookieJar, key string) string {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodGet, "https://chatgpt.com/backend-api/ps/plugins/list", nil)
+	jar.apply(key, r)
+	return r.Header.Get("Cookie")
+}
+
+// The whole point: a cookie captured from one upstream response must ride along
+// on the next request, or Cloudflare routes it to a different backend.
+func TestUpstreamCookiesAreReplayedOnNextRequest(t *testing.T) {
+	jar := newUpstreamCookieJar()
+	key := upstreamCookieKey("acct-alice", "chatgpt.com")
+	jar.capture(key, respWithCookies("__cflb=west-7; Path=/; Secure; HttpOnly"))
+
+	if got := cookieHeader(t, jar, key); got != "__cflb=west-7" {
+		t.Fatalf("Cookie header = %q, want __cflb=west-7", got)
+	}
+}
+
+// Only Cloudflare infrastructure cookies. Session and auth cookies identify a
+// user and must never be replayed by an intermediary.
+func TestUpstreamCookiesRejectNonCloudflareCookies(t *testing.T) {
+	jar := newUpstreamCookieJar()
+	key := upstreamCookieKey("acct-alice", "chatgpt.com")
+	jar.capture(key, respWithCookies(
+		"__cflb=west-7; Path=/",
+		"__Secure-next-auth.session-token=secret; Path=/",
+		"chatgpt_session=secret; Path=/",
+		"oai-auth-token=secret; Path=/",
+	))
+
+	got := cookieHeader(t, jar, key)
+	if got != "__cflb=west-7" {
+		t.Fatalf("Cookie header = %q, want only the Cloudflare cookie", got)
+	}
+}
+
+func TestUpstreamCookiesAllowlistMatchesCodex(t *testing.T) {
+	allowed := []string{
+		"__cf_bm", "__cflb", "__cfruid", "__cfseq", "__cfwaitingroom",
+		"_cfuvid", "cf_clearance", "cf_ob_info", "cf_use_ob", "cf_chl_rc_i",
+	}
+	for _, name := range allowed {
+		if !isCloudflareInfraCookie(name) {
+			t.Errorf("isCloudflareInfraCookie(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{
+		"__Secure-next-auth.session-token", "chatgpt_session", "oai-auth-token", "not_cf_clearance",
+	} {
+		if isCloudflareInfraCookie(name) {
+			t.Errorf("isCloudflareInfraCookie(%q) = true, want false", name)
+		}
+	}
+}
+
+// Two accounts must never share backend affinity, or their traffic is
+// correlatable and one account's clearance is replayed for another.
+func TestUpstreamCookiesAreScopedPerAccountAndHost(t *testing.T) {
+	jar := newUpstreamCookieJar()
+	alice := upstreamCookieKey("acct-alice", "chatgpt.com")
+	bob := upstreamCookieKey("acct-bob", "chatgpt.com")
+	otherHost := upstreamCookieKey("acct-alice", "api.openai.com")
+	jar.capture(alice, respWithCookies("__cflb=west-7; Path=/"))
+
+	if got := cookieHeader(t, jar, bob); got != "" {
+		t.Fatalf("bob got alice's cookie: %q", got)
+	}
+	if got := cookieHeader(t, jar, otherHost); got != "" {
+		t.Fatalf("api.openai.com got the chatgpt.com cookie: %q", got)
+	}
+}
+
+func TestUpstreamCookiesHonorExpiryAndDeletion(t *testing.T) {
+	jar := newUpstreamCookieJar()
+	key := upstreamCookieKey("acct-alice", "chatgpt.com")
+
+	jar.capture(key, respWithCookies("__cflb=stale; Max-Age=-1"))
+	if got := cookieHeader(t, jar, key); got != "" {
+		t.Fatalf("cleared cookie was stored: %q", got)
+	}
+
+	jar.capture(key, respWithCookies("__cf_bm=short; Max-Age=1"))
+	if got := cookieHeader(t, jar, key); got != "__cf_bm=short" {
+		t.Fatalf("Cookie header = %q, want __cf_bm=short", got)
+	}
+	jar.mu.Lock()
+	jar.entries[key]["__cf_bm"] = upstreamCookie{value: "short", expiresAt: time.Now().Add(-time.Second)}
+	jar.mu.Unlock()
+	if got := cookieHeader(t, jar, key); got != "" {
+		t.Fatalf("expired cookie was replayed: %q", got)
+	}
+}
+
+// The client knows its own session; a proxy-held cookie must not overwrite one
+// the client sent itself.
+func TestUpstreamCookiesDoNotClobberClientCookies(t *testing.T) {
+	jar := newUpstreamCookieJar()
+	key := upstreamCookieKey("acct-alice", "chatgpt.com")
+	jar.capture(key, respWithCookies("__cflb=proxy-side; Path=/"))
+
+	r := httptest.NewRequest(http.MethodGet, "https://chatgpt.com/backend-api/ps/plugins/list", nil)
+	r.AddCookie(&http.Cookie{Name: "__cflb", Value: "client-side"})
+	jar.apply(key, r)
+
+	cookies := r.Cookies()
+	if len(cookies) != 1 || cookies[0].Value != "client-side" {
+		t.Fatalf("cookies = %v, want only the client's own __cflb", cookies)
+	}
+}
+
+func TestUpstreamCookieJarIsBounded(t *testing.T) {
+	jar := newUpstreamCookieJar()
+	for i := 0; i < upstreamCookieMaxKeys*3; i++ {
+		jar.capture(upstreamCookieKey(fmt.Sprintf("acct-%d", i), "chatgpt.com"),
+			respWithCookies("__cflb=west; Path=/"))
+	}
+	if n := jar.len(); n > upstreamCookieMaxKeys {
+		t.Fatalf("jar holds %d keys, want <= %d", n, upstreamCookieMaxKeys)
+	}
+}
+
+// End to end over a fake Cloudflare-style upstream: a backend that only honors
+// a pagination cursor when the sticky cookie comes back, and otherwise restarts
+// the listing with a fresh cursor. A client following cursors terminates when
+// affinity is preserved and loops forever when it is not. This is the shape
+// that streamed 5.3 GB into one codex process.
+func TestUpstreamCookiesTerminatePaginationAgainstStickyBackend(t *testing.T) {
+	const totalPages = 3
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sticky, err := r.Cookie("__cflb")
+		if err != nil || sticky.Value != "backend-1" {
+			// Wrong backend: it has never seen this cursor, so it starts over.
+			http.SetCookie(w, &http.Cookie{Name: "__cflb", Value: "backend-1", Path: "/"})
+			fmt.Fprint(w, `{"page":1,"nextPageToken":"p2"}`)
+			return
+		}
+		switch r.URL.Query().Get("pageToken") {
+		case "":
+			fmt.Fprint(w, `{"page":1,"nextPageToken":"p2"}`)
+		case fmt.Sprintf("p%d", totalPages):
+			fmt.Fprint(w, `{"page":3}`)
+		default:
+			fmt.Fprintf(w, `{"page":2,"nextPageToken":"p%d"}`, totalPages)
+		}
+	}))
+	defer upstream.Close()
+
+	jar := newUpstreamCookieJar()
+	key := upstreamCookieKey("acct-alice", "upstream")
+	client := upstream.Client()
+
+	// Walk the cursor the way codex does: follow nextPageToken until it stops.
+	token := ""
+	pages := 0
+	for pages < 25 {
+		pages++
+		url := upstream.URL + "/ps/plugins/list?limit=200"
+		if token != "" {
+			url += "&pageToken=" + token
+		}
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		jar.apply(key, req)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		jar.capture(key, resp)
+		var body struct {
+			NextPageToken string `json:"nextPageToken"`
+		}
+		decodeJSON(t, resp, &body)
+		resp.Body.Close()
+		if body.NextPageToken == "" {
+			break
+		}
+		token = body.NextPageToken
+	}
+
+	if pages != totalPages {
+		t.Fatalf("walked %d pages, want %d: cursor affinity was not preserved", pages, totalPages)
+	}
+
+	// Same backend, no jar: this is the production behaviour before the fix.
+	// The walk never terminates, which is what made codex allocate without end.
+	noJarPages := 0
+	token = ""
+	for noJarPages < 25 {
+		noJarPages++
+		url := upstream.URL + "/ps/plugins/list?limit=200"
+		if token != "" {
+			url += "&pageToken=" + token
+		}
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var body struct {
+			NextPageToken string `json:"nextPageToken"`
+		}
+		decodeJSON(t, resp, &body)
+		resp.Body.Close()
+		if body.NextPageToken == "" {
+			break
+		}
+		token = body.NextPageToken
+	}
+	if noJarPages != 25 {
+		t.Fatalf("without the jar the walk terminated after %d pages; the test no longer reproduces the runaway", noJarPages)
+	}
+}
+
+func decodeJSON(t *testing.T, resp *http.Response, v any) {
+	t.Helper()
+	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+}


### PR DESCRIPTION
## What this does

Subrouter now keeps Cloudflare's infrastructure cookies (`__cflb`, `__cf_bm`, `_cfuvid`, `cf_clearance`, `cf_chl_*`) for its upstream requests, scoped per (account, upstream host).

Codex has its own jar for exactly these cookies, but `is_chatgpt_cookie_url` in `codex-rs/http-client/src/chatgpt_cloudflare_cookies.rs` requires an https scheme and an allowlisted ChatGPT host. Pointed at `http://127.0.0.1:31415`, it stores nothing and sends nothing, and that gating is correct: a client should not hand cookies to an arbitrary local proxy. The consequence is that every request subrouter makes upstream looks like a first-time visitor, discarding bot-management state and challenge clearance between requests. For a proxy we intend to ship publicly, presenting the continuity a normal client presents is the difference between looking like a client and looking like traffic worth challenging.

Same allowlist Codex uses. Session, account, and auth cookies are never stored. A cookie the client sent itself always wins. The jar is bounded (512 keys) with expiry honored.

## What this is not

This is hygiene, not a bug fix. I wrote it while chasing a codex memory blow-up and it did not fix that. Verified directly: walking the plugin catalog cursor with all three Cloudflare cookies present behaves identically to walking it with none, so backend affinity is not what governs that endpoint's pagination.

## Tests

Replay on the next request, allowlist parity with codex, per-account and per-host scoping, expiry and deletion, client cookies not clobbered, bounded jar, plus a round trip against an httptest backend that only honors a cursor when the sticky cookie returns.

`go test ./internal/...` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787919647&installation_model_id=21920&pr_number=106&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F106&signature=1ba12d75be031d328414e3ef2edf04bc1c1bdb01ba264339b460cda0c9b7ad0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hold and replay Cloudflare infrastructure cookies on upstream requests to preserve backend affinity and challenge clearance, making proxied traffic behave like a direct client. Adds a per-account, per-host cookie jar integrated into the reverse proxy.

- **New Features**
  - Store only Cloudflare infra cookies (`__cflb`, `__cf_bm`, `_cfuvid`, `cf_clearance`, `cf_chl_*`); matches Codex allowlist.
  - Scope cookies by (account, upstream host); never store session or auth cookies.
  - Honor expiry and deletions; cap the jar at 512 keys with eviction.
  - Client-sent cookies take precedence; jar adds cookies only if missing.
  - Apply cookies on outbound requests and capture from upstream responses.

<sup>Written for commit aa941ce2d3943438d330635cdfa4bc06e3a15f12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

