### PR TITLE
Make the autoupdater's failure paths real, and let verify only emit

### DIFF
--- a/deploy/gcp/subrouter-autoupdate.sh
+++ b/deploy/gcp/subrouter-autoupdate.sh
@@ -59,14 +59,32 @@ curl -fsSL -o "${tmp}/${asset}" "${base}/${asset}"
 curl -fsSL -o "${tmp}/SHA256SUMS" "${base}/SHA256SUMS"
 ( cd "${tmp}" && grep " ${asset}\$" SHA256SUMS | sha256sum -c - )
 
-cp -p "${BIN}" "${BIN}.bak-$(date +%Y%m%d-%H%M%S)" 2>/dev/null || true
-install -m 0755 -o root -g root "${tmp}/${asset}" "${BIN}"
+previous="${BIN}.bak-$(date +%Y%m%d-%H%M%S)"
+cp -p "${BIN}" "${previous}" 2>/dev/null || true
+# Write beside the target and rename, never onto it. Opening a running
+# executable for writing fails with ETXTBSY ("Text file busy"); rename replaces
+# the directory entry and leaves the running inode alone. Reproduced on the
+# staging VM, where writing directly to /usr/local/bin/subrouter fails while the
+# service is up.
+install -m 0755 -o root -g root "${tmp}/${asset}" "${BIN}.incoming"
+mv -f "${BIN}.incoming" "${BIN}"
+
+# Assert the bytes on disk are the bytes we verified. Overwriting a running
+# binary can fail (ETXTBSY) or partially succeed, and a silent no-op here means
+# the old code keeps serving while the version file claims otherwise.
+expected_sum="$(awk -v a="${asset}" '$2 == a || $2 == "*" a {print $1}' "${tmp}/SHA256SUMS" | head -1)"
+installed_sum="$(sha256sum "${BIN}" | awk '{print $1}')"
+if [ -n "${expected_sum}" ] && [ "${expected_sum}" != "${installed_sum}" ]; then
+  log "installed binary does not match the verified checksum; restoring ${previous}"
+  [ -f "${previous}" ] && mv -f "${previous}" "${BIN}"
+  exit 1
+fi
 if [ -S "${CONTROL_SOCKET}" ]; then
   log "asking the supervisor for a new worker generation"
   if ! curl -fsS --unix-socket "${CONTROL_SOCKET}" -X POST \
       http://localhost/_subrouter/upgrade >/dev/null; then
-    log "supervisor upgrade failed; restoring the previous worker"
-    mv -f "${BIN}.previous" "${BIN}" 2>/dev/null || true
+    log "supervisor upgrade failed; restoring ${previous}"
+    [ -f "${previous}" ] && mv -f "${previous}" "${BIN}"
     curl -fsS --unix-socket "${CONTROL_SOCKET}" -X POST \
       http://localhost/_subrouter/upgrade >/dev/null 2>&1 || true
     exit 1
@@ -80,7 +98,18 @@ i=0
 until curl -fsS http://127.0.0.1:31415/_subrouter/health >/dev/null 2>&1; do
   i=$((i + 1))
   if [ "${i}" -ge 30 ]; then
-    log "health check failed after restart; leaving new binary in place"
+    # Leaving a binary that cannot pass a health check in place is how a bad
+    # release becomes a permanent outage. Put the previous one back.
+    log "health check failed after upgrade; restoring ${previous}"
+    if [ -f "${previous}" ]; then
+      mv -f "${previous}" "${BIN}"
+      if [ -S "${CONTROL_SOCKET}" ]; then
+        curl -fsS --unix-socket "${CONTROL_SOCKET}" -X POST \
+          http://localhost/_subrouter/upgrade >/dev/null 2>&1 || true
+      else
+        systemctl restart "${SERVICE}" || true
+      fi
+    fi
     exit 1
   fi
   sleep 1

--- a/deploy/gcp/subrouter-verify.sh
+++ b/deploy/gcp/subrouter-verify.sh
@@ -25,26 +25,10 @@ now_epoch=$(date -u +%s)
 now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 alerts=0
 
