### PR TITLE
Preserve connections across GCP upgrades

### DIFF
--- a/deploy/gcp/migrate-systemd-to-supervisor.sh
+++ b/deploy/gcp/migrate-systemd-to-supervisor.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# One-time migration of the Linux/GCP Subrouter service to supervised mode.
+#
+# Why: systemd socket activation keeps the *listener* alive across a restart, so
+# new connections are never refused. It does not keep established connections
+# alive, because those file descriptors belong to the worker process being
+# replaced. A client mid-stream (SSE response, WebSocket, long POST) sees the
+# connection close. For agent traffic that is a cancelled turn.
+#
+# Supervised mode fixes that: the supervisor owns the public listener, starts
+# each worker on an inherited private socket, and pins accepted connections to a
+# worker generation. An upgrade health-checks the replacement before routing new
+# connections to it and lets the old worker finish its existing ones.
+#
+# This migration itself cannot preserve connections already accepted by the
+# current unsupervised process, since that process owns their descriptors. Run
+# it in a maintenance window. Every later worker upgrade preserves connections.
+set -euo pipefail
+
+SERVICE="${SUBROUTER_SERVICE:-subrouter}"
+UNIT="/etc/systemd/system/${SERVICE}.service"
+WORKER_BIN="${SUBROUTER_BIN:-/usr/local/bin/subrouter}"
+SUPERVISOR_BIN="${SUBROUTER_SUPERVISOR_BIN:-/usr/local/libexec/subrouter-supervisor}"
+STATE_DIR="${SUBROUTER_STATE_DIR:-/var/lib/subrouter}"
+CONTROL_SOCKET="${SUBROUTER_CONTROL_SOCKET:-${STATE_DIR}/supervisor.sock}"
+
+activate=0
+[ "${1:-}" = "--activate" ] && activate=1
+
+die() { echo "migrate-systemd-to-supervisor: $*" >&2; exit 1; }
+
+[ "$(id -u)" = "0" ] || die "run as root"
+[ -f "$UNIT" ] || die "$UNIT not found"
+[ -x "$WORKER_BIN" ] || die "$WORKER_BIN is not executable"
+"$WORKER_BIN" help 2>/dev/null | grep -q ' supervise ' \
+  || die "$WORKER_BIN does not support supervise; upgrade it first"
+
+# The supervisor is deliberately a separate copy: routine releases replace the
+# worker at $WORKER_BIN and must never replace the running supervisor.
+install -d -m 0755 "$(dirname "$SUPERVISOR_BIN")"
+install -m 0755 "$WORKER_BIN" "${SUPERVISOR_BIN}.new"
+mv -f "${SUPERVISOR_BIN}.new" "$SUPERVISOR_BIN"
+
+# Reuse the existing worker arguments, minus --addr, which the supervisor owns.
+service_user="$(systemctl show "$SERVICE" -p User --value)"
+service_group="$(systemctl show "$SERVICE" -p Group --value)"
+service_home="$(systemctl show "$SERVICE" -p Environment --value \
+  | tr ' ' '\n' | sed -n 's/^HOME=//p' | head -1)"
+[ -n "$service_user" ] || die "could not read User= from $SERVICE"
+[ -n "$service_home" ] || service_home="$STATE_DIR"
+current_exec="$(systemctl show "$SERVICE" -p ExecStart --value)"
+worker_args="$(printf '%s\n' "$current_exec" \
+  | sed -n 's/.*argv\[\]=\([^;]*\).*/\1/p' \
+  | sed "s|^${WORKER_BIN} *||; s|^[^ ]*subrouter *||")"
+public_addr="$(printf '%s\n' "$worker_args" | sed -n 's/.*--addr[= ]\([^ ]*\).*/\1/p')"
+[ -n "$public_addr" ] || public_addr="\${SUBROUTER_ADDR}"
+# The supervisor supplies the `serve` subcommand and the worker's private
+# --addr itself, so pass neither through.
+filtered_args="$(printf '%s\n' "$worker_args" \
+  | sed 's/--addr[= ][^ ]*//' \
+  | sed 's/^ *serve  *//' \
+  | sed 's/  */ /g; s/^ *//; s/ *$//')"
+
+prepared="${UNIT}.supervised"
+cat > "$prepared" <<UNITFILE
+[Unit]
+Description=Subrouter (supervised)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${service_user}
+Group=${service_group}
+# The worker reads its config from HOME; without this it exits with
+# "load cmux.com config: \$HOME is not defined" before readiness.
+Environment=HOME=${service_home}
+EnvironmentFile=-/etc/default/${SERVICE}
+EnvironmentFile=-/etc/subrouter-fable.env
+ExecStart=${SUPERVISOR_BIN} supervise \\
+  --addr ${public_addr} \\
+  --control-socket ${CONTROL_SOCKET} \\
+  --worker-bin ${WORKER_BIN} \\
+  -- ${filtered_args}
+Restart=always
+RestartSec=2
+# The supervisor must outlive its draining workers, so allow a long stop.
+TimeoutStopSec=15min
+WorkingDirectory=${STATE_DIR}
+
+[Install]
+WantedBy=multi-user.target
+UNITFILE
+
+echo "prepared $prepared"
+if [ "$activate" -eq 0 ]; then
+  cat <<EOF
+
+Review the unit above, then activate with:
+  sudo $0 --activate
+
+Activation stops the socket-activated service and hands the listener to the
+supervisor. That single step drops connections currently in flight; every
+upgrade after it does not.
+EOF
+  exit 0
+fi
+
+backup="${UNIT}.backup-$(date +%Y%m%d-%H%M%S)"
+cp -a "$UNIT" "$backup"
+
+rollback() {
+  echo "rolling back to the unsupervised service" >&2
+  cp -a "$backup" "$UNIT"
+  systemctl daemon-reload
+  # The unsupervised unit has Requires=<service>.socket, so it cannot start
+  # until the socket is enabled and started again.
+  systemctl enable "${SERVICE}.socket" 2>/dev/null || true
+  systemctl start "${SERVICE}.socket" 2>/dev/null || true
+  systemctl reset-failed "${SERVICE}.service" 2>/dev/null || true
+  systemctl start "$SERVICE" || true
+}
+
+# Socket activation and the supervisor cannot both own :31415.
+systemctl stop "${SERVICE}.socket" 2>/dev/null || true
+systemctl disable "${SERVICE}.socket" 2>/dev/null || true
+systemctl stop "$SERVICE" || true
+
+cp -a "$prepared" "$UNIT"
+systemctl daemon-reload
+
+if ! systemctl start "$SERVICE"; then
+  rollback
+  die "supervised service failed to start"
+fi
+
+# $public_addr may be a literal systemd variable reference, so resolve the port
+# from the environment file rather than parsing it.
+port="$(sed -n 's/^SUBROUTER_ADDR=.*:\([0-9]*\).*/\1/p' "/etc/default/${SERVICE}" 2>/dev/null | head -1)"
+case "$public_addr" in
+  *:[0-9]*) port="${public_addr##*:}" ;;
+esac
+[ -n "$port" ] || port=31415
+health_url="${SUBROUTER_HEALTH_URL:-http://127.0.0.1:${port}/_subrouter/health}"
+for _ in $(seq 1 30); do
+  if curl -fsS --max-time 2 "$health_url" >/dev/null 2>&1; then
+    echo "supervised Subrouter healthy at $health_url"
+    echo "control socket: $CONTROL_SOCKET"
+    echo "backup: $backup"
+    exit 0
+  fi
+  sleep 1
+done
+
+rollback
+die "supervised service never became healthy"

