### PR TITLE
Non-disruptive local upgrades, and make the deliverable testable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,31 @@ Go service for routing AI coding-agent traffic across subscription accounts and 
 - Do not log access tokens, refresh tokens, API keys, request bodies, or complete Authorization headers.
 - Prefer standard-library networking primitives unless a dependency removes meaningful complexity.
 
+## The deliverable is a command Lawrence can run on his Mac
+
+Work is not done when the server is correct. It is done when there is a command
+he can paste into his own terminal, on his own machine, and see the thing work.
+
+Every handoff states, in this order:
+
+1. The exact command(s) to run locally. No `ssh`, no `gcloud compute ssh`, no
+   admin token, no "first export this". If onboarding needs those, onboarding is
+   the bug.
+2. What he should see when it works.
+3. Anything that is *not* runnable by him, named explicitly, with the reason.
+
+Before claiming something works, run it the way he would: from a client machine,
+through the public endpoint, as a user without privileged credentials. Verifying
+from inside the VM, over SSH, or with an admin token proves the server works and
+says nothing about whether anyone can use it. Those are different claims and
+only the second one is the deliverable.
+
+An interactive OAuth login is the one thing an agent genuinely cannot complete.
+When a change depends on it, say so up front rather than at the end of a long
+report, because that sentence is the difference between him testing it now and
+him discovering he cannot after reading everything else.
+
+If a change cannot be exercised from his machine at all, say that plainly in the
+first line of the handoff. "Deployed and verified server-side, not yet testable
+by you, because X" is an acceptable status. Implying it is ready when it is not
+wastes the one thing he cannot get back.

