### PR TITLE
Aggregate plugin catalog pagination instead of relaying it

### DIFF
--- a/internal/proxy/catalog_aggregate.go
+++ b/internal/proxy/catalog_aggregate.go
@@ -1,0 +1,153 @@
+package proxy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Codex crawls the plugin catalog to exhaustion and its memory cost grows with
+// the number of pages it walks, not the number of entries it receives: one page
+// of 1,000 entries costs ~125 MB, while two pages of 200 cost ~9.6 GB and the
+// full 14-page crawl reaches 20 GB and can panic a machine. Codex only avoids
+// this against chatgpt.com because its catalog disk cache is keyed on
+// chatgpt_base_url, so a warm cache skips the crawl; any proxy is a cold key by
+// definition and cannot proxy its way out of it.
+//
+// So subrouter walks the pagination itself and hands back one page. The client
+// gets the whole catalog, sees no continuation token, and never paginates.
+const (
+	// catalogAggregateMaxPages bounds subrouter's own walk.
+	catalogAggregateMaxPages = 40
+	// catalogAggregateMaxBytes bounds it by size as well as page count.
+	catalogAggregateMaxBytes = 128 << 20
+)
+
+func isCatalogListPath(path string) bool {
+	p := path
+	if stripped, ok := stripChatGPTBackendPath(path); ok {
+		p = stripped
+	}
+	return strings.HasPrefix(p, "/ps/plugins/list")
+}
+
+func catalogNextPageToken(body []byte) string {
+	var decoded struct {
+		Pagination struct {
+			NextPageToken string `json:"next_page_token"`
+		} `json:"pagination"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return ""
+	}
+	return decoded.Pagination.NextPageToken
+}
+
+func catalogPlugins(body []byte) ([]json.RawMessage, bool) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, false
+	}
+	raw, ok := payload["plugins"]
+	if !ok {
+		return nil, false
+	}
+	var plugins []json.RawMessage
+	if err := json.Unmarshal(raw, &plugins); err != nil {
+		return nil, false
+	}
+	return plugins, true
+}
+
+// aggregateCatalogPages follows the catalog cursor upstream and returns a
+// single page carrying every entry, with no continuation token. It returns
+// (body, pages, entries, true) only when it actually merged something.
+func aggregateCatalogPages(
+	rt http.RoundTripper,
+	template *http.Request,
+	upstream *url.URL,
+	firstBody []byte,
+) ([]byte, int, int, bool) {
+	if rt == nil || template == nil || upstream == nil {
+		return firstBody, 0, 0, false
+	}
+	if !isCatalogListPath(template.URL.Path) {
+		return firstBody, 0, 0, false
+	}
+	token := catalogNextPageToken(firstBody)
+	if token == "" {
+		return firstBody, 0, 0, false
+	}
+	merged, ok := catalogPlugins(firstBody)
+	if !ok {
+		return firstBody, 0, 0, false
+	}
+
+	pages := 1
+	bytes := len(firstBody)
+	for token != "" && pages < catalogAggregateMaxPages && bytes < catalogAggregateMaxBytes {
+		next := template.Clone(template.Context())
+		next.RequestURI = ""
+		nextURL := *template.URL
+		nextURL.Scheme = upstream.Scheme
+		nextURL.Host = upstream.Host
+		// The reverse proxy joins the upstream's own path prefix onto the
+		// request path; re-issuing by hand has to do the same or it 404s.
+		if prefix := strings.TrimSuffix(upstream.Path, "/"); prefix != "" &&
+			!strings.HasPrefix(nextURL.Path, prefix+"/") {
+			nextURL.Path = prefix + nextURL.Path
+		}
+		q := nextURL.Query()
+		q.Set("pageToken", token)
+		nextURL.RawQuery = q.Encode()
+		next.URL = &nextURL
+		next.Host = upstream.Host
+		next.Body = nil
+		next.GetBody = nil
+		next.ContentLength = 0
+
+		resp, err := rt.RoundTrip(next)
+		if err != nil {
+			break
+		}
+		body, err := io.ReadAll(io.LimitReader(resp.Body, catalogAggregateMaxBytes))
+		resp.Body.Close()
+		if err != nil || resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			break
+		}
+		plugins, ok := catalogPlugins(body)
+		if !ok {
+			break
+		}
+		merged = append(merged, plugins...)
+		bytes += len(body)
+		pages++
+		token = catalogNextPageToken(body)
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(firstBody, &payload); err != nil {
+		return firstBody, 0, 0, false
+	}
+	mergedPlugins, err := json.Marshal(merged)
+	if err != nil {
+		return firstBody, 0, 0, false
+	}
+	payload["plugins"] = mergedPlugins
+	if rawPagination, ok := payload["pagination"]; ok {
+		var pagination map[string]json.RawMessage
+		if err := json.Unmarshal(rawPagination, &pagination); err == nil {
+			delete(pagination, "next_page_token")
+			if patched, err := json.Marshal(pagination); err == nil {
+				payload["pagination"] = patched
+			}
+		}
+	}
+	out, err := json.Marshal(payload)
+	if err != nil {
+		return firstBody, 0, 0, false
+	}
+	return out, pages, len(merged), true
+}

--- a/internal/proxy/catalog_aggregate_test.go
+++ b/internal/proxy/catalog_aggregate_test.go
@@ -189,3 +189,16 @@ func TestAggregateIgnoresUnrelatedResponses(t *testing.T) {
 		})
 	}
 }
+
+// The catalog gets a longer TTL than other polled endpoints because each miss
+// costs a full multi-page walk upstream.
+func TestCatalogListHasLongerCacheTTL(t *testing.T) {
+	listTTL := cacheablePath("/backend-api/ps/plugins/list")
+	installedTTL := cacheablePath("/backend-api/ps/plugins/installed")
+	if listTTL <= installedTTL {
+		t.Fatalf("catalog TTL %v, want longer than %v", listTTL, installedTTL)
+	}
+	if cacheablePath("/backend-api/codex/responses") != 0 {
+		t.Fatal("a non-cacheable path became cacheable")
+	}
+}

--- a/internal/proxy/catalog_aggregate_test.go
+++ b/internal/proxy/catalog_aggregate_test.go
@@ -1,0 +1,191 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// catalogUpstream serves `pages` pages of `perPage` entries under the given
+// path prefix, and records the paths it was asked for.
+func catalogUpstream(t *testing.T, prefix string, pages, perPage int) (*httptest.Server, *[]string) {
+	t.Helper()
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.URL.Path)
+		if r.URL.Path != prefix+"/ps/plugins/list" {
+			http.NotFound(w, r)
+			return
+		}
+		page := 1
+		if tok := r.URL.Query().Get("pageToken"); tok != "" {
+			fmt.Sscanf(tok, "page-%d", &page)
+		}
+		plugins := make([]map[string]string, 0, perPage)
+		for i := 0; i < perPage; i++ {
+			plugins = append(plugins, map[string]string{"id": fmt.Sprintf("p%d-%d", page, i)})
+		}
+		body := map[string]any{"plugins": plugins, "pagination": map[string]any{"limit": perPage}}
+		if page < pages {
+			body["pagination"] = map[string]any{
+				"limit":           perPage,
+				"next_page_token": fmt.Sprintf("page-%d", page+1),
+			}
+		}
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &seen
+}
+
+func firstPage(t *testing.T, srv *httptest.Server, prefix string) []byte {
+	t.Helper()
+	resp, err := srv.Client().Get(srv.URL + prefix + "/ps/plugins/list?scope=GLOBAL&limit=200")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	buf, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return buf
+}
+
+func requestFor(t *testing.T, srv *httptest.Server, prefix string) (*http.Request, *url.URL) {
+	t.Helper()
+	// The reverse proxy hands us a request whose path has already been mapped
+	// for the upstream; the upstream URL carries its own prefix.
+	req := httptest.NewRequest(http.MethodGet, "/ps/plugins/list?scope=GLOBAL&limit=200", nil)
+	up, err := url.Parse(srv.URL + prefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req, up
+}
+
+func pluginIDs(t *testing.T, body []byte) []string {
+	t.Helper()
+	var decoded struct {
+		Plugins    []map[string]string `json:"plugins"`
+		Pagination map[string]any      `json:"pagination"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("decode merged body: %v", err)
+	}
+	if _, ok := decoded.Pagination["next_page_token"]; ok {
+		t.Fatal("merged body still carries a continuation token")
+	}
+	ids := make([]string, 0, len(decoded.Plugins))
+	for _, p := range decoded.Plugins {
+		ids = append(ids, p["id"])
+	}
+	return ids
+}
+
+// The whole point: the client gets every entry in one page and never paginates.
+func TestAggregatesEveryCatalogPage(t *testing.T) {
+	srv, _ := catalogUpstream(t, "/backend-api", 5, 10)
+	req, up := requestFor(t, srv, "/backend-api")
+
+	merged, pages, entries, ok := aggregateCatalogPages(srv.Client().Transport, req, up, firstPage(t, srv, "/backend-api"))
+	if !ok {
+		t.Fatal("aggregation did not run")
+	}
+	if pages != 5 || entries != 50 {
+		t.Fatalf("pages=%d entries=%d, want 5 and 50", pages, entries)
+	}
+	if got := pluginIDs(t, merged); len(got) != 50 || got[0] != "p1-0" || got[49] != "p5-9" {
+		t.Fatalf("merged %d entries, first=%q last=%q", len(got), got[0], got[len(got)-1])
+	}
+}
+
+// Regression: the upstream URL carries a path prefix that the hand-issued
+// requests must reproduce, or every page after the first 404s and the client
+// silently receives only page one.
+func TestAggregatePreservesUpstreamPathPrefix(t *testing.T) {
+	srv, seen := catalogUpstream(t, "/backend-api", 3, 4)
+	req, up := requestFor(t, srv, "/backend-api")
+
+	_, pages, entries, ok := aggregateCatalogPages(srv.Client().Transport, req, up, firstPage(t, srv, "/backend-api"))
+	if !ok || pages != 3 || entries != 12 {
+		t.Fatalf("ok=%v pages=%d entries=%d, want 3 pages and 12 entries", ok, pages, entries)
+	}
+	for _, path := range *seen {
+		if path != "/backend-api/ps/plugins/list" {
+			t.Fatalf("requested %q, want the prefixed path", path)
+		}
+	}
+}
+
+func TestAggregateStopsAtPageCap(t *testing.T) {
+	srv, _ := catalogUpstream(t, "", catalogAggregateMaxPages+20, 2)
+	req, up := requestFor(t, srv, "")
+
+	_, pages, _, ok := aggregateCatalogPages(srv.Client().Transport, req, up, firstPage(t, srv, ""))
+	if !ok {
+		t.Fatal("aggregation did not run")
+	}
+	if pages != catalogAggregateMaxPages {
+		t.Fatalf("walked %d pages, want the %d cap", pages, catalogAggregateMaxPages)
+	}
+}
+
+// A mid-walk upstream failure must yield the pages already collected rather
+// than an error or a partial body with a dangling cursor.
+func TestAggregateKeepsWhatItHasWhenUpstreamFails(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls > 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"plugins":    []map[string]string{{"id": fmt.Sprintf("p%d", calls)}},
+			"pagination": map[string]any{"next_page_token": "more"},
+		})
+	}))
+	defer srv.Close()
+	req, up := requestFor(t, srv, "")
+
+	merged, pages, entries, ok := aggregateCatalogPages(srv.Client().Transport, req, up, firstPage(t, srv, ""))
+	if !ok || pages != 2 || entries != 2 {
+		t.Fatalf("ok=%v pages=%d entries=%d, want 2 and 2", ok, pages, entries)
+	}
+	if got := pluginIDs(t, merged); len(got) != 2 {
+		t.Fatalf("merged %d entries, want 2", len(got))
+	}
+}
+
+func TestAggregateIgnoresUnrelatedResponses(t *testing.T) {
+	srv, _ := catalogUpstream(t, "", 2, 1)
+	up, _ := url.Parse(srv.URL)
+
+	cases := []struct {
+		name string
+		path string
+		body string
+	}{
+		{"non-catalog path", "/codex/responses", `{"plugins":[],"pagination":{"next_page_token":"x"}}`},
+		{"no continuation", "/ps/plugins/list", `{"plugins":[{"id":"a"}],"pagination":{"limit":200}}`},
+		{"not json", "/ps/plugins/list", `nonsense`},
+		{"no plugins field", "/ps/plugins/list", `{"pagination":{"next_page_token":"x"}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			out, _, _, ok := aggregateCatalogPages(srv.Client().Transport, req, up, []byte(tc.body))
+			if ok {
+				t.Fatal("unexpectedly aggregated")
+			}
+			if string(out) != tc.body {
+				t.Fatalf("body was modified: %s", out)
+			}
+		})
+	}
+}

--- a/internal/proxy/dashboard_test.go
+++ b/internal/proxy/dashboard_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/manaflow-ai/subrouter/session"
 	"github.com/manaflow-ai/subrouter/internal/transcript"
+	"github.com/manaflow-ai/subrouter/session"
 )
 
 func TestDashboardAndTranscriptEndpoints(t *testing.T) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2000,8 +2000,21 @@ func (s Server) proxyHandler() http.Handler {
 			if cacheTTL := cacheablePath(r.URL.Path); cacheTTL > 0 {
 				rec := &cacheRecorder{}
 				rp.ServeHTTP(rec, proxyRequest)
+				payload := rec.buf.Bytes()
 				if rec.code >= 200 && rec.code < 300 {
-					s.ReadCache.set(r, rec.code, rec.header, rec.buf.Bytes(), cacheTTL)
+					// Walk catalog pagination here instead of relaying it: a
+					// client's cost grows with pages walked, not entries held.
+					if merged, pages, entries, ok := aggregateCatalogPages(transport, proxyRequest, upstream, payload); ok {
+						payload = merged
+						rec.buf.Reset()
+						rec.buf.Write(payload)
+						rec.header.Del("Content-Length")
+						if s.Logger != nil {
+							s.Logger.Info("aggregated plugin catalog pages", "account", account.ID,
+								"path", r.URL.Path, "pages", pages, "entries", entries)
+						}
+					}
+					s.ReadCache.set(r, rec.code, rec.header, payload, cacheTTL)
 				}
 				for k, vs := range rec.header {
 					for _, v := range vs {
@@ -2011,7 +2024,7 @@ func (s Server) proxyHandler() http.Handler {
 				if rec.code != 0 {
 					w.WriteHeader(rec.code)
 				}
-				_, _ = w.Write(rec.buf.Bytes())
+				_, _ = w.Write(payload)
 				return
 			}
 		}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -74,6 +74,8 @@ type Server struct {
 	MaxBodyBytes    int64
 	Transcripts     *transcript.Recorder
 	ReadCache       *readCache
+	// CacheFlight collapses identical concurrent cache misses.
+	CacheFlight *singleFlight
 	// Bedrock, when set, enables the /bedrock/* SigV4 signing gateway.
 	Bedrock *BedrockConfig
 	// ClaudeFableAPIKey, when set, serves Claude Fable requests via this Anthropic
@@ -915,6 +917,9 @@ func (s Server) Handler() http.Handler {
 	}
 	if s.ReadCache == nil {
 		s.ReadCache = newReadCache()
+	}
+	if s.CacheFlight == nil {
+		s.CacheFlight = newSingleFlight()
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/_subrouter/health", s.handleHealth)
@@ -1998,22 +2003,36 @@ func (s Server) proxyHandler() http.Handler {
 		// For cacheable GET paths, buffer the response so we can store it.
 		if r.Method == http.MethodGet {
 			if cacheTTL := cacheablePath(r.URL.Path); cacheTTL > 0 {
-				rec := &cacheRecorder{}
-				rp.ServeHTTP(rec, proxyRequest)
-				payload := rec.buf.Bytes()
-				if rec.code >= 200 && rec.code < 300 {
-					// Walk catalog pagination here instead of relaying it: a
-					// client's cost grows with pages walked, not entries held.
-					if merged, pages, entries, ok := aggregateCatalogPages(transport, proxyRequest, upstream, payload); ok {
-						payload = merged
-						rec.buf.Reset()
-						rec.buf.Write(payload)
-						rec.header.Del("Content-Length")
-						if s.Logger != nil {
-							s.Logger.Info("aggregated plugin catalog pages", "account", account.ID,
-								"path", r.URL.Path, "pages", pages, "entries", entries)
+				// Identical concurrent misses share one upstream fetch, and the
+				// whole catalog walk happens inside the flight so a burst of
+				// cold clients costs one walk, not one each.
+				flight, shared := s.CacheFlight.do(cacheKey(r), func() flightResult {
+					rec := &cacheRecorder{}
+					rp.ServeHTTP(rec, proxyRequest)
+					body := rec.buf.Bytes()
+					if rec.code >= 200 && rec.code < 300 {
+						if merged, pages, entries, ok := aggregateCatalogPages(transport, proxyRequest, upstream, body); ok {
+							body = merged
+							if s.Logger != nil {
+								s.Logger.Info("aggregated plugin catalog pages", "account", account.ID,
+									"path", r.URL.Path, "pages", pages, "entries", entries)
+							}
 						}
 					}
+					header := rec.header
+					if header == nil {
+						header = make(http.Header)
+					}
+					header.Del("Content-Length")
+					return flightResult{statusCode: rec.code, header: header, body: body}
+				})
+				rec := &cacheRecorder{code: flight.statusCode, header: flight.header}
+				if rec.header == nil {
+					rec.header = make(http.Header)
+				}
+				rec.buf.Write(flight.body)
+				payload := rec.buf.Bytes()
+				if rec.code >= 200 && rec.code < 300 && !shared {
 					s.ReadCache.set(r, rec.code, rec.header, payload, cacheTTL)
 				}
 				for k, vs := range rec.header {

--- a/internal/proxy/read_cache.go
+++ b/internal/proxy/read_cache.go
@@ -67,12 +67,22 @@ func cacheKey(r *http.Request) string {
 // resistance beyond 128 bits buys nothing here.
 func callerIdentity(r *http.Request) string {
 	h := sha256.New()
-	for _, header := range []string{"chatgpt-account-id", "Authorization", "chatgpt-user-id"} {
-		h.Write([]byte(header))
+	// Identity is the account, not the credential. Access tokens rotate per
+	// session, so hashing the bearer gives every new session its own cache and
+	// makes concurrent sessions each pay for the same upstream work.
+	account := r.Header.Get("chatgpt-account-id")
+	user := r.Header.Get("chatgpt-user-id")
+	if account != "" || user != "" {
+		h.Write([]byte("account\x00"))
+		h.Write([]byte(account))
 		h.Write([]byte{0})
-		h.Write([]byte(r.Header.Get(header)))
-		h.Write([]byte{0})
+		h.Write([]byte(user))
+		return hex.EncodeToString(h.Sum(nil)[:16])
 	}
+	// With no account headers the credential is all we have to separate
+	// callers by, and separating them is what matters.
+	h.Write([]byte("bearer\x00"))
+	h.Write([]byte(r.Header.Get("Authorization")))
 	return hex.EncodeToString(h.Sum(nil)[:16])
 }
 
@@ -154,6 +164,11 @@ func cacheablePath(path string) time.Duration {
 		p = stripped
 	}
 	switch {
+	case strings.HasPrefix(p, "/ps/plugins/list"):
+		// The catalog is large, changes slowly, and each miss costs a full
+		// multi-page walk upstream. A short TTL here is what turns a handful of
+		// sessions starting together into a burst of upstream traffic.
+		return 10 * time.Minute
 	case p == "/ps/plugins/installed",
 		strings.HasPrefix(p, "/ps/plugins/"),
 		p == "/plugins/installed",

--- a/internal/proxy/read_cache_regression_test.go
+++ b/internal/proxy/read_cache_regression_test.go
@@ -131,8 +131,17 @@ func TestCacheKeyCoversEveryRequestDimension(t *testing.T) {
 		"query scope": func(r *http.Request) { r.URL.RawQuery = "scope=WORKSPACE&limit=200" },
 		"method":      func(r *http.Request) { r.Method = http.MethodPost },
 		"account":     func(r *http.Request) { r.Header.Set("chatgpt-account-id", "acct-bob") },
-		"bearer":      func(r *http.Request) { r.Header.Set("Authorization", "Bearer bob-token") },
 		"user":        func(r *http.Request) { r.Header.Set("chatgpt-user-id", "user-bob") },
+		// The bearer is deliberately not a dimension while account headers are
+		// present: tokens rotate per session and the account is what decides
+		// which data comes back. It is a dimension only when nothing else
+		// identifies the caller, which TestReadCacheIdentityIgnoresRotatingBearer
+		// covers from both sides.
+		"bearer without account headers": func(r *http.Request) {
+			r.Header.Del("chatgpt-account-id")
+			r.Header.Del("chatgpt-user-id")
+			r.Header.Set("Authorization", "Bearer bob-token")
+		},
 	}
 	baseKey := cacheKey(base())
 	for name, mutate := range variants {
@@ -141,5 +150,40 @@ func TestCacheKeyCoversEveryRequestDimension(t *testing.T) {
 		if cacheKey(r) == baseKey {
 			t.Errorf("cacheKey ignores %s: two different requests share one cache entry", name)
 		}
+	}
+}
+
+// Access tokens rotate per session. If identity is the credential rather than
+// the account, every new session gets its own cache and concurrent sessions
+// each pay for the same upstream work.
+func TestReadCacheIdentityIgnoresRotatingBearer(t *testing.T) {
+	first := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/list?scope=GLOBAL", nil)
+	first.Header.Set("chatgpt-account-id", "acct-alice")
+	first.Header.Set("chatgpt-user-id", "user-alice")
+	first.Header.Set("Authorization", "Bearer token-from-session-1")
+
+	second := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/list?scope=GLOBAL", nil)
+	second.Header.Set("chatgpt-account-id", "acct-alice")
+	second.Header.Set("chatgpt-user-id", "user-alice")
+	second.Header.Set("Authorization", "Bearer token-from-session-2")
+
+	if cacheKey(first) != cacheKey(second) {
+		t.Fatal("a rotated access token split the cache for one account")
+	}
+
+	other := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/list?scope=GLOBAL", nil)
+	other.Header.Set("chatgpt-account-id", "acct-bob")
+	other.Header.Set("Authorization", "Bearer token-from-session-1")
+	if cacheKey(first) == cacheKey(other) {
+		t.Fatal("two accounts share a cache entry")
+	}
+
+	// With no account headers at all, the credential is the only separator.
+	anonA := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/list", nil)
+	anonA.Header.Set("Authorization", "Bearer a")
+	anonB := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/list", nil)
+	anonB.Header.Set("Authorization", "Bearer b")
+	if cacheKey(anonA) == cacheKey(anonB) {
+		t.Fatal("anonymous callers with different credentials share a cache entry")
 	}
 }

--- a/internal/proxy/single_flight.go
+++ b/internal/proxy/single_flight.go
@@ -1,0 +1,60 @@
+package proxy
+
+import "sync"
+
+// Cache misses arrive in bursts: several codex sessions starting at once all
+// ask for the same catalog before any of them has filled the cache. Each miss
+// then walks the catalog's pagination upstream, so N clients cost N times the
+// upstream requests for one identical answer. Measured with three concurrent
+// cold sessions: 12 catalog walks, 168 upstream page fetches in seconds, which
+// is the shape that gets a proxy bot-challenged.
+//
+// So identical concurrent misses share one upstream fetch. The first caller
+// does the work; the rest wait and take its result.
+
+type flightResult struct {
+	statusCode int
+	header     map[string][]string
+	body       []byte
+}
+
+type flightCall struct {
+	wg     sync.WaitGroup
+	result flightResult
+}
+
+type singleFlight struct {
+	mu    sync.Mutex
+	calls map[string]*flightCall
+}
+
+func newSingleFlight() *singleFlight {
+	return &singleFlight{calls: make(map[string]*flightCall)}
+}
+
+// do runs fetch for key, or waits for an in-flight fetch of the same key. The
+// bool reports whether this caller waited on someone else's fetch rather than
+// running its own.
+func (s *singleFlight) do(key string, fetch func() flightResult) (flightResult, bool) {
+	if s == nil {
+		return fetch(), false
+	}
+	s.mu.Lock()
+	if call, ok := s.calls[key]; ok {
+		s.mu.Unlock()
+		call.wg.Wait()
+		return call.result, true
+	}
+	call := &flightCall{}
+	call.wg.Add(1)
+	s.calls[key] = call
+	s.mu.Unlock()
+
+	call.result = fetch()
+	call.wg.Done()
+
+	s.mu.Lock()
+	delete(s.calls, key)
+	s.mu.Unlock()
+	return call.result, false
+}

--- a/internal/proxy/single_flight_test.go
+++ b/internal/proxy/single_flight_test.go
@@ -1,0 +1,86 @@
+package proxy
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Concurrent callers for one key must produce exactly one upstream fetch, and
+// all of them must receive its result.
+func TestSingleFlightCollapsesConcurrentMisses(t *testing.T) {
+	sf := newSingleFlight()
+	var fetches int32
+	release := make(chan struct{})
+
+	var wg sync.WaitGroup
+	results := make([]flightResult, 8)
+	shared := make([]bool, 8)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i], shared[i] = sf.do("catalog", func() flightResult {
+				atomic.AddInt32(&fetches, 1)
+				<-release
+				return flightResult{statusCode: 200, body: []byte("catalog-body")}
+			})
+		}(i)
+	}
+	time.Sleep(20 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&fetches); got != 1 {
+		t.Fatalf("%d upstream fetches, want 1", got)
+	}
+	sharedCount := 0
+	for i := range results {
+		if string(results[i].body) != "catalog-body" || results[i].statusCode != 200 {
+			t.Fatalf("caller %d got %+v", i, results[i])
+		}
+		if shared[i] {
+			sharedCount++
+		}
+	}
+	if sharedCount != 7 {
+		t.Fatalf("%d callers waited on the shared fetch, want 7", sharedCount)
+	}
+}
+
+// Different keys must not block each other.
+func TestSingleFlightKeepsKeysIndependent(t *testing.T) {
+	sf := newSingleFlight()
+	var fetches int32
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sf.do(string(rune('a'+i)), func() flightResult {
+				atomic.AddInt32(&fetches, 1)
+				return flightResult{statusCode: 200}
+			})
+		}(i)
+	}
+	wg.Wait()
+	if got := atomic.LoadInt32(&fetches); got != 4 {
+		t.Fatalf("%d fetches for 4 distinct keys, want 4", got)
+	}
+}
+
+// A finished flight must not be reused: the next caller fetches again.
+func TestSingleFlightDoesNotCacheAcrossCalls(t *testing.T) {
+	sf := newSingleFlight()
+	var fetches int32
+	for i := 0; i < 3; i++ {
+		sf.do("k", func() flightResult {
+			atomic.AddInt32(&fetches, 1)
+			return flightResult{statusCode: 200}
+		})
+	}
+	if got := atomic.LoadInt32(&fetches); got != 3 {
+		t.Fatalf("%d fetches for 3 sequential calls, want 3", got)
+	}
+}


### PR DESCRIPTION
## The failure

Any codex client pointed at subrouter, with `features.plugins = true` and a populated `CODEX_HOME`, allocates 20-31 GB within seconds of launch. On the machine this was found on, that exhausted the macOS VM compressor (100% segment capacity, 87 swapfiles) and produced three `watchdogd` kernel panics in 21 minutes.

Subrouter is not sending anything malformed. During a 20 GB balloon it served exactly **14** `/ps/plugins/list` requests: one complete, correct crawl, about 20 MB of JSON. The amplification is ~1000x and happens inside the client.

## Why a proxy triggers it and chatgpt.com does not

Codex's catalog disk cache is keyed on `chatgpt_base_url` (`codex-rs/core-plugins/src/remote/catalog_cache.rs:22`, 3 hour TTL). Against `chatgpt.com` the cache is warm and the endpoint is never called. Any different base URL is a cold key, and `fetch_directory_plugins_for_scope_with_optional_collection` (`codex-rs/core-plugins/src/remote.rs:1949`) then walks every page with no cap and no byte budget.

This is not subrouter-specific. A staging host, a different port, or any other proxy hits it identically.

The 2x2, all with plugins enabled:

| | via subrouter | direct |
|---|---|---|
| populated `CODEX_HOME` | 20-31 GB | 183 MB |
| fresh `CODEX_HOME` | 126 MB | 127 MB |

## What actually drives the cost

Pages walked, not entries received. Measured against the real catalog:

| what the client received | peak RSS |
|---|---|
| 2 pages x 200 entries | 9.6 GB |
| 1 page x 400 entries | 125 MB |
| 1 page x 1,000 entries | 125 MB |
| 14 pages x ~170 entries (full crawl) | 20.6 GB |

So the fix is not to truncate the catalog. Subrouter walks the cursor itself and returns one page carrying every entry with no `next_page_token`. The client receives the complete catalog and never paginates.

Bounded at 40 pages / 128 MB. A mid-walk upstream failure returns the pages already collected rather than an error.

## Verified end to end

Real `CODEX_HOME`, `features.plugins = true`, catalog cache cleared, codex TUI through subrouter:

- peak RSS 20.6 GB -> **192 MB**
- full catalog delivered: 2,283 entries in one page
- codex wrote a 9.0 MB catalog cache, the correct size for that catalog
- ran a shell tool call and answered normally

## Tests

Merges every page; preserves the upstream path prefix (a bug found in development: without it every page after the first 404s and the client silently gets page one); stops at the page cap; keeps collected pages when upstream fails mid-walk; ignores non-catalog paths, bodies without a continuation, non-JSON, and bodies without a `plugins` field.

`go test ./internal/...` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787920484&installation_model_id=21920&pr_number=107&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F107&signature=bcd8e6803a67d77b9a4ec83f68f072392d5a8926036b0397c3f7c2f40c7d8baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aggregate plugin catalog pages in the proxy and collapse concurrent cache misses so clients get one page with no continuation and we do one upstream walk. This fixes Codex page-walking memory blowups behind proxies and cuts upstream traffic (peak RSS ~20 GB -> ~192 MB; three cold sessions: 12 walks -> 1).

- **Bug Fixes**
  - Aggregates `/ps/plugins/list` server-side: walks cursor, merges all pages, strips `next_page_token`, capped at 40 pages or 128 MB; on mid-walk errors, returns entries collected so far.
  - Preserves the upstream path prefix when fetching subsequent pages; runs only for catalog JSON with a continuation, ignores others.
  - Shares identical concurrent cache misses via a single-flight; the whole walk runs inside the flight and one result is cached for all waiters.
  - Extends catalog TTL to 10 minutes and keys cache identity by account (not rotating bearer) to avoid per-session cache splits.
  - Caches the merged payload, logs aggregated pages/entries; adds tests for pagination, prefix handling, caps, failure behavior, ignore cases, single-flight, TTL, and identity.

<sup>Written for commit bda3c569a8b666090ecda9e9e38b760c4f591d61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

