### PR TITLE
Page on subrouter-verify alerts and check liveness

### DIFF
--- a/deploy/gcp/subrouter-verify.sh
+++ b/deploy/gcp/subrouter-verify.sh
@@ -25,14 +25,45 @@ now_epoch=$(date -u +%s)
 now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 alerts=0
 
+# Alerts that only reach a journal are alerts nobody sees. The notify worker
+# requires a "sender" field and rejects the payload without it. When notify
+# credentials are present, every ALERT is also delivered to Slack; delivery
+# failures never fail the check, since a broken notifier must not mask the
+# problem it was reporting.
+NOTIFY_ENV="${SUBROUTER_NOTIFY_ENV:-/etc/subrouter/notify.env}"
+[ -r "$NOTIFY_ENV" ] && . "$NOTIFY_ENV"
+
+page() { # message...
+  [ -n "${CMUX_NOTIFY_URL:-}" ] || return 0
+  [ -n "${CMUX_NOTIFY_TOKEN:-}" ] || return 0
+  local host; host="$(hostname -s 2>/dev/null || echo subrouter)"
+  local text="[subrouter/${host}] $*"
+  curl -fsS --max-time 10 -X POST "$CMUX_NOTIFY_URL" \
+    -H "authorization: Bearer $CMUX_NOTIFY_TOKEN" \
+    -H 'content-type: application/json' \
+    --data "$(python3 -c 'import json,sys; print(json.dumps({"sender": "subrouter", "text": sys.argv[1]}))' "$text")" \
+    >/dev/null 2>&1 || true
+}
+
 emit() { # level msg...
   local level="$1"; shift
   local line="$now_iso [$level] $*"
   echo "SUBROUTER-VERIFY $line"
   echo "$line" >> "$ALERTS"
-  [ "$level" = "ALERT" ] && alerts=$((alerts + 1))
+  if [ "$level" = "ALERT" ]; then
+    alerts=$((alerts + 1))
+    page "$*"
+  fi
   return 0
 }
+
+# --- is the service answering at all? ---
+if ! curl -fsS --max-time 5 "$HEALTH" >/dev/null 2>&1; then
+  emit ALERT "health endpoint is not answering at $HEALTH; service is down"
+else
+  active_state="$(systemctl is-active "$UNIT" 2>/dev/null || true)"
+  [ "$active_state" = "active" ] || emit ALERT "$UNIT is $active_state"
+fi
 
 # --- healthy Claude account count from usage-status (for the invariant) ---
 counts=$(curl -fsS "$USAGE" 2>/dev/null | python3 -c '


### PR DESCRIPTION
## Why

`subrouter-verify` wrote ALERT lines to a journal and `/var/lib/subrouter-verify/alerts.log`. Nothing read either. Production was down for several minutes today and the only reason it was caught is that I ran a health check by hand.

Worse, the check could not have caught it: it inspected Claude reroute behaviour and account counts, but never whether the service was answering at all.

## Changes

Every ALERT posts to the cmux notify worker when `/etc/subrouter/notify.env` provides `CMUX_NOTIFY_URL` and `CMUX_NOTIFY_TOKEN`. The worker requires a `sender` field (`{"error":"sender_required"}` without it), so the payload is `{"sender":"subrouter","text":"[subrouter/<host>] …"}`.

Delivery failures are deliberately swallowed. A notifier that fails must not mask the condition it was reporting, and must not fail the check that found it.

Adds a liveness check: health endpoint answering, and unit active. That is the condition that took the service down today.

## Delivery is currently blocked outside this repo

The worker reaches Slack but the bot is not in the target channel:

```
502 {"error":"slack_post_failed","slack_error":"missing_scope",
     "channel":"C0BA32V49FD",
     "hint":"invite the bot to the channel (/invite @cmux Internal Tools) or grant channels:join"}
```

So alerts will fire and be logged, but will not reach Slack until the bot is invited. That is a Slack workspace action, not a code change.

## Verified

The timer is installed and active on `subrouter-team`. The payload shape was confirmed against the live worker: `{"text":…}` returns `sender_required`, `{"sender":…,"text":…}` reaches Slack and fails only on the channel scope above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787978304&installation_model_id=21920&pr_number=113&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F113&signature=ce2e8171e32f1b59b3ffaf0c18206563a93e779405306dc64e6f7f80f86e7af5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send `subrouter-verify` ALERTs to the `cmux` notify worker and add a liveness check (health endpoint + unit state) to surface outages fast. Alerts no longer just write to disk; they can page Slack when configured.

- **New Features**
  - Posts every ALERT to the notify worker when `/etc/subrouter/notify.env` provides `CMUX_NOTIFY_URL` and `CMUX_NOTIFY_TOKEN` with payload `{"sender":"subrouter","text":"[subrouter/<host>] ..."}`.
  - Swallows notify delivery failures so checks don’t fail because paging is broken.
  - Adds liveness check: fails if the health endpoint doesn’t answer or the systemd unit isn’t active.

- **Migration**
  - Set `CMUX_NOTIFY_URL` and `CMUX_NOTIFY_TOKEN` in `/etc/subrouter/notify.env`.
  - Invite the Slack bot to the target channel or grant `channels:join` (e.g., `/invite @cmux Internal Tools`) so messages deliver.

<sup>Written for commit ef1209ffd0e2b0a4a689272ecead7920d95cdb79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

