### PR TITLE
Normalize pre-lifecycle staging supervisors

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -926,6 +926,8 @@ func TestDeploymentContractAcceptsPreLifecycleLegacySupervisorStatus(t *testing.
 		t.Fatalf("current legacy status result = %q, %v", output, err)
 	}
 	for _, invalid := range []string{
+		`{"retiring":false,"active":{"id":"generation-a"},"backends":[{"id":"generation-a","active":true,"connections":0}]}`,
+		`{"accepting":true,"active":{"id":"generation-a"},"backends":[{"id":"generation-a","active":true,"connections":0}]}`,
 		`{"accepting":false,"retiring":false,"active":{"id":"generation-a"},"backends":[{"id":"generation-a","active":true,"connections":0}]}`,
 		`{"accepting":true,"retiring":true,"active":{"id":"generation-a"},"backends":[{"id":"generation-a","active":true,"connections":0}]}`,
 		`{"active":{"id":"generation-a"},"backends":[{"id":"generation-b","active":true,"connections":0}]}`,

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -902,6 +902,41 @@ func TestDeploymentContractValidatesInstanceAndPrivateInputs(t *testing.T) {
 	}
 }
 
+func TestDeploymentContractAcceptsPreLifecycleLegacySupervisorStatus(t *testing.T) {
+	requireDeployScriptTools(t, "python3")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	helper := filepath.Join(repoRoot, "deploy", "gcp", "deployment-contract.py")
+	status := filepath.Join(t.TempDir(), "supervisor-status.json")
+	run := func(body string) ([]byte, error) {
+		t.Helper()
+		if err := os.WriteFile(status, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return exec.Command(
+			mustLookPath(t, "python3"), helper, "validate-legacy-supervisor-status", status,
+		).CombinedOutput()
+	}
+
+	preLifecycle := `{"active":{"id":"generation-a"},"backends":[{"id":"generation-a","active":true,"connections":2}]}`
+	if output, err := run(preLifecycle); err != nil || len(output) != 0 {
+		t.Fatalf("pre-lifecycle legacy status result = %q, %v", output, err)
+	}
+	current := `{"accepting":true,"retiring":false,"active":{"id":"generation-a"},"backends":[{"id":"generation-a","active":true,"connections":0}]}`
+	if output, err := run(current); err != nil || len(output) != 0 {
+		t.Fatalf("current legacy status result = %q, %v", output, err)
+	}
+	for _, invalid := range []string{
+		`{"accepting":false,"retiring":false,"active":{"id":"generation-a"},"backends":[{"id":"generation-a","active":true,"connections":0}]}`,
+		`{"accepting":true,"retiring":true,"active":{"id":"generation-a"},"backends":[{"id":"generation-a","active":true,"connections":0}]}`,
+		`{"active":{"id":"generation-a"},"backends":[{"id":"generation-b","active":true,"connections":0}]}`,
+		`{"active":{"id":"generation-a"},"backends":[{"id":"generation-a","active":true,"connections":-1}]}`,
+	} {
+		if output, err := run(invalid); err == nil {
+			t.Fatalf("invalid legacy status succeeded: %s\n%s", invalid, output)
+		}
+	}
+}
+
 func TestDeploymentContractValidatesAuthenticationAndURLMapTransitions(t *testing.T) {
 	requireDeployScriptTools(t, "python3")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/deploy/gcp/deployment-contract.py
+++ b/deploy/gcp/deployment-contract.py
@@ -218,6 +218,35 @@ def command_validate_instance_binding(args: argparse.Namespace) -> None:
         fail("live GCE instance is too old for fresh VM acceptance")
 
 
+def command_validate_legacy_supervisor_status(args: argparse.Namespace) -> None:
+    document = load_json(args.path, "legacy supervisor status")
+    for key, expected in (("accepting", True), ("retiring", False)):
+        if key in document and document[key] is not expected:
+            fail(f"legacy supervisor {key} must be {str(expected).lower()}")
+    active = document.get("active")
+    if not isinstance(active, dict):
+        fail("legacy supervisor active generation is missing")
+    active_id = active.get("id")
+    if not isinstance(active_id, str) or not active_id:
+        fail("legacy supervisor active generation ID is invalid")
+    backends = document.get("backends")
+    if not isinstance(backends, list) or not backends:
+        fail("legacy supervisor backends are missing")
+    active_matches = 0
+    for backend in backends:
+        if not isinstance(backend, dict):
+            fail("legacy supervisor backend is invalid")
+        connections = backend.get("connections")
+        if isinstance(connections, bool) or not isinstance(connections, int) or connections < 0:
+            fail("legacy supervisor backend connections are invalid")
+        if backend.get("id") == active_id:
+            active_matches += 1
+            if backend.get("active") is not True:
+                fail("legacy supervisor active backend is not marked active")
+    if active_matches != 1:
+        fail("legacy supervisor active generation must match exactly one backend")
+
+
 def command_probe_slot_endpoint(args: argparse.Namespace) -> None:
     if args.port < 1 or args.port > 65535:
         fail("slot endpoint port is invalid")
@@ -424,6 +453,10 @@ def build_parser() -> argparse.ArgumentParser:
     binding.add_argument("live_identity")
     binding.add_argument("--now")
     binding.set_defaults(handler=command_validate_instance_binding)
+
+    legacy_status = commands.add_parser("validate-legacy-supervisor-status")
+    add_path(legacy_status, "path")
+    legacy_status.set_defaults(handler=command_validate_legacy_supervisor_status)
 
     probe = commands.add_parser("probe-slot-endpoint")
     probe.add_argument("port", type=int)

--- a/deploy/gcp/deployment-contract.py
+++ b/deploy/gcp/deployment-contract.py
@@ -220,9 +220,15 @@ def command_validate_instance_binding(args: argparse.Namespace) -> None:
 
 def command_validate_legacy_supervisor_status(args: argparse.Namespace) -> None:
     document = load_json(args.path, "legacy supervisor status")
-    for key, expected in (("accepting", True), ("retiring", False)):
-        if key in document and document[key] is not expected:
-            fail(f"legacy supervisor {key} must be {str(expected).lower()}")
+    has_accepting = "accepting" in document
+    has_retiring = "retiring" in document
+    if has_accepting != has_retiring:
+        fail("legacy supervisor lifecycle fields must both be present or both be absent")
+    if has_accepting:
+        if document["accepting"] is not True:
+            fail("legacy supervisor accepting must be true")
+        if document["retiring"] is not False:
+            fail("legacy supervisor retiring must be false")
     active = document.get("active")
     if not isinstance(active, dict):
         fail("legacy supervisor active generation is missing")

--- a/deploy/gcp/normalize-staging-predecessor.sh
+++ b/deploy/gcp/normalize-staging-predecessor.sh
@@ -44,7 +44,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 log() { printf 'gcp-staging-normalization: %s\n' "$*"; }
 die() { log "$*" >&2; exit 1; }
-for command in "${GCLOUD_BINARY}" curl go jq python3 sha256sum; do
+for command in "${GCLOUD_BINARY}" curl go jq mktemp python3 sha256sum; do
   command -v "${command}" >/dev/null 2>&1 || die "required command not found: ${command}"
 done
 [[ "${INSTANCE}" == subrouter-staging ]] || die "normalization is restricted to subrouter-staging"
@@ -85,6 +85,12 @@ utc_now() { python3 -c 'from datetime import datetime, timezone; print(datetime.
 supervisor_status() { gcloud_ssh "sudo curl -fsS --unix-socket /var/lib/subrouter/supervisor.sock http://localhost/_subrouter/supervisor-status"; }
 service_restarts() { gcloud_ssh "systemctl show subrouter.service -p NRestarts --value" | tail -n 1; }
 service_oom() { gcloud_ssh "set -eu; cg=\$(systemctl show subrouter.service -p ControlGroup --value); awk '\$1 == \"oom_kill\" {print \$2}' /sys/fs/cgroup\${cg}/memory.events" | tail -n 1; }
+status_validation_file="$(mktemp "${TMPDIR:-/tmp}/subrouter-legacy-supervisor-status.XXXXXX")"
+validate_clean_legacy_status() {
+  printf '%s\n' "$1" >"${status_validation_file}"
+  python3 "${SCRIPT_DIR}/deployment-contract.py" \
+    validate-legacy-supervisor-status "${status_validation_file}"
+}
 
 lock_holder_pid=""
 normalization_started=0
@@ -133,10 +139,7 @@ rollback_normalization() {
             "${restored_generation}" != "${pre_rollback_generation}" &&
             "${restored_generation}" != "${before_generation}" &&
             "${restored_checksum}" == "${before_checksum}" ]] &&
-          jq -e '(.accepting == true) and (.retiring == false) and
-            (.active.id|type)=="string" and (.backends|type)=="array" and
-            ([.backends[].connections] | all(type=="number" and . >= 0))' \
-            <<<"${restored_status}" >/dev/null 2>&1 &&
+          validate_clean_legacy_status "${restored_status}" >/dev/null 2>&1 &&
           curl -fsS --max-time 2 "${PUBLIC_BASE_URL%/}/_subrouter/health" >/dev/null 2>&1 &&
           curl -fsS --max-time 2 "${PUBLIC_BASE_URL%/}/_subrouter/ready" >/dev/null 2>&1; then
         log "rollback restored checksum ${before_checksum} as healthy generation ${restored_generation}"
@@ -155,6 +158,7 @@ cleanup() {
   if [[ "${normalization_started}" == 1 && "${normalization_committed}" == 0 ]]; then
     rollback_normalization || status=1
   fi
+  unlink "${status_validation_file}" 2>/dev/null || true
   gcloud_ssh "rm -f '${REMOTE_CANDIDATE}' '${REMOTE_BACKUP}'" >/dev/null 2>&1 || true
   release_lock
   exit "${status}"
@@ -166,9 +170,8 @@ curl -fsS --max-time 10 "${PUBLIC_BASE_URL%/}/_subrouter/ready" >/dev/null || di
 acquire_lock
 gcloud_ssh "systemctl is-active --quiet subrouter.service; sudo test -S /var/lib/subrouter/supervisor.sock"
 before_status="$(supervisor_status)"
-jq -e '(.accepting == true) and (.retiring == false) and (.active.id|type)=="string" and
-  (.backends|type)=="array" and ([.backends[].connections] | all(type=="number" and . >= 0))' \
-  <<<"${before_status}" >/dev/null || die "staging legacy supervisor is not a clean active generation"
+validate_clean_legacy_status "${before_status}" \
+  || die "staging legacy supervisor is not a clean active generation"
 before_generation="$(jq -r '.active.id' <<<"${before_status}")"
 before_connections="$(jq -r --arg id "${before_generation}" '[.backends[] | select(.id == $id) | .connections][0] // -1' <<<"${before_status}")"
 inactive_connections_before="$(jq -r --arg id "${before_generation}" '[.backends[] | select(.id != $id) | .connections] | add // 0' <<<"${before_status}")"
@@ -181,9 +184,8 @@ if [[ "${before_checksum}" == "${PREDECESSOR_SHA256}" ]]; then
     || die "already-normalized staging has connections on an inactive generation"
   gcloud_ssh "printf '%s\n' v0.1.51 | sudo tee /etc/subrouter-version >/dev/null"
   after_status="$(supervisor_status)"
-  jq -e '(.accepting == true) and (.retiring == false) and (.active.id|type)=="string" and
-    (.backends|type)=="array" and ([.backends[].connections] | all(type=="number" and . >= 0))' \
-    <<<"${after_status}" >/dev/null || die "already-normalized staging changed supervisor state during verification"
+  validate_clean_legacy_status "${after_status}" \
+    || die "already-normalized staging changed supervisor state during verification"
   after_generation="$(jq -r '.active.id // empty' <<<"${after_status}")"
   after_connections="$(jq -r --arg id "${after_generation}" '[.backends[] | select(.id == $id) | .connections][0] // -1' <<<"${after_status}")"
   inactive_connections_after="$(jq -r --arg id "${after_generation}" '[.backends[] | select(.id != $id) | .connections] | add // 0' <<<"${after_status}")"


### PR DESCRIPTION
## Summary

- accept the historical supervisor status shape that predates lifecycle fields
- keep strict lifecycle validation when those fields are present
- bind the active generation to exactly one healthy backend before normalization

## Verification

- `go test ./...`
- `bash -n deploy/gcp/normalize-staging-predecessor.sh`
- `shellcheck deploy/gcp/normalize-staging-predecessor.sh`
- regression commit `1b40b0a` is red before fix and green after `664fe12`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788368788&installation_model_id=21920&pr_number=134&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F134&signature=d63f27676b1074507c360b7f4a393b0c0e3f0943942df7fa136a0e05e0abbba0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts and strictly validates legacy, pre‑lifecycle supervisor status during staging normalization. Centralizes validation, rejects partial lifecycle states, and ensures the active generation matches exactly one healthy backend before and after normalization.

- **Bug Fixes**
  - Added `validate-legacy-supervisor-status` to `deploy/gcp/deployment-contract.py`: lifecycle fields must be both present or both absent; if present enforce `accepting:true`/`retiring:false`; validate `active.id`; require exactly one matching active backend; non‑negative integer `connections`.
  - Updated `deploy/gcp/normalize-staging-predecessor.sh` to use the validator for normal and rollback checks; requires `mktemp` and cleans up temp files.
  - Added tests in `cmd/subrouter/deploy_scripts_test.go` for pre‑lifecycle and current shapes, rejecting partial lifecycle fields and other invalid states.

<sup>Written for commit 73533e42efac57fd228e81dd54d57b2610104f36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