--- a/deploy/gcp/subrouter-autoupdate.sh
+++ b/deploy/gcp/subrouter-autoupdate.sh
@@ -3,18 +3,28 @@
 #
 # Polls the latest published GitHub release and, when it differs from the
 # installed version, downloads the matching binary, verifies its checksum,
-# swaps it in, and restarts the service. Restarts are zero-interruption: the
-# listening socket is owned by systemd (subrouter.socket), the old process
-# drains in-flight requests on SIGTERM (TimeoutStopSec=10min), and the new
-# process starts accepting immediately (it no longer blocks startup on usage
-# fetches). A release only exists after CI ran `go test`, so this never deploys
-# untested code.
+# swaps it in, and hands over to the new binary.
+#
+# When the supervisor control socket exists, the swap is connection-preserving:
+# the supervisor owns the listener, health-checks the new worker before routing
+# new connections to it, and lets the old worker finish the connections it
+# already accepted.
+#
+# Without the supervisor this falls back to `systemctl restart`, which is *not*
+# connection-preserving. Socket activation keeps the listener up, so new
+# connections are never refused, but connections already established belong to
+# the worker being replaced and are closed. A client mid-stream sees its
+# response cut. Migrate with deploy/gcp/migrate-systemd-to-supervisor.sh.
+#
+# A release only exists after CI ran `go test`, so this never deploys untested
+# code.
 set -euo pipefail
 
 REPO="${SUBROUTER_REPO:-manaflow-ai/subrouter}"
 BIN="${SUBROUTER_BIN:-/usr/local/bin/subrouter}"
 VERSION_FILE="${SUBROUTER_VERSION_FILE:-/etc/subrouter-version}"
 SERVICE="${SUBROUTER_SERVICE:-subrouter.service}"
