### PR TITLE
Retire hosted tenants before account deletion

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -63,6 +63,15 @@ var goldenTestHooks struct {
 	sessionProcessDone     func(*os.Process)
 	outboundRequestWritten func(string) error
 	releaseStream          func(string) error
+	localEgressMaxGap      time.Duration
+	probeScheduleTolerance time.Duration
+}
+
+func goldenProbeScheduleToleranceForRun() time.Duration {
+	if goldenTestHooks.enabled && goldenTestHooks.probeScheduleTolerance > 0 {
+		return goldenTestHooks.probeScheduleTolerance
+	}
+	return goldenProbeScheduleTolerance
 }
 
 type goldenOptions struct {

--- a/cmd/subrouter-transport-observer/golden_local_egress.go
+++ b/cmd/subrouter-transport-observer/golden_local_egress.go
@@ -20,6 +20,13 @@ type goldenRemoteSocket struct {
 	DestinationID string
 }
 
+func goldenLocalEgressMaxGapForRun() time.Duration {
+	if goldenTestHooks.enabled && goldenTestHooks.localEgressMaxGap > 0 {
+		return goldenTestHooks.localEgressMaxGap
+	}
+	return goldenLocalEgressMonitorMaxGap
+}
+
 func newGoldenRemoteSocket(name string) (goldenRemoteSocket, bool) {
 	local, destination, found := strings.Cut(strings.TrimSpace(name), "->")
 	local = strings.TrimSpace(local)
@@ -583,7 +590,7 @@ func (monitor *goldenLocalEgressMonitor) sample() bool {
 		if gap > monitor.maxStartGap {
 			monitor.maxStartGap = gap
 		}
-		if gap > goldenLocalEgressMonitorMaxGap {
+		if gap > goldenLocalEgressMaxGapForRun() {
 			monitor.liveErr = failGolden("local_egress_monitor_gap")
 			monitor.mu.Unlock()
 			return false
@@ -662,7 +669,7 @@ func captureGoldenRemoteSocketEvidence(
 	if len(pids) == 0 {
 		pids = []int{pid}
 	}
-	sampleCtx, cancel := context.WithTimeout(context.Background(), goldenLocalEgressMonitorMaxGap)
+	sampleCtx, cancel := context.WithTimeout(context.Background(), goldenLocalEgressMaxGapForRun())
 	defer cancel()
 	remoteSockets := make([]goldenRemoteSocket, 0)
 	for _, processID := range pids {

--- a/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
+++ b/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
@@ -1119,6 +1119,11 @@ func enableGoldenTestMode(t *testing.T, releaseAPI, releaseDownloadRoot string) 
 	goldenTestHooks.releaseDownloadRoot = releaseDownloadRoot
 	goldenTestHooks.socketEndpoint = "127.0.0.1:41000"
 	goldenTestHooks.evidenceValidator = validator
+	// This test validates orchestration and evidence shape. Dedicated monitor
+	// tests retain the production cadence limits, while this synthetic process
+	// swarm tolerates busy shared CI schedulers.
+	goldenTestHooks.localEgressMaxGap = time.Second
+	goldenTestHooks.probeScheduleTolerance = time.Second
 	t.Cleanup(func() { goldenTestHooks = previous })
 }
 

--- a/cmd/subrouter-transport-observer/golden_probe_validation.go
+++ b/cmd/subrouter-transport-observer/golden_probe_validation.go
@@ -35,7 +35,7 @@ func (s *goldenProbeStats) validateInterval(start, end time.Time) error {
 		if len(stamps) < minimum {
 			return failGolden("health_probe_frequency_low")
 		}
-		maximumGap := goldenProbeInterval + goldenProbeScheduleTolerance
+		maximumGap := goldenProbeInterval + goldenProbeScheduleToleranceForRun()
 		if stamps[0].Sub(start) > maximumGap || end.Sub(stamps[len(stamps)-1]) > maximumGap {
 			return failGolden("health_probe_coverage_gap")
 		}

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -675,6 +675,52 @@ esac
 	}
 }
 
+func TestReleaseMainVerificationStreamsLargeComparison(t *testing.T) {
+	requireDeployScriptTools(t, "bash", "jq", "python3")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	fakeBin := t.TempDir()
+	revision := strings.Repeat("a", 40)
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "gh"), `#!/bin/sh
+case "$*" in
+  *'/commits/'*) printf '%s\n' "$TEST_REVISION" ;;
+  *'/compare/'*)
+    python3 - "$TEST_REVISION" <<'PY'
+import json
+import sys
+json.dump({
+    "merge_base_commit": {"sha": sys.argv[1]},
+    "status": "ahead",
+    "padding": "x" * (2 * 1024 * 1024),
+}, sys.stdout)
+PY
+    ;;
+  *) exit 2 ;;
+esac
+`)
+	helper := filepath.Join(repoRoot, "deploy", "gcp", "verify-release-on-main.sh")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	command := exec.CommandContext(
+		ctx,
+		mustLookPath(t, "bash"),
+		helper,
+		"manaflow-ai/subrouter",
+		"v0.1.51",
+		revision,
+	)
+	command.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"TEST_REVISION="+revision,
+	)
+	output, err := runDeployTestCommand(command)
+	if ctx.Err() != nil {
+		t.Fatalf("release verification deadlocked on a large comparison: %v\n%s", ctx.Err(), output)
+	}
+	if err != nil || strings.TrimSpace(string(output)) != revision {
+		t.Fatalf("release verification = %q, %v", output, err)
+	}
+}
+
 func TestDeploymentContractValidatesTargetAndManifest(t *testing.T) {
 	requireDeployScriptTools(t, "python3")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -732,9 +732,12 @@ case "$*" in
   *'/compare/'*) exit 23 ;;
   *) exit 2 ;;
 esac
-`)
+	`)
 	helper := filepath.Join(repoRoot, "deploy", "gcp", "verify-release-on-main.sh")
-	command := exec.Command(
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	command := exec.CommandContext(
+		ctx,
 		mustLookPath(t, "bash"),
 		helper,
 		"manaflow-ai/subrouter",
@@ -751,7 +754,7 @@ esac
 	}
 	if !strings.Contains(string(output), "failed to fetch comparison") ||
 		strings.Contains(string(output), "is not on main") {
-		t.Fatalf("comparison transport failure was misclassified: %s", output)
+		t.Fatalf("comparison transport failure was misclassified: %v: %s", err, output)
 	}
 }
 

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -721,6 +721,40 @@ esac
 	}
 }
 
