### PR TITLE
Fix the review findings on the coalescing path

### DIFF
--- a/internal/proxy/catalog_aggregate.go
+++ b/internal/proxy/catalog_aggregate.go
@@ -149,13 +149,17 @@ func aggregateCatalogPages(
 		return nil, pages, len(merged), false, fmt.Errorf("catalog exceeds aggregation bounds (%d pages, %d bytes)", pages, bytes)
 	}
 
+	// Marshalling failures after a completed walk are errors too: returning
+	// firstBody here would be safe (it still carries its cursor) but would
+	// silently discard a walk the caller believes succeeded, and nilerr flags
+	// it. One policy for every failed walk.
 	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(firstBody, &payload); err != nil {
-		return firstBody, 0, 0, false, nil
+		return nil, pages, len(merged), false, fmt.Errorf("catalog merge: decode first page: %w", err)
 	}
 	mergedPlugins, err := json.Marshal(merged)
 	if err != nil {
-		return firstBody, 0, 0, false, nil
+		return nil, pages, len(merged), false, fmt.Errorf("catalog merge: encode plugins: %w", err)
 	}
 	payload["plugins"] = mergedPlugins
 	if rawPagination, ok := payload["pagination"]; ok {
@@ -169,7 +173,7 @@ func aggregateCatalogPages(
 	}
 	out, err := json.Marshal(payload)
 	if err != nil {
-		return firstBody, 0, 0, false, nil
+		return nil, pages, len(merged), false, fmt.Errorf("catalog merge: encode payload: %w", err)
 	}
 	return out, pages, len(merged), true, nil
 }

