### PR TITLE
Make release verification file-backed

### DIFF
--- a/.github/workflows/gcp-deploy.yml
+++ b/.github/workflows/gcp-deploy.yml
@@ -92,13 +92,13 @@ jobs:
           done
           gh release download "${SUBROUTER_RELEASE_TAG}" --repo manaflow-ai/subrouter \
             --dir "${release_asset_dir}" "${download_args[@]}"
-          release_state="$(gh release view "${SUBROUTER_RELEASE_TAG}" --repo manaflow-ai/subrouter \
-            --json isDraft,isImmutable,tagName,targetCommitish,assets)"
+          release_state="${GITHUB_WORKSPACE}/artifacts/build-provenance/release-state.json"
+          gh release view "${SUBROUTER_RELEASE_TAG}" --repo manaflow-ai/subrouter \
+            --json isDraft,isImmutable,tagName,targetCommitish,assets >"${release_state}"
           jq -e --arg tag "${SUBROUTER_RELEASE_TAG}" \
-            '.tagName == $tag and (.isDraft | not) and .isImmutable' <<<"${release_state}" >/dev/null
-          printf '%s\n' "${release_state}" >"${GITHUB_WORKSPACE}/artifacts/build-provenance/release-state.json"
-          metadata="$(go version -m "${SUBROUTER_DEPLOY_BINARY}")"
-          printf '%s\n' "${metadata}" | tee "${GITHUB_WORKSPACE}/artifacts/build-provenance/candidate.txt"
+            '.tagName == $tag and (.isDraft | not) and .isImmutable' "${release_state}" >/dev/null
+          go version -m "${SUBROUTER_DEPLOY_BINARY}" \
+            | tee "${GITHUB_WORKSPACE}/artifacts/build-provenance/candidate.txt"
           release_commit="$(git -C "${GITHUB_WORKSPACE}/release-source" rev-parse HEAD)"
           printf '%s\n' "${release_commit}" | tee "${GITHUB_WORKSPACE}/artifacts/build-provenance/release-source-commit.txt"
           git -C "${GITHUB_WORKSPACE}/release-source" fetch --no-tags origin main
@@ -107,8 +107,7 @@ jobs:
               echo "release tag commit is not on protected main" >&2
               exit 1
             }
-          grep -Fq "vcs.revision=${release_commit}" <<<"${metadata}"
-          grep -Fq "vcs.modified=false" <<<"${metadata}"
+          bash deploy/gcp/verify-go-release-binary.sh "${SUBROUTER_DEPLOY_BINARY}" "${release_commit}"
           declare -A digests=()
           for asset in "${required_assets[@]}"; do
             path="${release_asset_dir}/${asset}"
@@ -116,16 +115,16 @@ jobs:
             digests["${asset}"]="$(sha256sum "${path}" | awk '{print $1}')"
             jq -e --arg asset "${asset}" --arg digest "sha256:${digests[${asset}]}" \
               '[.assets[]? | select(.name == $asset and .digest == $digest)] | length == 1' \
-              <<<"${release_state}" >/dev/null
+              "${release_state}" >/dev/null
             gh release verify-asset "${SUBROUTER_RELEASE_TAG}" "${path}" \
               --repo manaflow-ai/subrouter --format json >/dev/null
-            verification="$(gh attestation verify "${path}" \
+            gh attestation verify "${path}" \
               --repo manaflow-ai/subrouter \
               --signer-workflow manaflow-ai/subrouter/.github/workflows/release.yml \
               --source-ref "refs/tags/${SUBROUTER_RELEASE_TAG}" \
               --source-digest "${release_commit}" \
-              --deny-self-hosted-runners --format json)"
-            jq -e 'length > 0' <<<"${verification}" >/dev/null
+              --deny-self-hosted-runners --format json \
+              | jq -e 'length > 0' >/dev/null
           done
           [[ "$(sha256sum "${SUBROUTER_DEPLOY_BINARY}" | awk '{print $1}')" == "${digests[${binary_asset}]}" ]]
           for asset in SOURCE_PROVENANCE.json deployment-contract.py install.sh install-front-slots.sh "${binary_asset}"; do

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -413,7 +413,10 @@ func TestCreateVMTempFilesSurviveInterruptedAndRepeatedMacOSRuns(t *testing.T) {
 	}
 
 	writeExecutableTestFile(t, filepath.Join(fakeBin, "sha256sum"), "#!/bin/sh\nprintf '"+digest+"  %s\\n' \"$1\"\n")
