### PR TITLE
Honor explicit server targets for account commands

### DIFF
--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -201,6 +201,17 @@ func (r srRunner) run(ctx context.Context, args []string) error {
 	if len(args) == 0 {
 		return r.defaultInteractive(ctx, srSwitchOptions{})
 	}
+	// A named server in the environment is an explicit, one-command target.
+	// Honor it before the persisted credential source so wrappers such as
+	// `SUBROUTER_CODEX_SERVER=gcp-staging sr add` upload directly to that
+	// server even when this machine normally uses the team vault.
+	if strings.TrimSpace(os.Getenv("SUBROUTER_CODEX_SERVER")) != "" && shouldRouteSRCommand(args[0]) {
+		if server, ok, err := r.selectedRemoteServer(); err != nil {
+			return err
+		} else if ok {
+			return r.runRemoteAccountCommand(ctx, server, args)
+		}
+	}
 	if source == broker.CredentialSourceTeam {
 		if handled, err := r.runTeamCredentialCommand(ctx, args); handled {
 			return err

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -193,24 +193,27 @@ func (r srRunner) run(ctx context.Context, args []string) error {
 			return runDoctor(ctx, r.store, r.out)
 		}
 	}
-	config, err := cloudModeConfig()
-	if err != nil {
-		return fmt.Errorf("load credential storage: %w", err)
-	}
-	source := config.EffectiveCredentialSource()
 	if len(args) == 0 {
 		return r.defaultInteractive(ctx, srSwitchOptions{})
 	}
+	var source broker.CredentialSource
 	// A named server in the environment is an explicit, one-command target.
 	// Honor it before the persisted credential source so wrappers such as
 	// `SUBROUTER_CODEX_SERVER=gcp-staging sr add` upload directly to that
 	// server even when this machine normally uses the team vault.
-	if strings.TrimSpace(os.Getenv("SUBROUTER_CODEX_SERVER")) != "" && shouldRouteSRCommand(args[0]) {
-		if server, ok, err := r.selectedRemoteServer(); err != nil {
+	if target := strings.TrimSpace(os.Getenv("SUBROUTER_CODEX_SERVER")); target != "" && shouldRouteSRCommand(args[0]) {
+		if strings.EqualFold(target, "local") {
+			source = broker.CredentialSourceLocal
+		} else if handled, err := r.runSelectedRemoteAccountCommand(ctx, args); handled {
 			return err
-		} else if ok {
-			return r.runRemoteAccountCommand(ctx, server, args)
 		}
+	}
+	if source == "" {
+		config, err := cloudModeConfig()
+		if err != nil {
+			return fmt.Errorf("load credential storage: %w", err)
+		}
+		source = config.EffectiveCredentialSource()
 	}
 	if source == broker.CredentialSourceTeam {
 		if handled, err := r.runTeamCredentialCommand(ctx, args); handled {
@@ -218,10 +221,8 @@ func (r srRunner) run(ctx context.Context, args []string) error {
 		}
 	}
 	if source == broker.CredentialSourceLegacy && shouldRouteSRCommand(args[0]) {
-		if server, ok, err := r.selectedRemoteServer(); err != nil {
+		if handled, err := r.runSelectedRemoteAccountCommand(ctx, args); handled {
 			return err
-		} else if ok {
-			return r.runRemoteAccountCommand(ctx, server, args)
 		}
 	}
 	switch args[0] {
@@ -330,6 +331,14 @@ func (r srRunner) run(ctx context.Context, args []string) error {
 		}
 		return fmt.Errorf("unknown account command %q\n%s", args[0], srHelp)
 	}
+}
+
+func (r srRunner) runSelectedRemoteAccountCommand(ctx context.Context, args []string) (bool, error) {
+	server, ok, err := r.selectedRemoteServer()
+	if err != nil || !ok {
+		return ok, err
+	}
+	return true, r.runRemoteAccountCommand(ctx, server, args)
 }
 
 func shouldRouteSRCommand(command string) bool {

--- a/cmd/subrouter/sr_server_test.go
+++ b/cmd/subrouter/sr_server_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/internal/broker"
 )
 
 func TestSRServerAddStoresGCPServer(t *testing.T) {
@@ -383,6 +384,50 @@ func TestSRAddUsesDefaultRemoteServer(t *testing.T) {
 		t.Fatalf("top-level add should not add to local account store when a server is selected:\n%s", out.String())
 	}
 	if !strings.Contains(out.String(), "Uploaded fresh@example.com to server team.") {
+		t.Fatalf("missing server add confirmation:\n%s", out.String())
+	}
+}
+
+func TestSRAddUsesExplicitRemoteServerWhileTeamStorageIsActive(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SUBROUTER_CODEX_SERVER", "gcp-staging")
+	cloudConfigPath := filepath.Join(t.TempDir(), "cloud.json")
+	t.Setenv("SUBROUTER_CLOUD_CONFIG", cloudConfigPath)
+	if err := broker.SaveConfig(cloudConfigPath, broker.Config{
+		BaseURL:      "https://cmux.test",
+		AccessToken:  "stack-access",
+		RefreshToken: "stack-refresh",
+		TeamID:       "team-a",
+		TeamName:     "Team A",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	store := accounts.DefaultCodexStore()
+	if err := defaultSRServerStore(store).save(srServerFile{
+		Servers: []srServerConfig{{
+			Name: "gcp-staging",
+			URL:  "http://100.64.0.1:31415",
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	fake := &recordingSRCommandRunner{loginAuth: testCodexAuth("fresh@example.com", "acct_fresh")}
+	runner := srRunner{program: "sr", store: store, in: strings.NewReader(""), out: &out, errOut: &out, cmd: fake}
+	if err := runner.run(context.Background(), []string{"add", "--device-auth"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !fake.hasCommand("codex", "login", "--device-auth") {
+		t.Fatalf("missing remote login command: %#v", fake.commands)
+	}
+	if !fake.hasCommandPrefix("ssh", "-o", "BatchMode=yes") {
+		t.Fatalf("missing direct server upload command: %#v", fake.commands)
+	}
+	if !strings.Contains(out.String(), "Uploaded fresh@example.com to server gcp-staging.") {
 		t.Fatalf("missing server add confirmation:\n%s", out.String())
 	}
 }

--- a/cmd/subrouter/sr_server_test.go
+++ b/cmd/subrouter/sr_server_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
-	"github.com/manaflow-ai/subrouter/internal/broker"
 )
 
 func TestSRServerAddStoresGCPServer(t *testing.T) {
@@ -394,13 +393,7 @@ func TestSRAddUsesExplicitRemoteServerWhileTeamStorageIsActive(t *testing.T) {
 	t.Setenv("SUBROUTER_CODEX_SERVER", "gcp-staging")
 	cloudConfigPath := filepath.Join(t.TempDir(), "cloud.json")
 	t.Setenv("SUBROUTER_CLOUD_CONFIG", cloudConfigPath)
-	if err := broker.SaveConfig(cloudConfigPath, broker.Config{
-		BaseURL:      "https://cmux.test",
-		AccessToken:  "stack-access",
-		RefreshToken: "stack-refresh",
-		TeamID:       "team-a",
-		TeamName:     "Team A",
-	}); err != nil {
+	if err := os.WriteFile(cloudConfigPath, []byte("{"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Summary
- route account commands to `SUBROUTER_CODEX_SERVER` before persisted team storage
- make server-specific wrappers upload OAuth credentials to their named server

## Testing
- `go test ./...`
- `go test ./cmd/subrouter -run TestSRAddUsesExplicitRemoteServerWhileTeamStorageIsActive -count=1`
- installed the branch build locally and verified `sr-gcp status` reaches `gcp-staging`

## Context
`sr-gcp add` previously called the team-vault API because team storage took precedence over the wrapper’s explicit GCP server target.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788150585&installation_model_id=21920&pr_number=130&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F130&signature=408bedcf905926a81e19c407aee7aa42ffd7ee4e7e4efd1b491dc469f5e94198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route account commands to the server named in `SUBROUTER_CODEX_SERVER`, ahead of cloud config and team/legacy storage. Ensures wrappers like `sr-gcp` upload OAuth credentials and run account actions against the intended server (e.g., `gcp-staging`).

- **Bug Fixes**
  - Short-circuit routing for account commands when `SUBROUTER_CODEX_SERVER` is set, before loading cloud config; accept `SUBROUTER_CODEX_SERVER=local` to force local storage.
  - Added test to verify `sr add --device-auth` uploads to the explicit server even with active team storage.

<sup>Written for commit b28e17c980d03d8e9ceb3afe31e83030ab0d96ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account commands can now use an explicitly configured remote server before other credential storage options.
  * Added support for uploading device-auth credentials through the selected remote server while team storage is active.

* **Bug Fixes**
  * Improved remote routing to ensure commands use the selected server and report successful uploads without changing local account behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->