--- a/deploy/macos/migrate-launchagent-to-supervisor.sh
+++ b/deploy/macos/migrate-launchagent-to-supervisor.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Put a per-user Subrouter LaunchAgent behind the supervisor, so upgrading the
+# binary stops cutting connections that coding agents are actively streaming on.
+#
+# The existing migrate-launchdaemon-to-supervisor.sh handles the system-wide
+# LaunchDaemon (/Library/LaunchDaemons, `system` domain, root). A developer
+# machine runs a per-user LaunchAgent instead (~/Library/LaunchAgents,
+# `gui/<uid>` domain, no sudo), which that script cannot touch.
+#
+# Without the supervisor, replacing ~/bin/subrouter and restarting the agent
+# closes every established connection: an agent mid-turn loses its response.
+# With it, the supervisor owns the listener, health-checks the replacement, and
+# lets the old worker finish the connections it already accepted.
+#
+# The one-time transition below still drops in-flight connections, because the
+# unsupervised process owns those file descriptors. Run it when no agent is
+# mid-turn. Every upgrade after it is non-disruptive.
+set -euo pipefail
+
+LABEL="${SUBROUTER_LABEL:-ai.manaflow.subrouter}"
+PLIST="${SUBROUTER_PLIST:-$HOME/Library/LaunchAgents/${LABEL}.plist}"
+WORKER_BIN="${SUBROUTER_BIN:-$HOME/bin/subrouter}"
+SUPERVISOR_BIN="${SUBROUTER_SUPERVISOR_BIN:-$HOME/bin/subrouter-supervisor}"
+STATE_DIR="${SUBROUTER_STATE_DIR:-$HOME/.subrouter}"
+CONTROL_SOCKET="${SUBROUTER_CONTROL_SOCKET:-${STATE_DIR}/supervisor.sock}"
+DOMAIN="gui/$(id -u)"
+
+activate=0
+[ "${1:-}" = "--activate" ] && activate=1
+
+die() { echo "migrate-launchagent-to-supervisor: $*" >&2; exit 1; }
+
+[ -f "$PLIST" ] || die "$PLIST not found"
+[ -x "$WORKER_BIN" ] || die "$WORKER_BIN is not executable"
+"$WORKER_BIN" help 2>/dev/null | grep -q ' supervise ' \
+  || die "$WORKER_BIN does not support supervise; upgrade it first"
+
+# A separate copy, because routine upgrades replace the worker and must never
+# replace the supervisor that is holding the listener.
+mkdir -p "$(dirname "$SUPERVISOR_BIN")"
+cp -f "$WORKER_BIN" "${SUPERVISOR_BIN}.new"
+chmod 0755 "${SUPERVISOR_BIN}.new"
+mv -f "${SUPERVISOR_BIN}.new" "$SUPERVISOR_BIN"
+# An ad-hoc signature keeps macOS from killing the copy with OS_REASON_CODESIGNING.
+codesign -s - -f "$SUPERVISOR_BIN" >/dev/null 2>&1 || true
+
+prepared="${PLIST}.supervised"
+python3 - "$PLIST" "$prepared" "$SUPERVISOR_BIN" "$WORKER_BIN" "$CONTROL_SOCKET" <<'PY'
+import plistlib
+import sys
+
+source, destination, supervisor_bin, worker_bin, control_socket = sys.argv[1:6]
+with open(source, "rb") as handle:
+    plist = plistlib.load(handle)
+
+arguments = list(plist.get("ProgramArguments") or [])
+if not arguments:
+    raise SystemExit("existing plist has no ProgramArguments")
+
+# The supervisor owns the public address and supplies `serve` plus the worker's
+# private socket itself, so strip both from the inherited arguments.
+public_addr = None
+filtered = []
+index = 1 if len(arguments) > 1 and arguments[1] == "serve" else 1
+filtered_source = arguments[index:]
+i = 0
+while i < len(filtered_source):
+    argument = filtered_source[i]
+    if argument == "--addr":
+        if i + 1 >= len(filtered_source):
+            raise SystemExit("existing --addr has no value")
+        public_addr = filtered_source[i + 1]
+        i += 2
+        continue
+    if argument.startswith("--addr="):
+        public_addr = argument.split("=", 1)[1]
+        i += 1
+        continue
+    filtered.append(argument)
+    i += 1
+
+if not public_addr:
+    raise SystemExit("could not find --addr in the existing plist")
+
+plist["Program"] = supervisor_bin
+plist["ProgramArguments"] = [
+    supervisor_bin,
+    "supervise",
+    "--addr", public_addr,
+    "--control-socket", control_socket,
+    "--worker-bin", worker_bin,
+    "--",
+    *filtered,
+]
+# The supervisor must outlive its draining workers.
+plist["ExitTimeOut"] = 600
+plist["ThrottleInterval"] = 10
+
+with open(destination, "wb") as handle:
+    plistlib.dump(plist, handle, fmt=plistlib.FMT_XML, sort_keys=False)
+print(public_addr)
+PY
+
+public_addr="$(python3 - "$prepared" <<'PY'
+import plistlib, sys
+with open(sys.argv[1], "rb") as handle:
+    plist = plistlib.load(handle)
+arguments = plist["ProgramArguments"]
+print(arguments[arguments.index("--addr") + 1])
+PY
+)"
+health_url="http://${public_addr}/_subrouter/health"
+case "$public_addr" in
+  0.0.0.0:*) health_url="http://127.0.0.1:${public_addr##*:}/_subrouter/health" ;;
+esac
+
+echo "prepared $prepared"
+if [ "$activate" -eq 0 ]; then
+  cat <<EOF
+
+Review the plist above, then activate with:
+  $0 --activate
+
+Activation restarts the agent once, which drops connections currently in
+flight. Do it when no coding agent is mid-turn. Every upgrade after it
+preserves connections.
+EOF
+  exit 0
+fi
+
+backup="${PLIST}.backup-$(date +%Y%m%d-%H%M%S)"
+cp -a "$PLIST" "$backup"
+
+rollback() {
+  echo "rolling back to the unsupervised agent" >&2
+  cp -a "$backup" "$PLIST"
+  launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || true
+  launchctl bootstrap "$DOMAIN" "$PLIST" 2>/dev/null || true
+}
+
+cp -a "$prepared" "$PLIST"
+launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || true
+# bootout returns before the job is gone; bootstrapping too early fails.
+for _ in $(seq 1 30); do
+  launchctl print "$DOMAIN/$LABEL" >/dev/null 2>&1 || break
+  sleep 1
+done
+if ! launchctl bootstrap "$DOMAIN" "$PLIST"; then
+  rollback
+  die "supervised agent failed to bootstrap"
+fi
+
+for _ in $(seq 1 30); do
+  if curl -fsS --max-time 2 "$health_url" >/dev/null 2>&1; then
+    echo "supervised Subrouter healthy at $health_url"
+    echo "control socket: $CONTROL_SOCKET"
+    echo "backup: $backup"
+    echo
+    echo "Upgrades are now non-disruptive:"
+    echo "  curl -fsS --unix-socket $CONTROL_SOCKET -X POST http://localhost/_subrouter/upgrade"
+    exit 0
+  fi
+  sleep 1
+done
+
+rollback
+die "supervised agent never became healthy"