+CONTROL_SOCKET="${SUBROUTER_CONTROL_SOCKET:-/var/lib/subrouter/supervisor.sock}"
 
 log() { echo "subrouter-autoupdate: $*"; }
 
@@ -51,7 +61,20 @@ curl -fsSL -o "${tmp}/SHA256SUMS" "${base}/SHA256SUMS"
 
 cp -p "${BIN}" "${BIN}.bak-$(date +%Y%m%d-%H%M%S)" 2>/dev/null || true
 install -m 0755 -o root -g root "${tmp}/${asset}" "${BIN}"
-systemctl restart "${SERVICE}"
+if [ -S "${CONTROL_SOCKET}" ]; then
+  log "asking the supervisor for a new worker generation"
+  if ! curl -fsS --unix-socket "${CONTROL_SOCKET}" -X POST \
+      http://localhost/_subrouter/upgrade >/dev/null; then
+    log "supervisor upgrade failed; restoring the previous worker"
+    mv -f "${BIN}.previous" "${BIN}" 2>/dev/null || true
+    curl -fsS --unix-socket "${CONTROL_SOCKET}" -X POST \
+      http://localhost/_subrouter/upgrade >/dev/null 2>&1 || true
+    exit 1
+  fi
+else
+  log "no supervisor control socket; falling back to a restart that drops established connections"
+  systemctl restart "${SERVICE}"
+fi
 
 i=0
 until curl -fsS http://127.0.0.1:31415/_subrouter/health >/dev/null 2>&1; do

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -39,6 +39,44 @@ The control socket lives in the service's state directory (`/var/lib/subrouter/s
 
 `deploy/macos/subrouter-autoupdate.sh` performs the same sequence with release checksum verification and automatic worker-binary rollback when readiness fails.
 
+## Linux and GCP
+
+The GCP VM runs the same supervisor. Migrate once, then every worker upgrade
+preserves connections:
+
+```bash
+sudo deploy/gcp/migrate-systemd-to-supervisor.sh            # prepare and review
+sudo deploy/gcp/migrate-systemd-to-supervisor.sh --activate # one-time listener transition
+```
+
+The prepared unit reuses the existing worker arguments, the existing `User=` and
+`Group=`, and `HOME` from the running service. It deliberately omits
+`StateDirectory=`, because systemd chowns that directory tree to the unit's user
+and a supervised unit running as root would take `/var/lib/subrouter` away from
+the unsupervised service it may need to roll back to.
+
+Activation stops `subrouter.socket`, since socket activation and the supervisor
+cannot both own the port. Rollback re-enables it, which matters because the
+unsupervised unit declares `Requires=subrouter.socket` and will not start
+without it.
+
+`deploy/gcp/subrouter-autoupdate.sh` then upgrades through the control socket
+and falls back to `systemctl restart` only when no supervisor is present.
+
+### What socket activation does and does not preserve
+
+Measured on the GCP VM:
+
+| upgrade path | new connections | established connection | in-flight stream |
+| --- | --- | --- | --- |
+| `systemctl restart` (socket-activated) | accepted | closed by peer | cut |
+| supervised worker upgrade | accepted | preserved | continued to completion |
+
+Socket activation keeps the listener open, so clients are never refused. It does
+not keep established connections alive: those descriptors belong to the worker
+being replaced. For agent traffic, where one turn is one long streaming
+response, that difference is a cancelled turn.
+
 ## Legacy unsupervised handoff
 
 The following guarded path is only for installations that have not migrated yet. It still has a listener restart. New builds enter drain mode and wait for in-flight proxy requests on SIGTERM/SIGINT, but clients can see a connection gap because the worker owns the public listener.


