### PR TITLE
Advance golden candidate to v0.1.53

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -44,6 +44,7 @@ const (
 	goldenPinnedPredecessorVersion            = "0.1.51"
 	goldenPinnedPredecessorSHA256             = "74f4bfbbf6b8dcbe0509eaaa9f63b1eb688358a749ed3b451066e146591d2582"
 	goldenPinnedPredecessorRevision           = "5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8"
+	goldenPinnedCandidateTag                  = "v0.1.53"
 	goldenFakeStreamReleaseTokenEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_TOKEN"
 	goldenFakeStreamReleaseStateEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_STATE"
 )
@@ -172,9 +173,9 @@ func parseGoldenArgs(args []string) (goldenOptions, error) {
 		if strings.TrimSpace(options.evidenceValidator) == "" {
 			return options, errors.New("--deploy-evidence-validator is required")
 		}
-		if strings.TrimSpace(options.candidateTag) != "v0.1.52" || !validGoldenSHA256(options.candidateSHA256) ||
+		if strings.TrimSpace(options.candidateTag) != goldenPinnedCandidateTag || !validGoldenSHA256(options.candidateSHA256) ||
 			len(strings.TrimSpace(options.candidateRevision)) != 40 {
-			return options, errors.New("the golden candidate must be the verified immutable v0.1.52 release")
+			return options, fmt.Errorf("the golden candidate must be the verified immutable %s release", goldenPinnedCandidateTag)
 		}
 	} else if options.evidenceValidator == "" {
 		options.evidenceValidator = goldenTestHooks.evidenceValidator

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -331,7 +331,7 @@ func validGoldenActivationEvidence() *goldenDeployEvidence {
 	return &goldenDeployEvidence{
 		Schema: goldenDeployEvidenceSchema, EvidenceType: "slot-activation", Mode: "activation", Intent: "rehearsal", Success: true,
 		Release: goldenDeployRelease{
-			Tag: "v0.1.52", SHA256: strings.Repeat("b", 64), SourceRevision: strings.Repeat("c", 40),
+			Tag: goldenPinnedCandidateTag, SHA256: strings.Repeat("b", 64), SourceRevision: strings.Repeat("c", 40),
 			TagOnMain: true, AttestationVerified: true, Immutable: true,
 		},
 		Slots:     goldenDeploySlots{Before: "slot-a", Candidate: "slot-b", Final: "slot-b", OldGeneration: "generation-a", CandidateGeneration: "generation-b"},
@@ -363,7 +363,7 @@ func validGoldenRollbackEvidence() *goldenDeployEvidence {
 		Schema: goldenDeployEvidenceSchema, EvidenceType: "slot-rollback", Mode: "rollback-rehearsal", Intent: "rehearsal", Success: true,
 		ActivationEvidenceSHA256: strings.Repeat("d", 64),
 		Release: goldenDeployRelease{
-			Tag: "v0.1.52", SHA256: strings.Repeat("b", 64), SourceRevision: strings.Repeat("c", 40),
+			Tag: goldenPinnedCandidateTag, SHA256: strings.Repeat("b", 64), SourceRevision: strings.Repeat("c", 40),
 			TagOnMain: true, AttestationVerified: true, Immutable: true,
 		},
 		Slots:       goldenDeploySlots{From: "slot-b", To: "slot-a", Final: "slot-a", FromGeneration: "generation-b", ToGeneration: "generation-a"},
@@ -392,7 +392,7 @@ func validGoldenMigrationBaseEvidence(evidenceType, mode string) *goldenMigratio
 		Schema: goldenDeployEvidenceSchema, EvidenceType: evidenceType, Mode: mode, Success: true,
 		Run: goldenDeployRun{ID: "golden-run", Project: "project", Zone: "zone", Instance: "instance"},
 		Release: goldenDeployRelease{
-			Tag: "v0.1.52", SHA256: strings.Repeat("b", 64), SourceRevision: strings.Repeat("c", 40),
+			Tag: goldenPinnedCandidateTag, SHA256: strings.Repeat("b", 64), SourceRevision: strings.Repeat("c", 40),
 			TagOnMain: true, AttestationVerified: true, Immutable: true,
 		},
 		Predecessor: goldenMigrationPredecessor{
@@ -523,7 +523,7 @@ func validGoldenAcceptanceSummary() goldenSummary {
 		EvidenceType: "slot-activation", EvidenceFile: "activation.json", EvidenceSHA256: strings.Repeat("d", 64),
 		Mode: "activation", StartedAt: stamp, FinishedAt: finished, DurationMillis: 1_000,
 		RequestedAt: stamp, ActivatedAt: finished, PhaseDurationMillis: 1_000, ExitCode: 0, EvidenceValid: true,
-		ReleaseTag: "v0.1.52", ReleaseSourceRevision: strings.Repeat("c", 40),
+		ReleaseTag: goldenPinnedCandidateTag, ReleaseSourceRevision: strings.Repeat("c", 40),
 		FromSlot: "slot-a", ToSlot: "slot-b", ActiveSlot: "slot-b",
 		FromGenerationIDHash: hashGoldenValue("generation-a"), ToGenerationIDHash: hashGoldenValue("generation-b"),
 		ActiveGenerationIDHash: hashGoldenValue("generation-b"), FromReleaseSHA256: releaseA, ToReleaseSHA256: releaseB,

--- a/cmd/subrouter-transport-observer/golden_migration_evidence.go
+++ b/cmd/subrouter-transport-observer/golden_migration_evidence.go
@@ -417,7 +417,7 @@ func validateGoldenMigrationSummary(summary goldenSummary, testMode bool) error 
 	if err := validateGoldenMigrationActionSummary(preparation, "front-migration-preparation"); err != nil {
 		return err
 	}
-	if !testMode && (preparation.ReleaseTag != "v0.1.52" ||
+	if !testMode && (preparation.ReleaseTag != goldenPinnedCandidateTag ||
 		preparation.ReleaseSourceRevision != summary.Activation.ReleaseSourceRevision) {
 		return failGolden("migration_candidate_provenance_mismatch")
 	}

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGoldenOptionsRequireV0153Candidate(t *testing.T) {
+	previousHooks := goldenTestHooks
+	goldenTestHooks.enabled = false
+	t.Cleanup(func() { goldenTestHooks = previousHooks })
+
+	args := []string{
+		"--predecessor-version", "v0.1.51",
+		"--predecessor-sha256", goldenPinnedPredecessorSHA256,
+		"--candidate-tag", "v0.1.53",
+		"--candidate-sha256", strings.Repeat("b", 64),
+		"--candidate-revision", strings.Repeat("c", 40),
+		"--deploy-evidence-validator", "validator",
+		"--stream-lines", "100",
+		"--migration-prepare", "true",
+		"--migration-switch", "true",
+		"--legacy-retirement", "true",
+		"--activate", "true",
+		"--rollback", "true",
+		"--old-generation-check", "true",
+	}
+	if _, err := parseGoldenArgs(args); err != nil {
+		t.Fatalf("v0.1.53 candidate was rejected: %v", err)
+	}
+	for index := range args {
+		if args[index] == "v0.1.53" {
+			args[index] = "v0.1.52"
+			break
+		}
+	}
+	if _, err := parseGoldenArgs(args); err == nil {
+		t.Fatal("superseded v0.1.52 candidate was accepted")
+	}
+}

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify the immutable v0.1.51/v0.1.52 release inputs, then run the complete
+# Verify the immutable v0.1.51/v0.1.53 release inputs, then run the complete
 # legacy-to-front migration and slot-upgrade continuity gate from a local Mac.
 set -euo pipefail
 umask 077
@@ -12,8 +12,8 @@ predecessor_version="0.1.51"
 predecessor_revision="5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8"
 predecessor_darwin_sha="74f4bfbbf6b8dcbe0509eaaa9f63b1eb688358a749ed3b451066e146591d2582"
 predecessor_linux_sha="99fcd10d912184c160370eb228b382795101f2b5b2467244f995aa2d10b0c323"
-candidate_tag="v0.1.52"
-candidate_version="0.1.52"
+candidate_tag="v0.1.53"
+candidate_version="0.1.53"
 
 usage() {
   cat <<'EOF'
@@ -168,7 +168,7 @@ if ! gh release view "${candidate_tag}" --repo "${repository}" --json tagName,is
       '.tagName == $tag and (.isDraft | not) and (.isPrerelease | not) and .isImmutable == true and
        (.publishedAt | type == "string" and length > 0)' \
       >/dev/null; then
-  echo "v0.1.52 is not a published immutable release" >&2
+  echo "v0.1.53 is not a published immutable release" >&2
   exit 1
 fi
 candidate_revision="$(require_release_revision_on_main "${candidate_tag}")"


### PR DESCRIPTION
## Summary

- pin the local production-continuity gate to immutable v0.1.53
- share one candidate-tag constant across argument and migration-evidence validation
- reject the superseded v0.1.52 candidate

## Verification

- `go test ./...`
- `bash -n deploy/gcp/golden-local-mac-production-continuity.sh`
- regression commit `d0e07e3` is red before fix and green after `0b4d585`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788369421&installation_model_id=21920&pr_number=135&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F135&signature=3d6ba3e790742c6c93555682bf78e5b1857686acce62e92af4ddc7da1c7157ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advance the golden candidate to v0.1.53 and enforce it across validation and tooling. This aligns the continuity gate with the immutable v0.1.53 release and blocks the superseded v0.1.52.

- **Refactors**
  - Introduced a shared `goldenPinnedCandidateTag` constant and used it in arg parsing and migration validation.
  - Updated tests to expect v0.1.53; added a new test to reject v0.1.52.
  - Updated `deploy/gcp/golden-local-mac-production-continuity.sh` to verify v0.1.53.

<sup>Written for commit 0b4d585eb9797c44590e8a64e2a28ae7227cd6f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

