### PR TITLE
Test credential upload and refresh against real rotation semantics

### DIFF
--- a/cmd/subrouter/account_import_test.go
+++ b/cmd/subrouter/account_import_test.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/internal/broker"
+)
+
+// fakeVault stands in for the hosted team vault. It records every upload so a
+// test can assert exactly how many credentials left this machine.
+type fakeVault struct {
+	mu       sync.Mutex
+	uploads  []broker.AccountUpload
+	existing []broker.SharedAccount
+}
+
+func (v *fakeVault) start(t *testing.T) *broker.Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/subrouter/accounts":
+			v.mu.Lock()
+			defer v.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"accounts": v.existing})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/subrouter/accounts":
+			var upload broker.AccountUpload
+			if err := json.NewDecoder(r.Body).Decode(&upload); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			v.mu.Lock()
+			defer v.mu.Unlock()
+			v.uploads = append(v.uploads, upload)
+			label, _ := upload["label"].(string)
+			kind, _ := upload["provider"].(string)
+			shared := broker.SharedAccount{
+				ID:    fmt.Sprintf("shared-%d", len(v.uploads)),
+				Kind:  kind,
+				Label: label,
+			}
+			v.existing = append(v.existing, shared)
+			_ = json.NewEncoder(w).Encode(map[string]any{"account": shared})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return broker.NewClient(broker.Config{
+		BaseURL:          server.URL,
+		AccessToken:      "vault-access",
+		RefreshToken:     "vault-refresh",
+		TeamID:           "team-1",
+		CredentialSource: broker.CredentialSourceTeam,
+	})
+}
+
+func (v *fakeVault) uploadedLabels() []string {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	labels := make([]string, 0, len(v.uploads))
+	for _, upload := range v.uploads {
+		label, _ := upload["label"].(string)
+		labels = append(labels, label)
+	}
+	return labels
+}
+
+// importRunner builds a runner over a temp store seeded with OAuth credentials.
+// HOME is redirected so the test cannot restart or inspect the real daemon.
+func importRunner(t *testing.T, emails ...string) (srRunner, *bytes.Buffer, accounts.CodexStore) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	store := accounts.CodexStore{Dir: t.TempDir()}
+	for _, email := range emails {
+		if err := store.SaveStored(accounts.StoredCodexAccount{
+			Email:    email,
+			Provider: accounts.ProviderCodex,
+			AddedAt:  time.Now().UTC().Format(time.RFC3339),
+			Auth: accounts.CodexAuthFile{Tokens: &accounts.CodexTokens{
+				AccessToken:  "access-" + email,
+				RefreshToken: "refresh-" + email,
+				IDToken:      "id-" + email,
+			}},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var out bytes.Buffer
+	return srRunner{program: "sr", store: store, out: &out, errOut: &out}, &out, store
+}
+
+func activeLabels(t *testing.T, store accounts.CodexStore) []string {
+	t.Helper()
+	stored, err := store.ListStored()
+	if err != nil {
+		t.Fatal(err)
+	}
+	labels := make([]string, 0, len(stored))
+	for _, item := range stored {
+		labels = append(labels, item.Email)
+	}
+	return labels
+}
+
+func migratedRecordExists(t *testing.T, store accounts.CodexStore, email string) bool {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(store.Dir, accounts.MigratedDirName, "*.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range matches {
+		if strings.Contains(filepath.Base(path), strings.ReplaceAll(email, "+", "_")) {
+			return true
+		}
+	}
+	return false
+}
+
+// Uploading one credential must upload exactly that one, hand over only that
+// one, and leave the rest of the store refreshable here.
+func TestImportOnlyUploadsAndHandsOverASingleCredential(t *testing.T) {
+	runner, out, store := importRunner(t, "one@example.com", "two@example.com")
+	vault := &fakeVault{}
+	client := vault.start(t)
+
+	if err := runner.cloudAccountImport(
+		context.Background(), client, []string{"--only", "one@example.com"},
+	); err != nil {
+		t.Fatalf("import --only: %v\n%s", err, out.String())
+	}
+
+	if labels := vault.uploadedLabels(); len(labels) != 1 || labels[0] != "one@example.com" {
+		t.Fatalf("uploaded %v, want exactly [one@example.com]", labels)
+	}
+	active := activeLabels(t, store)
+	if len(active) != 1 || active[0] != "two@example.com" {
+		t.Fatalf("active store = %v, want only two@example.com", active)
+	}
+	if !migratedRecordExists(t, store, "one@example.com") {
+		t.Error("no rollback record for the handed-over credential")
+	}
+	if migratedRecordExists(t, store, "two@example.com") {
+		t.Error("an untouched credential was handed over")
+	}
+}
+
+// The bulk path uploads every credential and leaves nothing refreshable here,
+// which is what stops this machine and the vault from rotating the same chains.
+func TestImportAllUploadsAndHandsOverEveryCredential(t *testing.T) {
+	runner, out, store := importRunner(t, "one@example.com", "two@example.com", "three@example.com")
+	vault := &fakeVault{}
+	client := vault.start(t)
+
+	if err := runner.cloudAccountImport(
+		context.Background(), client, []string{"--all", "--yes"},
+	); err != nil {
+		t.Fatalf("import --all --yes: %v\n%s", err, out.String())
+	}
+
+	if labels := vault.uploadedLabels(); len(labels) != 3 {
+		t.Fatalf("uploaded %v, want 3", labels)
+	}
+	if active := activeLabels(t, store); len(active) != 0 {
+		t.Fatalf("active store still holds %v; this machine would keep refreshing them", active)
+	}
+	for _, email := range []string{"one@example.com", "two@example.com", "three@example.com"} {
+		if !migratedRecordExists(t, store, email) {
+			t.Errorf("no rollback record for %s", email)
+		}
+	}
+	if !strings.Contains(out.String(), "no longer refreshes them") {
+		t.Errorf("output does not state the ownership change:\n%s", out.String())
+	}
+}
+
+// A bulk import without --yes must refuse rather than uploading everything on a
+// typo, and must change nothing.
+func TestImportAllRequiresConfirmation(t *testing.T) {
+	runner, _, store := importRunner(t, "one@example.com", "two@example.com")
+	vault := &fakeVault{}
+	client := vault.start(t)
+
+	if err := runner.cloudAccountImport(
+		context.Background(), client, []string{"--all"},
+	); err == nil {
+		t.Fatal("bulk import proceeded without --yes")
+	}
+	if labels := vault.uploadedLabels(); len(labels) != 0 {
+		t.Fatalf("uploaded %v despite refusing", labels)
+	}
+	if active := activeLabels(t, store); len(active) != 2 {
+		t.Fatalf("active store = %v, want both credentials untouched", active)
+	}
+}
+
+func TestImportDryRunChangesNothing(t *testing.T) {
+	runner, out, store := importRunner(t, "one@example.com", "two@example.com")
+	vault := &fakeVault{}
+	client := vault.start(t)
+
+	if err := runner.cloudAccountImport(
+		context.Background(), client, []string{"--all", "--dry-run"},
+	); err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if labels := vault.uploadedLabels(); len(labels) != 0 {
+		t.Fatalf("dry run uploaded %v", labels)
+	}
+	if active := activeLabels(t, store); len(active) != 2 {
+		t.Fatalf("dry run changed the store: %v", active)
+	}
+	if !strings.Contains(out.String(), "would be uploaded") {
+		t.Errorf("dry run did not preview the change:\n%s", out.String())
+	}
+}
+
+// Re-running an import must not upload a second copy of a credential the vault
+// already holds, or the vault accumulates duplicate chains for one account.
+func TestImportSkipsCredentialsTheVaultAlreadyHas(t *testing.T) {
+	runner, out, store := importRunner(t, "one@example.com")
+	vault := &fakeVault{existing: []broker.SharedAccount{
+		{ID: "shared-existing", Kind: "codex", Label: "one@example.com"},
+	}}
+	client := vault.start(t)
+
+	if err := runner.cloudAccountImport(
+		context.Background(), client, []string{"--all", "--yes"},
+	); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if labels := vault.uploadedLabels(); len(labels) != 0 {
+		t.Fatalf("uploaded %v, want none: the vault already has it", labels)
+	}
+	if !strings.Contains(out.String(), "already shared") {
+		t.Errorf("output did not explain the skip:\n%s", out.String())
+	}
+	if active := activeLabels(t, store); len(active) != 1 {
+		t.Fatalf("a skipped credential was handed over anyway: %v", active)
+	}
+}
+
+// Importing twice in a row must be safe: the second run finds the credential
+// already shared and already handed over, and does nothing.
+func TestImportIsIdempotentAcrossRuns(t *testing.T) {
+	runner, _, store := importRunner(t, "one@example.com", "two@example.com")
+	vault := &fakeVault{}
+	client := vault.start(t)
+
+	for round := 1; round <= 2; round++ {
+		if err := runner.cloudAccountImport(
+			context.Background(), client, []string{"--all", "--yes"},
+		); err != nil && round == 1 {
+			t.Fatalf("round %d: %v", round, err)
+		}
+	}
+	if labels := vault.uploadedLabels(); len(labels) != 2 {
+		t.Fatalf("uploaded %v across two runs, want each credential once", labels)
+	}
+	if active := activeLabels(t, store); len(active) != 0 {
+		t.Fatalf("active store = %v after two imports", active)
+	}
+}

--- a/internal/accounts/codex_auth.go
+++ b/internal/accounts/codex_auth.go
@@ -16,7 +16,11 @@ import (
 	"time"
 )
 
-const codexOAuthTokenURL = "https://auth.openai.com/oauth/token"
+// codexOAuthTokenURL is a var so tests can point refresh at a fake OAuth server
+// that models the provider's rotate-on-use semantics. Nothing in production
+// reassigns it.
+var codexOAuthTokenURL = "https://auth.openai.com/oauth/token"
+
 const codexOAuthClientID = "app_EMoamEEZ73f0CkXaXp7hrann"
 const codexAuthBreadcrumbLimit = 50
 

--- a/internal/accounts/codex_rotation_test.go
+++ b/internal/accounts/codex_rotation_test.go
@@ -1,0 +1,323 @@
+package accounts
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// rotatingOAuthServer models the provider's actual refresh semantics: a refresh
+// token is single-use, and presenting a consumed one fails with
+// refresh_token_reused. That is the behaviour that killed 11 of 12 shared
+// accounts in production, so the tests below exercise refresh against it rather
+// than against a server that accepts any token forever.
+type rotatingOAuthServer struct {
+	mu sync.Mutex
+	// live is the only refresh token the provider will currently accept.
+	live string
+	// consumed records every token already exchanged, so reuse is detectable.
+	consumed map[string]bool
+	// exchanges counts successful rotations.
+	exchanges atomic.Int32
+	// reuseAttempts counts presentations of an already-consumed token, which is
+	// what permanently breaks an account chain.
+	reuseAttempts atomic.Int32
+	generation    int
+}
+
+func newRotatingOAuthServer(initial string) *rotatingOAuthServer {
+	return &rotatingOAuthServer{live: initial, consumed: map[string]bool{}}
+}
+
+// expiredJWT builds an access token the refresh logic will consider expired, so
+// a refresh is always attempted; freshJWT builds one that is still valid.
+func testJWT(email string, expiry time.Time) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	claims := fmt.Sprintf(`{"email":%q,"exp":%d}`, email, expiry.Unix())
+	return header + "." + base64.RawURLEncoding.EncodeToString([]byte(claims)) + ".sig"
+}
+
+func (s *rotatingOAuthServer) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			RefreshToken string `json:"refresh_token"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if payload.RefreshToken != s.live {
+			if s.consumed[payload.RefreshToken] {
+				s.reuseAttempts.Add(1)
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":{"code":"refresh_token_reused",` +
+					`"message":"Your refresh token has already been used to generate a new access token."}}`))
+				return
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":{"code":"refresh_token_invalidated","message":"unknown token"}}`))
+			return
+		}
+		s.consumed[payload.RefreshToken] = true
+		s.generation++
+		s.live = fmt.Sprintf("refresh-gen-%d", s.generation)
+		s.exchanges.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"access_token":  testJWT("chain@example.com", time.Now().Add(time.Hour)),
+			"refresh_token": s.live,
+			"id_token":      testJWT("chain@example.com", time.Now().Add(time.Hour)),
+		})
+	}))
+	t.Cleanup(server.Close)
+	previous := codexOAuthTokenURL
+	codexOAuthTokenURL = server.URL
+	t.Cleanup(func() { codexOAuthTokenURL = previous })
+	return server
+}
+
+func seedChainAccount(t *testing.T, store CodexStore, email, refresh string) {
+	t.Helper()
+	if err := store.SaveStored(StoredCodexAccount{
+		Email:    email,
+		Provider: ProviderCodex,
+		Auth: CodexAuthFile{Tokens: &CodexTokens{
+			// Already expired, so every refresh call actually exchanges.
+			AccessToken:  testJWT(email, time.Now().Add(-time.Hour)),
+			RefreshToken: refresh,
+			IDToken:      testJWT(email, time.Now().Add(time.Hour)),
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func storedRefreshToken(t *testing.T, store CodexStore, email string) string {
+	t.Helper()
+	account, ok, err := store.FindStored(email)
+	if err != nil || !ok {
+		t.Fatalf("account missing after refresh: ok=%v err=%v", ok, err)
+	}
+	if account.Auth.Tokens == nil {
+		t.Fatal("account has no tokens after refresh")
+	}
+	return account.Auth.Tokens.RefreshToken
+}
+
+// Refreshing repeatedly must keep working: each exchange rotates the chain and
+// the store must always hold the newest token, never a consumed one.
+func TestRefreshRotatesRepeatedlyWithoutReuse(t *testing.T) {
+	provider := newRotatingOAuthServer("refresh-gen-0")
+	provider.start(t)
+	store := CodexStore{Dir: t.TempDir()}
+	seedChainAccount(t, store, "chain@example.com", "refresh-gen-0")
+
+	previous := "refresh-gen-0"
+	for round := 1; round <= 5; round++ {
+		account, ok, err := store.FindStored("chain@example.com")
+		if err != nil || !ok {
+			t.Fatalf("round %d: account missing", round)
+		}
+		if _, _, err := store.RefreshStored(
+			context.Background(), nil, account,
+		); err != nil {
+			t.Fatalf("round %d refresh failed: %v", round, err)
+		}
+		current := storedRefreshToken(t, store, "chain@example.com")
+		if current == previous {
+			t.Fatalf("round %d did not rotate the stored token (%s)", round, current)
+		}
+		previous = current
+	}
+	if got := provider.exchanges.Load(); got != 5 {
+		t.Fatalf("provider performed %d exchanges, want 5", got)
+	}
+	if got := provider.reuseAttempts.Load(); got != 0 {
+		t.Fatalf("presented a consumed token %d times, want 0", got)
+	}
+}
+
+// Concurrent refreshes of one account must not present the same token twice.
+// Without serialisation each caller reads the same chain and the losers get
+// refresh_token_reused, which is terminal for the account.
+func TestConcurrentRefreshNeverReusesAToken(t *testing.T) {
+	provider := newRotatingOAuthServer("refresh-gen-0")
+	provider.start(t)
+	store := CodexStore{Dir: t.TempDir()}
+	seedChainAccount(t, store, "chain@example.com", "refresh-gen-0")
+
+	account, ok, err := store.FindStored("chain@example.com")
+	if err != nil || !ok {
+		t.Fatal("seed failed")
+	}
+
+	const callers = 10
+	var wg sync.WaitGroup
+	errs := make([]error, callers)
+	start := make(chan struct{})
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, _, refreshErr := store.RefreshStored(
+				context.Background(), nil, account,
+			)
+			errs[i] = refreshErr
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, refreshErr := range errs {
+		if refreshErr != nil {
+			t.Errorf("caller %d failed: %v", i, refreshErr)
+		}
+	}
+	if got := provider.reuseAttempts.Load(); got != 0 {
+		t.Fatalf("concurrent refresh presented a consumed token %d times; the account would be dead", got)
+	}
+	// A forced refresh is meant to exchange, so all ten rotate in turn. What
+	// matters is that each one presents the token that was live when its turn
+	// came, never a consumed one: exchanges equal callers and reuse stays zero.
+	if got := provider.exchanges.Load(); got != callers {
+		t.Errorf("%d forced callers produced %d exchanges, want %d", callers, got, callers)
+	}
+	// The chain must still be usable afterwards.
+	final := storedRefreshToken(t, store, "chain@example.com")
+	provider.mu.Lock()
+	live := provider.live
+	provider.mu.Unlock()
+	if final != live {
+		t.Fatalf("stored token %q is not the provider's live token %q", final, live)
+	}
+}
+
+// Two store handles on one directory model the daemon and the CLI running at
+// once on a single machine. They share the on-disk lock, so this must be safe;
+// it is the cross-machine case that cannot be, which is why team mode stops
+// local refreshing entirely.
+func TestTwoStoreHandlesOnOneDirectoryStaySafe(t *testing.T) {
+	provider := newRotatingOAuthServer("refresh-gen-0")
+	provider.start(t)
+	dir := t.TempDir()
+	daemon := CodexStore{Dir: dir}
+	cli := CodexStore{Dir: dir}
+	seedChainAccount(t, daemon, "chain@example.com", "refresh-gen-0")
+
+	account, _, err := daemon.FindStored("chain@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	for _, store := range []CodexStore{daemon, cli, daemon, cli} {
+		wg.Add(1)
+		go func(s CodexStore) {
+			defer wg.Done()
+			if _, _, refreshErr := s.RefreshStored(
+				context.Background(), nil, account,
+			); refreshErr != nil {
+				t.Errorf("refresh through a second handle failed: %v", refreshErr)
+			}
+		}(store)
+	}
+	wg.Wait()
+
+	if got := provider.reuseAttempts.Load(); got != 0 {
+		t.Fatalf("two handles on one directory reused a token %d times", got)
+	}
+	if storedRefreshToken(t, cli, "chain@example.com") == "refresh-gen-0" {
+		t.Fatal("no rotation happened at all")
+	}
+}
+
+// A consumed token must produce a terminal, recorded failure rather than a
+// silent retry loop, so `sr status` can tell the user to re-add the account.
+func TestReusedTokenIsRecordedAsTerminalFailure(t *testing.T) {
+	provider := newRotatingOAuthServer("refresh-gen-live")
+	provider.start(t)
+	store := CodexStore{Dir: t.TempDir()}
+	// Seed a token the provider has already consumed elsewhere, which is exactly
+	// what a second refresher leaves behind.
+	provider.mu.Lock()
+	provider.consumed["refresh-stale"] = true
+	provider.mu.Unlock()
+	seedChainAccount(t, store, "stale@example.com", "refresh-stale")
+
+	account, _, err := store.FindStored("stale@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, refreshErr := store.RefreshStored(
+		context.Background(), nil, account,
+	); refreshErr == nil {
+		t.Fatal("refreshing with a consumed token succeeded")
+	}
+	if got := provider.reuseAttempts.Load(); got != 1 {
+		t.Fatalf("reuse attempts = %d, want 1", got)
+	}
+	stored, ok, err := store.FindStored("stale@example.com")
+	if err != nil || !ok {
+		t.Fatal("account disappeared after a failed refresh")
+	}
+	if stored.Auth.RefreshFailure == nil {
+		t.Fatal("terminal refresh failure was not recorded; sr status cannot report it")
+	}
+}
+
+// The daemon refreshes only when the access token is expired, so a burst of
+// scoring passes must collapse into one exchange rather than rotating the chain
+// once per caller. The repo covers this with two callers and a stub transport;
+// this runs ten against a provider that actually invalidates consumed tokens.
+func TestExpiredRefreshHerdCollapsesToOneExchange(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	provider := newRotatingOAuthServer("refresh-gen-0")
+	provider.start(t)
+	store := CodexStore{Dir: t.TempDir()}
+	seedChainAccount(t, store, "chain@example.com", "refresh-gen-0")
+
+	account, ok, err := store.FindStored("chain@example.com")
+	if err != nil || !ok {
+		t.Fatal("seed failed")
+	}
+
+	const callers = 10
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	failures := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, _, refreshErr := store.RefreshStoredIfExpired(
+				context.Background(), nil, account,
+			); refreshErr != nil {
+				failures <- refreshErr
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(failures)
+	for refreshErr := range failures {
+		t.Errorf("caller failed: %v", refreshErr)
+	}
+
+	if got := provider.exchanges.Load(); got != 1 {
+		t.Errorf("%d expired-path callers caused %d exchanges, want 1", callers, got)
+	}
+	if got := provider.reuseAttempts.Load(); got != 0 {
+		t.Errorf("expired-path burst reused a token %d times", got)
+	}
+}

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -2047,7 +2047,10 @@ func TestHandlerLogsUpstreamResponseStreamReadErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var logs bytes.Buffer
+	// The proxy logs from its own goroutine while the assertions below read the
+	// buffer, so an unsynchronised bytes.Buffer is a data race the race detector
+	// reports on every run.
+	logs := &syncBuffer{}
 	handler := Server{
 		Upstream: upstreamURL,
 		Accounts: []accounts.Account{{
@@ -2057,7 +2060,7 @@ func TestHandlerLogsUpstreamResponseStreamReadErrors(t *testing.T) {
 		}},
 		Sessions:     store,
 		Scheduler:    selectacct.NewScheduler(nil),
-		Logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+		Logger:       slog.New(slog.NewTextHandler(logs, nil)),
 		MaxBodyBytes: 1024,
 	}.Handler()
 	subrouter := httptest.NewServer(handler)

--- a/internal/proxy/sync_buffer_test.go
+++ b/internal/proxy/sync_buffer_test.go
@@ -1,0 +1,26 @@
+package proxy
+
+import (
+	"bytes"
+	"sync"
+)
+
+// syncBuffer is a bytes.Buffer that tolerates being written by the code under
+// test while a test goroutine reads it. Handing an unsynchronised buffer to a
+// logger the proxy writes from another goroutine is a data race.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}


### PR DESCRIPTION
## Why

The existing refresh tests stub a token endpoint that accepts any refresh token forever. That endpoint cannot express the behaviour that killed 11 of 12 shared accounts in production: the provider invalidates a refresh token the moment it is exchanged, and presenting a consumed one returns `refresh_token_reused`, which is terminal.

So this adds a fake OAuth server that models single-use rotation and counts reuse attempts, and tests refresh against it.

## Refresh

| test | asserts |
|---|---|
| five sequential refreshes | each rotates, the store always holds the newest token, 5 exchanges, **0 reuse** |
| ten concurrent forced refreshes | every caller succeeds, 10 exchanges, **0 reuse**, chain still matches the provider's live token |
| ten concurrent expired-path refreshes | collapses to **1 exchange**, 0 reuse |
| two store handles, one directory | the daemon and CLI together rotate safely, 0 reuse |
| consumed token | fails, and records a terminal `RefreshFailure` so `sr status` can tell the user to re-add |

The forced and expired paths differ deliberately: `RefreshStored` is an explicit exchange so ten callers legitimately produce ten rotations, while `RefreshStoredIfExpired` (what the daemon uses) re-checks freshness after taking the lock and collapses a burst into one. I initially asserted one exchange for the forced path, which was wrong about the intended contract.

All of it passes under `-race`.

## Upload

Over a fake vault that records every upload:

- `--only <label>` uploads exactly that credential, hands over only that one, leaves the rest refreshable here
- `--all --yes` uploads every credential and leaves the active store empty, so this machine keeps no second refresher
- `--all` without `--yes` refuses and changes nothing
- `--dry-run` uploads nothing and changes nothing
- a credential the vault already holds is skipped rather than duplicated
- a second identical run is a no-op

`HOME` is redirected in these tests so they cannot restart or inspect a real daemon.

## Incidental

`codexOAuthTokenURL` becomes a var so tests can point refresh at the fake provider. Nothing in production reassigns it.

Fixes a pre-existing data race in `TestHandlerLogsUpstreamResponseStreamReadErrors`: it handed an unsynchronised `bytes.Buffer` to a logger the proxy writes from its own goroutine. It reported three races per run on `main`, which also means any newly introduced race was hidden in the noise. Verified 3 races before, 0 after, and the full suite is now race-clean.

## Still not covered

A live end-to-end upload against the real vault, because every Codex account on this machine currently needs re-authentication (`refresh_token_reused`) and the one healthy account is out of weekly quota. The vault client's HTTP surface is faked here, not exercised.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787964695&installation_model_id=21920&pr_number=111&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F111&signature=ecae189803fc06b876868c409bd3f187485cb8c78c09ae2b083974bb618b15d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a rotating OAuth test server and end-to-end tests for refresh and upload to match real single-use token semantics and prevent `refresh_token_reused` regressions. Also fixes a data race in proxy websocket log tests.

- **New Features**
  - Added a fake OAuth server that invalidates refresh tokens on use and tracks exchanges and reuse.
  - Expanded refresh coverage: sequential rotation, concurrent forced refreshes, concurrent expired-path collapsing to one exchange, two store handles on one dir, and recording terminal failure on reused tokens.
  - Added upload tests against a fake vault: single-label upload, bulk upload with confirmation, dry-run, skip existing credentials, and idempotent reruns.
  - Made `codexOAuthTokenURL` a var so tests can target the fake provider; production does not reassign it.

- **Bug Fixes**
  - Removed a data race in `TestHandlerLogsUpstreamResponseStreamReadErrors` by using a synchronized buffer for logger output.

<sup>Written for commit 2f8908c375e5d2637acc8cb4f07caffec676ced0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

