### PR TITLE
Support Windows with a per-user scheduled task

### DIFF
--- a/cmd/subrouter/install_windows_task.go
+++ b/cmd/subrouter/install_windows_task.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+// Windows persistence uses a per-user Scheduled Task rather than a Windows
+// Service. A service runs before and independently of login and needs
+// administrator rights to install, which is wrong for a daemon whose whole
+// purpose is holding one user's credentials on 127.0.0.1. A Startup-folder or
+// Run-key entry needs no elevation either but cannot restart after a crash and
+// has no queryable state. A logon-triggered task needs no administrator, starts
+// at sign-in, restarts on failure, and answers /Query, which is what `sr server
+// status` reports.
+const (
+	// defaultWindowsTaskName is the task path shown in Task Scheduler.
+	defaultWindowsTaskName = `\Subrouter\Daemon`
+	// windowsRestartCount bounds automatic restarts so a permanently broken
+	// binary stops flapping instead of looping forever.
+	windowsRestartCount = 3
+	// windowsRestartInterval is the Task Scheduler duration between restarts.
+	windowsRestartInterval = "PT1M"
+)
+
+// taskRunner runs an external command. commandRunner satisfies it; tests
+// substitute a recorder so Windows behaviour is verifiable on any OS.
+type taskRunner interface {
+	Run(name string, args ...string) error
+}
+
+// windowsPaths holds the per-user locations the daemon installs into. Everything
+// lives under LOCALAPPDATA: it is per-user, not roaming, and never synced to a
+// domain profile, which matters for credential material.
+type windowsPaths struct {
+	Root       string
+	BinDir     string
+	Exe        string
+	LogDir     string
+	StateDir   string
+	ConfigDir  string
+	TaskXMLDir string
+}
+
+func newWindowsPaths(localAppData string) windowsPaths {
+	root := filepath.Join(localAppData, "Subrouter")
+	return windowsPaths{
+		Root:       root,
+		BinDir:     filepath.Join(root, "bin"),
+		Exe:        filepath.Join(root, "bin", "subrouter.exe"),
+		LogDir:     filepath.Join(root, "logs"),
+		StateDir:   filepath.Join(root, "state"),
+		ConfigDir:  filepath.Join(root, "config"),
+		TaskXMLDir: filepath.Join(root, "tasks"),
+	}
+}
+
+// windowsTaskConfig describes the task to register.
+type windowsTaskConfig struct {
+	TaskName         string
+	Author           string
+	Exe              string
+	Addr             string
+	SRSwitchInterval string
+	WorkingDirectory string
+}
+
+// windowsTaskArguments builds the daemon's argument string. The listen address
+// stays loopback-only: this daemon holds credentials and must never be
+// reachable from the network.
+func windowsTaskArguments(config windowsTaskConfig) (string, error) {
+	addr := strings.TrimSpace(config.Addr)
+	if addr == "" {
+		addr = "127.0.0.1:31415"
+	}
+	if !strings.HasPrefix(addr, "127.0.0.1:") && !strings.HasPrefix(addr, "localhost:") {
+		return "", fmt.Errorf("daemon address %q must be loopback-only", addr)
+	}
+	args := []string{"serve", "--addr", addr}
+	if interval := strings.TrimSpace(config.SRSwitchInterval); interval != "" && interval != "0" {
+		args = append(args, "--sr-switch-interval", interval)
+	}
+	return strings.Join(args, " "), nil
+}
+
+const windowsTaskTemplate = `<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Author>{{.Author}}</Author>
+    <Description>Subrouter local daemon (loopback only)</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <DisallowStartOnRemoteAppSession>false</DisallowStartOnRemoteAppSession>
+    <UseUnifiedSchedulingEngine>true</UseUnifiedSchedulingEngine>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Priority>7</Priority>
+    <RestartOnFailure>
+      <Interval>{{.RestartInterval}}</Interval>
+      <Count>{{.RestartCount}}</Count>
+    </RestartOnFailure>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>{{.Exe}}</Command>
+      <Arguments>{{.Arguments}}</Arguments>
+      <WorkingDirectory>{{.WorkingDirectory}}</WorkingDirectory>
+    </Exec>
+  </Actions>
+</Task>
+`
+
+// windowsTaskXML renders the task definition. Task Scheduler XML must be UTF-16
+// when imported from a file, which installWindowsTask handles when writing.
+func windowsTaskXML(config windowsTaskConfig) (string, error) {
+	arguments, err := windowsTaskArguments(config)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(config.Exe) == "" {
+		return "", fmt.Errorf("task needs an executable path")
+	}
+	tmpl, err := template.New("task").Parse(windowsTaskTemplate)
+	if err != nil {
+		return "", err
+	}
+	author := config.Author
+	if strings.TrimSpace(author) == "" {
+		author = "Subrouter"
+	}
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, struct {
+		Author           string
+		Exe              string
+		Arguments        string
+		WorkingDirectory string
+		RestartCount     int
+		RestartInterval  string
+	}{
+		Author:           xmlEscape(author),
+		Exe:              xmlEscape(config.Exe),
+		Arguments:        xmlEscape(arguments),
+		WorkingDirectory: xmlEscape(config.WorkingDirectory),
+		RestartCount:     windowsRestartCount,
+		RestartInterval:  windowsRestartInterval,
+	})
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func xmlEscape(value string) string {
+	var buf bytes.Buffer
+	if err := xml.EscapeText(&buf, []byte(value)); err != nil {
+		return value
+	}
+	return buf.String()
+}
+
+// windowsController manages the registered task. It shells out to schtasks so
+// the task Task Scheduler shows and the task `sr` manages are the same object.
+type windowsController struct {
+	name     string
+	xmlPath  string
+	runner   taskRunner
+	queryErr func(name string) error
+}
+
+func (c windowsController) describe() string { return "scheduled task " + c.name }
+
+func (c windowsController) query() error {
+	if c.queryErr != nil {
+		return c.queryErr(c.name)
+	}
+	return c.runner.Run("schtasks", "/Query", "/TN", c.name)
+}
+
+func (c windowsController) installed() bool { return c.query() == nil }
+
+func (c windowsController) start() error {
+	return c.runner.Run("schtasks", "/Run", "/TN", c.name)
+}
+
+// stop ends the running instance. The task itself stays registered so the next
+// logon starts it again; `remove` is what uninstalls.
+func (c windowsController) stop() error {
+	return c.runner.Run("schtasks", "/End", "/TN", c.name)
+}
+
+func (c windowsController) restart() error {
+	// A failed /End means it was not running, which is not a restart failure.
+	_ = c.stop()
+	return c.start()
+}
+
+func (c windowsController) remove() error {
+	_ = c.stop()
+	return c.runner.Run("schtasks", "/Delete", "/TN", c.name, "/F")
+}
+
+// installWindowsTask writes the task definition and registers it, replacing any
+// existing registration so installation is repeatable.
+func installWindowsTask(paths windowsPaths, config windowsTaskConfig, runner taskRunner) error {
+	if strings.TrimSpace(config.TaskName) == "" {
+		config.TaskName = defaultWindowsTaskName
+	}
+	if strings.TrimSpace(config.Exe) == "" {
+		config.Exe = paths.Exe
+	}
+	if strings.TrimSpace(config.WorkingDirectory) == "" {
+		config.WorkingDirectory = paths.Root
+	}
+	definition, err := windowsTaskXML(config)
+	if err != nil {
+		return err
+	}
+	for _, dir := range []string{paths.BinDir, paths.LogDir, paths.StateDir, paths.ConfigDir, paths.TaskXMLDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return err
+		}
+	}
+	xmlPath := filepath.Join(paths.TaskXMLDir, "daemon.xml")
+	if err := os.WriteFile(xmlPath, encodeUTF16LEWithBOM(definition), 0o600); err != nil {
+		return err
+	}
+	return runner.Run("schtasks", "/Create", "/TN", config.TaskName, "/XML", xmlPath, "/F")
+}
+
+// encodeUTF16LEWithBOM converts the definition for schtasks /XML, which rejects
+// UTF-8 input despite the declared encoding.
+func encodeUTF16LEWithBOM(value string) []byte {
+	out := []byte{0xFF, 0xFE}
+	for _, r := range value {
+		if r > 0xFFFF {
+			r = 0xFFFD
+		}
+		out = append(out, byte(r), byte(r>>8))
+	}
+	return out
+}
+
+// secureWindowsCredentialDir removes inherited access and grants the current
+// user alone full control, the Windows equivalent of the 0700 the POSIX
+// installers rely on. Without it a credential directory inherits whatever the
+// parent allows.
+func secureWindowsCredentialDir(dir, user string, runner taskRunner) error {
+	if strings.TrimSpace(dir) == "" {
+		return fmt.Errorf("credential directory is required")
+	}
+	if strings.TrimSpace(user) == "" {
+		return fmt.Errorf("cannot lock %s without a user name", dir)
+	}
+	if err := runner.Run("icacls", dir, "/inheritance:r"); err != nil {
+		return fmt.Errorf("remove inherited access on %s: %w", dir, err)
+	}
+	if err := runner.Run("icacls", dir, "/grant:r", user+":(OI)(CI)F"); err != nil {
+		return fmt.Errorf("grant %s sole access to %s: %w", user, dir, err)
+	}
+	return nil
+}