-# Alerts that only reach a journal are alerts nobody sees. The notify worker
-# requires a "sender" field and rejects the payload without it. When notify
-# credentials are present, every ALERT is also delivered to Slack; delivery
-# failures never fail the check, since a broken notifier must not mask the
-# problem it was reporting.
-NOTIFY_ENV="${SUBROUTER_NOTIFY_ENV:-/etc/subrouter/notify.env}"
-[ -r "$NOTIFY_ENV" ] && . "$NOTIFY_ENV"
-
-page() { # message...
-  [ -n "${CMUX_NOTIFY_URL:-}" ] || return 0
-  [ -n "${CMUX_NOTIFY_TOKEN:-}" ] || return 0
-  local host; host="$(hostname -s 2>/dev/null || echo subrouter)"
-  local text="[subrouter/${host}] $*"
-  curl -fsS --max-time 10 -X POST "$CMUX_NOTIFY_URL" \
-    -H "authorization: Bearer $CMUX_NOTIFY_TOKEN" \
-    -H 'content-type: application/json' \
-    --data "$(python3 -c 'import json,sys; print(json.dumps({"sender": "subrouter", "text": sys.argv[1]}))' "$text")" \
-    >/dev/null 2>&1 || true
-}
-
+# This check emits; it does not deliver. A Cloud Monitoring log-based alert
+# policy matches "[ALERT]" in these lines and owns notification, rate limiting,
+# grouping and auto-close. Keeping delivery out of here means no webhook
+# credentials on the box and one place to change where alerts go.
 emit() { # level msg...
   local level="$1"; shift
   local line="$now_iso [$level] $*"
@@ -52,7 +36,6 @@ emit() { # level msg...
   echo "$line" >> "$ALERTS"
   if [ "$level" = "ALERT" ]; then
     alerts=$((alerts + 1))
-    page "$*"
   fi
   return 0
 }


### PR DESCRIPTION
## Three defects in the upgrade path

Two of these I introduced in #112, and staging found them before production did.

**The rollback restored a file that never exists.** Every failure branch did `mv -f "${BIN}.previous" "${BIN}"`, but the backup is written as `"${BIN}.bak-<timestamp>"`. So all rollbacks were silent no-ops. The backup path is now a variable.

**A failed health check left the broken binary in place.** It logged "leaving new binary in place" and exited 1, which converts a bad release into a permanent outage. It now restores the previous binary and asks the supervisor for a generation on it.

**The updater wrote onto the running binary.** Opening a running executable for writing fails with `ETXTBSY`. Reproduced directly on staging:

```
$ printf '...' | sudo tee /usr/local/bin/subrouter
tee: /usr/local/bin/subrouter: Text file busy
```

This is the same failure that silently reverted a hand deploy earlier in the day, where the old binary kept serving while I believed the new one was live. The updater now installs beside the target and `mv`s it into place, and asserts the installed bytes match the checksum it verified, so a partial or refused write cannot leave old code running behind a new version file.

## A safety property worth recording

Planting a deliberately broken worker on staging and asking the supervisor to adopt it:

```
health before        -> 200
planted broken worker via rename
health with broken   -> 200      <-- old generation still serving
health after revert  -> 200
```

The supervisor will not promote a worker that never becomes ready, so a bad release degrades to "no upgrade" rather than an outage. That is the behaviour the rollback path is a second line of defence for.

## verify emits, Monitoring delivers

`subrouter-verify` no longer posts to a webhook. A Cloud Monitoring log-based alert policy matches `[ALERT]` in its output and owns notification, rate limiting, grouping, and auto-close, with an email channel attached. The service emits; the monitoring system decides and delivers.

This removes the bespoke delivery code added in #113, keeps webhook credentials off the VM, and leaves one place to change where alerts go. Worth noting the class of bug this avoids: the first version of that policy filtered on `textPayload`, which the Ops Agent never populates, so it would have matched nothing forever. Alert rules need a synthetic trigger to prove they work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787994231&installation_model_id=21920&pr_number=114&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F114&signature=c846c7fea5deb192341f7de5788ebb128a0641249a0ebf805fe2c9dd5ce528d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the autoupdater so rollbacks actually work and failed upgrades revert cleanly, and changes `subrouter-verify` to only emit logs for alerts while Cloud Monitoring handles delivery.

- **Bug Fixes**
  - Use the real backup path and restore it on any failure.
  - Install beside the running binary and `mv` into place to avoid ETXTBSY; verify the installed checksum matches the release.
  - On health check failure after upgrade, restore the previous binary and request a new generation (or restart).

- **Migration**
  - Set a Cloud Monitoring log-based alert to match “[ALERT]” in `SUBROUTER-VERIFY` lines; remove webhook credentials from the VM.

<sup>Written for commit 47b82f4e39c699cfc8f22135304fc62d9156d0c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved binary updates with checksum verification and safer replacement handling.
  - Automatically restores the previous version when an upgrade or health check fails.
  - Added recovery actions to restart or re-trigger the service after an unsuccessful update.
  - Reduced the risk of running a corrupted or unhealthy version.

- **Changes**
  - Verification alerts are now recorded locally instead of being sent through external notification delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->