### PR DESCRIPTION
## Upgrades on a developer machine cut agent turns

`migrate-launchdaemon-to-supervisor.sh` only handles the system-wide LaunchDaemon (`/Library/LaunchDaemons`, `system` domain, root). A developer machine runs a per-user **LaunchAgent**, which that script cannot touch. So every local `sr` upgrade replaced the binary and restarted the agent, closing every established connection: any coding agent mid-turn loses its response.

This adds the LaunchAgent variant — `gui/<uid>` domain, no sudo, supervisor copy in `~/bin`, ad-hoc signed so macOS doesn't kill it with `OS_REASON_CODESIGNING`. It reuses the existing `ProgramArguments` minus `serve` and `--addr` (the supervisor supplies both), keeps a timestamped plist backup, and rolls back if the supervised agent fails to bootstrap or never becomes healthy.

Verified on an **isolated** LaunchAgent on a spare port against a local stand-in upstream, so a live daemon with running agents was never touched:

```
events before upgrade: 6
upgrade accepted
events after upgrade:  19
RESULT: in-flight stream SURVIVED the upgrade (+13)
```

The one-time transition still drops in-flight connections, because the unsupervised process owns those descriptors. The script says so and defaults to preparing the plist without activating, so it can be run at a quiet moment.

## AGENTS.md: the deliverable is a command Lawrence can run

Today's work produced a correct server and nothing he could test. `sr.cmux.dev` was verified with an admin token over curl and called ready, while the actual user path (`sr login`) was returning 500 the whole time.

The new section states the rule: the deliverable is a command he can paste into his own terminal, with no `ssh`, no `gcloud`, no admin token — and if onboarding needs those, onboarding is the bug. Verify from a client machine through the public endpoint, since verifying from inside the VM proves the server works and says nothing about whether anyone can use it. State an OAuth blocker in the first line, not after a long report.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788050296&installation_model_id=21920&pr_number=116&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F116&signature=2bb3cee9b0257f5d7ba787767bbc27227fd0a9f5ae9314fb9fe64ed8524557cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a supervisor-backed per-user LaunchAgent so local `subrouter` upgrades no longer drop in-flight agent streams. Updates `AGENTS.md` to make the deliverable testable: a pasteable command Lawrence can run from his Mac.

- **New Features**
  - `deploy/macos/migrate-launchagent-to-supervisor.sh` migrates the per-user LaunchAgent to a supervisor (`gui/<uid>`), no sudo needed.
  - Supervisor is a separate, ad‑hoc signed copy in `~/bin` that owns the listener and drains old workers safely.
  - Rewrites the plist to let the supervisor supply `serve` and `--addr`, and adds safe timeouts.
  - Keeps a timestamped backup and rolls back if bootstrap fails or the health check never passes.
  - `AGENTS.md` clarifies handoffs: verify via the public endpoint with a user path, and call out OAuth blockers up front.

- **Migration**
  - Run the script; it prepares a supervised plist without activating.
  - Activate once with `--activate` when agents are idle; that one restart will drop current connections.
  - After activation, trigger non‑disruptive upgrades via: `curl -fsS --unix-socket ~/.subrouter/supervisor.sock -X POST http://localhost/_subrouter/upgrade`.

<sup>Written for commit 25387344797093d98582406138bdbeb278e31148. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a macOS migration tool for moving existing Subrouter LaunchAgents to supervised operation.
  * Supports review-only and activation modes, with validation, backups, health checks, status reporting, and automatic rollback if activation fails.

* **Documentation**
  * Added delivery guidance for local macOS commands, endpoint verification, OAuth limitations, and transparently reporting unavailable testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->