-	writeExecutableTestFile(t, filepath.Join(fakeBin, "go"), "#!/bin/sh\nprintf 'vcs.revision="+revision+"\\nvcs.modified=false\\n'\n")
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "go"), `#!/bin/sh
+dd if=/dev/zero bs=1048576 count=2 2>/dev/null | tr '\000' x
+printf '\nvcs.revision=`+revision+`\nvcs.modified=false\n'
+`)
 	writeExecutableTestFile(t, filepath.Join(fakeBin, "gh"), `#!/bin/sh
 if [ "$1 $2" = "attestation verify" ]; then
   printf '[{"padding":"'
@@ -432,6 +435,7 @@ case "$*" in
   *".creation_timestamp"*) printf '%s\n' "$TEST_CREATED_AT" ;;
   *".id"*) printf '%s\n' 1234567890123456789 ;;
   *"-n"*|*"-c ."*) printf '{}\n' ;;
+  *) cat >/dev/null ;;
 esac
 exit 0
 `)
@@ -727,6 +731,37 @@ esac
 	}
 	if err != nil || strings.TrimSpace(string(output)) != revision {
 		t.Fatalf("release verification = %q, %v", output, err)
+	}
+}
+
+func TestGoReleaseBinaryVerificationUsesFileBackedMetadata(t *testing.T) {
+	requireDeployScriptTools(t, "bash", "dd", "tr")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	fakeBin := t.TempDir()
+	revision := strings.Repeat("a", 40)
+	binary := filepath.Join(t.TempDir(), "release-binary")
+	if err := os.WriteFile(binary, []byte("fake release binary\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "go"), `#!/bin/sh
+printf 'path\texample.test/subrouter\n'
+dd if=/dev/zero bs=1048576 count=2 2>/dev/null | tr '\000' x
+printf '\nbuild\tvcs.revision=%s\nbuild\tvcs.modified=false\n' "$TEST_REVISION"
+`)
+	helper := filepath.Join(repoRoot, "deploy", "gcp", "verify-go-release-binary.sh")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, mustLookPath(t, "bash"), helper, binary, revision)
+	command.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"TEST_REVISION="+revision,
+	)
+	output, err := runDeployTestCommand(command)
+	if ctx.Err() != nil {
+		t.Fatalf("Go release metadata verification deadlocked: %v\n%s", ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("Go release metadata verification failed: %v\n%s", err, output)
 	}
 }
 

--- a/deploy/gcp/create-subrouter-vm.sh
+++ b/deploy/gcp/create-subrouter-vm.sh
@@ -119,19 +119,22 @@ done
 jq -e --arg tag "${release_tag}" --arg revision "${release_revision}" \
   '.tag == $tag and .source_revision == $revision and .tag_on_main == true' \
   "${asset_dir}/SOURCE_PROVENANCE.json" >/dev/null || die "source provenance does not match release verification"
-binary_metadata="$(go version -m "${asset_dir}/${binary_asset}")"
-grep -Fq "vcs.revision=${release_revision}" <<<"${binary_metadata}" || die "binary embedded revision mismatch"
-grep -Fq 'vcs.modified=false' <<<"${binary_metadata}" || die "binary embedded metadata reports modified source"
+bash "${script_dir}/verify-go-release-binary.sh" "${asset_dir}/${binary_asset}" "${release_revision}" \
+  || die "binary embedded metadata is invalid"
 
 # Re-run the remote release and strict attestation checks here so VM creation
 # cannot trust a caller-authored boolean-only verification document.
-release_state="$(gh release view "${release_tag}" --repo manaflow-ai/subrouter --json isDraft,isImmutable,tagName)"
-jq -e --arg tag "${release_tag}" '.tagName == $tag and (.isDraft | not) and .isImmutable' \
-  <<<"${release_state}" >/dev/null || die "release is missing, draft, or mutable"
-compare_state="$(gh api "repos/manaflow-ai/subrouter/compare/${release_revision}...main")"
-jq -e --arg revision "${release_revision}" \
-  '.merge_base_commit.sha == $revision and (.status == "ahead" or .status == "identical")' \
-  <<<"${compare_state}" >/dev/null || die "release tag commit is not on protected main"
+if ! gh release view "${release_tag}" --repo manaflow-ai/subrouter --json isDraft,isImmutable,tagName \
+    | jq -e --arg tag "${release_tag}" \
+      '.tagName == $tag and (.isDraft | not) and .isImmutable' >/dev/null; then
+  die "release is missing, draft, or mutable"
+fi
+if ! gh api "repos/manaflow-ai/subrouter/compare/${release_revision}...main" \
+    | jq -e --arg revision "${release_revision}" \
+      '.merge_base_commit.sha == $revision and (.status == "ahead" or .status == "identical")' \
+      >/dev/null; then
+  die "release tag commit is not on protected main"
+fi
 for asset in "${required_assets[@]}"; do
   path="${asset_dir}/${asset}"
   gh release verify-asset "${release_tag}" "${path}" --repo manaflow-ai/subrouter --format json >/dev/null \

--- a/deploy/gcp/deploy-live-upgrade.sh
+++ b/deploy/gcp/deploy-live-upgrade.sh
@@ -109,11 +109,8 @@ DEPLOYMENT_CONTRACT_SHA256="$(sha256sum "${DEPLOYMENT_CONTRACT}" | awk '{print $
 (( MAX_MEMORY_BYTES > 0 )) || die "SUBROUTER_MAX_MEMORY_BYTES must be positive"
 (( MAX_MEMORY_BYTES == 201326592 )) || die "SUBROUTER_MAX_MEMORY_BYTES must match the 192 MiB slot MemoryMax"
 [[ "${DEPLOY_REVISION}" =~ ^[0-9a-f]{40}$ ]] || die "SUBROUTER_DEPLOY_REVISION must be a full verified commit"
-candidate_metadata="$(go version -m "${DEPLOY_BINARY}")"
-grep -Fq "vcs.revision=${DEPLOY_REVISION}" <<<"${candidate_metadata}" \
-  || die "candidate embedded revision does not match the verified release commit"
-grep -Fq 'vcs.modified=false' <<<"${candidate_metadata}" \
-  || die "candidate embedded metadata reports modified source"
+bash "${SCRIPT_DIR}/verify-go-release-binary.sh" "${DEPLOY_BINARY}" "${DEPLOY_REVISION}" \
+  || die "candidate embedded metadata is invalid"
 [[ "${TAG_ON_MAIN}" == "true" ]] || die "release tag commit was not proven to be on main"
 [[ "${ATTESTATION_VERIFIED}" == "true" ]] || die "release artifact attestation was not verified"
 [[ "${RELEASE_IMMUTABLE}" == "true" ]] || die "release was not proven published and immutable"

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -130,20 +130,20 @@ require_release_revision_on_main() {
 verify_go_release_binary() {
   local path="$1"
   local revision="$2"
-  local metadata
-  metadata="$(go version -m "${path}")"
-  grep -Fq "vcs.revision=${revision}" <<<"${metadata}" || { echo "embedded revision mismatch: ${path}" >&2; exit 1; }
-  grep -Fq 'vcs.modified=false' <<<"${metadata}" || { echo "release binary reports modified source: ${path}" >&2; exit 1; }
+  bash "${root}/deploy/gcp/verify-go-release-binary.sh" "${path}" "${revision}"
 }
 
 predecessor_dir="${private_root}/predecessor"
 candidate_dir="${private_root}/candidate"
 mkdir -p "${predecessor_dir}" "${candidate_dir}"
 
-predecessor_state="$(gh release view "${predecessor_tag}" --repo "${repository}" --json tagName,isDraft,publishedAt)"
-jq -e --arg tag "${predecessor_tag}" \
-  '.tagName == $tag and (.isDraft | not) and (.publishedAt | type == "string" and length > 0)' \
-  <<<"${predecessor_state}" >/dev/null || { echo "v0.1.51 is not a published release" >&2; exit 1; }
+if ! gh release view "${predecessor_tag}" --repo "${repository}" --json tagName,isDraft,publishedAt \
+    | jq -e --arg tag "${predecessor_tag}" \
+      '.tagName == $tag and (.isDraft | not) and (.publishedAt | type == "string" and length > 0)' \
+      >/dev/null; then
+  echo "v0.1.51 is not a published release" >&2
+  exit 1
+fi
 resolved_predecessor_revision="$(require_release_revision_on_main "${predecessor_tag}" "${predecessor_revision}")"
 
 predecessor_darwin_asset="subrouter_${predecessor_version}_darwin_arm64"
@@ -163,11 +163,14 @@ chmod 0700 "${predecessor_darwin}" "${predecessor_linux}"
 verify_go_release_binary "${predecessor_darwin}" "${resolved_predecessor_revision}"
 verify_go_release_binary "${predecessor_linux}" "${resolved_predecessor_revision}"
 
-candidate_state="$(gh release view "${candidate_tag}" --repo "${repository}" --json tagName,isDraft,isPrerelease,isImmutable,publishedAt)"
-jq -e --arg tag "${candidate_tag}" \
-  '.tagName == $tag and (.isDraft | not) and (.isPrerelease | not) and .isImmutable == true and
-   (.publishedAt | type == "string" and length > 0)' \
-  <<<"${candidate_state}" >/dev/null || { echo "v0.1.52 is not a published immutable release" >&2; exit 1; }
+if ! gh release view "${candidate_tag}" --repo "${repository}" --json tagName,isDraft,isPrerelease,isImmutable,publishedAt \
+    | jq -e --arg tag "${candidate_tag}" \
+      '.tagName == $tag and (.isDraft | not) and (.isPrerelease | not) and .isImmutable == true and
+       (.publishedAt | type == "string" and length > 0)' \
+      >/dev/null; then
+  echo "v0.1.52 is not a published immutable release" >&2
+  exit 1
+fi
 candidate_revision="$(require_release_revision_on_main "${candidate_tag}")"
 [[ "${candidate_revision}" != "${resolved_predecessor_revision}" ]] \
   || { echo "candidate and predecessor revisions must differ" >&2; exit 1; }

--- a/deploy/gcp/migrate-to-front-slots.sh
+++ b/deploy/gcp/migrate-to-front-slots.sh
@@ -108,18 +108,13 @@ manifest_predecessor_sha="$(awk '$2 == "subrouter_0.1.51_linux_amd64" {print $1}
 [[ "${PREDECESSOR_SHA256}" != "${EXPECTED_SHA256}" ]] \
   || die "predecessor worker must differ from the control release"
 [[ "${DEPLOY_REVISION}" =~ ^[0-9a-f]{40}$ ]] || die "SUBROUTER_DEPLOY_REVISION must be a full verified commit"
-candidate_metadata="$(go version -m "${DEPLOY_BINARY}")"
-grep -Fq "vcs.revision=${DEPLOY_REVISION}" <<<"${candidate_metadata}" \
-  || die "candidate embedded revision does not match the verified release commit"
-grep -Fq 'vcs.modified=false' <<<"${candidate_metadata}" \
-  || die "candidate embedded metadata reports modified source"
+bash "${SCRIPT_DIR}/verify-go-release-binary.sh" "${DEPLOY_BINARY}" "${DEPLOY_REVISION}" \
+  || die "candidate embedded metadata is invalid"
 [[ "${PREDECESSOR_REVISION}" == 5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8 ]] \
   || die "predecessor revision does not match the compiled-in v0.1.51 hard pin"
-predecessor_metadata="$(go version -m "${PREDECESSOR_BINARY}")"
-grep -Fq 'vcs.revision=5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8' <<<"${predecessor_metadata}" \
-  || die "predecessor embedded revision does not match v0.1.51"
-grep -Fq 'vcs.modified=false' <<<"${predecessor_metadata}" \
-  || die "predecessor embedded metadata reports modified source"
+bash "${SCRIPT_DIR}/verify-go-release-binary.sh" \
+  "${PREDECESSOR_BINARY}" 5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8 \
+  || die "predecessor embedded metadata is invalid"
 [[ "${TAG_ON_MAIN}" == true ]] || die "release tag commit was not proven to be on main"
 [[ "${ATTESTATION_VERIFIED}" == true ]] || die "release artifact attestation was not verified"
 [[ "${RELEASE_IMMUTABLE}" == true ]] || die "release was not proven published and immutable"

--- a/deploy/gcp/normalize-staging-predecessor.sh
+++ b/deploy/gcp/normalize-staging-predecessor.sh
@@ -61,9 +61,9 @@ PREDECESSOR_SHA256="$(tr -d '[:space:]' <"${PREDECESSOR_SHA256_FILE}")"
   || die "v0.1.51 worker bytes changed"
 [[ "$(awk '$2 == "subrouter_0.1.51_linux_amd64" {print $1}' "${PREDECESSOR_SHA256SUMS_FILE}")" == "${PREDECESSOR_SHA256}" ]] \
   || die "v0.1.51 SHA256SUMS does not match the hard pin"
-metadata="$(go version -m "${PREDECESSOR_BINARY}")"
-grep -Fq 'vcs.revision=5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8' <<<"${metadata}" || die "v0.1.51 embedded revision mismatch"
-grep -Fq 'vcs.modified=false' <<<"${metadata}" || die "v0.1.51 embedded metadata reports modified source"
+bash "${SCRIPT_DIR}/verify-go-release-binary.sh" \
+  "${PREDECESSOR_BINARY}" 5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8 \
+  || die "v0.1.51 embedded metadata is invalid"
 [[ "${DRAIN_TIMEOUT_SECONDS}" =~ ^[0-9]+$ ]] || die "normalization drain timeout must be an integer"
 (( DRAIN_TIMEOUT_SECONDS > 0 )) || die "normalization drain timeout must be positive"
 

--- a/deploy/gcp/verify-go-release-binary.sh
+++ b/deploy/gcp/verify-go-release-binary.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Verify Go build provenance without routing multi-line metadata through shell
+# variables or here-strings. macOS Bash can block while constructing those
+# redirections, so the metadata file is the sole owner of the command output.
+set -euo pipefail
+umask 077
+
+usage() {
+  cat <<'EOF'
+Usage: verify-go-release-binary.sh BINARY EXPECTED_REVISION
+EOF
+}
+
+if (( $# != 2 )); then
+  usage >&2
+  exit 2
+fi
+
+binary="$1"
+expected_revision="$2"
+[[ -f "${binary}" && ! -L "${binary}" ]] || {
+  echo "release binary is missing or unsafe: ${binary}" >&2
+  exit 1
+}
+[[ "${expected_revision}" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "expected release revision must be a full commit" >&2
+  exit 1
+}
+for command in go grep mktemp; do
+  command -v "${command}" >/dev/null 2>&1 || {
+    echo "${command} is required" >&2
+    exit 1
+  }
+done
+
+metadata_file="$(mktemp "${TMPDIR:-/tmp}/subrouter-go-release-metadata.XXXXXX")"
+cleanup() {
+  unlink "${metadata_file}" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+go version -m "${binary}" >"${metadata_file}" || {
+  echo "could not read Go release metadata: ${binary}" >&2
+  exit 1
+}
+grep -F "vcs.revision=${expected_revision}" "${metadata_file}" >/dev/null || {
+  echo "release binary embedded revision mismatch: ${binary}" >&2
+  exit 1
+}
+grep -F 'vcs.modified=false' "${metadata_file}" >/dev/null || {
+  echo "release binary reports modified source: ${binary}" >&2
+  exit 1
+}


### PR DESCRIPTION
## Summary

- make multi-line release metadata and GitHub evidence file-backed or directly streamed
- share one Go binary provenance verifier across local golden, GCP migration, VM creation, and hosted deployment
- cover multi-megabyte Go metadata and attestation output on macOS Bash

## Verification

- `bash -n` on every changed deployment script
- `actionlint .github/workflows/gcp-deploy.yml`
- `shellcheck` on every changed deployment script
- `go test ./...`
- regression commit `c7422e0` is red before fix and green after `8131367`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788368352&installation_model_id=21920&pr_number=133&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F133&signature=d71a40e4e1be4aca57a82a8423248c17a478c6925f94c1d3b88613122a29e2f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make release verification file-backed to prevent macOS Bash hangs with large, multi-line Go metadata and GitHub evidence. Centralizes Go binary provenance checks into `deploy/gcp/verify-go-release-binary.sh` and updates GHA + GCP scripts and tests to use file-based I/O.

- **Bug Fixes**
  - Avoid macOS stalls by writing `go version -m` output to a temp file instead of here-strings/vars.
  - Stream `gh attestation verify` output directly to `jq` and read release state from a file.
  - Harden checks by re-running release immutability and “on main” validations where needed.

- **Refactors**
  - Add `deploy/gcp/verify-go-release-binary.sh` and use it in GHA, VM creation, live upgrade, migration, and staging scripts.
  - Add tests to cover multi‑MB metadata and file-backed verification on macOS.

<sup>Written for commit 8131367e0bdbb5f31dc7dc7ad28430b0d43646d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

