### PR TITLE
Fix the sr add test broken by the provider prompt

### DIFF
--- a/cmd/subrouter/sr_test.go
+++ b/cmd/subrouter/sr_test.go
@@ -269,7 +269,9 @@ func TestSRAddRestoresPreviouslyActiveAccount(t *testing.T) {
 
 	var out bytes.Buffer
 	runner := srRunner{store: store, in: strings.NewReader(""), out: &out, errOut: &out}
-	if err := runner.run(context.Background(), []string{"add"}); err != nil {
+	// "add" now asks which provider; this test exercises the Codex path, so it
+	// names it rather than relying on a default that no longer exists.
+	if err := runner.run(context.Background(), []string{"add", "codex"}); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
`main` is red. `TestSRAddRestoresPreviouslyActiveAccount` calls `run(["add"])` and relied on that meaning Codex. Since #115 made bare `add` ask which provider, the call now fails with `no provider given` against the test's non-interactive reader.

The test exercises the Codex path, so it names it: `run(["add", "codex"])`.

Two process failures on my side worth stating: I merged #115 before its CI run finished, and then merged #116 on top of an already-failing run. `go test ./...` is green with this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788050552&installation_model_id=21920&pr_number=117&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F117&signature=41643a0e2f363f3662b01101706f0fa7af6c573cedc7efcd9de898c6be0b7fa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing test after `add` became interactive by explicitly selecting the provider.

Updates `TestSRAddRestoresPreviouslyActiveAccount` to call `run(["add", "codex"])` instead of `run(["add"])`, so it exercises the Codex path non-interactively and restores green CI.

<sup>Written for commit 86a9c39d16b86c028aa1009973ac0e8bb1765a93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