--- a/cmd/subrouter/install_windows_task_test.go
+++ b/cmd/subrouter/install_windows_task_test.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type recordingRunner struct {
+	calls []string
+	fail  map[string]error
+}
+
+func (r *recordingRunner) Run(name string, args ...string) error {
+	call := name + " " + strings.Join(args, " ")
+	r.calls = append(r.calls, call)
+	for prefix, err := range r.fail {
+		if strings.Contains(call, prefix) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *recordingRunner) sawContaining(fragment string) bool {
+	for _, call := range r.calls {
+		if strings.Contains(call, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+// The daemon holds credentials, so it must never listen anywhere but loopback.
+func TestWindowsTaskRefusesNonLoopbackAddress(t *testing.T) {
+	for _, addr := range []string{"0.0.0.0:31415", "192.168.1.10:31415", ":31415"} {
+		if _, err := windowsTaskArguments(windowsTaskConfig{Exe: `C:\s.exe`, Addr: addr}); err == nil {
+			t.Errorf("address %q was accepted; it must be rejected", addr)
+		}
+	}
+	args, err := windowsTaskArguments(windowsTaskConfig{Exe: `C:\s.exe`, Addr: "127.0.0.1:31415"})
+	if err != nil {
+		t.Fatalf("loopback address rejected: %v", err)
+	}
+	if args != "serve --addr 127.0.0.1:31415" {
+		t.Fatalf("arguments = %q", args)
+	}
+}
+
+func TestWindowsTaskArgumentsIncludeSwitchIntervalWhenSet(t *testing.T) {
+	args, err := windowsTaskArguments(windowsTaskConfig{
+		Exe: `C:\s.exe`, Addr: "127.0.0.1:31415", SRSwitchInterval: "10m",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(args, "--sr-switch-interval 10m") {
+		t.Fatalf("arguments = %q, want the switch interval", args)
+	}
+	off, err := windowsTaskArguments(windowsTaskConfig{
+		Exe: `C:\s.exe`, Addr: "127.0.0.1:31415", SRSwitchInterval: "0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(off, "sr-switch-interval") {
+		t.Fatalf("arguments = %q, want no interval when disabled", off)
+	}
+}
+
+// The task definition carries the three properties that justify choosing Task
+// Scheduler over a Run-key entry: start at logon, restart after failure, and no
+// elevation.
+func TestWindowsTaskDefinitionHasLogonRestartAndNoElevation(t *testing.T) {
+	definition, err := windowsTaskXML(windowsTaskConfig{
+		Exe:              `C:\Users\lc\AppData\Local\Subrouter\bin\subrouter.exe`,
+		Addr:             "127.0.0.1:31415",
+		WorkingDirectory: `C:\Users\lc\AppData\Local\Subrouter`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"<LogonTrigger>",
+		"<RestartOnFailure>",
+		"<Count>3</Count>",
+		"<Interval>PT1M</Interval>",
+		"<RunLevel>LeastPrivilege</RunLevel>",
+		"<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>",
+		"<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>",
+		"subrouter.exe",
+		"serve --addr 127.0.0.1:31415",
+	} {
+		if !strings.Contains(definition, want) {
+			t.Errorf("task definition missing %q", want)
+		}
+	}
+	if strings.Contains(definition, "HighestAvailable") {
+		t.Error("task requests elevation; per-user credentials must not run elevated")
+	}
+}
+
+func TestWindowsPathsStayUnderLocalAppData(t *testing.T) {
+	paths := newWindowsPaths(`C:\Users\lc\AppData\Local`)
+	root := filepath.Join(`C:\Users\lc\AppData\Local`, "Subrouter")
+	if paths.Root != root {
+		t.Fatalf("root = %q", paths.Root)
+	}
+	for name, dir := range map[string]string{
+		"bin": paths.BinDir, "logs": paths.LogDir, "state": paths.StateDir,
+		"config": paths.ConfigDir, "tasks": paths.TaskXMLDir,
+	} {
+		if !strings.HasPrefix(dir, root) {
+			t.Errorf("%s dir %q escaped %q", name, dir, root)
+		}
+	}
+	// Roaming would sync credentials into a domain profile.
+	if strings.Contains(paths.Root, "Roaming") {
+		t.Error("paths must not use the roaming profile")
+	}
+}
+
+func TestInstallWindowsTaskRegistersAndWritesUTF16(t *testing.T) {
+	paths := newWindowsPaths(t.TempDir())
+	runner := &recordingRunner{}
+	if err := installWindowsTask(paths, windowsTaskConfig{Addr: "127.0.0.1:31415"}, runner); err != nil {
+		t.Fatal(err)
+	}
+	if !runner.sawContaining("schtasks /Create /TN " + defaultWindowsTaskName) {
+		t.Fatalf("calls = %v", runner.calls)
+	}
+	// /F makes reinstallation repeatable instead of failing on an existing task.
+	if !runner.sawContaining("/F") {
+		t.Fatalf("registration is not idempotent: %v", runner.calls)
+	}
+	body, err := os.ReadFile(filepath.Join(paths.TaskXMLDir, "daemon.xml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) < 2 || body[0] != 0xFF || body[1] != 0xFE {
+		t.Fatal("task XML lacks a UTF-16LE BOM; schtasks /XML rejects UTF-8")
+	}
+	for _, dir := range []string{paths.BinDir, paths.LogDir, paths.StateDir, paths.ConfigDir} {
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("stat %s: %v", dir, err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o700 {
+			t.Errorf("%s mode %o, want 700", dir, perm)
+		}
+	}
+}
+
+func TestWindowsControllerIssuesExpectedCommands(t *testing.T) {
+	runner := &recordingRunner{}
+	controller := windowsController{name: defaultWindowsTaskName, runner: runner}
+
+	if err := controller.start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := controller.stop(); err != nil {
+		t.Fatal(err)
+	}
+	if err := controller.restart(); err != nil {
+		t.Fatal(err)
+	}
+	if err := controller.remove(); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"/Run", "/End", "/Delete"} {
+		if !runner.sawContaining("schtasks " + want) {
+			t.Errorf("missing schtasks %s in %v", want, runner.calls)
+		}
+	}
+	if !controller.installed() {
+		t.Error("installed() should be true when /Query succeeds")
+	}
+	if got := controller.describe(); !strings.Contains(got, defaultWindowsTaskName) {
+		t.Errorf("describe() = %q", got)
+	}
+}
+
+// restart must survive a task that is not currently running, which is the
+// common case after a crash.
+func TestWindowsControllerRestartsWhenNotRunning(t *testing.T) {
+	runner := &recordingRunner{fail: map[string]error{"/End": fmt.Errorf("task is not running")}}
+	controller := windowsController{name: defaultWindowsTaskName, runner: runner}
+	if err := controller.restart(); err != nil {
+		t.Fatalf("restart failed because the task was stopped: %v", err)
+	}
+	if !runner.sawContaining("schtasks /Run") {
+		t.Fatalf("restart never started the task: %v", runner.calls)
+	}
+}
+
+func TestWindowsControllerReportsMissingTask(t *testing.T) {
+	runner := &recordingRunner{fail: map[string]error{"/Query": fmt.Errorf("cannot find the task")}}
+	controller := windowsController{name: defaultWindowsTaskName, runner: runner}
+	if controller.installed() {
+		t.Error("installed() should be false when /Query fails")
+	}
+}
+
+// The credential directory must end up user-only, with inheritance removed.
+func TestSecureWindowsCredentialDirLocksToOneUser(t *testing.T) {
+	runner := &recordingRunner{}
+	if err := secureWindowsCredentialDir(`C:\state`, "lc", runner); err != nil {
+		t.Fatal(err)
+	}
+	if !runner.sawContaining("icacls C:\\state /inheritance:r") {
+		t.Fatalf("inheritance was not removed: %v", runner.calls)
+	}
+	if !runner.sawContaining(`/grant:r lc:(OI)(CI)F`) {
+		t.Fatalf("user was not granted sole access: %v", runner.calls)
+	}
+	if err := secureWindowsCredentialDir(`C:\state`, "", runner); err == nil {
+		t.Error("locking without a user name should fail rather than silently skip")
+	}
+}

--- a/cmd/subrouter/lifecycle.go
+++ b/cmd/subrouter/lifecycle.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -158,6 +159,17 @@ func newServiceController() (serviceController, error) {
 		return systemdController{
 			service: defaultSystemdServiceName,
 			home:    home,
+			runner:  commandRunner{},
+		}, nil
+	case "windows":
+		localAppData := os.Getenv("LOCALAPPDATA")
+		if strings.TrimSpace(localAppData) == "" {
+			return nil, fmt.Errorf("LOCALAPPDATA is not set; cannot locate the per-user daemon")
+		}
+		paths := newWindowsPaths(localAppData)
+		return windowsController{
+			name:    defaultWindowsTaskName,
+			xmlPath: filepath.Join(paths.TaskXMLDir, "daemon.xml"),
 			runner:  commandRunner{},
 		}, nil
 	default:

--- a/cmd/subrouter/sr_setup.go
+++ b/cmd/subrouter/sr_setup.go
@@ -58,6 +58,25 @@ func runSetup(ctx context.Context, store accounts.CodexStore, args []string, out
 			); err != nil {
 				return fmt.Errorf("install user daemon: %w", err)
 			}
+		case "windows":
+			fmt.Fprintln(out, "installing the per-user scheduled task...")
+			localAppData := os.Getenv("LOCALAPPDATA")
+			if strings.TrimSpace(localAppData) == "" {
+				return errors.New("LOCALAPPDATA is not set; cannot install the per-user daemon")
+			}
+			paths := newWindowsPaths(localAppData)
+			if err := installWindowsTask(paths, windowsTaskConfig{
+				TaskName:         defaultWindowsTaskName,
+				Addr:             "127.0.0.1:31415",
+				SRSwitchInterval: "10m",
+			}, commandRunner{}); err != nil {
+				return fmt.Errorf("install scheduled task: %w", err)
+			}
+			if user := os.Getenv("USERNAME"); strings.TrimSpace(user) != "" {
+				if err := secureWindowsCredentialDir(paths.StateDir, user, commandRunner{}); err != nil {
+					return fmt.Errorf("lock credential directory: %w", err)
+				}
+			}
 		default:
 			return fmt.Errorf("daemon installation is not supported on %s", runtime.GOOS)
 		}


### PR DESCRIPTION
## Why

`sr setup` and the lifecycle commands covered macOS (LaunchAgent) and Linux (user systemd unit); `newServiceController` returned "managing the local daemon is not supported on windows". The `serviceController` abstraction was already the right shape, so this fills in the third implementation.

## Why a scheduled task

| option | elevation | restart after crash | queryable state |
|---|---|---|---|
| Windows Service | administrator | yes | yes |
| Startup folder / Run key | none | no | no |
| **per-user scheduled task** | **none** | **yes** | **yes** |

A service runs before and independently of login and needs administrator rights to install, which is wrong for a daemon whose entire purpose is holding one user's credentials on loopback. A Run-key entry avoids elevation but cannot restart after a crash and gives `sr server status` nothing to query. A logon-triggered task is the only option with all three properties.

```
Task:    \Subrouter\Daemon
Trigger: at logon
Command: %LOCALAPPDATA%\Subrouter\bin\subrouter.exe serve --addr 127.0.0.1:31415
Restart: 3 times, 1 minute apart
Level:   LeastPrivilege
```

## Security properties, asserted by tests

- **loopback only**: a non-loopback `--addr` is rejected outright rather than accepted and quietly exposed. This daemon holds credentials.
- **never Roaming**: everything is under `%LOCALAPPDATA%`, so credentials are never synced into a domain profile.
- **no elevation**: `LeastPrivilege`, with a test asserting `HighestAvailable` never appears.
- **user-only credentials**: `icacls /inheritance:r` then `/grant:r <user>:(OI)(CI)F`, the Windows equivalent of the 0700 the POSIX installers rely on. Locking with an empty user name fails rather than silently skipping.

## Testable on any OS

The installer and controller take an injected `taskRunner`, so the task XML, every `schtasks` argument list, and the `icacls` calls are verified on macOS in CI. Also compiled and vetted with `GOOS=windows GOARCH=amd64`.

Covered: loopback enforcement, switch-interval on and off, the three task properties that justify the choice, path containment under LOCALAPPDATA, registration with `/F` so reinstall is repeatable, UTF-16LE BOM (schtasks `/XML` rejects UTF-8), 0700 directory modes, the `/Run` `/End` `/Delete` command set, restart when the task is not running, missing-task detection, and the ACL calls.

## Not covered

Real-hardware verification: installation, logon-triggered start, restart after killing the daemon, native Codex and Claude routing, and cleanup all still need a run on an actual Windows machine. Everything above is behaviour-level but runner-faked.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787963397&installation_model_id=21920&pr_number=109&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F109&signature=b2b5b5790b9969d1fbc076c4133bf24c89aff05fdb350353d4379e4c37412a5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows support for the local daemon using a per-user Scheduled Task that starts at logon, restarts on failure, and can be managed with existing lifecycle commands. No admin rights required; everything lives under `%LOCALAPPDATA%`.

- **New Features**
  - Installs `\Subrouter\Daemon` as a per-user task at logon; managed via `schtasks` (start/stop/restart/query).
  - `sr setup` now installs the task and locks `%LOCALAPPDATA%\Subrouter\state` to the current user using `icacls`.
  - Security: loopback-only `--addr` enforced, runs at `LeastPrivilege`, data stored only under `%LOCALAPPDATA%` (non-roaming).
  - Reliability: auto-restarts 3 times at 1-minute intervals; idempotent registration with `/F`; task XML written as UTF-16LE for `schtasks /XML`.
  - Tests use an injected runner to verify XML, `schtasks` args, and ACL calls; `newServiceController` now returns a Windows controller.

<sup>Written for commit f4b7d18d27a6784e73a90ee3598ddd82ade581b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

