### PR TITLE
sr add asks which provider instead of assuming Codex

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -1007,7 +1007,9 @@ Team vault management:
 
 Usage:
   %[1]s                    Show Codex and Claude usage, grouped by provider
-  %[1]s add                Add a new Codex account (opens OAuth login)
+  %[1]s add                Add an account; asks whether it is Codex or Claude
+  %[1]s add codex          Add a Codex account (opens OAuth login)
+  %[1]s add claude         Add a Claude account (opens OAuth login)
   %[1]s add-key            Add an API key account
   %[1]s import             Import current ~/.codex/auth.json account
   %[1]s list               List all Codex accounts

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -215,7 +215,7 @@ func (r srRunner) run(ctx context.Context, args []string) error {
 	}
 	switch args[0] {
 	case "add":
-		return r.add(ctx)
+		return r.addProvider(ctx, args[1:])
 	case "logout":
 		return r.cloudLogout(ctx)
 	case "team":
@@ -429,6 +429,56 @@ func parseRemoteAddArgs(command string, args []string) (bool, error) {
 
 func (r srRunner) unsupportedRemoteCommand(command string, server srServerConfig, detail string) error {
 	return fmt.Errorf("%s is configured to use server %s (%s), so %s will not edit local Codex state; %s", r.programOrSubrouter(), server.Name, server.URL, r.programOrSubrouter()+" "+command, detail)
+}
+
+// addProvider is the one command a new user runs to attach a credential.
+// "sr add codex" and "sr add claude" are explicit; bare "sr add" asks, because
+// a user who has just installed this does not yet know which provider names the
+// tool expects, and guessing Codex silently was a trap for Claude users.
+func (r srRunner) addProvider(ctx context.Context, args []string) error {
+	provider := ""
+	if len(args) > 0 {
+		provider = strings.ToLower(strings.TrimSpace(args[0]))
+	}
+	if provider == "" {
+		chosen, err := r.promptProvider()
+		if err != nil {
+			return err
+		}
+		provider = chosen
+	}
+	switch provider {
+	case "codex", "openai", "chatgpt":
+		return r.add(ctx)
+	case "claude", "anthropic":
+		return r.claude(ctx, append([]string{"add"}, args[1:]...))
+	default:
+		return fmt.Errorf("unknown provider %q; use '%s add codex' or '%s add claude'",
+			provider, r.program, r.program)
+	}
+}
+
+// promptProvider asks which provider to attach. A non-interactive caller gets
+// an error naming both commands rather than a hang on a read that never returns.
+func (r srRunner) promptProvider() (string, error) {
+	if !readerIsTerminal(r.in) {
+		return "", fmt.Errorf("no provider given; run '%s add codex' or '%s add claude'",
+			r.program, r.program)
+	}
+	fmt.Fprintf(r.out, "Which account do you want to add?\n\n  1) Codex   (ChatGPT subscription or API key)\n  2) Claude  (Anthropic subscription or API key)\n\nChoice [1]: ")
+	line, err := bufio.NewReader(r.in).ReadString('\n')
+	if err != nil && strings.TrimSpace(line) == "" {
+		return "", fmt.Errorf("no provider selected")
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "", "1", "codex":
+		return "codex", nil
+	case "2", "claude":
+		return "claude", nil
+	default:
+		return "", fmt.Errorf("unrecognised choice %q; run '%s add codex' or '%s add claude'",
+			strings.TrimSpace(line), r.program, r.program)
+	}
 }
 
 func (r srRunner) add(ctx context.Context) error {

--- a/cmd/subrouter/sr_add_provider_test.go
+++ b/cmd/subrouter/sr_add_provider_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// "sr add" with no argument must not silently pick a provider. A Claude user
+// who runs it and gets a ChatGPT login has been sent somewhere they did not ask
+// to go, and on a pipe it must say what to run rather than block on a read.
+func TestAddWithoutProviderRefusesNonInteractively(t *testing.T) {
+	var out, errOut bytes.Buffer
+	runner := srRunner{program: "sr", in: strings.NewReader(""), out: &out, errOut: &errOut}
+	err := runner.addProvider(context.Background(), nil)
+	if err == nil {
+		t.Fatal("bare 'sr add' on a pipe did not error")
+	}
+	for _, want := range []string{"sr add codex", "sr add claude"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not tell the user to run %q", err.Error(), want)
+		}
+	}
+}
+
+func TestAddRejectsUnknownProvider(t *testing.T) {
+	var out, errOut bytes.Buffer
+	runner := srRunner{program: "sr", in: strings.NewReader(""), out: &out, errOut: &errOut}
+	err := runner.addProvider(context.Background(), []string{"gemini"})
+	if err == nil || !strings.Contains(err.Error(), "gemini") {
+		t.Fatalf("error = %v, want it to name the unknown provider", err)
+	}
+	if !strings.Contains(err.Error(), "sr add codex") {
+		t.Errorf("error %q does not suggest a valid provider", err.Error())
+	}
+}
+
+// Aliases exist because users type what their vendor calls itself.
+func TestProviderAliasesResolve(t *testing.T) {
+	for _, alias := range []string{"codex", "Codex", "openai", "chatgpt", "claude", "CLAUDE", "anthropic"} {
+		var out, errOut bytes.Buffer
+		runner := srRunner{program: "sr", in: strings.NewReader(""), out: &out, errOut: &errOut}
+		err := runner.addProvider(context.Background(), []string{alias})
+		// These reach the real login paths, which fail in a test environment.
+		// What matters is that they are not rejected as unknown providers.
+		if err != nil && strings.Contains(err.Error(), "unknown provider") {
+			t.Errorf("alias %q was rejected as unknown", alias)
+		}
+	}
+}

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -15,6 +15,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+
+	"golang.org/x/term"
 	"sort"
 	"strings"
 	"time"
@@ -1375,6 +1377,16 @@ func (r srRunner) startServerUploadProgress(email, serverName string) func() {
 		close(done)
 		<-finished
 	}
+}
+
+// readerIsTerminal reports whether input comes from a human. A prompt on a pipe
+// would block forever, so callers use this to fail with instructions instead.
+func readerIsTerminal(rd io.Reader) bool {
+	file, ok := rd.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(file.Fd()))
 }
 
 func writerIsTerminal(w io.Writer) bool {


### PR DESCRIPTION
## Why

`sr add` opened a ChatGPT OAuth login with no way to say otherwise. Adding a Claude account required knowing to type `sr claude add`, which a new user cannot guess. A Claude user running the documented command was sent to the wrong vendor's login page and had no signal that they had.

## Change

```
sr add            asks whether it is Codex or Claude
sr add codex      Codex OAuth
sr add claude     Claude OAuth
```

`openai`, `chatgpt` and `anthropic` are accepted as aliases, because people type what their vendor calls itself rather than what our CLI calls it.

A prompt on a pipe blocks on a read that never returns, so a non-interactive caller gets an error that names both commands instead of hanging.

```
$ echo | sr add
subrouter: no provider given; run 'sr add codex' or 'sr add claude'

$ sr add gemini
subrouter: unknown provider "gemini"; use 'sr add codex' or 'sr add claude'
```

## Tests

Bare `add` on a pipe errors and names both commands; an unknown provider is rejected and names the valid ones; every alias resolves rather than being rejected as unknown.

## Not in this change

This only fixes the local `sr add`. The bigger onboarding problem is that attaching a credential to the hosted service still requires `sr server add --admin-token …` followed by `sr server login`, which is two commands too many and leaks an admin token to the client. That needs an identity flow on the hosted service, which does not exist yet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788035050&installation_model_id=21920&pr_number=115&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F115&signature=8a4164472610a5e202fd8a80a39eeacff060c638d0ea421abdcd57834164c87c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`sr add` now asks you to pick a provider instead of assuming Codex, so new users land in the right OAuth flow. It also avoids hanging in non-interactive runs by failing fast with clear guidance.

- **New Features**
  - Interactive provider choice: `sr add` prompts for Codex or Claude; explicit `sr add codex` and `sr add claude` also work. Accepts aliases: `openai`/`chatgpt` for Codex and `anthropic` for Claude. CLI help text updated.
  - Non-interactive safety: when input isn’t a TTY, `sr add` errors with “run 'sr add codex' or 'sr add claude'” instead of blocking. Uses `golang.org/x/term` to detect terminals. Tests cover alias resolution and error messages.

<sup>Written for commit b71fb327a2185fdedcf66a630d45b86ce5622b42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for adding either Codex or Claude accounts with `sr add codex` and `sr add claude`.
  * Running `sr add` interactively now prompts you to choose a provider.
  * Provider names and supported aliases are handled case-insensitively.

* **Bug Fixes**
  * Non-interactive usage now avoids hanging on prompts and provides clear guidance when a provider is required.
  * Unknown providers return an error listing valid commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->