--- a/internal/proxy/plugin_endpoints_regression_test.go
+++ b/internal/proxy/plugin_endpoints_regression_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 	"github.com/manaflow-ai/subrouter/selectacct"
@@ -210,6 +212,41 @@ func TestCatalogWalkFailureIsAnErrorNotAPartialBody(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 	if rr.Code < 500 {
 		t.Fatalf("mid-walk failure returned status %d with body %q, want 5xx: a partial catalog would be cached as complete", rr.Code, rr.Body.String())
+	}
+}
+
+// The flight's work is shared, so the leader's disconnect must not cancel it:
+// the walk runs on a context detached from the initiating request. Cancel the
+// leader mid-walk and assert the walk still reaches the final page.
+func TestLeaderDisconnectDoesNotCancelSharedWalk(t *testing.T) {
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	var pagesServed atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := 1
+		if tok := r.URL.Query().Get("pageToken"); tok != "" {
+			fmt.Sscanf(tok, "page-%d", &page)
+		}
+		pagesServed.Add(1)
+		if page == 2 {
+			// Kill the initiating client while its walk is mid-flight.
+			cancelLeader()
+			time.Sleep(50 * time.Millisecond)
+		}
+		body := map[string]any{"plugins": []map[string]string{{"id": fmt.Sprintf("p%d", page)}}, "pagination": map[string]any{}}
+		if page < 3 {
+			body["pagination"] = map[string]any{"next_page_token": fmt.Sprintf("page-%d", page+1)}
+		}
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	defer upstream.Close()
+	handler := pluginTestServer(t, upstream)
+
+	req := httptest.NewRequest(http.MethodGet, "/backend-api/ps/plugins/list?scope=GLOBAL&limit=1", nil).WithContext(leaderCtx)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if got := pagesServed.Load(); got != 3 {
+		t.Fatalf("walk served %d pages after the leader disconnected, want all 3: the shared flight died with its leader", got)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2054,11 +2054,15 @@ func (s Server) proxyHandler() http.Handler {
 		// Nothing is retained after the flight completes.
 		if r.Method == http.MethodGet && coalescablePath(r.URL.Path) {
 			flight, _ := s.CacheFlight.do(flightKey(r), func() flightResult {
+				// The flight's work is shared by every waiter, so it must not
+				// die with the leader: detach it from the leader's context or
+				// one disconnecting client cancels the walk for everyone.
+				flightRequest := proxyRequest.Clone(context.WithoutCancel(proxyRequest.Context()))
 				rec := &responseRecorder{}
-				rp.ServeHTTP(rec, proxyRequest)
+				rp.ServeHTTP(rec, flightRequest)
 				body := rec.buf.Bytes()
 				if rec.code >= 200 && rec.code < 300 {
-					merged, pages, entries, ok, err := aggregateCatalogPages(transport, proxyRequest, upstream, body)
+					merged, pages, entries, ok, err := aggregateCatalogPages(transport, flightRequest, upstream, body)
 					if err != nil {
 						// A partial catalog has no continuation token, so the
 						// client would cache it as complete (codex pins it on

--- a/internal/proxy/request_coalesce.go
+++ b/internal/proxy/request_coalesce.go
@@ -38,8 +38,9 @@ func coalescablePath(path string) bool {
 }
 
 // flightKey identifies everything a shared response depends on: the method,
-// the path, every query parameter, and the calling identity. Anything left out
-// here is a request that gets served somebody else's body.
+// the path, every query parameter, the calling identity, and the response
+// encoding the caller can accept. Anything left out here is a request that
+// gets served somebody else's body.
 func flightKey(r *http.Request) string {
 	var b strings.Builder
 	b.WriteString(r.Method)
@@ -48,6 +49,11 @@ func flightKey(r *http.Request) string {
 	b.WriteByte('\n')
 	// Encode() sorts by key, so parameter order does not fragment the key space.
 	b.WriteString(r.URL.Query().Encode())
+	b.WriteByte('\n')
+	// The reverse proxy forwards Accept-Encoding upstream, so the buffered
+	// body carries whatever Content-Encoding the leader negotiated. A gzip
+	// body handed to a waiter that never offered gzip is garbage bytes.
+	b.WriteString(r.Header.Get("Accept-Encoding"))
 	b.WriteByte('\n')
 	b.WriteString(callerIdentity(r))
 	return b.String()

--- a/internal/proxy/request_coalesce_test.go
+++ b/internal/proxy/request_coalesce_test.go
@@ -29,6 +29,10 @@ func TestFlightKeyCoversEveryRequestDimension(t *testing.T) {
 		"method":      func(r *http.Request) { r.Method = http.MethodPost },
 		"account":     func(r *http.Request) { r.Header.Set("chatgpt-account-id", "acct-bob") },
 		"user":        func(r *http.Request) { r.Header.Set("chatgpt-user-id", "user-bob") },
+		// The buffered body carries the Content-Encoding the leader
+		// negotiated; a waiter that never offered gzip must not join a
+		// gzip flight.
+		"accept-encoding": func(r *http.Request) { r.Header.Set("Accept-Encoding", "identity") },
 		// The bearer is deliberately not a dimension while account headers are
 		// present: tokens rotate per session and the account is what decides
 		// which data comes back. It is a dimension only when nothing else


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/subrouter/pull/121, addressing the three CodeRabbit findings that landed after merge.

**Accept-Encoding joins `flightKey`.** The reverse proxy forwards the client's Accept-Encoding upstream, so the flight's buffered body carries whatever Content-Encoding the leader negotiated. Two concurrent same-account callers differing only in Accept-Encoding used to share one flight, handing gzip bytes to a caller that never offered gzip. Now a key dimension, covered by the key-completeness test.

**The shared walk survives its leader's disconnect.** The flight ran on the leader's request context, so one client disconnecting canceled the catalog walk for every waiter. The flight now clones the request with `context.WithoutCancel`. `TestLeaderDisconnectDoesNotCancelSharedWalk` cancels the leader mid-walk and asserts all pages are still fetched.

**Marshalling failures are errors.** `aggregateCatalogPages` returned `firstBody, nil` from its encode/decode failure paths (nilerr), silently discarding a completed walk. All failure paths now return an error, so every failed walk takes the same 502 route.

`go build`, `go vet`, `gofmt`, full `go test ./...` pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788088212&installation_model_id=21920&pr_number=122&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F122&signature=6c93be32615f3e91c9d22e47a7f0c14207c87a63ed0856e24ed0414e4df1f78c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the coalescing path to prevent cross-client leaks and make failures consistent. Flights now key on `Accept-Encoding`, run detached from the leader’s cancellation, and return errors on marshal/unmarshal failures.

- **Bug Fixes**
  - Added `Accept-Encoding` to `flightKey` to avoid sharing bodies across different encodings.
  - Detached the shared walk from the leader with `context.WithoutCancel` so one disconnect doesn’t cancel others.
  - `aggregateCatalogPages` now returns errors on JSON encode/decode failures; failed walks consistently 502 instead of returning partial results.

<sup>Written for commit 80e473de182e12b55e7ff0d8304e31bd6721edfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

