### PR TITLE
Define when agents may stop and hand off

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,15 +77,41 @@ gh pr merge <PR> --repo manaflow-ai/subrouter --squash --delete-branch
 If CI is red on `main`, fixing it comes before any other work, including work
 that was already in progress.
 
-## Stopping means handing over exact commands
+## When to stop, and what stopping means
 
-Never end a turn with a description of what could be done. End it with the
-literal commands to run and the literal things to look at:
+Stop only when the next step needs something only Lawrence can supply:
 
-- the shell commands, copy-pasteable, in the order they should be run
-- what each one should print when it worked
-- which files or PR URLs to review, by path and number, not by description
-- what is still not verified, named as such
+- **His identity.** A browser OAuth login, a 2FA prompt, a Slack invite, an
+  approval that must be made as him.
+- **His judgment on the product.** Does this feel right, is this the UX we want,
+  should this be the default. That is dogfooding, and it is the only kind of
+  review worth his time.
+- **His authority.** Spending money, deleting customer data, publishing
+  something public, anything irreversible that affects other people.
+- **His hardware.** A physical device, a cable, a machine that is not reachable.
 
-"You should check the alert fired" is not a handover. "Run `gcloud logging read
-...`, expect one line containing `[ALERT]`, and review PR 114" is.
+Do not stop for anything else. Verification, CI runs, PR review, deployment,
+cleanup, monitoring, infrastructure naming, or a choice between two reasonable
+options are all the agent's job. When two options are defensible, pick the
+better one, say which and why in one sentence, and keep going. A question that
+the filesystem, the API, or a test could answer is not a question for him.
+If a check, deployment, or background command is still queued or running,
+monitor it to a completed success or failure instead of handing the wait to
+him.
+
+Never ask him to run a verification command. If a command proves the work, run
+it and report the output. Never ask him to review a pull request; if the code
+needs a second opinion, that is what review bots and tests are for.
+
+When stopping is genuinely warranted, the handover is an invitation to use the
+product, not a checklist:
+
+- one command that exercises the thing, copy-pasteable, that works from his
+  machine with no ssh, no admin token, and no environment setup
+- what he should see, in one line
+- the single question being asked, if there is one
+- anything still unverified, named as such
+
+"Review PR 118 and confirm CI is green" is homework. "Run `sr login`, you should
+get a browser prompt and land back at a shell that says which team you are in"
+is a handover.


### PR DESCRIPTION
Codifies that agents own verification, CI, deployment, monitoring, and code review. Handoffs are reserved for identity, product judgment, authority, or inaccessible hardware, and must be runnable product dogfood rather than diagnostic homework.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788053472&installation_model_id=21920&pr_number=119&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F119&signature=a074deffeaa181d42e890183571141ed63270c058ed1ed09421018e852280972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies when agents may stop and hand off, and what a proper handover looks like. Agents own verification, CI, deployment, monitoring, and code review; stop only for identity, product judgment, authority, or unreachable hardware, and provide a single runnable command with expected output and the one question being asked.

<sup>Written for commit 68d142b86e89f78cf5dd1fe4e19f776c556b49ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

