### PR TITLE
Write down why main broke and how to not repeat it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,55 @@ If a change cannot be exercised from his machine at all, say that plainly in the
 first line of the handoff. "Deployed and verified server-side, not yet testable
 by you, because X" is an acceptable status. Implying it is ready when it is not
 wastes the one thing he cannot get back.
+
+## Never report a green suite you did not actually see
+
+`main` was broken by a change whose test run was reported as passing. The
+command was:
+
+```
+go test ./... 2>&1 | grep -vE '^ok|no test files' | head -5; echo SUITE_OK
+```
+
+Three defects, all in the verification rather than the code. A pipeline's exit
+status is its last command, so `head` masked the failure. `echo` was joined with
+`;` rather than `&&`, so the success marker printed unconditionally. And
+`head -5` was consumed by unrelated install output, so the `--- FAIL` line was
+never displayed.
+
+So: never print a success marker that is not gated on the exit status, never
+truncate test output in a way that can hide a failure line, and grep *for*
+`FAIL` rather than filtering `ok` away. Prefer:
+
+```
+go test ./... > /tmp/test.log 2>&1 && echo PASS || { echo FAIL; grep -E '^(---|FAIL|panic)' /tmp/test.log | head -20; }
+```
+
+## Never merge before the run finishes
+
+The same change reached `main` because it was merged while its CI run was still
+going, and the next PR was merged on top of a run that had already failed. A
+local pass is not a merge signal, and a queued run is not a passing run.
+
+Merge only after the run completes and passes:
+
+```
+gh pr checks <PR> --repo manaflow-ai/subrouter --watch
+gh pr merge <PR> --repo manaflow-ai/subrouter --squash --delete-branch
+```
+
+If CI is red on `main`, fixing it comes before any other work, including work
+that was already in progress.
+
+## Stopping means handing over exact commands
+
+Never end a turn with a description of what could be done. End it with the
+literal commands to run and the literal things to look at:
+
+- the shell commands, copy-pasteable, in the order they should be run
+- what each one should print when it worked
+- which files or PR URLs to review, by path and number, not by description
+- what is still not verified, named as such
+
+"You should check the alert fired" is not a handover. "Run `gcloud logging read
+...`, expect one line containing `[ALERT]`, and review PR 114" is.


### PR DESCRIPTION
## What happened

A change reached `main` with a failing test, and the run that reported it was described as passing. The verification command was:

```
go test ./... 2>&1 | grep -vE '^ok|no test files' | head -5; echo SUITE_OK
```

Three defects, none of them in the code under test:

1. A pipeline's exit status is its **last** command, so `head` swallowed `go test`'s failure.
2. `echo SUITE_OK` was joined with `;` instead of `&&`, so the success marker printed unconditionally.
3. `head -5` was consumed by unrelated install output from another test, so the `--- FAIL` line was never displayed.

Then the PR was merged while its CI run was still in progress, and the following PR was merged on top of a run that had already failed.

## Rules added

**Never report a green suite you did not see.** Gate success on exit status, grep *for* `FAIL` rather than filtering `ok` away, and never truncate in a way that can hide a failure line.

**Never merge before the run finishes.** A local pass is not a merge signal and a queued run is not a passing run. Red `main` is fixed before anything else.

**Stopping means handing over exact commands** — copy-pasteable, in order, with expected output, the PR numbers and file paths to review, and an explicit list of what remains unverified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788050971&installation_model_id=21920&pr_number=118&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F118&signature=76b988c8adfb9bdd973bd27731dc4f3da0893abb0c71f858e9179a2ef24d6735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents why `main` broke and adds three rules to prevent false green test reports and unsafe merges. Clarifies commands and handoff steps so CI results are trustworthy and merges happen only after passing runs.

- **Rules**
  - Gate success on exit status, grep for `FAIL`, and avoid truncating output that can hide failures.
  - Merge only after the CI run completes and passes; fix red `main` before anything else.
  - End handoffs with exact commands, expected output, and the specific PRs and file paths to review.

<sup>Written for commit d37c064e38e591dbce16813648ac1838d4fe5e3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