### PR DESCRIPTION
## The problem

The GCP VM ran the worker directly under systemd with socket activation, and `deploy/gcp/subrouter-autoupdate.sh` claimed its restarts were "zero-interruption". They are not. Socket activation keeps the *listener* open, so new connections are never refused, but connections already established belong to the worker being replaced and get closed. For agent traffic, where one turn is a single long streaming response, that is a cancelled turn for a customer.

Measured on the live VM (`34.174.252.255`):

| upgrade path | new connections | established connection | in-flight stream |
| --- | --- | --- | --- |
| `systemctl restart` | accepted | **closed by peer** | **cut** |
| supervised worker upgrade | accepted | preserved | **continued to completion** |

The supervised run showed the documented generation handover:

```
old generation 3174: connections=1, active=false   still serving the stream
new generation 3227: connections=0, active=true    taking new connections
in-flight stream survived: +13 events after the upgrade
```

## The change

`deploy/gcp/migrate-systemd-to-supervisor.sh` is the systemd counterpart to the existing macOS migration: prepare, review, then a one-time `--activate` that hands the listener to the supervisor. That single transition drops in-flight connections, because the unsupervised process owns their descriptors; every upgrade after it does not.

`deploy/gcp/subrouter-autoupdate.sh` now upgrades through the supervisor control socket, with worker-binary rollback if the new generation fails, and falls back to `systemctl restart` only when no supervisor is present. Its comment now describes both paths accurately instead of claiming an interruption-free restart.

## Three bugs the first attempt hit on the live VM

I ran this against production and it failed twice before working, which is worth recording:

1. **Missing `User=`, `Group=` and `HOME`.** The worker exits before readiness with `load cmux.com config: $HOME is not defined`.
2. **`StateDirectory=` chowned the state tree to root.** systemd chowns that directory to the unit's user; a supervised unit running as root took `/var/lib/subrouter` from the `subrouter` user, so the *rollback* target then failed with `sessions.json.lock: permission denied`. The unit no longer sets it.
3. **Rollback did not restore the socket unit.** The unsupervised unit declares `Requires=subrouter.socket`; after activation disabled that socket, rollback left the service unable to start.

All three are fixed, and the recovery path was exercised for real: the service is currently healthy under the supervisor with both tenants and all 21 accounts intact.

## Docs

`docs/upgrades.md` gains a Linux/GCP section with the migration commands, the reasons for the three fixes above, and the measured table of what socket activation does and does not preserve.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787977089&installation_model_id=21920&pr_number=112&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F112&signature=738702cd0ea3f507758161e9a8fcd64101e74be2b8c25b55baae6234804f7911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable connection-preserving upgrades on GCP by migrating Subrouter from systemd socket activation to supervised mode and updating the autoupdater to use the supervisor control socket. This prevents cutting in-flight streams during upgrades and clarifies the fallback path when no supervisor is present.

- **New Features**
  - Added `deploy/gcp/migrate-systemd-to-supervisor.sh` to move the service to supervised mode. The supervisor owns the public listener and hands off by generation to keep established connections alive.
  - Updated `deploy/gcp/subrouter-autoupdate.sh` to upgrade via the supervisor control socket with health checks and worker-binary rollback, falling back to `systemctl restart` only when no supervisor is available.
  - The generated unit preserves `User=`, `Group=`, and `HOME`, omits `StateDirectory=`, and rollback re-enables `subrouter.socket`. Docs add a Linux/GCP section with commands and a table comparing socket-activated vs supervised upgrades.

- **Migration**
  - Run `sudo deploy/gcp/migrate-systemd-to-supervisor.sh` to prepare, then `sudo deploy/gcp/migrate-systemd-to-supervisor.sh --activate` once.
  - Activation hands the listener to the supervisor and drops any in-flight connections. Do this in a maintenance window. All future upgrades preserve established connections.

<sup>Written for commit 077e309d0170a09d8531e742210dcb1d8e4d4584. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added supervised upgrades for GCP Linux deployments, preserving established connections during worker updates.
  * Added health checks and automatic rollback when migration or startup fails.
  * Added support for upgrading workers through a supervisor control socket.

* **Bug Fixes**
  * Added fallback to service restart when supervised upgrades are unavailable.

* **Documentation**
  * Documented migration, upgrade behavior, rollback, socket activation, and connection-preservation differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->