+func TestReleaseMainVerificationReportsComparisonTransportFailure(t *testing.T) {
+	requireDeployScriptTools(t, "bash", "jq")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	fakeBin := t.TempDir()
+	revision := strings.Repeat("a", 40)
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "gh"), `#!/bin/sh
+case "$*" in
+  *'/commits/'*) printf '%s\n' "$TEST_REVISION" ;;
+  *'/compare/'*) exit 23 ;;
+  *) exit 2 ;;
+esac
+`)
+	helper := filepath.Join(repoRoot, "deploy", "gcp", "verify-release-on-main.sh")
+	command := exec.Command(
+		mustLookPath(t, "bash"),
+		helper,
+		"manaflow-ai/subrouter",
+		"v0.1.51",
+		revision,
+	)
+	command.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"TEST_REVISION="+revision,
+	)
+	output, err := runDeployTestCommand(command)
+	if err == nil {
+		t.Fatalf("comparison transport failure succeeded: %s", output)
+	}
+	if !strings.Contains(string(output), "failed to fetch comparison") ||
+		strings.Contains(string(output), "is not on main") {
+		t.Fatalf("comparison transport failure was misclassified: %s", output)
+	}
+}
+
 func TestDeploymentContractValidatesTargetAndManifest(t *testing.T) {
 	requireDeployScriptTools(t, "python3")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -365,7 +365,6 @@ func serve(args []string) error {
 		*stackProjectID,
 		*stackPublishableClientKey,
 		*stackTenantKeySecret,
-		*stackTenantDeleteToken,
 	}
 	stackLoginConfigured := 0
 	for _, value := range stackLoginValues {
@@ -374,7 +373,7 @@ func serve(args []string) error {
 		}
 	}
 	if stackLoginConfigured != 0 && stackLoginConfigured != len(stackLoginValues) {
-		return errors.New("hosted Stack login requires project ID, publishable key, tenant-key secret, and tenant-delete token (or their SUBROUTER_STACK_* environment or secret-file equivalents)")
+		return errors.New("hosted Stack login requires all of --stack-project-id, --stack-publishable-client-key, and --stack-tenant-key-secret (or their SUBROUTER_STACK_* environment or secret-file equivalents)")
 	}
 	if *stackTenantKeySecret != "" && len(*stackTenantKeySecret) < 32 {
 		return errors.New("--stack-tenant-key-secret or SUBROUTER_STACK_TENANT_KEY_SECRET must be at least 32 bytes")

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -302,6 +302,7 @@ func serve(args []string) error {
 	stackProjectID := flags.String("stack-project-id", "", "Stack Auth project ID enabling hosted login; defaults to SUBROUTER_STACK_PROJECT_ID")
 	stackPublishableClientKey := flags.String("stack-publishable-client-key", "", "Stack Auth publishable client key; defaults to SUBROUTER_STACK_PUBLISHABLE_CLIENT_KEY")
 	stackTenantKeySecret := flags.String("stack-tenant-key-secret", "", "local-development override for stable Stack-team tenant keys; deployments use SUBROUTER_STACK_TENANT_KEY_SECRET")
+	stackTenantDeleteToken := flags.String("stack-tenant-delete-token", "", "trusted cmux.com token required for hosted tenant deletion; deployments use SUBROUTER_STACK_TENANT_DELETE_TOKEN")
 	bedrockEnable := flags.Bool("bedrock", false, "enable the /bedrock/* AWS SigV4 signing gateway for Claude Code Bedrock mode")
 	bedrockRegion := flags.String("bedrock-region", "us-east-1", "comma-separated AWS regions for the Bedrock signing gateway")
 	bedrockGatewayToken := flags.String("bedrock-gateway-token", "", "optional bearer token clients must present to the Bedrock gateway; defaults to SUBROUTER_BEDROCK_GATEWAY_TOKEN")
@@ -352,7 +353,20 @@ func serve(args []string) error {
 	if err != nil {
 		return err
 	}
-	stackLoginValues := []string{*stackProjectID, *stackPublishableClientKey, *stackTenantKeySecret}
+	*stackTenantDeleteToken, err = secretValue(
+		*stackTenantDeleteToken,
+		"SUBROUTER_STACK_TENANT_DELETE_TOKEN",
+		"SUBROUTER_STACK_TENANT_DELETE_TOKEN_FILE",
+	)
+	if err != nil {
+		return err
+	}
+	stackLoginValues := []string{
+		*stackProjectID,
+		*stackPublishableClientKey,
+		*stackTenantKeySecret,
+		*stackTenantDeleteToken,
+	}
 	stackLoginConfigured := 0
 	for _, value := range stackLoginValues {
 		if value != "" {
@@ -360,10 +374,13 @@ func serve(args []string) error {
 		}
 	}
 	if stackLoginConfigured != 0 && stackLoginConfigured != len(stackLoginValues) {
-		return errors.New("hosted Stack login requires all of --stack-project-id, --stack-publishable-client-key, and --stack-tenant-key-secret (or their SUBROUTER_STACK_* environment or secret-file equivalents)")
+		return errors.New("hosted Stack login requires project ID, publishable key, tenant-key secret, and tenant-delete token (or their SUBROUTER_STACK_* environment or secret-file equivalents)")
 	}
 	if *stackTenantKeySecret != "" && len(*stackTenantKeySecret) < 32 {
 		return errors.New("--stack-tenant-key-secret or SUBROUTER_STACK_TENANT_KEY_SECRET must be at least 32 bytes")
+	}
+	if *stackTenantDeleteToken != "" && len(*stackTenantDeleteToken) < 32 {
+		return errors.New("--stack-tenant-delete-token or SUBROUTER_STACK_TENANT_DELETE_TOKEN must be at least 32 bytes")
 	}
 	*publicURL, err = normalizePublicSubrouterURL(*publicURL)
 	if err != nil {
@@ -605,6 +622,7 @@ func serve(args []string) error {
 			HTTPClient:           stackHTTPClient,
 		}
 		multiTenantHandler.StackTenantKeySecret = []byte(*stackTenantKeySecret)
+		multiTenantHandler.StackTenantDeleteToken = []byte(*stackTenantDeleteToken)
 	}
 	httpServer := &http.Server{
 		Addr:              *addr,

--- a/cmd/subrouter/main_test.go
+++ b/cmd/subrouter/main_test.go
@@ -112,6 +112,21 @@ func TestNormalizePublicSubrouterURLTrimsFlagValues(t *testing.T) {
 	}
 }
 
+func TestServeKeepsHostedLoginCompatibleWithoutTenantDeleteToken(t *testing.T) {
+	t.Setenv("SUBROUTER_STATE_DIR", t.TempDir())
+	t.Setenv("SUBROUTER_STACK_PROJECT_ID", "project")
+	t.Setenv("SUBROUTER_STACK_PUBLISHABLE_CLIENT_KEY", "publishable")
+	t.Setenv("SUBROUTER_STACK_TENANT_KEY_SECRET", "0123456789abcdef0123456789abcdef")
+	t.Setenv("SUBROUTER_STACK_TENANT_KEY_SECRET_FILE", "")
+	t.Setenv("SUBROUTER_STACK_TENANT_DELETE_TOKEN", "")
+	t.Setenv("SUBROUTER_STACK_TENANT_DELETE_TOKEN_FILE", "")
+
+	err := serve([]string{"--public-url", "http://sr.example.com"})
+	if err == nil || !strings.Contains(err.Error(), "must use HTTPS") {
+		t.Fatalf("serve error = %v, want public URL validation after legacy hosted-login config", err)
+	}
+}
+
 func TestSystemdListenFDsParsesCurrentProcess(t *testing.T) {
 	env := map[string]string{
 		"LISTEN_PID": "123",

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -123,19 +123,8 @@ manifest_sha() {
 require_release_revision_on_main() {
   local tag="$1"
   local expected_revision="${2:-}"
-  local revision
-  local comparison
-  revision="$(gh api "repos/${repository}/commits/${tag}" --jq '.sha')"
-  [[ "${revision}" =~ ^[0-9a-f]{40}$ ]] || { echo "${tag} did not resolve to a commit" >&2; exit 1; }
-  if [[ -n "${expected_revision}" && "${revision}" != "${expected_revision}" ]]; then
-    echo "${tag} revision does not match its hard pin" >&2
-    exit 1
-  fi
-  comparison="$(gh api "repos/${repository}/compare/${revision}...main")"
-  jq -e --arg revision "${revision}" \
-    '.merge_base_commit.sha == $revision and (.status == "ahead" or .status == "identical")' \
-    <<<"${comparison}" >/dev/null || { echo "${tag} is not on main" >&2; exit 1; }
-  printf '%s\n' "${revision}"
+  "${root}/deploy/gcp/verify-release-on-main.sh" \
+    "${repository}" "${tag}" "${expected_revision}"
 }
 
 verify_go_release_binary() {

--- a/deploy/gcp/verify-release-on-main.sh
+++ b/deploy/gcp/verify-release-on-main.sh
@@ -53,7 +53,7 @@ else
   comparison_status=("${PIPESTATUS[@]}")
   if (( comparison_status[0] != 0 )); then
     echo "failed to fetch comparison for ${tag} against main" >&2
-  elif (( comparison_status[1] != 0 )); then
+  elif (( comparison_status[1] != 0 && comparison_status[1] != 1 )); then
     echo "failed to process comparison for ${tag} against main" >&2
   else
     echo "${tag} is not on main" >&2

--- a/deploy/gcp/verify-release-on-main.sh
+++ b/deploy/gcp/verify-release-on-main.sh
@@ -44,11 +44,18 @@ if [[ -n "${expected_revision}" && "${revision}" != "${expected_revision}" ]]; t
   echo "${tag} revision does not match its hard pin" >&2
   exit 1
 fi
-if ! gh api "repos/${repository}/compare/${revision}...main" |
+if gh api "repos/${repository}/compare/${revision}...main" |
     jq -e --arg revision "${revision}" \
       '.merge_base_commit.sha == $revision and (.status == "ahead" or .status == "identical")' \
       >/dev/null; then
-  echo "${tag} is not on main" >&2
+  :
+else
+  comparison_status=("${PIPESTATUS[@]}")
+  if (( comparison_status[0] != 0 )); then
+    echo "failed to fetch comparison for ${tag} against main" >&2
+  else
+    echo "${tag} is not on main" >&2
+  fi
   exit 1
 fi
 printf '%s\n' "${revision}"

--- a/deploy/gcp/verify-release-on-main.sh
+++ b/deploy/gcp/verify-release-on-main.sh
@@ -53,6 +53,8 @@ else
   comparison_status=("${PIPESTATUS[@]}")
   if (( comparison_status[0] != 0 )); then
     echo "failed to fetch comparison for ${tag} against main" >&2
+  elif (( comparison_status[1] != 0 )); then
+    echo "failed to process comparison for ${tag} against main" >&2
   else
     echo "${tag} is not on main" >&2
   fi

--- a/deploy/gcp/verify-release-on-main.sh
+++ b/deploy/gcp/verify-release-on-main.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: verify-release-on-main.sh REPOSITORY TAG [EXPECTED_REVISION]
+
+Resolves TAG to a commit and verifies that commit is on the repository's main
+branch. The GitHub comparison is streamed into jq so a large response cannot
+deadlock Bash while constructing a here-string.
+EOF
+}
+
+if (( $# < 2 || $# > 3 )); then
+  usage >&2
+  exit 2
+fi
+
+repository="$1"
+tag="$2"
+expected_revision="${3:-}"
+
+[[ "${repository}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
+  echo "repository is invalid" >&2
+  exit 1
+}
+[[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || {
+  echo "release tag is invalid" >&2
+  exit 1
+}
+for command in gh jq; do
+  command -v "${command}" >/dev/null 2>&1 || {
+    echo "${command} is required" >&2
+    exit 1
+  }
+done
+
+revision="$(gh api "repos/${repository}/commits/${tag}" --jq '.sha')"
+[[ "${revision}" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "${tag} did not resolve to a commit" >&2
+  exit 1
+}
+if [[ -n "${expected_revision}" && "${revision}" != "${expected_revision}" ]]; then
+  echo "${tag} revision does not match its hard pin" >&2
+  exit 1
+fi
+if ! gh api "repos/${repository}/compare/${revision}...main" |
+    jq -e --arg revision "${revision}" \
+      '.merge_base_commit.sha == $revision and (.status == "ahead" or .status == "identical")' \
+      >/dev/null; then
+  echo "${tag} is not on main" >&2
+  exit 1
+fi
+printf '%s\n' "${revision}"

--- a/internal/proxy/multitenant.go
+++ b/internal/proxy/multitenant.go
@@ -518,6 +518,7 @@ func (m *MultiTenant) handleStackTenantDelete(w http.ResponseWriter, r *http.Req
 	}
 	retired, err := m.Registry.RetireExternal(teamID)
 	if err != nil {
+		m.scheduleTenantDeletion(teamID)
 		http.Error(w, "tenant retirement failed", http.StatusInternalServerError)
 		return
 	}
@@ -582,12 +583,16 @@ func (m *MultiTenant) scheduleTenantDeletion(id string) {
 		}()
 		backoff := 100 * time.Millisecond
 		for {
-			deletionLock, err := m.Registry.AcquireExclusiveUse(id)
+			_, err := m.Registry.RetireExternal(id)
 			if err == nil {
-				_, err = m.Registry.DeleteRetired(id)
-				closeErr := deletionLock.Close()
+				var deletionLock *tenant.UseLock
+				deletionLock, err = m.Registry.AcquireExclusiveUse(id)
 				if err == nil {
-					err = closeErr
+					_, err = m.Registry.DeleteRetired(id)
+					closeErr := deletionLock.Close()
+					if err == nil {
+						err = closeErr
+					}
 				}
 			}
 			if err == nil {

--- a/internal/proxy/multitenant.go
+++ b/internal/proxy/multitenant.go
@@ -52,8 +52,9 @@ type MultiTenant struct {
 	StackTeams interface {
 		ListTeams(context.Context, string) ([]stackauth.Team, error)
 	}
-	StackTenantKeySecret []byte
-	PublicURL            string
+	StackTenantKeySecret   []byte
+	StackTenantDeleteToken []byte
+	PublicURL              string
 
 	mu       sync.Mutex
 	servers  map[string]*Server
@@ -450,8 +451,13 @@ func (m *MultiTenant) handleStackTenantDelete(w http.ResponseWriter, r *http.Req
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if m.StackVerifier == nil || len(m.StackTenantKeySecret) < 32 {
+	if m.StackVerifier == nil || len(m.StackTenantKeySecret) < 32 || len(m.StackTenantDeleteToken) < 32 {
 		http.NotFound(w, r)
+		return
+	}
+	deleteToken := strings.TrimSpace(r.Header.Get("X-Subrouter-Tenant-Delete-Token"))
+	if subtle.ConstantTimeCompare([]byte(deleteToken), m.StackTenantDeleteToken) != 1 {
+		http.Error(w, "trusted tenant deletion credential required", http.StatusUnauthorized)
 		return
 	}
 	token := bearerToken(r.Header.Get("Authorization"))

--- a/internal/proxy/multitenant.go
+++ b/internal/proxy/multitenant.go
@@ -523,6 +523,7 @@ func (m *MultiTenant) handleStackTenantDelete(w http.ResponseWriter, r *http.Req
 	}
 	useLock, acquired, err := m.Registry.TryAcquireExclusiveUse(teamID)
 	if err != nil {
+		m.scheduleTenantDeletion(teamID)
 		http.Error(w, "tenant retirement failed", http.StatusInternalServerError)
 		return
 	}

--- a/internal/proxy/multitenant.go
+++ b/internal/proxy/multitenant.go
@@ -39,9 +39,8 @@ type MultiTenant struct {
 	// TranscriptDir, when set, scopes each tenant's transcripts under
 	// <TranscriptDir>/tenants/<id>.
 	TranscriptDir string
-	// Enabled forces tenant-key semantics for header-borne keys even before
-	// the first tenant exists (the --multi-tenant serve flag). Path-borne
-	// /t/<key>/ requests are always tenant-scoped.
+	// Enabled is retained for --multi-tenant CLI compatibility. Tenant-shaped
+	// credentials now always fail closed when they do not resolve.
 	Enabled bool
 	// StackVerifier enables normal-user tenant exchange at
 	// /_subrouter/auth/stack. StackTenantKeySecret deterministically derives
@@ -59,11 +58,16 @@ type MultiTenant struct {
 	mu       sync.Mutex
 	servers  map[string]*Server
 	handlers map[string]http.Handler
+
+	deletionMu   sync.Mutex
+	deletions    map[string]struct{}
+	resumeDelete sync.Once
 }
 
 // Handler wraps the legacy single-tenant handler with tenant routing and the
 // admin tenant CRUD endpoints.
 func (m *MultiTenant) Handler(fallback http.Handler) http.Handler {
+	m.resumeDelete.Do(m.resumeTenantDeletions)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/_subrouter/auth/stack/tenant" {
 			m.handleStackTenantDelete(w, r)
@@ -91,13 +95,11 @@ func (m *MultiTenant) Handler(fallback http.Handler) http.Handler {
 				m.serveResolvedTenant(w, r, resolved, r.URL.Path, key)
 				return
 			}
-			// A key-shaped credential that resolves to nothing is rejected once
-			// multi-tenant mode is active; before that, legacy traffic that
-			// happens to carry such a token keeps today's behavior.
-			if m.Enabled || m.Registry.HasTenants() {
-				http.Error(w, "unknown tenant key", http.StatusUnauthorized)
-				return
-			}
+			// srt_ credentials belong exclusively to tenant routing. Always fail
+			// closed, including after the last tenant has been deleted, so a
+			// retired key can never fall through to the legacy global pool.
+			http.Error(w, "unknown tenant key", http.StatusUnauthorized)
+			return
 		}
 		if r.Method == http.MethodPost && r.URL.Path == "/_subrouter/reload-accounts" && isLoopbackRemote(r.RemoteAddr) {
 			// The account-upload flow POSTs the global reload endpoint from
@@ -516,10 +518,6 @@ func (m *MultiTenant) handleStackTenantDelete(w http.ResponseWriter, r *http.Req
 	}
 	retired, err := m.Registry.RetireExternal(teamID)
 	if err != nil {
-		if errors.Is(err, tenant.ErrTenantRetired) {
-			http.Error(w, "tenant is retired", http.StatusConflict)
-			return
-		}
 		http.Error(w, "tenant retirement failed", http.StatusInternalServerError)
 		return
 	}
@@ -530,6 +528,7 @@ func (m *MultiTenant) handleStackTenantDelete(w http.ResponseWriter, r *http.Req
 	}
 	w.Header().Set("Cache-Control", "no-store")
 	if !acquired {
+		m.scheduleTenantDeletion(teamID)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 		writeJSON(w, map[string]any{"ok": false, "deletionPending": true})
@@ -538,11 +537,62 @@ func (m *MultiTenant) handleStackTenantDelete(w http.ResponseWriter, r *http.Req
 	defer useLock.Close()
 	deleted, err := m.Registry.DeleteRetired(teamID)
 	if err != nil {
+		m.scheduleTenantDeletion(teamID)
 		http.Error(w, "tenant deletion failed", http.StatusInternalServerError)
 		return
 	}
 	m.forgetTenant(teamID)
 	writeJSON(w, map[string]any{"ok": true, "deleted": retired || deleted})
+}
+
+func (m *MultiTenant) resumeTenantDeletions() {
+	if m.Registry == nil {
+		return
+	}
+	ids, err := m.Registry.PendingDeletionIDs()
+	if err != nil {
+		if m.Base.Logger != nil {
+			m.Base.Logger.Error("tenant deletion recovery scan failed", "error", err)
+		}
+		return
+	}
+	for _, id := range ids {
+		m.scheduleTenantDeletion(id)
+	}
+}
+
+func (m *MultiTenant) scheduleTenantDeletion(id string) {
+	m.deletionMu.Lock()
+	if m.deletions == nil {
+		m.deletions = map[string]struct{}{}
+	}
+	if _, exists := m.deletions[id]; exists {
+		m.deletionMu.Unlock()
+		return
+	}
+	m.deletions[id] = struct{}{}
+	m.deletionMu.Unlock()
+
+	go func() {
+		deletionLock, err := m.Registry.AcquireExclusiveUse(id)
+		if err == nil {
+			_, err = m.Registry.DeleteRetired(id)
+			closeErr := deletionLock.Close()
+			if err == nil {
+				err = closeErr
+			}
+		}
+		if err != nil {
+			if m.Base.Logger != nil {
+				m.Base.Logger.Error("background tenant deletion failed", "tenant", id, "error", err)
+			}
+		} else {
+			m.forgetTenant(id)
+		}
+		m.deletionMu.Lock()
+		delete(m.deletions, id)
+		m.deletionMu.Unlock()
+	}()
 }
 
 func (m *MultiTenant) forgetTenant(id string) {

--- a/internal/proxy/multitenant.go
+++ b/internal/proxy/multitenant.go
@@ -574,24 +574,40 @@ func (m *MultiTenant) scheduleTenantDeletion(id string) {
 	m.deletionMu.Unlock()
 
 	go func() {
-		deletionLock, err := m.Registry.AcquireExclusiveUse(id)
-		if err == nil {
-			_, err = m.Registry.DeleteRetired(id)
-			closeErr := deletionLock.Close()
+		defer func() {
+			m.deletionMu.Lock()
+			delete(m.deletions, id)
+			m.deletionMu.Unlock()
+		}()
+		backoff := 100 * time.Millisecond
+		for {
+			deletionLock, err := m.Registry.AcquireExclusiveUse(id)
 			if err == nil {
-				err = closeErr
+				_, err = m.Registry.DeleteRetired(id)
+				closeErr := deletionLock.Close()
+				if err == nil {
+					err = closeErr
+				}
 			}
-		}
-		if err != nil {
+			if err == nil {
+				m.forgetTenant(id)
+				return
+			}
 			if m.Base.Logger != nil {
 				m.Base.Logger.Error("background tenant deletion failed", "tenant", id, "error", err)
 			}
-		} else {
-			m.forgetTenant(id)
+			if m.Base.Lifecycle != nil && m.Base.Lifecycle.Draining() {
+				return
+			}
+			timer := time.NewTimer(backoff)
+			<-timer.C
+			if backoff < 30*time.Second {
+				backoff *= 2
+				if backoff > 30*time.Second {
+					backoff = 30 * time.Second
+				}
+			}
 		}
-		m.deletionMu.Lock()
-		delete(m.deletions, id)
-		m.deletionMu.Unlock()
 	}()
 }
 

--- a/internal/proxy/multitenant.go
+++ b/internal/proxy/multitenant.go
@@ -653,16 +653,12 @@ func (m *MultiTenant) scheduleTenantDeletion(id string) {
 }
 
 func (m *MultiTenant) deleteRetiredTenant(id string) (bool, error) {
-	deleted, err := m.Registry.DeleteRetired(id)
-	if err != nil {
-		return false, err
-	}
 	if m.TranscriptDir != "" {
 		if err := os.RemoveAll(filepath.Join(m.TranscriptDir, "tenants", id)); err != nil {
 			return false, err
 		}
 	}
-	return deleted, nil
+	return m.Registry.DeleteRetired(id)
 }
 
 func (m *MultiTenant) forgetTenant(id string) {

--- a/internal/proxy/multitenant.go
+++ b/internal/proxy/multitenant.go
@@ -430,6 +430,10 @@ func (m *MultiTenant) handleStackAuth(w http.ResponseWriter, r *http.Request) {
 	}
 	created, err := m.Registry.EnsureExternal(teamID, teamName, key)
 	if err != nil {
+		if errors.Is(err, tenant.ErrTenantRetired) {
+			http.Error(w, "tenant is retired", http.StatusGone)
+			return
+		}
 		http.Error(w, "tenant unavailable", http.StatusInternalServerError)
 		return
 	}

--- a/internal/proxy/multitenant.go
+++ b/internal/proxy/multitenant.go
@@ -64,6 +64,10 @@ type MultiTenant struct {
 // admin tenant CRUD endpoints.
 func (m *MultiTenant) Handler(fallback http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_subrouter/auth/stack/tenant" {
+			m.handleStackTenantDelete(w, r)
+			return
+		}
 		if r.URL.Path == "/_subrouter/auth/stack" {
 			m.handleStackAuth(w, r)
 			return
@@ -83,7 +87,7 @@ func (m *MultiTenant) Handler(fallback http.Handler) http.Handler {
 				return
 			}
 			if ok {
-				m.serveResolvedTenant(w, r, resolved, r.URL.Path)
+				m.serveResolvedTenant(w, r, resolved, r.URL.Path, key)
 				return
 			}
 			// A key-shaped credential that resolves to nothing is rejected once
@@ -143,10 +147,31 @@ func (m *MultiTenant) serveTenant(w http.ResponseWriter, r *http.Request, key, r
 		http.Error(w, "unknown tenant key", http.StatusUnauthorized)
 		return
 	}
-	m.serveResolvedTenant(w, r, resolved, rest)
+	m.serveResolvedTenant(w, r, resolved, rest, key)
 }
 
-func (m *MultiTenant) serveResolvedTenant(w http.ResponseWriter, r *http.Request, t tenant.Tenant, path string) {
+func (m *MultiTenant) serveResolvedTenant(
+	w http.ResponseWriter,
+	r *http.Request,
+	t tenant.Tenant,
+	path string,
+	key string,
+) {
+	useLock, err := m.Registry.AcquireUse(t.ID)
+	if err != nil {
+		http.Error(w, "tenant unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	defer useLock.Close()
+	fresh, ok, err := m.Registry.ResolveFresh(key)
+	if err != nil {
+		http.Error(w, "tenant registry error", http.StatusInternalServerError)
+		return
+	}
+	if !ok || subtle.ConstantTimeCompare([]byte(fresh.ID), []byte(t.ID)) != 1 {
+		http.Error(w, "unknown tenant key", http.StatusUnauthorized)
+		return
+	}
 	handler, err := m.handlerFor(r.Context(), t)
 	if err != nil {
 		if m.Base.Logger != nil {
@@ -356,7 +381,8 @@ func (m *MultiTenant) handleStackAuth(w http.ResponseWriter, r *http.Request) {
 	if teamID == "" {
 		teamID = claims.SelectedTeamID
 	}
-	if subtle.ConstantTimeCompare([]byte(teamID), []byte(claims.SelectedTeamID)) != 1 {
+	if subtle.ConstantTimeCompare([]byte(teamID), []byte(claims.SelectedTeamID)) != 1 &&
+		subtle.ConstantTimeCompare([]byte(teamID), []byte(claims.Subject)) != 1 {
 		if m.StackTeams == nil {
 			http.Error(w, "Stack team membership cannot be verified", http.StatusServiceUnavailable)
 			return
@@ -413,6 +439,107 @@ func (m *MultiTenant) handleStackAuth(w http.ResponseWriter, r *http.Request) {
 		"tenantId": created.ID, "tenantName": created.Name,
 		"tenantKey": key, "proxyUrl": proxyURL,
 	})
+}
+
+func (m *MultiTenant) handleStackTenantDelete(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if m.StackVerifier == nil || len(m.StackTenantKeySecret) < 32 {
+		http.NotFound(w, r)
+		return
+	}
+	token := bearerToken(r.Header.Get("Authorization"))
+	if token == "" {
+		http.Error(w, "Stack access token required", http.StatusUnauthorized)
+		return
+	}
+	claims, err := m.StackVerifier.Verify(r.Context(), token)
+	if err != nil {
+		if m.Base.Logger != nil {
+			m.Base.Logger.Warn("Stack tenant deletion rejected", "error", err)
+		}
+		http.Error(w, "invalid Stack access token", http.StatusUnauthorized)
+		return
+	}
+	var input struct {
+		TeamID string `json:"teamId"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, tenantAdminMaxBodyBytes)).Decode(&input); err != nil && !errors.Is(err, io.EOF) {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	teamID := strings.TrimSpace(input.TeamID)
+	if teamID == "" {
+		teamID = claims.SelectedTeamID
+	}
+	if !tenant.ValidExternalID(teamID) {
+		http.Error(w, "team ID is invalid", http.StatusBadRequest)
+		return
+	}
+	authorized := subtle.ConstantTimeCompare([]byte(teamID), []byte(claims.SelectedTeamID)) == 1 ||
+		subtle.ConstantTimeCompare([]byte(teamID), []byte(claims.Subject)) == 1
+	if !authorized {
+		if m.StackTeams == nil {
+			http.Error(w, "Stack team membership cannot be verified", http.StatusServiceUnavailable)
+			return
+		}
+		teams, err := m.StackTeams.ListTeams(r.Context(), token)
+		if err != nil {
+			if m.Base.Logger != nil {
+				m.Base.Logger.Warn("Stack tenant deletion membership lookup failed", "error", err)
+			}
+			http.Error(w, "Stack team membership unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		for _, candidate := range teams {
+			if subtle.ConstantTimeCompare([]byte(candidate.ID), []byte(teamID)) == 1 {
+				authorized = true
+				break
+			}
+		}
+	}
+	if !authorized {
+		http.Error(w, "Stack access token does not belong to that team", http.StatusForbidden)
+		return
+	}
+	retired, err := m.Registry.RetireExternal(teamID)
+	if err != nil {
+		if errors.Is(err, tenant.ErrTenantRetired) {
+			http.Error(w, "tenant is retired", http.StatusConflict)
+			return
+		}
+		http.Error(w, "tenant retirement failed", http.StatusInternalServerError)
+		return
+	}
+	useLock, acquired, err := m.Registry.TryAcquireExclusiveUse(teamID)
+	if err != nil {
+		http.Error(w, "tenant retirement failed", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	if !acquired {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		writeJSON(w, map[string]any{"ok": false, "deletionPending": true})
+		return
+	}
+	defer useLock.Close()
+	deleted, err := m.Registry.DeleteRetired(teamID)
+	if err != nil {
+		http.Error(w, "tenant deletion failed", http.StatusInternalServerError)
+		return
+	}
+	m.forgetTenant(teamID)
+	writeJSON(w, map[string]any{"ok": true, "deleted": retired || deleted})
+}
+
+func (m *MultiTenant) forgetTenant(id string) {
+	m.mu.Lock()
+	delete(m.servers, id)
+	delete(m.handlers, id)
+	m.mu.Unlock()
 }
 
 func validStackTeamName(name string) bool {

--- a/internal/proxy/multitenant.go
+++ b/internal/proxy/multitenant.go
@@ -537,7 +537,7 @@ func (m *MultiTenant) handleStackTenantDelete(w http.ResponseWriter, r *http.Req
 		return
 	}
 	defer useLock.Close()
-	deleted, err := m.Registry.DeleteRetired(teamID)
+	deleted, err := m.deleteRetiredTenant(teamID)
 	if err != nil {
 		m.scheduleTenantDeletion(teamID)
 		http.Error(w, "tenant deletion failed", http.StatusInternalServerError)
@@ -551,15 +551,50 @@ func (m *MultiTenant) resumeTenantDeletions() {
 	if m.Registry == nil {
 		return
 	}
+	if err := m.scanPendingTenantDeletions(); err == nil {
+		return
+	} else {
+		m.logTenantDeletionRecoveryFailure(err)
+	}
+	go m.retryTenantDeletionRecovery()
+}
+
+func (m *MultiTenant) scanPendingTenantDeletions() error {
 	ids, err := m.Registry.PendingDeletionIDs()
 	if err != nil {
-		if m.Base.Logger != nil {
-			m.Base.Logger.Error("tenant deletion recovery scan failed", "error", err)
-		}
-		return
+		return err
 	}
 	for _, id := range ids {
 		m.scheduleTenantDeletion(id)
+	}
+	return nil
+}
+
+func (m *MultiTenant) retryTenantDeletionRecovery() {
+	backoff := 100 * time.Millisecond
+	for {
+		if m.Base.Lifecycle != nil && m.Base.Lifecycle.Draining() {
+			return
+		}
+		timer := time.NewTimer(backoff)
+		<-timer.C
+		if err := m.scanPendingTenantDeletions(); err == nil {
+			return
+		} else {
+			m.logTenantDeletionRecoveryFailure(err)
+		}
+		if backoff < 30*time.Second {
+			backoff *= 2
+			if backoff > 30*time.Second {
+				backoff = 30 * time.Second
+			}
+		}
+	}
+}
+
+func (m *MultiTenant) logTenantDeletionRecoveryFailure(err error) {
+	if m.Base.Logger != nil {
+		m.Base.Logger.Error("tenant deletion recovery scan failed", "error", err)
 	}
 }
 
@@ -588,7 +623,7 @@ func (m *MultiTenant) scheduleTenantDeletion(id string) {
 				var deletionLock *tenant.UseLock
 				deletionLock, err = m.Registry.AcquireExclusiveUse(id)
 				if err == nil {
-					_, err = m.Registry.DeleteRetired(id)
+					_, err = m.deleteRetiredTenant(id)
 					closeErr := deletionLock.Close()
 					if err == nil {
 						err = closeErr
@@ -615,6 +650,19 @@ func (m *MultiTenant) scheduleTenantDeletion(id string) {
 			}
 		}
 	}()
+}
+
+func (m *MultiTenant) deleteRetiredTenant(id string) (bool, error) {
+	deleted, err := m.Registry.DeleteRetired(id)
+	if err != nil {
+		return false, err
+	}
+	if m.TranscriptDir != "" {
+		if err := os.RemoveAll(filepath.Join(m.TranscriptDir, "tenants", id)); err != nil {
+			return false, err
+		}
+	}
+	return deleted, nil
 }
 
 func (m *MultiTenant) forgetTenant(id string) {

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -712,6 +712,120 @@ func TestStackTenantDeletionRetriesAfterExclusiveLockSetupFailure(t *testing.T) 
 	}
 }
 
+func TestStackTenantDeletionRetriesRetirementFailures(t *testing.T) {
+	for _, testCase := range []struct {
+		name  string
+		fault func(*testing.T, string, *tenant.Registry) func()
+	}{
+		{
+			name: "after committed revocation",
+			fault: func(t *testing.T, stateDir string, _ *tenant.Registry) func() {
+				t.Helper()
+				blocker := filepath.Join(stateDir, "retiring-tenants")
+				if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return func() {
+					if err := os.Remove(blocker); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+		},
+		{
+			name: "before committed revocation",
+			fault: func(t *testing.T, _ string, registry *tenant.Registry) func() {
+				t.Helper()
+				backup := registry.Path() + ".backup"
+				if err := os.Rename(registry.Path(), backup); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Mkdir(registry.Path(), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				return func() {
+					if err := os.Remove(registry.Path()); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.Rename(backup, registry.Path()); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			stateDir := t.TempDir()
+			registry := tenant.NewRegistry(stateDir)
+			key, err := tenant.DeriveKey(
+				[]byte("0123456789abcdef0123456789abcdef"),
+				"project",
+				"user-1",
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			created, err := registry.EnsureExternal("user-1", "User One", key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeTenantAPIKeyAccount(t, registry, created.ID, "apikey:openai-apikey:work", "sk-test")
+			recoverFault := testCase.fault(t, stateDir, registry)
+
+			base := Server{MaxBodyBytes: 1024}
+			multi := &MultiTenant{
+				Base: base, Registry: registry,
+				StackVerifier: fakeStackVerifier{claims: stackauth.Claims{
+					Subject: "user-1", ProjectID: "project", SelectedTeamID: "team-123",
+				}},
+				StackTenantKeySecret:   []byte("0123456789abcdef0123456789abcdef"),
+				StackTenantDeleteToken: []byte(testStackTenantDeleteToken),
+			}
+			handler := multi.Handler(base.Handler())
+			req := httptest.NewRequest(
+				http.MethodDelete,
+				"/_subrouter/auth/stack/tenant",
+				strings.NewReader(`{"teamId":"user-1"}`),
+			)
+			req.Header.Set("Authorization", "Bearer stack-access")
+			req.Header.Set("X-Subrouter-Tenant-Delete-Token", testStackTenantDeleteToken)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, req)
+			if response.Code != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want 500, body = %s", response.Code, response.Body.String())
+			}
+			recoverFault()
+
+			deadline := time.Now().Add(time.Second)
+			for {
+				_, err := os.Stat(registry.Dir(created.ID))
+				if errors.Is(err, os.ErrNotExist) {
+					break
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				if time.Now().After(deadline) {
+					t.Fatal("retired tenant was not deleted after retirement recovered")
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			for {
+				multi.deletionMu.Lock()
+				_, pending := multi.deletions[created.ID]
+				multi.deletionMu.Unlock()
+				if !pending {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatal("background tenant deletion did not finish")
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+		})
+	}
+}
+
 func TestStackTenantDeletionRevokesNewRequestsThenDrainsInFlightTraffic(t *testing.T) {
 	releaseUpstream := make(chan struct{})
 	upstreamReleased := false

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -178,6 +178,35 @@ func TestMultiTenantRejectsUnknownKeys(t *testing.T) {
 	}
 }
 
+func TestMultiTenantRejectsADeletedFinalTenantKey(t *testing.T) {
+	registry, handler, _ := newMultiTenantFixture(t)
+	created, key, err := registry.Create("only-tenant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.RetireExternal(created.ID); err != nil {
+		t.Fatal(err)
+	}
+	lock, acquired, err := registry.TryAcquireExclusiveUse(created.ID)
+	if err != nil || !acquired {
+		t.Fatalf("exclusive use lock = %v, %v", acquired, err)
+	}
+	if _, err := registry.DeleteRetired(created.ID); err != nil {
+		lock.Close()
+		t.Fatal(err)
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	response := doProxyRequest(t, handler, "/v1/responses", "deleted", func(r *http.Request) {
+		r.Header.Set("Authorization", "Bearer "+key)
+	})
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("deleted final tenant key status = %d, body = %s", response.Code, response.Body.String())
+	}
+}
+
 func TestMultiTenantHeaderKeyFallsThroughBeforeFirstTenant(t *testing.T) {
 	_, handler, _ := newMultiTenantFixture(t)
 	// No tenants exist and --multi-tenant is off: a key-shaped bearer token
@@ -702,6 +731,20 @@ func TestStackTenantDeletionRevokesNewRequestsThenDrainsInFlightTraffic(t *testi
 		}
 	case <-time.After(time.Second):
 		t.Fatal("in-flight request did not drain")
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		_, err := os.Stat(registry.Dir("user-1"))
+		if errors.Is(err, os.ErrNotExist) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("retired tenant was not deleted after in-flight requests drained")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 	finalDelete := deleteTenant()
 	if finalDelete.Code != http.StatusOK {

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -632,6 +632,73 @@ func TestStackTenantDeletionRequiresTrustedServiceCredential(t *testing.T) {
 	}
 }
 
+func TestStackTenantDeletionRetriesAfterExclusiveLockSetupFailure(t *testing.T) {
+	stateDir := t.TempDir()
+	registry := tenant.NewRegistry(stateDir)
+	key, err := tenant.DeriveKey(
+		[]byte("0123456789abcdef0123456789abcdef"),
+		"project",
+		"user-1",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := registry.EnsureExternal("user-1", "User One", key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTenantAPIKeyAccount(t, registry, created.ID, "apikey:openai-apikey:work", "sk-test")
+
+	// A non-directory at the lock-directory path makes both the synchronous
+	// lock attempt and the background worker's first attempt fail.
+	lockDirectory := filepath.Join(stateDir, "tenant-use-locks")
+	if err := os.WriteFile(lockDirectory, []byte("blocked"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	base := Server{MaxBodyBytes: 1024}
+	handler := (&MultiTenant{
+		Base: base, Registry: registry,
+		StackVerifier: fakeStackVerifier{claims: stackauth.Claims{
+			Subject: "user-1", ProjectID: "project", SelectedTeamID: "team-123",
+		}},
+		StackTenantKeySecret:   []byte("0123456789abcdef0123456789abcdef"),
+		StackTenantDeleteToken: []byte(testStackTenantDeleteToken),
+	}).Handler(base.Handler())
+	req := httptest.NewRequest(
+		http.MethodDelete,
+		"/_subrouter/auth/stack/tenant",
+		strings.NewReader(`{"teamId":"user-1"}`),
+	)
+	req.Header.Set("Authorization", "Bearer stack-access")
+	req.Header.Set("X-Subrouter-Tenant-Delete-Token", testStackTenantDeleteToken)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, req)
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500, body = %s", response.Code, response.Body.String())
+	}
+	if _, ok, err := registry.Resolve(key); err != nil || ok {
+		t.Fatalf("retired key still resolves: ok=%v err=%v", ok, err)
+	}
+	if err := os.Remove(lockDirectory); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		_, err := os.Stat(registry.Dir(created.ID))
+		if errors.Is(err, os.ErrNotExist) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("retired tenant was not deleted after the lock setup recovered")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func TestStackTenantDeletionRevokesNewRequestsThenDrainsInFlightTraffic(t *testing.T) {
 	releaseUpstream := make(chan struct{})
 	upstreamReleased := false

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -632,6 +632,115 @@ func TestStackTenantDeletionRequiresTrustedServiceCredential(t *testing.T) {
 	}
 }
 
+func TestStackTenantDeletionRemovesTenantTranscripts(t *testing.T) {
+	registry := tenant.NewRegistry(t.TempDir())
+	key, err := tenant.DeriveKey(
+		[]byte("0123456789abcdef0123456789abcdef"),
+		"project",
+		"user-1",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.EnsureExternal("user-1", "User One", key); err != nil {
+		t.Fatal(err)
+	}
+	transcriptRoot := t.TempDir()
+	tenantTranscriptDir := filepath.Join(transcriptRoot, "tenants", "user-1")
+	if err := os.MkdirAll(tenantTranscriptDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tenantTranscriptDir, "session.jsonl"), []byte("secret transcript"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	base := Server{MaxBodyBytes: 1024}
+	handler := (&MultiTenant{
+		Base: base, Registry: registry, TranscriptDir: transcriptRoot,
+		StackVerifier: fakeStackVerifier{claims: stackauth.Claims{
+			Subject: "user-1", ProjectID: "project", SelectedTeamID: "team-123",
+		}},
+		StackTenantKeySecret:   []byte("0123456789abcdef0123456789abcdef"),
+		StackTenantDeleteToken: []byte(testStackTenantDeleteToken),
+	}).Handler(base.Handler())
+	req := httptest.NewRequest(
+		http.MethodDelete,
+		"/_subrouter/auth/stack/tenant",
+		strings.NewReader(`{"teamId":"user-1"}`),
+	)
+	req.Header.Set("Authorization", "Bearer stack-access")
+	req.Header.Set("X-Subrouter-Tenant-Delete-Token", testStackTenantDeleteToken)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, req)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	if _, err := os.Stat(tenantTranscriptDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("tenant transcripts remain after deletion: %v", err)
+	}
+}
+
+func TestTenantDeletionRecoveryRetriesAfterTransientStartupScanFailure(t *testing.T) {
+	stateDir := t.TempDir()
+	registry := tenant.NewRegistry(stateDir)
+	key, err := tenant.DeriveKey(
+		[]byte("0123456789abcdef0123456789abcdef"),
+		"project",
+		"user-1",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := registry.EnsureExternal("user-1", "User One", key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retired, err := registry.RetireExternal(created.ID); err != nil || !retired {
+		t.Fatalf("retire = %v, %v", retired, err)
+	}
+
+	registryBackup := registry.Path() + ".backup"
+	if err := os.Rename(registry.Path(), registryBackup); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(registry.Path(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	recoveryFailure := make(chan struct{}, 1)
+	base := Server{Logger: slog.New(slog.NewTextHandler(signalLogWriter{
+		match: "tenant deletion recovery scan failed",
+		seen:  recoveryFailure,
+	}, nil))}
+	multi := &MultiTenant{Base: base, Registry: registry}
+	_ = multi.Handler(base.Handler())
+	select {
+	case <-recoveryFailure:
+	case <-time.After(time.Second):
+		t.Fatal("startup recovery scan did not report the injected failure")
+	}
+	if err := os.Remove(registry.Path()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(registryBackup, registry.Path()); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		_, err := os.Stat(registry.Dir(created.ID))
+		if errors.Is(err, os.ErrNotExist) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("startup deletion recovery was not retried after the registry recovered")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func TestStackTenantDeletionRetriesAfterExclusiveLockSetupFailure(t *testing.T) {
 	stateDir := t.TempDir()
 	registry := tenant.NewRegistry(stateDir)

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -670,6 +670,17 @@ func TestStackTenantDeletionRevokesNewRequestsThenDrainsInFlightTraffic(t *testi
 	if _, found, err := registry.Find("user-1"); err != nil || found {
 		t.Fatalf("tenant registry entry remains: found=%v err=%v", found, err)
 	}
+	reactivate := httptest.NewRequest(
+		http.MethodPost,
+		"/_subrouter/auth/stack",
+		strings.NewReader(`{"teamId":"user-1","teamName":"User One"}`),
+	)
+	reactivate.Header.Set("Authorization", "Bearer stack-access")
+	reactivateResponse := httptest.NewRecorder()
+	handler.ServeHTTP(reactivateResponse, reactivate)
+	if reactivateResponse.Code != http.StatusGone {
+		t.Fatalf("retired tenant reactivation status = %d, body = %s", reactivateResponse.Code, reactivateResponse.Body.String())
+	}
 	if repeated := deleteTenant(); repeated.Code != http.StatusOK {
 		t.Fatalf("idempotent deletion status = %d, body = %s", repeated.Code, repeated.Body.String())
 	}

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -467,7 +467,8 @@ func TestStackLoginCreatesStableTenantAndAcceptsDirectAccountUpload(t *testing.T
 	}
 	multi := &MultiTenant{
 		Base: base, Registry: registry, PublicURL: "https://sr.example",
-		StackTenantKeySecret: []byte("0123456789abcdef0123456789abcdef"),
+		StackTenantKeySecret:   []byte("0123456789abcdef0123456789abcdef"),
+		StackTenantDeleteToken: []byte(testStackTenantDeleteToken),
 		StackVerifier: fakeStackVerifier{claims: stackauth.Claims{
 			ProjectID: "project", SelectedTeamID: "team-123",
 			Email: "user@example.com",
@@ -569,7 +570,8 @@ func TestStackTenantDeletionRequiresTrustedServiceCredential(t *testing.T) {
 		StackVerifier: fakeStackVerifier{claims: stackauth.Claims{
 			Subject: "ordinary-member", ProjectID: "project", SelectedTeamID: "team-victim",
 		}},
-		StackTenantKeySecret: []byte("0123456789abcdef0123456789abcdef"),
+		StackTenantKeySecret:   []byte("0123456789abcdef0123456789abcdef"),
+		StackTenantDeleteToken: []byte(testStackTenantDeleteToken),
 	}).Handler(base.Handler())
 	req := httptest.NewRequest(
 		http.MethodDelete,
@@ -579,8 +581,8 @@ func TestStackTenantDeletionRequiresTrustedServiceCredential(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer stack-access")
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, req)
-	if response.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want 404, body = %s", response.Code, response.Body.String())
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401, body = %s", response.Code, response.Body.String())
 	}
 	if resolved, ok, err := registry.Resolve(key); err != nil || !ok || resolved.ID != "team-victim" {
 		t.Fatalf("untrusted deletion changed tenant: resolved=%#v ok=%v err=%v", resolved, ok, err)
@@ -636,7 +638,8 @@ func TestStackTenantDeletionRevokesNewRequestsThenDrainsInFlightTraffic(t *testi
 	writeTenantAPIKeyAccount(t, registry, created.ID, "apikey:openai-apikey:work", "sk-test")
 	multi := &MultiTenant{
 		Base: base, Registry: registry, PublicURL: "https://sr.example",
-		StackTenantKeySecret: []byte("0123456789abcdef0123456789abcdef"),
+		StackTenantKeySecret:   []byte("0123456789abcdef0123456789abcdef"),
+		StackTenantDeleteToken: []byte(testStackTenantDeleteToken),
 		StackVerifier: fakeStackVerifier{claims: stackauth.Claims{
 			Subject: "user-1", ProjectID: "project", SelectedTeamID: "team-123",
 		}},
@@ -745,8 +748,9 @@ func TestStackTenantDeletionRejectsNonMemberWithoutRetiringTenant(t *testing.T) 
 		StackVerifier: fakeStackVerifier{claims: stackauth.Claims{
 			Subject: "user-1", ProjectID: "project", SelectedTeamID: "team-123",
 		}},
-		StackTeams:           fakeStackTeams{teams: []stackauth.Team{{ID: "team-123"}}},
-		StackTenantKeySecret: []byte("0123456789abcdef0123456789abcdef"),
+		StackTeams:             fakeStackTeams{teams: []stackauth.Team{{ID: "team-123"}}},
+		StackTenantKeySecret:   []byte("0123456789abcdef0123456789abcdef"),
+		StackTenantDeleteToken: []byte(testStackTenantDeleteToken),
 	}).Handler(base.Handler())
 	req := httptest.NewRequest(
 		http.MethodDelete,

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -778,7 +778,7 @@ func TestTenantDeletionRecoveryRetriesAfterTransientStartupScanFailure(t *testin
 		t.Fatal(err)
 	}
 
-	deadline := time.Now().Add(time.Second)
+	deadline := time.Now().Add(5 * time.Second)
 	for {
 		_, err := os.Stat(registry.Dir(created.ID))
 		if errors.Is(err, os.ErrNotExist) {
@@ -792,6 +792,7 @@ func TestTenantDeletionRecoveryRetriesAfterTransientStartupScanFailure(t *testin
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	deadline = time.Now().Add(5 * time.Second)
 	for {
 		multi.deletionMu.Lock()
 		_, pending := multi.deletions[created.ID]
@@ -858,7 +859,7 @@ func TestStackTenantDeletionRetriesAfterExclusiveLockSetupFailure(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	deadline := time.Now().Add(time.Second)
+	deadline := time.Now().Add(5 * time.Second)
 	for {
 		_, err := os.Stat(registry.Dir(created.ID))
 		if errors.Is(err, os.ErrNotExist) {
@@ -872,6 +873,7 @@ func TestStackTenantDeletionRetriesAfterExclusiveLockSetupFailure(t *testing.T) 
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	deadline = time.Now().Add(5 * time.Second)
 	for {
 		multi.deletionMu.Lock()
 		_, pending := multi.deletions[created.ID]

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -656,14 +656,15 @@ func TestStackTenantDeletionRetriesAfterExclusiveLockSetupFailure(t *testing.T) 
 		t.Fatal(err)
 	}
 	base := Server{MaxBodyBytes: 1024}
-	handler := (&MultiTenant{
+	multi := &MultiTenant{
 		Base: base, Registry: registry,
 		StackVerifier: fakeStackVerifier{claims: stackauth.Claims{
 			Subject: "user-1", ProjectID: "project", SelectedTeamID: "team-123",
 		}},
 		StackTenantKeySecret:   []byte("0123456789abcdef0123456789abcdef"),
 		StackTenantDeleteToken: []byte(testStackTenantDeleteToken),
-	}).Handler(base.Handler())
+	}
+	handler := multi.Handler(base.Handler())
 	req := httptest.NewRequest(
 		http.MethodDelete,
 		"/_subrouter/auth/stack/tenant",
@@ -694,6 +695,18 @@ func TestStackTenantDeletionRetriesAfterExclusiveLockSetupFailure(t *testing.T) 
 		}
 		if time.Now().After(deadline) {
 			t.Fatal("retired tenant was not deleted after the lock setup recovered")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	for {
+		multi.deletionMu.Lock()
+		_, pending := multi.deletions[created.ID]
+		multi.deletionMu.Unlock()
+		if !pending {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("background tenant deletion did not finish")
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -576,9 +576,9 @@ func TestStackTenantDeletionRevokesNewRequestsThenDrainsInFlightTraffic(t *testi
 		t.Fatal(err)
 	}
 	base := Server{
-		Upstream: upstreamURL,
-		Sessions: sessions,
-		Scheduler: selectacct.NewScheduler(nil),
+		Upstream:     upstreamURL,
+		Sessions:     sessions,
+		Scheduler:    selectacct.NewScheduler(nil),
 		MaxBodyBytes: 1024,
 	}
 	registry := tenant.NewRegistry(t.TempDir())
@@ -694,7 +694,7 @@ func TestStackTenantDeletionRejectsNonMemberWithoutRetiringTenant(t *testing.T) 
 		StackVerifier: fakeStackVerifier{claims: stackauth.Claims{
 			Subject: "user-1", ProjectID: "project", SelectedTeamID: "team-123",
 		}},
-		StackTeams: fakeStackTeams{teams: []stackauth.Team{{ID: "team-123"}}},
+		StackTeams:           fakeStackTeams{teams: []stackauth.Team{{ID: "team-123"}}},
 		StackTenantKeySecret: []byte("0123456789abcdef0123456789abcdef"),
 	}).Handler(base.Handler())
 	req := httptest.NewRequest(

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -207,15 +207,13 @@ func TestMultiTenantRejectsADeletedFinalTenantKey(t *testing.T) {
 	}
 }
 
-func TestMultiTenantHeaderKeyFallsThroughBeforeFirstTenant(t *testing.T) {
+func TestMultiTenantRejectsUnknownHeaderKeyBeforeFirstTenant(t *testing.T) {
 	_, handler, _ := newMultiTenantFixture(t)
-	// No tenants exist and --multi-tenant is off: a key-shaped bearer token
-	// keeps legacy behavior instead of a 401.
 	resp := doProxyRequest(t, handler, "/v1/responses", "s", func(r *http.Request) {
 		r.Header.Set("Authorization", "Bearer srt_00000000000000000000000000000000")
 	})
-	if resp.Code != http.StatusOK || resp.Body.String() != "Bearer legacy-token" {
-		t.Fatalf("legacy fallthrough = %d %q", resp.Code, resp.Body.String())
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("unknown tenant-shaped bearer status = %d, body = %q", resp.Code, resp.Body.String())
 	}
 }
 

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -38,6 +38,8 @@ type fakeStackTeams struct {
 	err   error
 }
 
+const testStackTenantDeleteToken = "0123456789abcdef0123456789abcdef-delete"
+
 func (f fakeStackTeams) ListTeams(context.Context, string) ([]stackauth.Team, error) {
 	return f.teams, f.err
 }
@@ -548,6 +550,43 @@ func TestStackLoginCreatesStableTenantAndAcceptsDirectAccountUpload(t *testing.T
 	}
 }
 
+func TestStackTenantDeletionRequiresTrustedServiceCredential(t *testing.T) {
+	registry := tenant.NewRegistry(t.TempDir())
+	key, err := tenant.DeriveKey(
+		[]byte("0123456789abcdef0123456789abcdef"),
+		"project",
+		"team-victim",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.EnsureExternal("team-victim", "Victim", key); err != nil {
+		t.Fatal(err)
+	}
+	base := Server{MaxBodyBytes: 1024}
+	handler := (&MultiTenant{
+		Base: base, Registry: registry,
+		StackVerifier: fakeStackVerifier{claims: stackauth.Claims{
+			Subject: "ordinary-member", ProjectID: "project", SelectedTeamID: "team-victim",
+		}},
+		StackTenantKeySecret: []byte("0123456789abcdef0123456789abcdef"),
+	}).Handler(base.Handler())
+	req := httptest.NewRequest(
+		http.MethodDelete,
+		"/_subrouter/auth/stack/tenant",
+		strings.NewReader(`{"teamId":"team-victim"}`),
+	)
+	req.Header.Set("Authorization", "Bearer stack-access")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, req)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404, body = %s", response.Code, response.Body.String())
+	}
+	if resolved, ok, err := registry.Resolve(key); err != nil || !ok || resolved.ID != "team-victim" {
+		t.Fatalf("untrusted deletion changed tenant: resolved=%#v ok=%v err=%v", resolved, ok, err)
+	}
+}
+
 func TestStackTenantDeletionRevokesNewRequestsThenDrainsInFlightTraffic(t *testing.T) {
 	releaseUpstream := make(chan struct{})
 	upstreamReleased := false
@@ -624,6 +663,7 @@ func TestStackTenantDeletionRevokesNewRequestsThenDrainsInFlightTraffic(t *testi
 			strings.NewReader(`{"teamId":"user-1"}`),
 		)
 		req.Header.Set("Authorization", "Bearer stack-access")
+		req.Header.Set("X-Subrouter-Tenant-Delete-Token", testStackTenantDeleteToken)
 		response := httptest.NewRecorder()
 		handler.ServeHTTP(response, req)
 		return response
@@ -714,6 +754,7 @@ func TestStackTenantDeletionRejectsNonMemberWithoutRetiringTenant(t *testing.T) 
 		strings.NewReader(`{"teamId":"team-victim"}`),
 	)
 	req.Header.Set("Authorization", "Bearer stack-access")
+	req.Header.Set("X-Subrouter-Tenant-Delete-Token", testStackTenantDeleteToken)
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, req)
 	if response.Code != http.StatusForbidden {

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -36,6 +37,21 @@ func (f fakeStackVerifier) Verify(context.Context, string) (stackauth.Claims, er
 type fakeStackTeams struct {
 	teams []stackauth.Team
 	err   error
+}
+
+type signalLogWriter struct {
+	match string
+	seen  chan struct{}
+}
+
+func (w signalLogWriter) Write(body []byte) (int, error) {
+	if strings.Contains(string(body), w.match) {
+		select {
+		case w.seen <- struct{}{}:
+		default:
+		}
+	}
+	return len(body), nil
 }
 
 const testStackTenantDeleteToken = "0123456789abcdef0123456789abcdef-delete"
@@ -619,6 +635,7 @@ func TestStackTenantDeletionRequiresTrustedServiceCredential(t *testing.T) {
 func TestStackTenantDeletionRevokesNewRequestsThenDrainsInFlightTraffic(t *testing.T) {
 	releaseUpstream := make(chan struct{})
 	upstreamReleased := false
+	backgroundFailure := make(chan struct{}, 1)
 	defer func() {
 		if !upstreamReleased {
 			close(releaseUpstream)
@@ -648,6 +665,10 @@ func TestStackTenantDeletionRevokesNewRequestsThenDrainsInFlightTraffic(t *testi
 		Sessions:     sessions,
 		Scheduler:    selectacct.NewScheduler(nil),
 		MaxBodyBytes: 1024,
+		Logger: slog.New(slog.NewTextHandler(signalLogWriter{
+			match: "background tenant deletion failed",
+			seen:  backgroundFailure,
+		}, nil)),
 	}
 	registry := tenant.NewRegistry(t.TempDir())
 	key, err := tenant.DeriveKey(
@@ -719,6 +740,13 @@ func TestStackTenantDeletionRevokesNewRequestsThenDrainsInFlightTraffic(t *testi
 	if rejected.Code != http.StatusUnauthorized {
 		t.Fatalf("new request after retirement status = %d", rejected.Code)
 	}
+	registryBackup := registry.Path() + ".test-backup"
+	if err := os.Rename(registry.Path(), registryBackup); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(registry.Path(), 0o700); err != nil {
+		t.Fatal(err)
+	}
 
 	close(releaseUpstream)
 	upstreamReleased = true
@@ -729,6 +757,17 @@ func TestStackTenantDeletionRevokesNewRequestsThenDrainsInFlightTraffic(t *testi
 		}
 	case <-time.After(time.Second):
 		t.Fatal("in-flight request did not drain")
+	}
+	select {
+	case <-backgroundFailure:
+	case <-time.After(time.Second):
+		t.Fatal("background tenant deletion did not report the injected transient failure")
+	}
+	if err := os.Remove(registry.Path()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(registryBackup, registry.Path()); err != nil {
+		t.Fatal(err)
 	}
 	deadline := time.Now().Add(time.Second)
 	for {

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -548,6 +548,171 @@ func TestStackLoginCreatesStableTenantAndAcceptsDirectAccountUpload(t *testing.T
 	}
 }
 
+func TestStackTenantDeletionRevokesNewRequestsThenDrainsInFlightTraffic(t *testing.T) {
+	releaseUpstream := make(chan struct{})
+	upstreamReleased := false
+	defer func() {
+		if !upstreamReleased {
+			close(releaseUpstream)
+		}
+	}()
+	upstreamStarted := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case <-upstreamStarted:
+		default:
+			close(upstreamStarted)
+		}
+		<-releaseUpstream
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessions, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := Server{
+		Upstream: upstreamURL,
+		Sessions: sessions,
+		Scheduler: selectacct.NewScheduler(nil),
+		MaxBodyBytes: 1024,
+	}
+	registry := tenant.NewRegistry(t.TempDir())
+	key, err := tenant.DeriveKey(
+		[]byte("0123456789abcdef0123456789abcdef"),
+		"project",
+		"user-1",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := registry.EnsureExternal("user-1", "User One", key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTenantAPIKeyAccount(t, registry, created.ID, "apikey:openai-apikey:work", "sk-test")
+	multi := &MultiTenant{
+		Base: base, Registry: registry, PublicURL: "https://sr.example",
+		StackTenantKeySecret: []byte("0123456789abcdef0123456789abcdef"),
+		StackVerifier: fakeStackVerifier{claims: stackauth.Claims{
+			Subject: "user-1", ProjectID: "project", SelectedTeamID: "team-123",
+		}},
+	}
+	handler := multi.Handler(base.Handler())
+
+	inFlightDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		inFlightDone <- doProxyRequest(t, handler, "/v1/responses", "held-session", func(req *http.Request) {
+			req.Header.Set("Authorization", "Bearer "+key)
+		})
+	}()
+	select {
+	case <-upstreamStarted:
+	case <-time.After(time.Second):
+		t.Fatal("tenant request did not reach upstream")
+	}
+
+	deleteTenant := func() *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(
+			http.MethodDelete,
+			"/_subrouter/auth/stack/tenant",
+			strings.NewReader(`{"teamId":"user-1"}`),
+		)
+		req.Header.Set("Authorization", "Bearer stack-access")
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, req)
+		return response
+	}
+
+	firstDelete := deleteTenant()
+	if firstDelete.Code != http.StatusAccepted {
+		t.Fatalf("first deletion status = %d, body = %s", firstDelete.Code, firstDelete.Body.String())
+	}
+	var pending map[string]any
+	if err := json.Unmarshal(firstDelete.Body.Bytes(), &pending); err != nil {
+		t.Fatal(err)
+	}
+	if pending["deletionPending"] != true {
+		t.Fatalf("pending deletion response = %#v", pending)
+	}
+	if _, ok, err := registry.Resolve(key); err != nil || ok {
+		t.Fatalf("retired key still resolves: ok=%v err=%v", ok, err)
+	}
+	rejected := doProxyRequest(t, handler, "/v1/responses", "new-session", func(req *http.Request) {
+		req.Header.Set("Authorization", "Bearer "+key)
+	})
+	if rejected.Code != http.StatusUnauthorized {
+		t.Fatalf("new request after retirement status = %d", rejected.Code)
+	}
+
+	close(releaseUpstream)
+	upstreamReleased = true
+	select {
+	case response := <-inFlightDone:
+		if response.Code != http.StatusOK {
+			t.Fatalf("in-flight request status = %d, body = %s", response.Code, response.Body.String())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("in-flight request did not drain")
+	}
+	finalDelete := deleteTenant()
+	if finalDelete.Code != http.StatusOK {
+		t.Fatalf("final deletion status = %d, body = %s", finalDelete.Code, finalDelete.Body.String())
+	}
+	if _, err := os.Stat(registry.Dir("user-1")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("tenant state remains after deletion: %v", err)
+	}
+	if _, found, err := registry.Find("user-1"); err != nil || found {
+		t.Fatalf("tenant registry entry remains: found=%v err=%v", found, err)
+	}
+	if repeated := deleteTenant(); repeated.Code != http.StatusOK {
+		t.Fatalf("idempotent deletion status = %d, body = %s", repeated.Code, repeated.Body.String())
+	}
+}
+
+func TestStackTenantDeletionRejectsNonMemberWithoutRetiringTenant(t *testing.T) {
+	registry := tenant.NewRegistry(t.TempDir())
+	key, err := tenant.DeriveKey(
+		[]byte("0123456789abcdef0123456789abcdef"),
+		"project",
+		"team-victim",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.EnsureExternal("team-victim", "Victim", key); err != nil {
+		t.Fatal(err)
+	}
+	base := Server{MaxBodyBytes: 1024}
+	handler := (&MultiTenant{
+		Base: base, Registry: registry,
+		StackVerifier: fakeStackVerifier{claims: stackauth.Claims{
+			Subject: "user-1", ProjectID: "project", SelectedTeamID: "team-123",
+		}},
+		StackTeams: fakeStackTeams{teams: []stackauth.Team{{ID: "team-123"}}},
+		StackTenantKeySecret: []byte("0123456789abcdef0123456789abcdef"),
+	}).Handler(base.Handler())
+	req := httptest.NewRequest(
+		http.MethodDelete,
+		"/_subrouter/auth/stack/tenant",
+		strings.NewReader(`{"teamId":"team-victim"}`),
+	)
+	req.Header.Set("Authorization", "Bearer stack-access")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, req)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	if resolved, ok, err := registry.Resolve(key); err != nil || !ok || resolved.ID != "team-victim" {
+		t.Fatalf("unauthorized deletion changed tenant: resolved=%#v ok=%v err=%v", resolved, ok, err)
+	}
+}
+
 func TestTenantAccountUploadValidatesRepairTargetAndBodyShape(t *testing.T) {
 	registry, handler, _ := newMultiTenantFixture(t)
 	_, key, err := registry.Create("team")

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -680,6 +680,59 @@ func TestStackTenantDeletionRemovesTenantTranscripts(t *testing.T) {
 	}
 }
 
+func TestTenantTranscriptDeletionFailureStaysRecoverable(t *testing.T) {
+	registry := tenant.NewRegistry(t.TempDir())
+	key, err := tenant.DeriveKey(
+		[]byte("0123456789abcdef0123456789abcdef"),
+		"project",
+		"user-1",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := registry.EnsureExternal("user-1", "User One", key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retired, err := registry.RetireExternal(created.ID); err != nil || !retired {
+		t.Fatalf("retire = %v, %v", retired, err)
+	}
+	transcriptRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(transcriptRoot, "tenants"), []byte("blocks tenant transcript cleanup"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	multi := &MultiTenant{Registry: registry, TranscriptDir: transcriptRoot}
+	useLock, err := registry.AcquireExclusiveUse(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := multi.deleteRetiredTenant(created.ID); err == nil {
+		useLock.Close()
+		t.Fatal("blocked transcript cleanup unexpectedly succeeded")
+	}
+	if err := useLock.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	pendingIDs, err := registry.PendingDeletionIDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending := false
+	for _, id := range pendingIDs {
+		if id == created.ID {
+			pending = true
+			break
+		}
+	}
+	if !pending {
+		t.Fatal("transcript cleanup failure finalized the deletion marker")
+	}
+	if _, err := os.Stat(registry.Dir(created.ID)); err != nil {
+		t.Fatalf("credential state was removed before transcript cleanup completed: %v", err)
+	}
+}
+
 func TestTenantDeletionRecoveryRetriesAfterTransientStartupScanFailure(t *testing.T) {
 	stateDir := t.TempDir()
 	registry := tenant.NewRegistry(stateDir)

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -739,6 +739,18 @@ func TestTenantDeletionRecoveryRetriesAfterTransientStartupScanFailure(t *testin
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	for {
+		multi.deletionMu.Lock()
+		_, pending := multi.deletions[created.ID]
+		multi.deletionMu.Unlock()
+		if !pending {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("startup deletion recovery worker did not finish")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func TestStackTenantDeletionRetriesAfterExclusiveLockSetupFailure(t *testing.T) {

--- a/internal/tenant/lock_windows.go
+++ b/internal/tenant/lock_windows.go
@@ -3,15 +3,26 @@
 package tenant
 
 import (
+	"fmt"
 	"os"
+	"syscall"
+	"unsafe"
 )
 
 type registryLock struct {
-	file *os.File
+	file       *os.File
+	overlapped syscall.Overlapped
 }
 
-// lockRegistry mirrors the unix flock variant; like
-// accounts.lockStoredAccount, Windows gets a best-effort lock file only.
+const registryExclusiveLock = 0x00000002
+
+var (
+	registryKernel32 = syscall.NewLazyDLL("kernel32.dll")
+	registryLockFile = registryKernel32.NewProc("LockFileEx")
+	registryUnlock   = registryKernel32.NewProc("UnlockFileEx")
+)
+
+// lockRegistry serializes tenant registry mutations across Windows processes.
 func (r *Registry) lockRegistry() (*registryLock, error) {
 	if err := os.MkdirAll(r.stateDir, 0o700); err != nil {
 		return nil, err
@@ -20,9 +31,33 @@ func (r *Registry) lockRegistry() (*registryLock, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &registryLock{file: file}, nil
+	lock := &registryLock{file: file}
+	result, _, callErr := registryLockFile.Call(
+		file.Fd(),
+		registryExclusiveLock,
+		0,
+		uintptr(^uint32(0)),
+		uintptr(^uint32(0)),
+		uintptr(unsafe.Pointer(&lock.overlapped)),
+	)
+	if result == 0 {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock tenant registry: %w", callErr)
+	}
+	return lock, nil
 }
 
 func (l *registryLock) Close() error {
-	return l.file.Close()
+	result, _, callErr := registryUnlock.Call(
+		l.file.Fd(),
+		0,
+		uintptr(^uint32(0)),
+		uintptr(^uint32(0)),
+		uintptr(unsafe.Pointer(&l.overlapped)),
+	)
+	closeErr := l.file.Close()
+	if result == 0 {
+		return fmt.Errorf("unlock tenant registry: %w", callErr)
+	}
+	return closeErr
 }

--- a/internal/tenant/lock_windows_test.go
+++ b/internal/tenant/lock_windows_test.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+package tenant
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWindowsRegistryLockSerializesProcesses(t *testing.T) {
+	root := t.TempDir()
+	first := NewRegistry(root)
+	second := NewRegistry(root)
+	firstLock, err := first.lockRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	type result struct {
+		lock *registryLock
+		err  error
+	}
+	acquired := make(chan result, 1)
+	go func() {
+		lock, err := second.lockRegistry()
+		acquired <- result{lock: lock, err: err}
+	}()
+	select {
+	case result := <-acquired:
+		if result.lock != nil {
+			result.lock.Close()
+		}
+		t.Fatalf("second registry lock acquired early: %v", result.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if err := firstLock.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case result := <-acquired:
+		if result.err != nil {
+			t.Fatal(result.err)
+		}
+		if err := result.lock.Close(); err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second registry lock did not acquire after release")
+	}
+}

--- a/internal/tenant/tenant.go
+++ b/internal/tenant/tenant.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -75,6 +76,10 @@ func (r *Registry) Dir(id string) string {
 
 func (r *Registry) retiredPath(id string) string {
 	return filepath.Join(r.stateDir, "retired-tenants", id)
+}
+
+func (r *Registry) retiringPath(id string) string {
+	return filepath.Join(r.stateDir, "retiring-tenants", id)
 }
 
 // ValidKeyFormat reports whether value is shaped like a tenant key
@@ -337,10 +342,12 @@ func (r *Registry) EnsureExternal(id, name, plaintextKey string) (Tenant, error)
 	if err != nil {
 		return Tenant{}, err
 	}
-	if _, err := os.Stat(r.retiredPath(id)); err == nil {
-		return Tenant{}, ErrTenantRetired
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return Tenant{}, err
+	for _, marker := range []string{r.retiredPath(id), r.retiringPath(id)} {
+		if _, err := os.Stat(marker); err == nil {
+			return Tenant{}, ErrTenantRetired
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return Tenant{}, err
+		}
 	}
 	hash := HashKey(plaintextKey)
 	for i := range file.Tenants {
@@ -453,7 +460,7 @@ func (r *Registry) DeleteRetired(id string) (bool, error) {
 		return false, err
 	}
 	found := false
-	kept := file.Tenants[:0]
+	kept := make([]Tenant, 0, len(file.Tenants))
 	for _, existing := range file.Tenants {
 		if existing.ID != id {
 			kept = append(kept, existing)
@@ -464,29 +471,125 @@ func (r *Registry) DeleteRetired(id string) (bool, error) {
 		}
 		found = true
 	}
-	retiredDir := filepath.Dir(r.retiredPath(id))
-	if err := os.MkdirAll(retiredDir, 0o700); err != nil {
-		return false, err
-	}
-	if err := os.WriteFile(r.retiredPath(id), nil, 0o600); err != nil {
-		return false, err
-	}
-	if found {
-		file.Tenants = append([]Tenant(nil), kept...)
-		if err := r.save(file); err != nil {
-			return false, err
-		}
-	}
 	hadState := false
 	if _, err := os.Lstat(r.Dir(id)); err == nil {
 		hadState = true
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return false, err
 	}
+	retiredPath := r.retiredPath(id)
+	retiringPath := r.retiringPath(id)
+	retiredExists, err := pathExists(retiredPath)
+	if err != nil {
+		return false, err
+	}
+	retiringExists, err := pathExists(retiringPath)
+	if err != nil {
+		return false, err
+	}
+	if !found && !hadState {
+		if retiredExists {
+			return true, nil
+		}
+		if retiringExists {
+			if err := finalizeRetirementMarker(retiringPath, retiredPath); err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+		// The trusted deletion caller may race a first tenant exchange. Record
+		// the deletion intent even when no state exists yet so that exchange
+		// cannot recreate the identity before its Stack account is removed.
+		if err := writeRetirementMarker(retiredPath); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	if !retiringExists {
+		if err := writeRetirementMarker(retiringPath); err != nil {
+			return false, err
+		}
+	}
 	if err := os.RemoveAll(r.Dir(id)); err != nil {
 		return false, err
 	}
-	return found || hadState, nil
+	if found {
+		file.Tenants = kept
+		if err := r.save(file); err != nil {
+			return false, err
+		}
+	}
+	if err := finalizeRetirementMarker(retiringPath, retiredPath); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func pathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
+func writeRetirementMarker(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, nil, 0o600)
+}
+
+func finalizeRetirementMarker(retiringPath, retiredPath string) error {
+	if exists, err := pathExists(retiredPath); err != nil {
+		return err
+	} else if exists {
+		return os.Remove(retiringPath)
+	}
+	if err := os.MkdirAll(filepath.Dir(retiredPath), 0o700); err != nil {
+		return err
+	}
+	return os.Rename(retiringPath, retiredPath)
+}
+
+// PendingDeletionIDs lists retired registry entries and crash-recovery markers
+// that need credential-state deletion after active requests drain.
+func (r *Registry) PendingDeletionIDs() ([]string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	lock, err := r.lockRegistry()
+	if err != nil {
+		return nil, err
+	}
+	defer lock.Close()
+	file, err := r.loadFresh()
+	if err != nil {
+		return nil, err
+	}
+	ids := map[string]struct{}{}
+	for _, existing := range file.Tenants {
+		if existing.Retired && ValidExternalID(existing.ID) {
+			ids[existing.ID] = struct{}{}
+		}
+	}
+	entries, err := os.ReadDir(filepath.Join(r.stateDir, "retiring-tenants"))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() && ValidExternalID(entry.Name()) {
+			ids[entry.Name()] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(ids))
+	for id := range ids {
+		out = append(out, id)
+	}
+	slices.Sort(out)
+	return out, nil
 }
 
 // CreateKey mints an additional key for an existing tenant and returns it in

--- a/internal/tenant/tenant.go
+++ b/internal/tenant/tenant.go
@@ -403,9 +403,10 @@ func (r *Registry) EnsureExternal(id, name, plaintextKey string) (Tenant, error)
 	return created, nil
 }
 
-// RetireExternal revokes every key for an externally owned tenant before its
-// state is removed. It is idempotent so an account-deletion workflow can retry
-// while existing requests drain.
+// RetireExternal revokes every key and records deletion intent under one
+// interprocess registry lock. This prevents a first exchange from creating an
+// absent tenant between retirement and deletion. It is idempotent while active
+// requests drain.
 func (r *Registry) RetireExternal(id string) (bool, error) {
 	id = strings.TrimSpace(id)
 	if !ValidExternalID(id) {
@@ -422,21 +423,41 @@ func (r *Registry) RetireExternal(id string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	found := false
+	changed := false
 	for i := range file.Tenants {
 		if file.Tenants[i].ID != id {
 			continue
 		}
-		if file.Tenants[i].Retired && len(file.Tenants[i].Keys) == 0 {
-			return true, nil
+		found = true
+		if !file.Tenants[i].Retired || len(file.Tenants[i].Keys) != 0 {
+			file.Tenants[i].Retired = true
+			file.Tenants[i].Keys = nil
+			changed = true
 		}
-		file.Tenants[i].Retired = true
-		file.Tenants[i].Keys = nil
+		break
+	}
+	if changed {
 		if err := r.save(file); err != nil {
 			return false, err
 		}
-		return true, nil
 	}
-	return false, nil
+	retiredExists, err := pathExists(r.retiredPath(id))
+	if err != nil {
+		return false, err
+	}
+	if found || !retiredExists {
+		retiringExists, err := pathExists(r.retiringPath(id))
+		if err != nil {
+			return false, err
+		}
+		if !retiringExists {
+			if err := writeRetirementMarker(r.retiringPath(id)); err != nil {
+				return false, err
+			}
+		}
+	}
+	return found, nil
 }
 
 // DeleteRetired permanently removes a retired tenant's credential-bearing

--- a/internal/tenant/tenant.go
+++ b/internal/tenant/tenant.go
@@ -35,6 +35,7 @@ type Tenant struct {
 	Name      string    `json:"name"`
 	CreatedAt time.Time `json:"createdAt"`
 	Keys      []Key     `json:"keys,omitempty"`
+	Retired   bool      `json:"retired,omitempty"`
 }
 
 type registryFile struct {
@@ -53,6 +54,8 @@ type Registry struct {
 	size     int64
 }
 
+var ErrTenantRetired = errors.New("tenant is retired")
+
 func NewRegistry(stateDir string) *Registry {
 	return &Registry{stateDir: stateDir}
 }
@@ -68,6 +71,10 @@ func (r *Registry) TenantsDir() string {
 // Dir returns the tenant's isolated state dir.
 func (r *Registry) Dir(id string) string {
 	return filepath.Join(r.TenantsDir(), id)
+}
+
+func (r *Registry) retiredPath(id string) string {
+	return filepath.Join(r.stateDir, "retired-tenants", id)
 }
 
 // ValidKeyFormat reports whether value is shaped like a tenant key
@@ -330,10 +337,18 @@ func (r *Registry) EnsureExternal(id, name, plaintextKey string) (Tenant, error)
 	if err != nil {
 		return Tenant{}, err
 	}
+	if _, err := os.Stat(r.retiredPath(id)); err == nil {
+		return Tenant{}, ErrTenantRetired
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return Tenant{}, err
+	}
 	hash := HashKey(plaintextKey)
 	for i := range file.Tenants {
 		if file.Tenants[i].ID != id {
 			continue
+		}
+		if file.Tenants[i].Retired {
+			return Tenant{}, ErrTenantRetired
 		}
 		changed := false
 		if file.Tenants[i].Name != name {
@@ -379,6 +394,99 @@ func (r *Registry) EnsureExternal(id, name, plaintextKey string) (Tenant, error)
 		return Tenant{}, err
 	}
 	return created, nil
+}
+
+// RetireExternal revokes every key for an externally owned tenant before its
+// state is removed. It is idempotent so an account-deletion workflow can retry
+// while existing requests drain.
+func (r *Registry) RetireExternal(id string) (bool, error) {
+	id = strings.TrimSpace(id)
+	if !ValidExternalID(id) {
+		return false, errors.New("invalid external tenant ID")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	lock, err := r.lockRegistry()
+	if err != nil {
+		return false, err
+	}
+	defer lock.Close()
+	file, err := r.loadFresh()
+	if err != nil {
+		return false, err
+	}
+	for i := range file.Tenants {
+		if file.Tenants[i].ID != id {
+			continue
+		}
+		if file.Tenants[i].Retired && len(file.Tenants[i].Keys) == 0 {
+			return true, nil
+		}
+		file.Tenants[i].Retired = true
+		file.Tenants[i].Keys = nil
+		if err := r.save(file); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// DeleteRetired permanently removes a retired tenant's credential-bearing
+// state. A durable tombstone prevents a still-valid Stack token from
+// recreating the tenant in the interval before the owning identity is deleted.
+// The caller must hold the tenant's exclusive use lock.
+func (r *Registry) DeleteRetired(id string) (bool, error) {
+	id = strings.TrimSpace(id)
+	if !ValidExternalID(id) {
+		return false, errors.New("invalid external tenant ID")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	lock, err := r.lockRegistry()
+	if err != nil {
+		return false, err
+	}
+	defer lock.Close()
+	file, err := r.loadFresh()
+	if err != nil {
+		return false, err
+	}
+	found := false
+	kept := file.Tenants[:0]
+	for _, existing := range file.Tenants {
+		if existing.ID != id {
+			kept = append(kept, existing)
+			continue
+		}
+		if !existing.Retired || len(existing.Keys) != 0 {
+			return false, errors.New("tenant must be retired before deletion")
+		}
+		found = true
+	}
+	retiredDir := filepath.Dir(r.retiredPath(id))
+	if err := os.MkdirAll(retiredDir, 0o700); err != nil {
+		return false, err
+	}
+	if err := os.WriteFile(r.retiredPath(id), nil, 0o600); err != nil {
+		return false, err
+	}
+	if found {
+		file.Tenants = append([]Tenant(nil), kept...)
+		if err := r.save(file); err != nil {
+			return false, err
+		}
+	}
+	hadState := false
+	if _, err := os.Lstat(r.Dir(id)); err == nil {
+		hadState = true
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	if err := os.RemoveAll(r.Dir(id)); err != nil {
+		return false, err
+	}
+	return found || hadState, nil
 }
 
 // CreateKey mints an additional key for an existing tenant and returns it in
@@ -475,6 +583,32 @@ func (r *Registry) Resolve(key string) (Tenant, bool, error) {
 		return Tenant{}, false, err
 	}
 	for _, t := range file.Tenants {
+		for _, k := range t.Keys {
+			if k.Hash == hash {
+				return t, true, nil
+			}
+		}
+	}
+	return Tenant{}, false, nil
+}
+
+// ResolveFresh bypasses the metadata cache after a request has acquired its
+// shared use lock. This closes the cross-process race with tenant retirement.
+func (r *Registry) ResolveFresh(key string) (Tenant, bool, error) {
+	if !ValidKeyFormat(key) {
+		return Tenant{}, false, nil
+	}
+	hash := HashKey(key)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	file, err := r.loadFresh()
+	if err != nil {
+		return Tenant{}, false, err
+	}
+	for _, t := range file.Tenants {
+		if t.Retired {
+			continue
+		}
 		for _, k := range t.Keys {
 			if k.Hash == hash {
 				return t, true, nil

--- a/internal/tenant/tenant.go
+++ b/internal/tenant/tenant.go
@@ -631,6 +631,9 @@ func (r *Registry) CreateKey(tenantID string) (Tenant, string, error) {
 		if file.Tenants[i].ID != tenantID {
 			continue
 		}
+		if file.Tenants[i].Retired {
+			return Tenant{}, "", ErrTenantRetired
+		}
 		plaintext, key, err := newKey()
 		if err != nil {
 			return Tenant{}, "", err

--- a/internal/tenant/tenant_test.go
+++ b/internal/tenant/tenant_test.go
@@ -120,6 +120,28 @@ func TestEnsureExternalIsStableAndUpdatesName(t *testing.T) {
 	}
 }
 
+func TestDeleteRetiredDoesNotTombstoneAnAbsentTenant(t *testing.T) {
+	registry := NewRegistry(t.TempDir())
+	deleted, err := registry.DeleteRetired("team-absent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted {
+		t.Fatal("absent tenant reported deleted")
+	}
+	key, err := DeriveKey(
+		[]byte("0123456789abcdef0123456789abcdef"),
+		"stack-project",
+		"team-absent",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.EnsureExternal("team-absent", "Team", key); err != nil {
+		t.Fatalf("absent tenant was permanently tombstoned: %v", err)
+	}
+}
+
 func TestEnsureExternalDoesNotPersistBeforeAccountDirectoryExists(t *testing.T) {
 	root := t.TempDir()
 	registry := NewRegistry(root)

--- a/internal/tenant/tenant_test.go
+++ b/internal/tenant/tenant_test.go
@@ -1,6 +1,7 @@
 package tenant
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -120,7 +121,7 @@ func TestEnsureExternalIsStableAndUpdatesName(t *testing.T) {
 	}
 }
 
-func TestDeleteRetiredDoesNotTombstoneAnAbsentTenant(t *testing.T) {
+func TestDeleteRetiredTombstonesAnAbsentTenantDeletionIntent(t *testing.T) {
 	registry := NewRegistry(t.TempDir())
 	deleted, err := registry.DeleteRetired("team-absent")
 	if err != nil {
@@ -137,8 +138,8 @@ func TestDeleteRetiredDoesNotTombstoneAnAbsentTenant(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := registry.EnsureExternal("team-absent", "Team", key); err != nil {
-		t.Fatalf("absent tenant was permanently tombstoned: %v", err)
+	if _, err := registry.EnsureExternal("team-absent", "Team", key); !errors.Is(err, ErrTenantRetired) {
+		t.Fatalf("absent tenant deletion intent did not block a racing exchange: %v", err)
 	}
 }
 

--- a/internal/tenant/tenant_test.go
+++ b/internal/tenant/tenant_test.go
@@ -65,6 +65,23 @@ func TestCreateKeyAddsSecondKey(t *testing.T) {
 	}
 }
 
+func TestCreateKeyRejectsRetiredTenant(t *testing.T) {
+	registry := NewRegistry(t.TempDir())
+	created, _, err := registry.Create("acme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retired, err := registry.RetireExternal(created.ID); err != nil || !retired {
+		t.Fatalf("retire = %v, %v", retired, err)
+	}
+	if _, _, err := registry.CreateKey(created.ID); !errors.Is(err, ErrTenantRetired) {
+		t.Fatalf("retired tenant accepted a new key: %v", err)
+	}
+	if deleted, err := registry.DeleteRetired(created.ID); err != nil || !deleted {
+		t.Fatalf("delete = %v, %v", deleted, err)
+	}
+}
+
 func TestDuplicateTenantNameRejected(t *testing.T) {
 	registry := NewRegistry(t.TempDir())
 	if _, _, err := registry.Create("acme"); err != nil {

--- a/internal/tenant/tenant_test.go
+++ b/internal/tenant/tenant_test.go
@@ -143,6 +143,28 @@ func TestDeleteRetiredTombstonesAnAbsentTenantDeletionIntent(t *testing.T) {
 	}
 }
 
+func TestRetireExternalAtomicallyBlocksAnAbsentTenantExchange(t *testing.T) {
+	registry := NewRegistry(t.TempDir())
+	retired, err := registry.RetireExternal("team-race")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retired {
+		t.Fatal("absent tenant reported retired")
+	}
+	key, err := DeriveKey(
+		[]byte("0123456789abcdef0123456789abcdef"),
+		"stack-project",
+		"team-race",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.EnsureExternal("team-race", "Team", key); !errors.Is(err, ErrTenantRetired) {
+		t.Fatalf("exchange raced past retirement intent: %v", err)
+	}
+}
+
 func TestEnsureExternalDoesNotPersistBeforeAccountDirectoryExists(t *testing.T) {
 	root := t.TempDir()
 	registry := NewRegistry(root)

--- a/internal/tenant/use_lock_unix.go
+++ b/internal/tenant/use_lock_unix.go
@@ -53,6 +53,20 @@ func (r *Registry) TryAcquireExclusiveUse(id string) (*UseLock, bool, error) {
 	return &UseLock{file: file}, true, nil
 }
 
+// AcquireExclusiveUse waits until every active request has released its shared
+// tenant-use lock, then holds the deletion lock.
+func (r *Registry) AcquireExclusiveUse(id string) (*UseLock, error) {
+	file, err := r.openUseLock(id)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return &UseLock{file: file}, nil
+}
+
 func (l *UseLock) Close() error {
 	unlockErr := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
 	closeErr := l.file.Close()

--- a/internal/tenant/use_lock_unix.go
+++ b/internal/tenant/use_lock_unix.go
@@ -1,0 +1,63 @@
+//go:build !windows
+
+package tenant
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// UseLock coordinates live tenant requests with permanent tenant deletion
+// across supervisor worker generations.
+type UseLock struct {
+	file *os.File
+}
+
+func (r *Registry) openUseLock(id string) (*os.File, error) {
+	if !ValidExternalID(id) {
+		return nil, errors.New("invalid tenant ID")
+	}
+	dir := filepath.Join(r.stateDir, "tenant-use-locks")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	return os.OpenFile(filepath.Join(dir, id+".lock"), os.O_CREATE|os.O_RDWR, 0o600)
+}
+
+func (r *Registry) AcquireUse(id string) (*UseLock, error) {
+	file, err := r.openUseLock(id)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_SH); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return &UseLock{file: file}, nil
+}
+
+func (r *Registry) TryAcquireExclusiveUse(id string) (*UseLock, bool, error) {
+	file, err := r.openUseLock(id)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = file.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return &UseLock{file: file}, true, nil
+}
+
+func (l *UseLock) Close() error {
+	unlockErr := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	closeErr := l.file.Close()
+	if unlockErr != nil {
+		return unlockErr
+	}
+	return closeErr
+}

--- a/internal/tenant/use_lock_windows.go
+++ b/internal/tenant/use_lock_windows.go
@@ -86,6 +86,29 @@ func (r *Registry) TryAcquireExclusiveUse(id string) (*UseLock, bool, error) {
 	return lock, true, nil
 }
 
+// AcquireExclusiveUse waits until every active request has released its shared
+// tenant-use lock, then holds the deletion lock.
+func (r *Registry) AcquireExclusiveUse(id string) (*UseLock, error) {
+	file, err := r.openUseLock(id)
+	if err != nil {
+		return nil, err
+	}
+	lock := &UseLock{file: file}
+	result, _, callErr := tenantUseLockFile.Call(
+		file.Fd(),
+		tenantUseExclusiveLock,
+		0,
+		uintptr(^uint32(0)),
+		uintptr(^uint32(0)),
+		uintptr(unsafe.Pointer(&lock.overlapped)),
+	)
+	if result == 0 {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock tenant deletion: %w", callErr)
+	}
+	return lock, nil
+}
+
 func (l *UseLock) Close() error {
 	result, _, callErr := tenantUseUnlock.Call(
 		l.file.Fd(),

--- a/internal/tenant/use_lock_windows.go
+++ b/internal/tenant/use_lock_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package tenant
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// UseLock is a best-effort file lifetime guard on Windows. Hosted deployments
+// run on Linux, where the implementation provides cross-process flocking.
+type UseLock struct {
+	file *os.File
+}
+
+func (r *Registry) openUseLock(id string) (*os.File, error) {
+	if !ValidExternalID(id) {
+		return nil, errors.New("invalid tenant ID")
+	}
+	dir := filepath.Join(r.stateDir, "tenant-use-locks")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	return os.OpenFile(filepath.Join(dir, id+".lock"), os.O_CREATE|os.O_RDWR, 0o600)
+}
+
+func (r *Registry) AcquireUse(id string) (*UseLock, error) {
+	file, err := r.openUseLock(id)
+	if err != nil {
+		return nil, err
+	}
+	return &UseLock{file: file}, nil
+}
+
+func (r *Registry) TryAcquireExclusiveUse(id string) (*UseLock, bool, error) {
+	file, err := r.openUseLock(id)
+	if err != nil {
+		return nil, false, err
+	}
+	return &UseLock{file: file}, true, nil
+}
+
+func (l *UseLock) Close() error {
+	return l.file.Close()
+}

--- a/internal/tenant/use_lock_windows.go
+++ b/internal/tenant/use_lock_windows.go
@@ -4,14 +4,30 @@ package tenant
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
+	"unsafe"
 )
 
-// UseLock is a best-effort file lifetime guard on Windows. Hosted deployments
-// run on Linux, where the implementation provides cross-process flocking.
+const (
+	tenantUseFailImmediately = 0x00000001
+	tenantUseExclusiveLock   = 0x00000002
+	tenantUseLockViolation   = syscall.Errno(33)
+)
+
+var (
+	tenantUseKernel32 = syscall.NewLazyDLL("kernel32.dll")
+	tenantUseLockFile = tenantUseKernel32.NewProc("LockFileEx")
+	tenantUseUnlock   = tenantUseKernel32.NewProc("UnlockFileEx")
+)
+
+// UseLock coordinates active tenant requests with permanent deletion across
+// Windows worker processes using a shared/exclusive whole-file lock.
 type UseLock struct {
-	file *os.File
+	file       *os.File
+	overlapped syscall.Overlapped
 }
 
 func (r *Registry) openUseLock(id string) (*os.File, error) {
@@ -30,7 +46,20 @@ func (r *Registry) AcquireUse(id string) (*UseLock, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &UseLock{file: file}, nil
+	lock := &UseLock{file: file}
+	result, _, callErr := tenantUseLockFile.Call(
+		file.Fd(),
+		0,
+		0,
+		uintptr(^uint32(0)),
+		uintptr(^uint32(0)),
+		uintptr(unsafe.Pointer(&lock.overlapped)),
+	)
+	if result == 0 {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock tenant use: %w", callErr)
+	}
+	return lock, nil
 }
 
 func (r *Registry) TryAcquireExclusiveUse(id string) (*UseLock, bool, error) {
@@ -38,9 +67,36 @@ func (r *Registry) TryAcquireExclusiveUse(id string) (*UseLock, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
-	return &UseLock{file: file}, true, nil
+	lock := &UseLock{file: file}
+	result, _, callErr := tenantUseLockFile.Call(
+		file.Fd(),
+		tenantUseExclusiveLock|tenantUseFailImmediately,
+		0,
+		uintptr(^uint32(0)),
+		uintptr(^uint32(0)),
+		uintptr(unsafe.Pointer(&lock.overlapped)),
+	)
+	if result == 0 {
+		_ = file.Close()
+		if errors.Is(callErr, tenantUseLockViolation) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("lock tenant deletion: %w", callErr)
+	}
+	return lock, true, nil
 }
 
 func (l *UseLock) Close() error {
-	return l.file.Close()
+	result, _, callErr := tenantUseUnlock.Call(
+		l.file.Fd(),
+		0,
+		uintptr(^uint32(0)),
+		uintptr(^uint32(0)),
+		uintptr(unsafe.Pointer(&l.overlapped)),
+	)
+	closeErr := l.file.Close()
+	if result == 0 {
+		return fmt.Errorf("unlock tenant use: %w", callErr)
+	}
+	return closeErr
 }

--- a/internal/tenant/use_lock_windows_test.go
+++ b/internal/tenant/use_lock_windows_test.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package tenant
+
+import "testing"
+
+func TestWindowsTenantUseLockDefersDeletionWhileRequestIsActive(t *testing.T) {
+	registry := NewRegistry(t.TempDir())
+	shared, err := registry.AcquireUse("team-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shared.Close()
+
+	exclusive, acquired, err := registry.TryAcquireExclusiveUse("team-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acquired {
+		exclusive.Close()
+		t.Fatal("exclusive tenant lock acquired while a request held the shared lock")
+	}
+}


### PR DESCRIPTION
Retires Stack-owned hosted tenants before identity deletion, revokes keys before draining in-flight requests, and leaves durable non-secret tombstones. Also streams release ancestry verification so large GitHub comparisons cannot deadlock the continuity harness.

Tests: go test ./...
Tests: go test -race ./internal/proxy ./internal/tenant
Tests: Windows cross-compile for internal/tenant and internal/proxy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788360021&installation_model_id=21920&pr_number=131&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F131&signature=3f1beab4143b286d8881fa437d0748cee929a092ccb258654bd2c684322d7c9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires Stack-owned hosted tenants before identity deletion. Revokes keys, blocks new requests, drains in-flight traffic, and deletes state with durable tombstones and crash-safe recovery (including when the tenant never existed). Also streams release ancestry verification and clearly classifies failures.

- **New Features**
  - Added DELETE `/_subrouter/auth/stack/tenant`: requires `X-Subrouter-Tenant-Delete-Token` (set via `--stack-tenant-delete-token`/`SUBROUTER_STACK_TENANT_DELETE_TOKEN`) and Stack team membership; token must be ≥32 bytes. Returns 202 while draining, then deletes; idempotent, resumes pending deletions on restart, and writes durable tombstones for both existing and absent tenants.
  - Coordinated tenant-use locking and fresh resolution: per-request shared locks with `ResolveFresh`; exclusive locks (`AcquireUse`, `TryAcquireExclusiveUse`) gate deletion; registry exposes `RetireExternal`, `DeleteRetired`, `PendingDeletionIDs`, and `ErrTenantRetired`. `/_subrouter/auth/stack` returns 410 Gone for retired tenants; unknown `srt_` credentials always return 401.

- **Bug Fixes**
  - Completed restart recovery for tenant deletions: scan retired/retiring markers, retry with exponential backoff, respect process drain; background worker finishes transcript cleanup and leaves deletions pending (without dropping credentials) if transcript removal fails.
  - Rejected new key creation for retired tenants.
  - Kept hosted login working when `SUBROUTER_STACK_TENANT_DELETE_TOKEN` is unset; the delete endpoint is disabled unless configured.
  - Stabilized deployment/test harnesses: added `deploy/gcp/verify-release-on-main.sh` to stream large GitHub comparisons into `jq` and accurately classify transport vs. processing failures; allowed test-only probe/egress tolerance overrides to reduce CI jitter.

<sup>Written for commit fedb1d099b05e41c6477c3ab50b1bbde5a72f1d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Stack tenant deletion with authorization checks and safe coordination with active requests.
  - Retired tenants reject new requests, return `410 Gone`, and support crash recovery and cleanup.
  - Added consistent tenant resolution and usage coordination across supported platforms.
  - Added release verification for confirming revisions are on the main branch.

- **Bug Fixes**
  - Prevented stale or unknown tenant credentials from reaching the wrong tenant.
  - Improved repeated deletion and unauthorized request handling.
  - Release verification now handles large responses and reports transport failures clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->