### PR TITLE
Give each credential exactly one refresher

### DIFF
--- a/cmd/subrouter/sr_cloud.go
+++ b/cmd/subrouter/sr_cloud.go
@@ -771,17 +771,35 @@ func (r srRunner) cloudAccountImport(
 		)
 	}
 	uploaded := 0
+	migrated := 0
 	for _, upload := range pending {
 		if _, err := client.UploadAccount(ctx, upload.body); err != nil {
 			return fmt.Errorf("upload %s %s: %w", upload.kind, upload.label, err)
 		}
 		uploaded++
 		fmt.Fprintf(r.out, "uploaded %-20s %s\n", upload.kind, upload.label)
+		// Hand over ownership as well as the bytes. The provider rotates the
+		// refresh token on every use, so leaving a refreshable local copy makes
+		// this machine and the vault invalidate each other's chain. The record
+		// is kept for rollback, just where the daemon will not refresh it.
+		if upload.kind != "codex" {
+			continue
+		}
+		path, ok, err := r.store.MigrateStoredAway(upload.label)
+		if err != nil {
+			return fmt.Errorf("hand over %s: %w", upload.label, err)
+		}
+		if ok {
+			migrated++
+			fmt.Fprintf(r.out, "  local copy kept as a record at %s\n", path)
+		}
 	}
 	fmt.Fprintf(
 		r.out,
-		"\nUploaded %d shared account(s). Central refresh adoption may rotate OAuth chains; local files remain only as migration records and may require re-authentication for rollback.\n",
+		"\nUploaded %d shared account(s); %d local credential(s) handed over. This machine no longer refreshes them, so the vault owns their token chains. Rollback records remain in %s.\n",
 		uploaded,
+		migrated,
+		filepath.Join(r.store.StoreDir(), accounts.MigratedDirName),
 	)
 	return restartInstalledDaemon()
 }

--- a/internal/accounts/codex_store.go
+++ b/internal/accounts/codex_store.go
@@ -292,6 +292,32 @@ func (s CodexStore) RemoveStored(identifier string) (StoredCodexAccount, bool, e
 	return account, true, nil
 }
 
