### PR TITLE
Fix large attestation verification deadlock

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -378,7 +378,7 @@ func TestPublishSubrouterRejectsNonHTTPSManagedURLBeforeMutation(t *testing.T) {
 }
 
 func TestCreateVMTempFilesSurviveInterruptedAndRepeatedMacOSRuns(t *testing.T) {
-	requireDeployScriptTools(t, "bash")
+	requireDeployScriptTools(t, "bash", "dd", "tr")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))
 	fakeBin := t.TempDir()
 	tempDir := t.TempDir()
@@ -414,9 +414,18 @@ func TestCreateVMTempFilesSurviveInterruptedAndRepeatedMacOSRuns(t *testing.T) {
 
 	writeExecutableTestFile(t, filepath.Join(fakeBin, "sha256sum"), "#!/bin/sh\nprintf '"+digest+"  %s\\n' \"$1\"\n")
 	writeExecutableTestFile(t, filepath.Join(fakeBin, "go"), "#!/bin/sh\nprintf 'vcs.revision="+revision+"\\nvcs.modified=false\\n'\n")
-	writeExecutableTestFile(t, filepath.Join(fakeBin, "gh"), "#!/bin/sh\nprintf '{}\\n'\n")
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "gh"), `#!/bin/sh
+if [ "$1 $2" = "attestation verify" ]; then
+  printf '[{"padding":"'
+  dd if=/dev/zero bs=1048576 count=2 2>/dev/null | tr '\000' x
+  printf '"}]\n'
+else
+  printf '{}\n'
+fi
+`)
 	writeExecutableTestFile(t, filepath.Join(fakeBin, "jq"), `#!/bin/sh
 case "$*" in
+  *"length > 0"*) cat >/dev/null ;;
   *".source_revision"*) printf '%s\n' "$TEST_REVISION" ;;
   *".assets["*) printf '%s\n' "$TEST_DIGEST" ;;
   *"subrouter-release-metadata-sha256"*) printf '%s\n' "$TEST_DIGEST" ;;

--- a/deploy/gcp/create-subrouter-vm.sh
+++ b/deploy/gcp/create-subrouter-vm.sh
@@ -136,12 +136,13 @@ for asset in "${required_assets[@]}"; do
   path="${asset_dir}/${asset}"
   gh release verify-asset "${release_tag}" "${path}" --repo manaflow-ai/subrouter --format json >/dev/null \
     || die "immutable release asset verification failed: ${asset}"
-  attestation="$(gh attestation verify "${path}" --repo manaflow-ai/subrouter \
-    --signer-workflow manaflow-ai/subrouter/.github/workflows/release.yml \
-    --source-ref "refs/tags/${release_tag}" --source-digest "${release_revision}" \
-    --deny-self-hosted-runners --format json)"
-  jq -e 'length > 0' <<<"${attestation}" >/dev/null \
-    || die "strict build attestation verification failed: ${asset}"
+  if ! gh attestation verify "${path}" --repo manaflow-ai/subrouter \
+      --signer-workflow manaflow-ai/subrouter/.github/workflows/release.yml \
+      --source-ref "refs/tags/${release_tag}" --source-digest "${release_revision}" \
+      --deny-self-hosted-runners --format json \
+      | jq -e 'length > 0' >/dev/null; then
+    die "strict build attestation verification failed: ${asset}"
+  fi
 done
 
 mkdir -p "${artifact_dir}"

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -187,12 +187,14 @@ for asset in "${candidate_assets[@]}"; do
   [[ -f "${path}" && ! -L "${path}" ]] || { echo "candidate release asset is missing or unsafe: ${asset}" >&2; exit 1; }
   candidate_digests["${asset}"]="$(sha256_file "${path}")"
   gh release verify-asset "${candidate_tag}" "${path}" --repo "${repository}" --format json >/dev/null
-  attestation="$(gh attestation verify "${path}" --repo "${repository}" \
-    --signer-workflow "${repository}/.github/workflows/release.yml" \
-    --source-ref "refs/tags/${candidate_tag}" --source-digest "${candidate_revision}" \
-    --deny-self-hosted-runners --format json)"
-  jq -e 'length > 0' <<<"${attestation}" >/dev/null \
-    || { echo "strict build attestation verification failed: ${asset}" >&2; exit 1; }
+  if ! gh attestation verify "${path}" --repo "${repository}" \
+      --signer-workflow "${repository}/.github/workflows/release.yml" \
+      --source-ref "refs/tags/${candidate_tag}" --source-digest "${candidate_revision}" \
+      --deny-self-hosted-runners --format json \
+      | jq -e 'length > 0' >/dev/null; then
+    echo "strict build attestation verification failed: ${asset}" >&2
+    exit 1
+  fi
 done
 for asset in SOURCE_PROVENANCE.json deployment-contract.py install.sh install-front-slots.sh "${candidate_linux_asset}"; do
   [[ "$(manifest_sha "${candidate_manifest}" "${asset}")" == "${candidate_digests[${asset}]}" ]] \


### PR DESCRIPTION
## Summary

- stream GitHub attestation JSON directly into jq in both deployment gates
- cover multi-megabyte attestation evidence on macOS Bash

## Verification

- `go test ./...`
- regression commit `8f991ac` times out before fix and passes after `96b425b`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788367633&installation_model_id=21920&pr_number=132&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F132&signature=86d0d85079589c85c0285c33104c9b69decc7492667cb6fa93d8a0093e5a6a37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deadlock when verifying large release attestations by streaming JSON from `gh` directly into `jq`, preventing stalls on macOS Bash. Adds test coverage for multi‑MB attestation evidence.

- **Bug Fixes**
  - Stream `gh attestation verify` output into `jq` in `deploy/gcp/create-subrouter-vm.sh` and `deploy/gcp/golden-local-mac-production-continuity.sh` to avoid buffering hangs.
  - Tests: require `dd` and `tr`; fake `gh` emits a 2 MB payload; `jq` stub consumes streamed input.

<sup>Written for commit 96b425bbb8626b11995a687d316e25bd22410632. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment attestation verification to process large verification results reliably.
  - Deployments now fail immediately when attestation verification returns invalid or empty data.
  - Maintained existing failure behavior while reducing the risk of hangs or resource issues during verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->