+// MigratedDirName holds credentials this machine has handed to the team vault.
+// The store does not scan it, so the local daemon stops refreshing them: the
+// provider rotates refresh tokens on use, so a credential must have exactly one
+// refresher or the two invalidate each other.
+const MigratedDirName = "migrated"
+
+// MigrateStoredAway moves a stored account out of the active store and into the
+// migrated directory, keeping it as a rollback record the daemon will not touch.
+// It returns the path the record now lives at.
+func (s CodexStore) MigrateStoredAway(identifier string) (string, bool, error) {
+	account, ok, err := s.FindStored(identifier)
+	if err != nil || !ok {
+		return "", ok, err
+	}
+	name := emailToFilename(account.Email)
+	dest := filepath.Join(s.Dir, MigratedDirName)
+	if err := os.MkdirAll(dest, 0o700); err != nil {
+		return "", false, err
+	}
+	target := filepath.Join(dest, name)
+	if err := os.Rename(filepath.Join(s.Dir, name), target); err != nil {
+		return "", false, err
+	}
+	return target, true, nil
+}
+
 func emailToFilename(email string) string {
 	var b strings.Builder
 	for _, r := range email {

--- a/internal/accounts/codex_store_migrate_test.go
+++ b/internal/accounts/codex_store_migrate_test.go
@@ -1,0 +1,66 @@
+package accounts
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A credential handed to the team vault must stop being refreshed here: the
+// provider rotates refresh tokens on use, so two refreshers invalidate each
+// other. Moving the file out of the scanned store is what disowns it, while
+// keeping it readable for rollback.
+func TestMigrateStoredAwayDisownsButKeepsRecord(t *testing.T) {
+	store := CodexStore{Dir: t.TempDir()}
+	account := StoredCodexAccount{
+		Email: "lc+8@cmux.com",
+		Auth: CodexAuthFile{Tokens: &CodexTokens{
+			AccessToken:  "access",
+			RefreshToken: "refresh",
+			IDToken:      "id",
+		}},
+	}
+	if err := store.SaveStored(account); err != nil {
+		t.Fatal(err)
+	}
+	if stored, err := store.ListStored(); err != nil || len(stored) != 1 {
+		t.Fatalf("precondition: stored=%d err=%v", len(stored), err)
+	}
+
+	path, ok, err := store.MigrateStoredAway("lc+8@cmux.com")
+	if err != nil || !ok {
+		t.Fatalf("migrate: ok=%v err=%v", ok, err)
+	}
+
+	stored, err := store.ListStored()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stored) != 0 {
+		t.Fatalf("account still in the active store after handover: %+v", stored)
+	}
+	if filepath.Dir(path) != filepath.Join(store.Dir, MigratedDirName) {
+		t.Fatalf("record landed at %s, want it under %s", path, MigratedDirName)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("rollback record unreadable: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("rollback record is empty")
+	}
+	info, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("record directory mode %o, want 700", perm)
+	}
+}
+
+func TestMigrateStoredAwayReportsMissingAccount(t *testing.T) {
+	store := CodexStore{Dir: t.TempDir()}
+	if _, ok, err := store.MigrateStoredAway("nobody@example.com"); ok || err != nil {
+		t.Fatalf("ok=%v err=%v, want false and no error", ok, err)
+	}
+}

--- a/internal/proxy/dashboard_test.go
+++ b/internal/proxy/dashboard_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/manaflow-ai/subrouter/session"
 	"github.com/manaflow-ai/subrouter/internal/transcript"
+	"github.com/manaflow-ai/subrouter/session"
 )
 
 func TestDashboardAndTranscriptEndpoints(t *testing.T) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1195,6 +1195,14 @@ func (s Server) reloadAccounts(ctx context.Context) (int, int, error) {
 	if s.SchedulerRef == nil {
 		return len(loaded), 0, nil
 	}
+	// In team mode the vault owns these credentials and the broker picks the
+	// account, so local scoring is both unnecessary and destructive: scoring
+	// refreshes every OAuth account, the provider rotates the refresh token on
+	// every use, and a second refresher invalidates the vault's chain (and vice
+	// versa). Two refreshers permanently break each other's accounts.
+	if s.CredentialBroker != nil {
+		return len(loaded), 0, nil
+	}
 	scores, scored := s.scoreAccounts(ctx, loaded)
 	if scored == 0 {
 		if s.Logger != nil {
@@ -3364,6 +3372,11 @@ func codexResponsePath(path string) bool {
 // wholesale: a codex-triggered refresh must not wipe claude scores or vice
 // versa.
 func (s Server) refreshUsageScoresIfStale(ctx context.Context) {
+	// See reloadAccounts: in team mode refreshing local OAuth accounts rotates
+	// refresh tokens the vault owns, which invalidates them for both sides.
+	if s.CredentialBroker != nil {
+		return
+	}
 	if s.SchedulerRef == nil || !s.SchedulerRef.BeginRefreshIfStale(s.UsageScoreTTL) {
 		return
 	}

--- a/internal/proxy/team_mode_refresh_test.go
+++ b/internal/proxy/team_mode_refresh_test.go
@@ -1,0 +1,72 @@
+package proxy
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/selectacct"
+)
+
+// In team mode the vault owns the credentials and refreshes them. The provider
+// rotates the refresh token on every use, so a second refresher invalidates the
+// vault's chain and the vault invalidates this machine's: both sides end up
+// dead. Observed in production across a laptop and a mac mini sharing one
+// account store, where 11 of 12 accounts failed with refresh_token_reused.
+//
+// So a server with a credential broker must never refresh a local OAuth
+// account, on any path.
+func TestTeamModeNeverRefreshesLocalAccounts(t *testing.T) {
+	local := []accounts.Account{
+		{ID: "a@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "a"},
+		{ID: "b@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "b"},
+	}
+
+	newServer := func(refreshes *int32, credBroker CredentialBroker) Server {
+		return Server{
+			Accounts:     local,
+			SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler(nil)),
+			AccountRef:   NewAccountRef(accounts.CodexStore{Dir: t.TempDir()}, local, nil),
+			RefreshAccountFn: func(_ context.Context, a accounts.Account) (accounts.Account, error) {
+				atomic.AddInt32(refreshes, 1)
+				return a, nil
+			},
+			CredentialBroker: credBroker,
+			UsageScoreTTL:    0,
+		}
+	}
+
+	t.Run("reloadAccounts", func(t *testing.T) {
+		var teamRefreshes int32
+		team := newServer(&teamRefreshes, &fakeCredentialBroker{})
+		if _, _, err := team.reloadAccounts(context.Background()); err != nil {
+			t.Fatalf("reload in team mode: %v", err)
+		}
+		if got := atomic.LoadInt32(&teamRefreshes); got != 0 {
+			t.Fatalf("team mode refreshed %d local accounts, want 0", got)
+		}
+	})
+
+	t.Run("refreshUsageScoresIfStale", func(t *testing.T) {
+		var teamRefreshes int32
+		team := newServer(&teamRefreshes, &fakeCredentialBroker{})
+		team.refreshUsageScoresIfStale(context.Background())
+		if got := atomic.LoadInt32(&teamRefreshes); got != 0 {
+			t.Fatalf("team mode refreshed %d local accounts while scoring, want 0", got)
+		}
+	})
+
+	// Local mode is the other half of the contract: with no broker this machine
+	// is the only refresher, so it must still refresh or scores go stale.
+	t.Run("local mode still refreshes", func(t *testing.T) {
+		var localRefreshes int32
+		solo := newServer(&localRefreshes, nil)
+		if _, _, err := solo.reloadAccounts(context.Background()); err != nil {
+			t.Fatalf("reload in local mode: %v", err)
+		}
+		if got := atomic.LoadInt32(&localRefreshes); got == 0 {
+			t.Fatal("local mode refreshed nothing; the gate is too wide")
+		}
+	})
+}

--- a/internal/proxy/team_mode_refresh_test.go
+++ b/internal/proxy/team_mode_refresh_test.go
@@ -23,11 +23,32 @@ func TestTeamModeNeverRefreshesLocalAccounts(t *testing.T) {
 		{ID: "b@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "b"},
 	}
 
+	// The store must contain the accounts, not just the in-memory slice:
+	// reloadAccounts re-reads it, so a test that relies on whatever the developer
+	// happens to have in ~/.subrouter passes locally and fails in CI.
+	newStore := func() accounts.CodexStore {
+		store := accounts.CodexStore{Dir: t.TempDir()}
+		for _, account := range local {
+			if err := store.SaveStored(accounts.StoredCodexAccount{
+				Email:    account.ID,
+				Provider: accounts.ProviderCodex,
+				Auth: accounts.CodexAuthFile{Tokens: &accounts.CodexTokens{
+					AccessToken:  "access-" + account.ID,
+					RefreshToken: "refresh-" + account.ID,
+					IDToken:      "id-" + account.ID,
+				}},
+			}); err != nil {
+				t.Fatalf("seed store: %v", err)
+			}
+		}
+		return store
+	}
+
 	newServer := func(refreshes *int32, credBroker CredentialBroker) Server {
 		return Server{
 			Accounts:     local,
 			SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler(nil)),
-			AccountRef:   NewAccountRef(accounts.CodexStore{Dir: t.TempDir()}, local, nil),
+			AccountRef:   NewAccountRef(newStore(), local, nil),
 			RefreshAccountFn: func(_ context.Context, a accounts.Account) (accounts.Account, error) {
 				atomic.AddInt32(refreshes, 1)
 				return a, nil


### PR DESCRIPTION
## Why

OpenAI rotates a Codex refresh token on every use and invalidates the previous one. A credential can therefore have exactly one refresher, and two of them destroy each other.

That is what happened in production: a laptop and a mac mini shared one account store, both refreshed independently, and **11 of 12 accounts now fail with `refresh_token_reused`**, some recorded as far back as 2026-05-25. `sr status` on both hosts shows the same error for the same accounts. Re-adding accounts into that arrangement just kills them again, so this is a precondition for the hosted-vault migration rather than a cleanup.

## What was wrong

Team mode already leases from the broker and never sends a local refresh token upstream. But the local scheduler still refreshed every OAuth account to score usage, on two ungated paths:

- `reloadAccounts` → `scoreAccounts`
- `refreshUsageScoresIfStale` → `scoreAccounts`

`scoreAccounts` refreshes each OAuth account before fetching usage. So a team-mode machine kept rotating tokens the vault owns, invalidating them for the vault, while the vault invalidated them here. Someone had already noticed the scheduler is irrelevant under a broker (`proxy.go` gates `NoteRouted` on `CredentialBroker == nil`); the scoring paths were simply missed.

## Changes

Both refresh paths return early when a credential broker is configured. Local mode is untouched and still refreshes, since there it is the only refresher.

Upload now hands over ownership as well as bytes. `sr account import` moves each uploaded local credential to `<store>/migrated/`, which `ListStored` does not scan, so the daemon stops refreshing it. The file stays readable for rollback and the command prints where each record went. The old wording promised "local files remain only as migration records" while leaving them fully refreshable; now that is actually true.

## Tests

`TestTeamModeNeverRefreshesLocalAccounts` covers both paths under a broker and asserts zero refreshes, plus a third case asserting local mode still refreshes so the gate cannot be widened into breaking scoring. Verified it fails without the gate (`team mode refreshed 1 local accounts, want 0`).

`TestMigrateStoredAwayDisownsButKeepsRecord` asserts the account leaves the active store, the record remains readable, and the directory is 0700.

`go test ./internal/... ./cmd/...` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787963188&installation_model_id=21920&pr_number=108&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F108&signature=dc9d799566481f4458f0528ea5ddead4f37fc37feb3b592d0d4541feb9e9d0ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop local refresh of shared OAuth credentials in team mode and hand off ownership on upload to prevent `refresh_token_reused` and broken token chains.

- **Bug Fixes**
  - In team mode (`CredentialBroker` set), short-circuit `reloadAccounts` and `refreshUsageScoresIfStale` so no local OAuth refresh occurs; local mode unchanged. Tests now seed a temp store to make refresh behavior deterministic in CI.

- **Migration**
  - `sr account import` now moves uploaded `codex` credentials to `<store>/migrated/` (0700). The store does not scan this dir, so the daemon stops refreshing them. The rollback record remains and the path is printed.

<sup>Written for commit a766657ea6a6509164337fdcf6686fff6c09f363. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud account imports now hand off local Codex credentials after upload.
  * Migrated credentials remain available as rollback records in a protected directory.
  * Import results now report uploaded accounts, migrated credentials, and rollback record location.

* **Bug Fixes**
  * Team mode no longer refreshes or updates usage scores for local accounts when centralized credential management is enabled.
  * Local mode continues to refresh accounts normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->