### PR TITLE
Stream local GCP deployment values

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -765,6 +765,29 @@ printf '\nbuild\tvcs.revision=%s\nbuild\tvcs.modified=false\n' "$TEST_REVISION"
 	}
 }
 
+func TestShellValueStreamSupportsNestedLargeJSONQueries(t *testing.T) {
+	requireDeployScriptTools(t, "bash", "dd", "jq", "tr")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	helper := filepath.Join(repoRoot, "deploy", "gcp", "stream-shell-value.sh")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, mustLookPath(t, "bash"), "-c", `
+set -euo pipefail
+source "$1"
+padding="$(dd if=/dev/zero bs=1048576 count=2 2>/dev/null | tr '\000' x)"
+document="$(printf '{\"padding\":\"%s\",\"active\":{\"id\":\"generation-a\"}}' "$padding")"
+active="$(jq -r '.active.id' < <(stream_shell_value "$document"))"
+[[ "$active" == generation-a ]]
+`, "test-shell-value-stream", helper)
+	output, err := runDeployTestCommand(command)
+	if ctx.Err() != nil {
+		t.Fatalf("nested JSON query deadlocked: %v\n%s", ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("nested JSON query failed: %v\n%s", err, output)
+	}
+}
+
 func TestReleaseMainVerificationReportsComparisonTransportFailure(t *testing.T) {
 	requireDeployScriptTools(t, "bash", "jq")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/deploy/gcp/create-subrouter-vm.sh
+++ b/deploy/gcp/create-subrouter-vm.sh
@@ -23,6 +23,8 @@ while (( $# > 0 )); do
 done
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy/gcp/stream-shell-value.sh
+source "${script_dir}/stream-shell-value.sh"
 deployment_contract="$(bash "${script_dir}/resolve-release-contract.sh" "${script_dir}/deployment-contract.py")"
 instance_name="${INSTANCE_NAME:-subrouter-team}"
 zone="${ZONE:-us-south1-a}"
@@ -113,7 +115,7 @@ done
 for asset in SOURCE_PROVENANCE.json deployment-contract.py install.sh install-front-slots.sh "${binary_asset}"; do
   expected="$(jq -r --arg asset "${asset}" '.assets[$asset]' "${verification_json}")"
   manifest_matches="$(awk -v asset="${asset}" '$2 == asset || $2 == "*" asset {print $1}' "${asset_dir}/SHA256SUMS")"
-  [[ "$(wc -l <<<"${manifest_matches}" | tr -d '[:space:]')" == 1 && "${manifest_matches}" == "${expected}" ]] \
+  [[ "$(wc -l < <(stream_shell_value "${manifest_matches}") | tr -d '[:space:]')" == 1 && "${manifest_matches}" == "${expected}" ]] \
     || die "SHA256SUMS does not bind ${asset} to release verification"
 done
 jq -e --arg tag "${release_tag}" --arg revision "${release_revision}" \
@@ -182,8 +184,8 @@ gcloud services enable compute.googleapis.com --project "${project_id}" >/dev/nu
 instance_created=false
 if instance_json="$(gcloud compute instances describe "${instance_name}" \
     --project "${project_id}" --zone "${zone}" --format=json 2>/dev/null)"; then
-  existing_metadata_sha="$(jq -r '[.metadata.items[]? | select(.key == "subrouter-release-metadata-sha256")][0].value // empty' <<<"${instance_json}")"
-  existing_content_sha="$(python3 -c 'import hashlib,json,sys; document=json.load(sys.stdin); values=[item.get("value","") for item in document.get("metadata",{}).get("items",[]) if item.get("key")=="subrouter-release-metadata"]; print(hashlib.sha256(values[0].encode()).hexdigest() if len(values)==1 else "")' <<<"${instance_json}")"
+  existing_metadata_sha="$(jq -r '[.metadata.items[]? | select(.key == "subrouter-release-metadata-sha256")][0].value // empty' < <(stream_shell_value "${instance_json}"))"
+  existing_content_sha="$(python3 -c 'import hashlib,json,sys; document=json.load(sys.stdin); values=[item.get("value","") for item in document.get("metadata",{}).get("items",[]) if item.get("key")=="subrouter-release-metadata"]; print(hashlib.sha256(values[0].encode()).hexdigest() if len(values)==1 else "")' < <(stream_shell_value "${instance_json}"))"
   [[ "${existing_metadata_sha}" == "${metadata_sha256}" ]] \
     || die "existing instance release metadata digest differs; rebuild explicitly instead of mutating it"
   [[ "${existing_content_sha}" == "${metadata_sha256}" ]] \
@@ -261,8 +263,8 @@ gcloud compute ssh "${instance_name}" --project "${project_id}" --zone "${zone}"
 query_instance_identity
 [[ "${instance_identity_json}" == "${provisioned_instance_identity}" ]] \
   || die "GCE instance identity changed while VM topology was being verified"
-instance_id="$(jq -r '.id' <<<"${provisioned_instance_identity}")"
-instance_creation_timestamp="$(jq -r '.creation_timestamp' <<<"${provisioned_instance_identity}")"
+instance_id="$(jq -r '.id' < <(stream_shell_value "${provisioned_instance_identity}"))"
+instance_creation_timestamp="$(jq -r '.creation_timestamp' < <(stream_shell_value "${provisioned_instance_identity}"))"
 
 emitted_at="$(utc_now)"
 evidence_tmp="$(mktemp "${evidence_json}.tmp.XXXXXX")"

--- a/deploy/gcp/deploy-live-upgrade.sh
+++ b/deploy/gcp/deploy-live-upgrade.sh
@@ -84,6 +84,8 @@ REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
 REMOTE_LOCK_SENTINEL="/tmp/subrouter-deploy-lock-${RUN_LABEL}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy/gcp/stream-shell-value.sh
+source "${SCRIPT_DIR}/stream-shell-value.sh"
 
 log() { printf 'gcp-slot-deploy: %s\n' "$*"; }
 die() { log "$*" >&2; exit 1; }
@@ -170,7 +172,7 @@ slot_address() {
 front_connections() {
   local status="$1"
   local slot="$2"
-  jq -r --arg id "${slot}" '[.backends[]? | select(.id == $id) | .connections][0] // 0' <<<"${status}"
+  jq -r --arg id "${slot}" '[.backends[]? | select(.id == $id) | .connections][0] // 0' < <(stream_shell_value "${status}")
 }
 
 utc_now() {
@@ -182,12 +184,12 @@ epoch_millis() {
 }
 
 front_active_json() {
-  jq -c '.active | {id,network,address}' <<<"$1"
+  jq -c '.active | {id,network,address}' < <(stream_shell_value "$1")
 }
 
 front_backend_active() {
   local status="$1" slot="$2"
-  jq -r --arg id "${slot}" '[.backends[]? | select(.id == $id) | .active][0] // false' <<<"${status}"
+  jq -r --arg id "${slot}" '[.backends[]? | select(.id == $id) | .active][0] // false' < <(stream_shell_value "${status}")
 }
 
 slot_status() {
@@ -205,11 +207,11 @@ slot_snapshot() {
       (.accepting | type) == "boolean" and (.retiring | type) == "boolean" and
       (.active.id | type) == "string" and (.backends | type) == "array" and
       ([.backends[].connections] | all(type == "number" and . >= 0))
-    ' <<<"${status}" >/dev/null || die "${slot} supervisor returned an invalid status schema"
+    ' < <(stream_shell_value "${status}") >/dev/null || die "${slot} supervisor returned an invalid status schema"
     service_active="$(gcloud_ssh "if systemctl is-active --quiet '$(slot_service "${slot}")'; then echo true; else echo false; fi" | tail -n 1)"
-    active_id="$(jq -r '.active.id' <<<"${status}")"
-    active_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id == $id) | .connections][0] // -1' <<<"${status}")"
-    inactive_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id != $id) | .connections] | add // 0' <<<"${status}")"
+    active_id="$(jq -r '.active.id' < <(stream_shell_value "${status}"))"
+    active_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id == $id) | .connections][0] // -1' < <(stream_shell_value "${status}"))"
+    inactive_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id != $id) | .connections] | add // 0' < <(stream_shell_value "${status}"))"
     [[ "${active_connections}" =~ ^[0-9]+$ && "${inactive_connections}" =~ ^[0-9]+$ ]] \
       || die "${slot} supervisor returned invalid generation connection counts"
     jq -nc --argjson status "${status}" --argjson front_active "${front_active}" \
@@ -238,7 +240,7 @@ validate_front_slot_status() {
   address="$(slot_address "${slot}")"
   jq -e --arg id "${slot}" --arg address "${address}" \
     '.active.id == $id and .active.network == "tcp" and .active.address == $address' \
-    <<<"${status}" >/dev/null
+    < <(stream_shell_value "${status}") >/dev/null
 }
 
 wait_for_front_active() {
@@ -246,7 +248,7 @@ wait_for_front_active() {
   local status active
   for _ in $(seq 1 300); do
     status="$(front_status)"
-    active="$(jq -r '.active.id // empty' <<<"${status}")"
+    active="$(jq -r '.active.id // empty' < <(stream_shell_value "${status}"))"
     [[ "${active}" == "${expected}" ]] && return 0
     sleep 0.1
   done
@@ -475,7 +477,7 @@ rollback_deployment() {
   disable_slot "${candidate_slot}" || return 1
   retire_slot "${candidate_slot}" || return 1
   restored_status="$(front_status)" || return 1
-  [[ "$(jq -r '.active.id // empty' <<<"${restored_status}")" == "${old_slot}" ]] || return 1
+  [[ "$(jq -r '.active.id // empty' < <(stream_shell_value "${restored_status}"))" == "${old_slot}" ]] || return 1
   candidate_connections_after_rollback="$(front_connections "${restored_status}" "${candidate_slot}")" || return 1
   (( candidate_connections_after_rollback >= candidate_connections_before_rollback )) || return 1
   rollback_completed=1
@@ -513,7 +515,7 @@ acquire_deploy_lock
 gcloud_ssh "sudo test -S '${FRONT_SOCKET}' && systemctl is-active --quiet subrouter-front.service" \
   || die "front topology is not installed; run the explicit migrate-front operation first"
 initial_front_status="$(front_status)"
-old_slot="$(jq -r '.active.id // empty' <<<"${initial_front_status}")"
+old_slot="$(jq -r '.active.id // empty' < <(stream_shell_value "${initial_front_status}"))"
 [[ "${old_slot}" == "slot-a" || "${old_slot}" == "slot-b" ]] \
   || die "front has no valid active slot"
 validate_front_slot_status "${initial_front_status}" "${old_slot}" \
@@ -521,9 +523,9 @@ validate_front_slot_status "${initial_front_status}" "${old_slot}" \
 if [[ "${old_slot}" == "slot-a" ]]; then candidate_slot="slot-b"; else candidate_slot="slot-a"; fi
 initial_front_active_json="$(front_active_json "${initial_front_status}")"
 old_snapshot_before="$(slot_snapshot "${old_slot}" "${initial_front_status}")"
-old_generation="$(jq -r '.active_generation' <<<"${old_snapshot_before}")"
+old_generation="$(jq -r '.active_generation' < <(stream_shell_value "${old_snapshot_before}"))"
 jq -e '.accepting and (.retiring | not) and .front_active and .service_active and .inactive_connections == 0' \
-  <<<"${old_snapshot_before}" >/dev/null \
+  < <(stream_shell_value "${old_snapshot_before}") >/dev/null \
   || die "old slot is not a clean accepting active generation"
 old_installed_before="$(gcloud_ssh "sudo sha256sum '/opt/subrouter/slots/${old_slot}/worker' | awk '{print \$1}'" | tail -n 1)"
 [[ "${old_installed_before}" =~ ^[0-9a-f]{64}$ ]] || die "old slot installed checksum is invalid"
@@ -554,9 +556,9 @@ candidate_control_socket="$(slot_control_socket "${candidate_slot}")"
 gcloud_ssh "sudo curl -fsS --unix-socket '${candidate_control_socket}' http://localhost/_subrouter/supervisor-status >/dev/null"
 prepared_front_status="$(front_status)"
 candidate_snapshot_before="$(slot_snapshot "${candidate_slot}" "${prepared_front_status}")"
-candidate_generation="$(jq -r '.active_generation' <<<"${candidate_snapshot_before}")"
+candidate_generation="$(jq -r '.active_generation' < <(stream_shell_value "${candidate_snapshot_before}"))"
 jq -e '.accepting and (.retiring | not) and (.front_active | not) and .service_active and .inactive_connections == 0' \
-  <<<"${candidate_snapshot_before}" >/dev/null \
+  < <(stream_shell_value "${candidate_snapshot_before}") >/dev/null \
   || die "candidate slot is not a clean accepting generation"
 [[ "${candidate_generation}" != "${old_generation}" ]] || die "candidate and old supervisor generations are identical"
 candidate_installed="$(gcloud_ssh "sudo sha256sum '/opt/subrouter/slots/${candidate_slot}/worker' | awk '{print \$1}'" | tail -n 1)"
@@ -590,11 +592,11 @@ candidate_connections_before_switch="$(front_connections "${before_switch_status
 (( old_connections_before_switch >= EXPECTED_ORIGINAL_CONNECTIONS )) \
   || die "only ${old_connections_before_switch}/${EXPECTED_ORIGINAL_CONNECTIONS} externally held original connections were pinned before the switch"
 old_snapshot_at_switch="$(slot_snapshot "${old_slot}" "${before_switch_status}")"
-old_generation_connections="$(jq -r '.active_connections' <<<"${old_snapshot_at_switch}")"
+old_generation_connections="$(jq -r '.active_connections' < <(stream_shell_value "${old_snapshot_at_switch}"))"
 (( old_generation_connections >= EXPECTED_ORIGINAL_CONNECTIONS )) \
   || die "old supervisor did not correlate every original front connection to its active generation"
 jq -e '.inactive_connections == 0 and .accepting and (.retiring | not)' \
-  <<<"${old_snapshot_at_switch}" >/dev/null \
+  < <(stream_shell_value "${old_snapshot_at_switch}") >/dev/null \
   || die "old supervisor had an accepting or inactive-generation inconsistency at the switch"
 
 log "persisting and switching front to ${candidate_slot}"
@@ -615,7 +617,7 @@ old_connections_after_switch="$(front_connections "${switched_status}" "${old_sl
 switched_front_active_json="$(front_active_json "${switched_status}")"
 old_snapshot_after_switch="$(slot_snapshot "${old_slot}" "${switched_status}")"
 jq -e '.accepting and (.retiring | not) and (.front_active | not) and .inactive_connections == 0' \
-  <<<"${old_snapshot_after_switch}" >/dev/null \
+  < <(stream_shell_value "${old_snapshot_after_switch}") >/dev/null \
   || die "old slot state changed unexpectedly during the front switch"
 
 ack_challenge="$(python3 -c 'import secrets; print(secrets.token_hex(16))')"
@@ -664,7 +666,7 @@ candidate_snapshot_after_ack="$(slot_snapshot "${candidate_slot}" "${acknowledge
 jq -e --arg generation "${candidate_generation}" --argjson minimum "${EXPECTED_ROLLBACK_CONNECTIONS}" \
   '.active_generation == $generation and .active_connections >= $minimum and
    .inactive_connections == 0 and .accepting and (.retiring | not) and .front_active' \
-  <<<"${candidate_snapshot_after_ack}" >/dev/null \
+  < <(stream_shell_value "${candidate_snapshot_after_ack}") >/dev/null \
   || die "golden fresh direct connection was not correlated to the candidate generation"
 
 retirement_target="${old_slot}"
@@ -712,7 +714,7 @@ front_peak_rss="$(stop_rss_sampler front)"
 old_snapshot_after="${old_snapshot_after_switch}"
 
 final_status="$(front_status)"
-final_active="$(jq -r '.active.id // empty' <<<"${final_status}")"
+final_active="$(jq -r '.active.id // empty' < <(stream_shell_value "${final_status}"))"
 [[ "${final_active}" == "${active_slot}" ]] || die "front active slot changed unexpectedly"
 validate_front_slot_status "${final_status}" "${active_slot}" \
   || die "front final active slot metadata is inconsistent"

--- a/deploy/gcp/finalize-legacy-retirement.sh
+++ b/deploy/gcp/finalize-legacy-retirement.sh
@@ -38,6 +38,8 @@ REMOTE_LOCK_SENTINEL="/tmp/subrouter-deploy-lock-${RUN_LABEL}"
 REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy/gcp/stream-shell-value.sh
+source "${SCRIPT_DIR}/stream-shell-value.sh"
 
 log() { printf 'gcp-legacy-retirement: %s\n' "$*"; }
 die() { log "$*" >&2; exit 1; }
@@ -88,11 +90,11 @@ legacy_status() { gcloud_ssh "sudo curl -fsS --unix-socket /var/lib/subrouter/su
 legacy_counts() {
   local status="$1" active_id active_connections inactive_connections
   jq -e '(.active.id|type)=="string" and (.backends|type)=="array" and ([.backends[].connections] | all(type=="number" and . >= 0))' \
-    <<<"${status}" >/dev/null || die "legacy supervisor returned invalid status"
-  active_id="$(jq -r '.active.id' <<<"${status}")"
+    < <(stream_shell_value "${status}") >/dev/null || die "legacy supervisor returned invalid status"
+  active_id="$(jq -r '.active.id' < <(stream_shell_value "${status}"))"
   [[ "${active_id}" == "${legacy_generation}" ]] || die "legacy generation changed from cutover evidence"
-  active_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id == $id) | .connections][0] // -1' <<<"${status}")"
-  inactive_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id != $id) | .connections] | add // 0' <<<"${status}")"
+  active_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id == $id) | .connections][0] // -1' < <(stream_shell_value "${status}"))"
+  inactive_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id != $id) | .connections] | add // 0' < <(stream_shell_value "${status}"))"
   jq -nc --argjson active "${active_connections}" --argjson inactive "${inactive_connections}" \
     '{active:$active,inactive:$inactive,total:($active+$inactive)}'
 }
@@ -185,7 +187,7 @@ deadline=$(( $(date +%s) + DRAIN_TIMEOUT_SECONDS ))
 while true; do
   status="$(legacy_status)"
   counts="$(legacy_counts "${status}")"
-  if [[ "$(jq -r '.total' <<<"${counts}")" == 0 ]]; then
+  if [[ "$(jq -r '.total' < <(stream_shell_value "${counts}"))" == 0 ]]; then
     last_connection_closed_at="$(utc_now)"
     last_connection_closed_ms="$(epoch_millis)"
     break

--- a/deploy/gcp/finalize-slot-retirement.sh
+++ b/deploy/gcp/finalize-slot-retirement.sh
@@ -41,6 +41,8 @@ REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
 REMOTE_LOCK_SENTINEL="/tmp/subrouter-deploy-lock-${RUN_LABEL}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy/gcp/stream-shell-value.sh
+source "${SCRIPT_DIR}/stream-shell-value.sh"
 
 log() { printf 'gcp-slot-retirement: %s\n' "$*"; }
 die() { log "$*" >&2; exit 1; }
@@ -107,7 +109,7 @@ slot_socket() { printf '%s/%s.sock\n' "${STATE_DIR}" "$1"; }
 utc_now() { python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z"))'; }
 epoch_millis() { python3 -c 'import time; print(time.time_ns() // 1_000_000)'; }
 front_status() { gcloud_ssh "sudo curl -fsS --unix-socket '${FRONT_SOCKET}' http://localhost/_subrouter/front-status"; }
-front_connections() { jq -r --arg id "$2" '[.backends[]? | select(.id == $id) | .connections][0] // 0' <<<"$1"; }
+front_connections() { jq -r --arg id "$2" '[.backends[]? | select(.id == $id) | .connections][0] // 0' < <(stream_shell_value "$1"); }
 
 supervisor_status() {
   gcloud_ssh "sudo curl -fsS --unix-socket '$(slot_socket "${retired_slot}")' http://localhost/_subrouter/supervisor-status"
@@ -116,12 +118,12 @@ supervisor_status() {
 assert_supervisor_status() {
   local status="$1" accepting="$2" retiring="$3" active_id active_connections inactive_connections
   jq -e '(.accepting|type)=="boolean" and (.retiring|type)=="boolean" and (.active.id|type)=="string" and (.backends|type)=="array" and ([.backends[].connections] | all(type=="number" and . >= 0))' \
-    <<<"${status}" >/dev/null || die "retired slot returned invalid supervisor status"
-  active_id="$(jq -r '.active.id' <<<"${status}")"
+    < <(stream_shell_value "${status}") >/dev/null || die "retired slot returned invalid supervisor status"
+  active_id="$(jq -r '.active.id' < <(stream_shell_value "${status}"))"
   [[ "${active_id}" == "${retired_generation}" ]] || die "retired generation changed from linked evidence"
-  active_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id == $id) | .connections][0] // -1' <<<"${status}")"
-  inactive_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id != $id) | .connections] | add // 0' <<<"${status}")"
-  [[ "$(jq -r '.accepting' <<<"${status}")" == "${accepting}" && "$(jq -r '.retiring' <<<"${status}")" == "${retiring}" ]] \
+  active_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id == $id) | .connections][0] // -1' < <(stream_shell_value "${status}"))"
+  inactive_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id != $id) | .connections] | add // 0' < <(stream_shell_value "${status}"))"
+  [[ "$(jq -r '.accepting' < <(stream_shell_value "${status}"))" == "${accepting}" && "$(jq -r '.retiring' < <(stream_shell_value "${status}"))" == "${retiring}" ]] \
     || die "retired slot accepting state does not match the transition phase"
   (( inactive_connections == 0 )) || die "inactive supervisor generations still hold connections"
   printf '%s\n' "${active_connections}"
@@ -203,7 +205,7 @@ gcloud_scp "${INSTALL_FRONT_SLOTS}" "${REMOTE_INSTALLER}"
 gcloud_scp "${DEPLOYMENT_CONTRACT}" "${REMOTE_DEPLOYMENT_CONTRACT}"
 gcloud_ssh "printf '%s  %s\n%s  %s\n' '${INSTALL_FRONT_SLOTS_SHA256}' '${REMOTE_INSTALLER}' '${DEPLOYMENT_CONTRACT_SHA256}' '${REMOTE_DEPLOYMENT_CONTRACT}' | sha256sum -c - >/dev/null"
 initial_front="$(front_status)"
-[[ "$(jq -r '.active.id' <<<"${initial_front}")" == "${active_slot}" ]] || die "linked active slot is no longer selected"
+[[ "$(jq -r '.active.id' < <(stream_shell_value "${initial_front}"))" == "${active_slot}" ]] || die "linked active slot is no longer selected"
 initial_sum="$(gcloud_ssh "sudo sha256sum '/opt/subrouter/slots/${retired_slot}/worker' | awk '{print \$1}'" | tail -n 1)"
 [[ "${initial_sum}" == "${retired_checksum}" ]] || die "retired slot bytes differ from linked evidence"
 current_oom="$(service_oom_kills)"
@@ -267,7 +269,7 @@ stop_retirement_sampler
 gcloud_ssh "${REMOTE_INSTALL_COMMAND} stop-drained-slot '${retired_slot}'"
 
 final_front="$(front_status)"
-[[ "$(jq -r '.active.id' <<<"${final_front}")" == "${active_slot}" ]] || die "active slot changed during retirement"
+[[ "$(jq -r '.active.id' < <(stream_shell_value "${final_front}"))" == "${active_slot}" ]] || die "active slot changed during retirement"
 final_connections="$(front_connections "${final_front}" "${retired_slot}")"
 (( final_connections == 0 )) || die "retired front backend regained connections"
 final_restarts="$(service_restarts)"

--- a/deploy/gcp/migrate-to-front-slots.sh
+++ b/deploy/gcp/migrate-to-front-slots.sh
@@ -54,6 +54,8 @@ REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
 REMOTE_LOCK_SENTINEL="/tmp/subrouter-deploy-lock-${RUN_LABEL}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy/gcp/stream-shell-value.sh
+source "${SCRIPT_DIR}/stream-shell-value.sh"
 
 case "${INSTANCE}" in
   subrouter-team)
@@ -215,9 +217,9 @@ map_state="$(python3 "${DEPLOYMENT_CONTRACT}" classify-url-map \
 [[ "${map_state}" == "legacy" ]] \
   || die "${URL_MAP} already routes this environment to ${FRONT_BACKEND_SERVICE}; migration is complete"
 
-http_named_port_count="$(jq -r '[.namedPorts[]? | select(.name == "http" and .port == 31415)] | length' <<<"${group_json}")"
-front_named_port="$(jq -r '[.namedPorts[]? | select(.name == "front") | .port][0] // empty' <<<"${group_json}")"
-old_drain_timeout="$(jq -r '.connectionDraining.drainingTimeoutSec // 0' <<<"${backend_json}")"
+http_named_port_count="$(jq -r '[.namedPorts[]? | select(.name == "http" and .port == 31415)] | length' < <(stream_shell_value "${group_json}"))"
+front_named_port="$(jq -r '[.namedPorts[]? | select(.name == "front") | .port][0] // empty' < <(stream_shell_value "${group_json}"))"
+old_drain_timeout="$(jq -r '.connectionDraining.drainingTimeoutSec // 0' < <(stream_shell_value "${backend_json}"))"
 [[ "${http_named_port_count}" == "1" ]] || die "expected exactly one legacy named port http:31415"
 [[ -z "${front_named_port}" || "${front_named_port}" == "31416" ]] \
   || die "existing front named port is ${front_named_port}, expected 31416"
@@ -256,7 +258,7 @@ if "${GCLOUD_BINARY}" compute health-checks describe "${FRONT_HEALTH_CHECK}" \
   front_hc_json="$("${GCLOUD_BINARY}" compute health-checks describe "${FRONT_HEALTH_CHECK}" \
     --project "${PROJECT_ID}" --global --format=json)"
   jq -e '.type == "HTTP" and .httpHealthCheck.port == 31416 and .httpHealthCheck.portSpecification == "USE_FIXED_PORT" and .httpHealthCheck.requestPath == "/_subrouter/ready"' \
-    <<<"${front_hc_json}" >/dev/null \
+    < <(stream_shell_value "${front_hc_json}") >/dev/null \
     || die "existing ${FRONT_HEALTH_CHECK} does not probe fixed port 31416 readiness"
 else
   "${GCLOUD_BINARY}" compute health-checks create http "${FRONT_HEALTH_CHECK}" \
@@ -275,14 +277,14 @@ desired_named_ports="$(jq -r '
   ((.namedPorts // []) | map(select(.name != "front"))) + [{name:"front",port:31416}]
   | map(.name + ":" + (.port | tostring))
   | join(",")
-' <<<"${group_json}")"
+' < <(stream_shell_value "${group_json}"))"
 "${GCLOUD_BINARY}" compute instance-groups set-named-ports "${INSTANCE_GROUP}" \
   --project "${PROJECT_ID}" --zone "${ZONE}" \
   --named-ports "${desired_named_ports}"
 updated_group_json="$("${GCLOUD_BINARY}" compute instance-groups describe "${INSTANCE_GROUP}" \
   --project "${PROJECT_ID}" --zone "${ZONE}" --format=json)"
 jq -e '.namedPorts | any(.name == "http" and .port == 31415) and any(.name == "front" and .port == 31416)' \
-  <<<"${updated_group_json}" >/dev/null || die "instance-group named ports were not preserved"
+  < <(stream_shell_value "${updated_group_json}") >/dev/null || die "instance-group named ports were not preserved"
 
 if ! "${GCLOUD_BINARY}" compute backend-services describe "${FRONT_BACKEND_SERVICE}" \
     --project "${PROJECT_ID}" --global >/dev/null 2>&1; then
@@ -299,9 +301,9 @@ jq -e --arg hc "${FRONT_HEALTH_CHECK}" --arg group "${INSTANCE_GROUP}" \
    (.healthChecks | length) == 1 and (.healthChecks[0] | endswith("/" + $hc)) and
    ((.backends | length) == 0 or
     ((.backends | length) == 1 and (.backends[0].group | endswith("/" + $group))))' \
-  <<<"${front_backend_json}" >/dev/null \
+  < <(stream_shell_value "${front_backend_json}") >/dev/null \
   || die "existing ${FRONT_BACKEND_SERVICE} does not match the front topology"
-if [[ "$(jq -r '.backends | length' <<<"${front_backend_json}")" == "0" ]]; then
+if [[ "$(jq -r '.backends | length' < <(stream_shell_value "${front_backend_json}"))" == "0" ]]; then
   "${GCLOUD_BINARY}" compute backend-services add-backend "${FRONT_BACKEND_SERVICE}" \
     --project "${PROJECT_ID}" --global --instance-group "${INSTANCE_GROUP}" \
     --instance-group-zone "${ZONE}" --balancing-mode UTILIZATION --capacity-scaler 1
@@ -313,7 +315,7 @@ jq -e --arg hc "${FRONT_HEALTH_CHECK}" --arg group "${INSTANCE_GROUP}" \
    (.timeoutSec == 3600) and (.connectionDraining.drainingTimeoutSec == 3600) and
    (.healthChecks | length) == 1 and (.healthChecks[0] | endswith("/" + $hc)) and
    (.backends | length) == 1 and (.backends[0].group | endswith("/" + $group))' \
-  <<<"${front_backend_json}" >/dev/null \
+  < <(stream_shell_value "${front_backend_json}") >/dev/null \
   || die "${FRONT_BACKEND_SERVICE} was not configured atomically"
 
 log "waiting for the fixed-port front health check before routing traffic"
@@ -321,7 +323,7 @@ for _ in $(seq 1 120); do
   health_json="$("${GCLOUD_BINARY}" compute backend-services get-health "${FRONT_BACKEND_SERVICE}" \
     --project "${PROJECT_ID}" --global --format=json 2>/dev/null || true)"
   if jq -e '[.[].status.healthStatus[]? | select(.healthState == "HEALTHY")] | length > 0' \
-      <<<"${health_json:-[]}" >/dev/null 2>&1; then
+      < <(stream_shell_value "${health_json:-[]}") >/dev/null 2>&1; then
     break
   fi
   sleep 1
@@ -329,22 +331,22 @@ done
 health_json="$("${GCLOUD_BINARY}" compute backend-services get-health "${FRONT_BACKEND_SERVICE}" \
   --project "${PROJECT_ID}" --global --format=json)"
 jq -e '[.[].status.healthStatus[]? | select(.healthState == "HEALTHY")] | length > 0' \
-  <<<"${health_json}" >/dev/null || die "front did not become healthy in the load balancer"
+  < <(stream_shell_value "${health_json}") >/dev/null || die "front did not become healthy in the load balancer"
 
 legacy_status="$(gcloud_ssh "sudo curl -fsS --unix-socket /var/lib/subrouter/supervisor.sock http://localhost/_subrouter/supervisor-status")"
 jq -e '(.active.id|type)=="string" and (.backends|type)=="array" and ([.backends[].connections] | all(type=="number" and . >= 0))' \
-  <<<"${legacy_status}" >/dev/null || die "legacy supervisor status is unavailable or invalid"
-legacy_generation="$(jq -r '.active.id' <<<"${legacy_status}")"
-legacy_inactive_connections="$(jq -r --arg id "${legacy_generation}" '[.backends[] | select(.id != $id) | .connections] | add // 0' <<<"${legacy_status}")"
+  < <(stream_shell_value "${legacy_status}") >/dev/null || die "legacy supervisor status is unavailable or invalid"
+legacy_generation="$(jq -r '.active.id' < <(stream_shell_value "${legacy_status}"))"
+legacy_inactive_connections="$(jq -r --arg id "${legacy_generation}" '[.backends[] | select(.id != $id) | .connections] | add // 0' < <(stream_shell_value "${legacy_status}"))"
 (( legacy_inactive_connections == 0 )) || die "legacy supervisor has inactive generations with held connections"
 legacy_checksum="$(gcloud_ssh "sudo sha256sum /usr/local/bin/subrouter | awk '{print \$1}'" | tail -n 1)"
 [[ "${legacy_checksum}" =~ ^[0-9a-f]{64}$ ]] || die "legacy installed checksum is invalid"
 [[ "${legacy_checksum}" == "${PREDECESSOR_SHA256}" ]] \
   || die "legacy worker bytes do not match the separately verified predecessor"
 front_status="$(gcloud_ssh "sudo curl -fsS --unix-socket /var/lib/subrouter/front.sock http://localhost/_subrouter/front-status")"
-front_slot="$(jq -r '.active.id' <<<"${front_status}")"
+front_slot="$(jq -r '.active.id' < <(stream_shell_value "${front_status}"))"
 front_generation_status="$(gcloud_ssh "sudo curl -fsS --unix-socket /var/lib/subrouter/${front_slot}.sock http://localhost/_subrouter/supervisor-status")"
-front_generation="$(jq -r '.active.id' <<<"${front_generation_status}")"
+front_generation="$(jq -r '.active.id' < <(stream_shell_value "${front_generation_status}"))"
 front_checksum="$(gcloud_ssh "sudo sha256sum /opt/subrouter/front/subrouter | awk '{print \$1}'" | tail -n 1)"
 [[ "${front_checksum}" == "${EXPECTED_SHA256}" ]] || die "front checksum changed after preparation"
 control_checksum="$(gcloud_ssh "sudo sha256sum /opt/subrouter/control/subrouter | awk '{print \$1}'" | tail -n 1)"

--- a/deploy/gcp/normalize-staging-predecessor.sh
+++ b/deploy/gcp/normalize-staging-predecessor.sh
@@ -41,6 +41,8 @@ REMOTE_CANDIDATE="/tmp/subrouter-v0.1.51-${RUN_LABEL}"
 REMOTE_BACKUP="/tmp/subrouter-pre-normalization-${RUN_LABEL}"
 REMOTE_LOCK_SENTINEL="/tmp/subrouter-deploy-lock-${RUN_LABEL}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy/gcp/stream-shell-value.sh
+source "${SCRIPT_DIR}/stream-shell-value.sh"
 
 log() { printf 'gcp-staging-normalization: %s\n' "$*"; }
 die() { log "$*" >&2; exit 1; }
@@ -122,7 +124,7 @@ rollback_normalization() {
     log "could not read the generation before rollback" >&2
     return 1
   fi
-  pre_rollback_generation="$(jq -r '.active.id // empty' <<<"${pre_rollback_status}")"
+  pre_rollback_generation="$(jq -r '.active.id // empty' < <(stream_shell_value "${pre_rollback_status}"))"
   [[ -n "${pre_rollback_generation}" ]] || {
     log "supervisor had no active generation before rollback" >&2
     return 1
@@ -133,7 +135,7 @@ rollback_normalization() {
   fi
   for _ in $(seq 1 120); do
     if restored_status="$(supervisor_status 2>/dev/null)"; then
-      restored_generation="$(jq -r '.active.id // empty' <<<"${restored_status}")"
+      restored_generation="$(jq -r '.active.id // empty' < <(stream_shell_value "${restored_status}"))"
       restored_checksum="$(gcloud_ssh "sudo sha256sum /usr/local/bin/subrouter | awk '{print \$1}'" 2>/dev/null | tail -n 1)"
       if [[ -n "${restored_generation}" &&
             "${restored_generation}" != "${pre_rollback_generation}" &&
@@ -172,9 +174,9 @@ gcloud_ssh "systemctl is-active --quiet subrouter.service; sudo test -S /var/lib
 before_status="$(supervisor_status)"
 validate_clean_legacy_status "${before_status}" \
   || die "staging legacy supervisor is not a clean active generation"
-before_generation="$(jq -r '.active.id' <<<"${before_status}")"
-before_connections="$(jq -r --arg id "${before_generation}" '[.backends[] | select(.id == $id) | .connections][0] // -1' <<<"${before_status}")"
-inactive_connections_before="$(jq -r --arg id "${before_generation}" '[.backends[] | select(.id != $id) | .connections] | add // 0' <<<"${before_status}")"
+before_generation="$(jq -r '.active.id' < <(stream_shell_value "${before_status}"))"
+before_connections="$(jq -r --arg id "${before_generation}" '[.backends[] | select(.id == $id) | .connections][0] // -1' < <(stream_shell_value "${before_status}"))"
+inactive_connections_before="$(jq -r --arg id "${before_generation}" '[.backends[] | select(.id != $id) | .connections] | add // 0' < <(stream_shell_value "${before_status}"))"
 before_checksum="$(gcloud_ssh "sudo sha256sum /usr/local/bin/subrouter | awk '{print \$1}'" | tail -n 1)"
 [[ "${before_checksum}" =~ ^[0-9a-f]{64}$ ]] || die "staging worker checksum is invalid"
 restarts_before="$(service_restarts)"
@@ -186,9 +188,9 @@ if [[ "${before_checksum}" == "${PREDECESSOR_SHA256}" ]]; then
   after_status="$(supervisor_status)"
   validate_clean_legacy_status "${after_status}" \
     || die "already-normalized staging changed supervisor state during verification"
-  after_generation="$(jq -r '.active.id // empty' <<<"${after_status}")"
-  after_connections="$(jq -r --arg id "${after_generation}" '[.backends[] | select(.id == $id) | .connections][0] // -1' <<<"${after_status}")"
-  inactive_connections_after="$(jq -r --arg id "${after_generation}" '[.backends[] | select(.id != $id) | .connections] | add // 0' <<<"${after_status}")"
+  after_generation="$(jq -r '.active.id // empty' < <(stream_shell_value "${after_status}"))"
+  after_connections="$(jq -r --arg id "${after_generation}" '[.backends[] | select(.id == $id) | .connections][0] // -1' < <(stream_shell_value "${after_status}"))"
+  inactive_connections_after="$(jq -r --arg id "${after_generation}" '[.backends[] | select(.id != $id) | .connections] | add // 0' < <(stream_shell_value "${after_status}"))"
   [[ "${after_generation}" == "${before_generation}" ]] \
     || die "already-normalized staging changed generation during verification"
   (( inactive_connections_after == 0 )) \
@@ -245,7 +247,7 @@ gcloud_ssh "sudo curl -fsS --unix-socket /var/lib/subrouter/supervisor.sock -X P
 
 for _ in $(seq 1 120); do
   after_status="$(supervisor_status)"
-  after_generation="$(jq -r '.active.id // empty' <<<"${after_status}")"
+  after_generation="$(jq -r '.active.id // empty' < <(stream_shell_value "${after_status}"))"
   if [[ -n "${after_generation}" && "${after_generation}" != "${before_generation}" ]] && \
       curl -fsS --max-time 2 "${PUBLIC_BASE_URL%/}/_subrouter/health" >/dev/null 2>&1 && \
       curl -fsS --max-time 2 "${PUBLIC_BASE_URL%/}/_subrouter/ready" >/dev/null 2>&1; then
@@ -259,8 +261,8 @@ done
 deadline=$(( $(date +%s) + DRAIN_TIMEOUT_SECONDS ))
 while true; do
   after_status="$(supervisor_status)"
-  old_connections="$(jq -r --arg id "${before_generation}" '[.backends[] | select(.id == $id) | .connections][0] // 0' <<<"${after_status}")"
-  inactive_connections="$(jq -r --arg id "$(jq -r '.active.id' <<<"${after_status}")" '[.backends[] | select(.id != $id) | .connections] | add // 0' <<<"${after_status}")"
+  old_connections="$(jq -r --arg id "${before_generation}" '[.backends[] | select(.id == $id) | .connections][0] // 0' < <(stream_shell_value "${after_status}"))"
+  inactive_connections="$(jq -r --arg id "$(jq -r '.active.id' < <(stream_shell_value "${after_status}"))" '[.backends[] | select(.id != $id) | .connections] | add // 0' < <(stream_shell_value "${after_status}"))"
   if (( old_connections == 0 && inactive_connections == 0 )); then
     drained_at="$(utc_now)"
     break
@@ -268,7 +270,7 @@ while true; do
   (( $(date +%s) < deadline )) || die "pre-normalization generation did not drain"
   sleep 0.1
 done
-after_generation="$(jq -r '.active.id' <<<"${after_status}")"
+after_generation="$(jq -r '.active.id' < <(stream_shell_value "${after_status}"))"
 after_checksum="$(gcloud_ssh "sudo sha256sum /usr/local/bin/subrouter | awk '{print \$1}'" | tail -n 1)"
 [[ "${after_checksum}" == "${PREDECESSOR_SHA256}" ]] || die "staging normalization installed unexpected bytes"
 restarts_after="$(service_restarts)"

--- a/deploy/gcp/preflight-deployment.sh
+++ b/deploy/gcp/preflight-deployment.sh
@@ -39,6 +39,8 @@ ARTIFACT_DIR="${SUBROUTER_DEPLOY_ARTIFACT_DIR:-${PWD}/artifacts/gcp-preflight}"
 RUN_LABEL="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-preflight-$$"
 RUN_LABEL="${RUN_LABEL//[^a-zA-Z0-9._-]/-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy/gcp/stream-shell-value.sh
+source "${SCRIPT_DIR}/stream-shell-value.sh"
 
 case "${INSTANCE}" in
   subrouter-team)
@@ -93,21 +95,21 @@ url_map_json="$("${GCLOUD_BINARY}" compute url-maps describe "${URL_MAP}" --proj
 group_json="$("${GCLOUD_BINARY}" compute instance-groups describe "${INSTANCE_GROUP}" --project "${PROJECT_ID}" --zone "${ZONE}" --format=json)"
 legacy_backend_url="https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/global/backendServices/${LEGACY_BACKEND_SERVICE}"
 front_backend_url="https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/global/backendServices/${FRONT_BACKEND_SERVICE}"
-legacy_refs="$(jq -r --arg value "${legacy_backend_url}" '[.. | strings | select(. == $value)] | length' <<<"${url_map_json}")"
-front_refs="$(jq -r --arg value "${front_backend_url}" '[.. | strings | select(. == $value)] | length' <<<"${url_map_json}")"
+legacy_refs="$(jq -r --arg value "${legacy_backend_url}" '[.. | strings | select(. == $value)] | length' < <(stream_shell_value "${url_map_json}"))"
+front_refs="$(jq -r --arg value "${front_backend_url}" '[.. | strings | select(. == $value)] | length' < <(stream_shell_value "${url_map_json}"))"
 
 if [[ "${MODE}" == migrate-front ]]; then
   [[ "${legacy_refs}" == 1 && "${front_refs}" == 0 ]] || die "URL map is not exactly on the legacy backend"
-  jq -e '[.namedPorts[]? | select(.name == "http" and .port == 31415)] | length == 1' <<<"${group_json}" >/dev/null \
+  jq -e '[.namedPorts[]? | select(.name == "http" and .port == 31415)] | length == 1' < <(stream_shell_value "${group_json}") >/dev/null \
     || die "legacy named port http:31415 is missing"
   front_state="$(gcloud_ssh "if systemctl is-active --quiet subrouter-front.service || sudo test -S /var/lib/subrouter/front.sock; then echo present; else echo absent; fi" | tail -n 1)"
   [[ "${front_state}" == absent ]] || die "front topology already exists; use a slot preflight or finish the existing migration"
   legacy_status="$(gcloud_ssh "systemctl is-active --quiet subrouter.service; sudo curl -fsS --unix-socket /var/lib/subrouter/supervisor.sock http://localhost/_subrouter/supervisor-status")"
   jq -e '(.active.id|type)=="string" and (.backends|type)=="array" and ([.backends[].connections] | all(type=="number" and . >= 0))' \
-    <<<"${legacy_status}" >/dev/null || die "legacy supervisor status is invalid"
-  legacy_generation="$(jq -r '.active.id' <<<"${legacy_status}")"
-  legacy_active_connections="$(jq -r --arg id "${legacy_generation}" '[.backends[] | select(.id == $id) | .connections][0] // -1' <<<"${legacy_status}")"
-  legacy_inactive_connections="$(jq -r --arg id "${legacy_generation}" '[.backends[] | select(.id != $id) | .connections] | add // 0' <<<"${legacy_status}")"
+    < <(stream_shell_value "${legacy_status}") >/dev/null || die "legacy supervisor status is invalid"
+  legacy_generation="$(jq -r '.active.id' < <(stream_shell_value "${legacy_status}"))"
+  legacy_active_connections="$(jq -r --arg id "${legacy_generation}" '[.backends[] | select(.id == $id) | .connections][0] // -1' < <(stream_shell_value "${legacy_status}"))"
+  legacy_inactive_connections="$(jq -r --arg id "${legacy_generation}" '[.backends[] | select(.id != $id) | .connections] | add // 0' < <(stream_shell_value "${legacy_status}"))"
   (( legacy_inactive_connections == 0 )) || die "legacy inactive generation still owns connections"
   legacy_checksum="$(gcloud_ssh "sudo sha256sum /usr/local/bin/subrouter | awk '{print \$1}'" | tail -n 1)"
   [[ "${legacy_checksum}" =~ ^[0-9a-f]{64}$ && "${legacy_checksum}" != "${EXPECTED_SHA256}" ]] \
@@ -121,14 +123,14 @@ if [[ "${MODE}" == migrate-front ]]; then
 else
   [[ "${legacy_refs}" == 0 && "${front_refs}" == 1 ]] || die "URL map is not exactly on the front backend"
   front_status="$(gcloud_ssh "systemctl is-active --quiet subrouter-front.service; sudo curl -fsS --unix-socket /var/lib/subrouter/front.sock http://localhost/_subrouter/front-status")"
-  active_slot="$(jq -r '.active.id // empty' <<<"${front_status}")"
+  active_slot="$(jq -r '.active.id // empty' < <(stream_shell_value "${front_status}"))"
   [[ "${active_slot}" == slot-a || "${active_slot}" == slot-b ]] || die "front active slot is invalid"
   slot_status="$(gcloud_ssh "systemctl is-active --quiet 'subrouter-slot@${active_slot}.service'; sudo curl -fsS --unix-socket '/var/lib/subrouter/${active_slot}.sock' http://localhost/_subrouter/supervisor-status")"
   jq -e '(.accepting == true) and (.retiring == false) and (.active.id|type)=="string" and
     (.backends|type)=="array" and ([.backends[].connections] | all(type=="number" and . >= 0))' \
-    <<<"${slot_status}" >/dev/null || die "active slot supervisor status is invalid"
-  slot_generation="$(jq -r '.active.id' <<<"${slot_status}")"
-  slot_inactive_connections="$(jq -r --arg id "${slot_generation}" '[.backends[] | select(.id != $id) | .connections] | add // 0' <<<"${slot_status}")"
+    < <(stream_shell_value "${slot_status}") >/dev/null || die "active slot supervisor status is invalid"
+  slot_generation="$(jq -r '.active.id' < <(stream_shell_value "${slot_status}"))"
+  slot_inactive_connections="$(jq -r --arg id "${slot_generation}" '[.backends[] | select(.id != $id) | .connections] | add // 0' < <(stream_shell_value "${slot_status}"))"
   (( slot_inactive_connections == 0 )) || die "active slot has inactive-generation connections"
   worker_checksum="$(gcloud_ssh "sudo sha256sum '/opt/subrouter/slots/${active_slot}/worker' | awk '{print \$1}'" | tail -n 1)"
   control_checksum="$(gcloud_ssh "sudo sha256sum /opt/subrouter/control/subrouter | awk '{print \$1}'" | tail -n 1)"

--- a/deploy/gcp/publish-subrouter.sh
+++ b/deploy/gcp/publish-subrouter.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy/gcp/stream-shell-value.sh
+source "${script_dir}/stream-shell-value.sh"
 deployment_contract="$(bash "${script_dir}/resolve-release-contract.sh" "${script_dir}/deployment-contract.py")"
 instance_name="${INSTANCE_NAME:-subrouter-team}"
 server_name="${SERVER_NAME:-team}"
@@ -204,8 +206,8 @@ if [[ "${topology}" == "fresh-prepared" ]]; then
   fresh_instance_identity_json="${live_instance_identity_json}"
   python3 "${deployment_contract}" validate-instance-binding \
     "${bootstrap_snapshot}" "${fresh_instance_identity_json}"
-  fresh_instance_id="$(jq -r '.id' <<<"${fresh_instance_identity_json}")"
-  fresh_instance_creation_timestamp="$(jq -r '.creation_timestamp' <<<"${fresh_instance_identity_json}")"
+  fresh_instance_id="$(jq -r '.id' < <(stream_shell_value "${fresh_instance_identity_json}"))"
+  fresh_instance_creation_timestamp="$(jq -r '.creation_timestamp' < <(stream_shell_value "${fresh_instance_identity_json}"))"
 fi
 
 "${sr_bin}" server add "${server_name}" \

--- a/deploy/gcp/rollback-slot.sh
+++ b/deploy/gcp/rollback-slot.sh
@@ -41,6 +41,8 @@ REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
 REMOTE_LOCK_SENTINEL="/tmp/subrouter-deploy-lock-${RUN_LABEL}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy/gcp/stream-shell-value.sh
+source "${SCRIPT_DIR}/stream-shell-value.sh"
 
 log() { printf 'gcp-slot-rollback: %s\n' "$*"; }
 die() { log "$*" >&2; exit 1; }
@@ -106,19 +108,19 @@ slot_service() { printf 'subrouter-slot@%s.service\n' "$1"; }
 slot_socket() { printf '%s/%s.sock\n' "${STATE_DIR}" "$1"; }
 utc_now() { python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z"))'; }
 front_status() { gcloud_ssh "sudo curl -fsS --unix-socket '${FRONT_SOCKET}' http://localhost/_subrouter/front-status"; }
-front_active_json() { jq -c '.active | {id,network,address}' <<<"$1"; }
-front_connections() { jq -r --arg id "$2" '[.backends[]? | select(.id == $id) | .connections][0] // 0' <<<"$1"; }
+front_active_json() { jq -c '.active | {id,network,address}' < <(stream_shell_value "$1"); }
+front_connections() { jq -r --arg id "$2" '[.backends[]? | select(.id == $id) | .connections][0] // 0' < <(stream_shell_value "$1"); }
 
 slot_snapshot() {
   local slot="$1" front="$2" status active_id active_connections inactive_connections service_active front_active
   status="$(gcloud_ssh "sudo curl -fsS --unix-socket '$(slot_socket "${slot}")' http://localhost/_subrouter/supervisor-status")"
   jq -e '(.accepting|type)=="boolean" and (.retiring|type)=="boolean" and (.active.id|type)=="string" and (.backends|type)=="array"' \
-    <<<"${status}" >/dev/null || die "${slot} returned an invalid supervisor status"
-  active_id="$(jq -r '.active.id' <<<"${status}")"
-  active_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id == $id) | .connections][0] // -1' <<<"${status}")"
-  inactive_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id != $id) | .connections] | add // 0' <<<"${status}")"
+    < <(stream_shell_value "${status}") >/dev/null || die "${slot} returned an invalid supervisor status"
+  active_id="$(jq -r '.active.id' < <(stream_shell_value "${status}"))"
+  active_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id == $id) | .connections][0] // -1' < <(stream_shell_value "${status}"))"
+  inactive_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id != $id) | .connections] | add // 0' < <(stream_shell_value "${status}"))"
   service_active="$(gcloud_ssh "if systemctl is-active --quiet '$(slot_service "${slot}")'; then echo true; else echo false; fi" | tail -n 1)"
-  front_active="$(jq -r --arg id "${slot}" '[.backends[]? | select(.id == $id) | .active][0] // false' <<<"${front}")"
+  front_active="$(jq -r --arg id "${slot}" '[.backends[]? | select(.id == $id) | .active][0] // false' < <(stream_shell_value "${front}"))"
   jq -nc --argjson status "${status}" --argjson service_active "${service_active}" \
     --argjson front_active "${front_active}" --arg active_id "${active_id}" \
     --argjson active_connections "${active_connections}" --argjson inactive_connections "${inactive_connections}" \
@@ -228,16 +230,16 @@ gcloud_scp "${INSTALL_FRONT_SLOTS}" "${REMOTE_INSTALLER}"
 gcloud_scp "${DEPLOYMENT_CONTRACT}" "${REMOTE_DEPLOYMENT_CONTRACT}"
 gcloud_ssh "printf '%s  %s\n%s  %s\n' '${INSTALL_FRONT_SLOTS_SHA256}' '${REMOTE_INSTALLER}' '${DEPLOYMENT_CONTRACT_SHA256}' '${REMOTE_DEPLOYMENT_CONTRACT}' | sha256sum -c - >/dev/null"
 before_status="$(front_status)"
-[[ "$(jq -r '.active.id' <<<"${before_status}")" == "${candidate_slot}" ]] \
+[[ "$(jq -r '.active.id' < <(stream_shell_value "${before_status}"))" == "${candidate_slot}" ]] \
   || die "front no longer selects activation candidate ${candidate_slot}"
 candidate_before="$(slot_snapshot "${candidate_slot}" "${before_status}")"
 old_before="$(slot_snapshot "${old_slot}" "${before_status}")"
 jq -e --arg generation "${candidate_generation}" \
   '.accepting and (.retiring|not) and .front_active and .service_active and .active_generation == $generation and .inactive_connections == 0' \
-  <<<"${candidate_before}" >/dev/null || die "candidate cannot be rolled back cleanly"
+  < <(stream_shell_value "${candidate_before}") >/dev/null || die "candidate cannot be rolled back cleanly"
 jq -e --arg generation "${old_generation}" \
   '.accepting and (.retiring|not) and (.front_active|not) and .service_active and .active_generation == $generation and .inactive_connections == 0' \
-  <<<"${old_before}" >/dev/null || die "old slot cannot be restored cleanly"
+  < <(stream_shell_value "${old_before}") >/dev/null || die "old slot cannot be restored cleanly"
 connections_before="$(front_connections "${before_status}" "${candidate_slot}")"
 (( connections_before >= EXPECTED_CONNECTIONS )) \
   || die "candidate has ${connections_before}/${EXPECTED_CONNECTIONS} required externally held connections"
@@ -272,13 +274,13 @@ gcloud_ssh "${REMOTE_INSTALL_COMMAND} retire-slot '${candidate_slot}'"
 transition_committed=1
 
 after_status="$(front_status)"
-[[ "$(jq -r '.active.id' <<<"${after_status}")" == "${old_slot}" ]] || die "front did not restore ${old_slot}"
+[[ "$(jq -r '.active.id' < <(stream_shell_value "${after_status}"))" == "${old_slot}" ]] || die "front did not restore ${old_slot}"
 connections_after="$(front_connections "${after_status}" "${candidate_slot}")"
 (( connections_after >= EXPECTED_CONNECTIONS )) || die "rollback cut candidate connections"
 candidate_after="$(slot_snapshot "${candidate_slot}" "${after_status}")"
 jq -e --arg generation "${candidate_generation}" \
   '(.accepting|not) and .retiring and (.front_active|not) and .service_active and .active_generation == $generation and .inactive_connections == 0' \
-  <<<"${candidate_after}" >/dev/null || die "candidate did not enter retirement"
+  < <(stream_shell_value "${candidate_after}") >/dev/null || die "candidate did not enter retirement"
 
 candidate_restarts_after="$(service_restarts "${candidate_slot}")"
 candidate_oom_after="$(service_oom_kills "${candidate_slot}")"

--- a/deploy/gcp/stream-shell-value.sh
+++ b/deploy/gcp/stream-shell-value.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Feed a shell value through a concurrent process-substitution stream. Bash
+# 5.1+ may implement here-strings with a pipe that it fills before starting the
+# reader, which can deadlock inside command substitutions on macOS.
+
+stream_shell_value() {
+  if (( $# != 1 )); then
+    echo "stream_shell_value requires exactly one value" >&2
+    return 2
+  fi
+  printf '%s\n' "$1"
+}

--- a/deploy/gcp/switch-front-migration.sh
+++ b/deploy/gcp/switch-front-migration.sh
@@ -46,6 +46,8 @@ REMOTE_LOCK_SENTINEL="/tmp/subrouter-deploy-lock-${RUN_LABEL}"
 REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy/gcp/stream-shell-value.sh
+source "${SCRIPT_DIR}/stream-shell-value.sh"
 LEGACY_RSS_LIMIT_BYTES="${SUBROUTER_LEGACY_RSS_LIMIT_BYTES:-201326592}"
 
 log() { printf 'gcp-front-transition: %s\n' "$*"; }
@@ -192,19 +194,19 @@ supervisor_snapshot() {
   local kind="$1" status active_id generation_connections inactive_connections public_connections slot
   if [[ "${kind}" == legacy ]]; then
     status="$(gcloud_ssh "sudo curl -fsS --unix-socket /var/lib/subrouter/supervisor.sock http://localhost/_subrouter/supervisor-status")"
-    public_connections="$(jq -r --arg id "$(jq -r '.active.id' <<<"${status}")" '[.backends[] | select(.id == $id) | .connections][0] // -1' <<<"${status}")"
+    public_connections="$(jq -r --arg id "$(jq -r '.active.id' < <(stream_shell_value "${status}"))" '[.backends[] | select(.id == $id) | .connections][0] // -1' < <(stream_shell_value "${status}"))"
   else
     front_status="$(gcloud_ssh "sudo curl -fsS --unix-socket /var/lib/subrouter/front.sock http://localhost/_subrouter/front-status")"
-    slot="$(jq -r '.active.id' <<<"${front_status}")"
-    [[ "${slot}" == "$(jq -r '.slot' <<<"${front_json}")" ]] || die "front active slot differs from preparation evidence"
-    public_connections="$(jq -r --arg id "${slot}" '[.backends[] | select(.id == $id) | .connections][0] // -1' <<<"${front_status}")"
+    slot="$(jq -r '.active.id' < <(stream_shell_value "${front_status}"))"
+    [[ "${slot}" == "$(jq -r '.slot' < <(stream_shell_value "${front_json}"))" ]] || die "front active slot differs from preparation evidence"
+    public_connections="$(jq -r --arg id "${slot}" '[.backends[] | select(.id == $id) | .connections][0] // -1' < <(stream_shell_value "${front_status}"))"
     status="$(gcloud_ssh "sudo curl -fsS --unix-socket /var/lib/subrouter/${slot}.sock http://localhost/_subrouter/supervisor-status")"
   fi
   jq -e '(.active.id|type)=="string" and (.backends|type)=="array" and ([.backends[].connections] | all(type=="number" and . >= 0))' \
-    <<<"${status}" >/dev/null || die "${kind} supervisor status is invalid"
-  active_id="$(jq -r '.active.id' <<<"${status}")"
-  generation_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id == $id) | .connections][0] // -1' <<<"${status}")"
-  inactive_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id != $id) | .connections] | add // 0' <<<"${status}")"
+    < <(stream_shell_value "${status}") >/dev/null || die "${kind} supervisor status is invalid"
+  active_id="$(jq -r '.active.id' < <(stream_shell_value "${status}"))"
+  generation_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id == $id) | .connections][0] // -1' < <(stream_shell_value "${status}"))"
+  inactive_connections="$(jq -r --arg id "${active_id}" '[.backends[] | select(.id != $id) | .connections] | add // 0' < <(stream_shell_value "${status}"))"
   [[ "${public_connections}" =~ ^[0-9]+$ && "${generation_connections}" =~ ^[0-9]+$ && "${inactive_connections}" =~ ^[0-9]+$ ]] \
     || die "${kind} returned invalid connection counts"
   jq -nc --arg kind "${kind}" --arg generation "${active_id}" \
@@ -268,7 +270,7 @@ acquire_lock
 gcloud_scp "${INSTALL_FRONT_SLOTS}" "${REMOTE_INSTALLER}"
 gcloud_scp "${DEPLOYMENT_CONTRACT}" "${REMOTE_DEPLOYMENT_CONTRACT}"
 gcloud_ssh "printf '%s  %s\n%s  %s\n' '${INSTALL_FRONT_SLOTS_SHA256}' '${REMOTE_INSTALLER}' '${DEPLOYMENT_CONTRACT_SHA256}' '${REMOTE_DEPLOYMENT_CONTRACT}' | sha256sum -c - >/dev/null"
-active_migration_slot="$(jq -r '.slot' <<<"${front_json}")"
+active_migration_slot="$(jq -r '.slot' < <(stream_shell_value "${front_json}"))"
 legacy_restarts_before="$(service_restarts legacy)"
 legacy_oom_before="$(service_oom_kills legacy)"
 slot_restarts_before="$(service_restarts "${active_migration_slot}")"
@@ -289,7 +291,7 @@ python3 "${DEPLOYMENT_CONTRACT}" rewrite-url-map \
 source_before="$(supervisor_snapshot "${source_kind}")"
 jq -e --argjson expected "${EXPECTED_CONNECTIONS}" \
   '.public_connections >= $expected and .generation_connections >= $expected and .inactive_connections == 0' \
-  <<<"${source_before}" >/dev/null || die "source did not correlate every external migration connection"
+  < <(stream_shell_value "${source_before}") >/dev/null || die "source did not correlate every external migration connection"
 destination_before="$(supervisor_snapshot "${destination_kind}")"
 
 transition_requested_at="$(utc_now)"
@@ -304,19 +306,19 @@ python3 "${DEPLOYMENT_CONTRACT}" assert-url-map \
 source_after="$(supervisor_snapshot "${source_kind}")"
 jq -e --argjson expected "${EXPECTED_CONNECTIONS}" \
   '.public_connections >= $expected and .generation_connections >= $expected and .inactive_connections == 0' \
-  <<<"${source_after}" >/dev/null || die "URL-map transition cut externally held source connections"
+  < <(stream_shell_value "${source_after}") >/dev/null || die "URL-map transition cut externally held source connections"
 source_snapshot_sha256="$(printf '%s' "${source_after}" | sha256sum | awk '{print $1}')"
 if [[ "${destination_kind}" == front ]]; then
-  destination_generation="$(jq -r '.generation' <<<"${front_json}")"
+  destination_generation="$(jq -r '.generation' < <(stream_shell_value "${front_json}"))"
 else
-  destination_generation="$(jq -r '.generation' <<<"${legacy_json}")"
+  destination_generation="$(jq -r '.generation' < <(stream_shell_value "${legacy_json}"))"
 fi
 proof_challenge="$(python3 -c 'import secrets; print(secrets.token_hex(16))')"
 proof_request_tmp="$(mktemp "${DESTINATION_PROOF_REQUEST}.tmp.XXXXXX")"
 jq -n --arg schema 'subrouter.gcp.destination-proof-request/v1' \
   --arg challenge "${proof_challenge}" --arg operation "${OPERATION}" \
   --arg destination "${destination_kind}" --arg generation "${destination_generation}" \
-  --arg source "${source_kind}" --arg source_generation "$(jq -r '.generation' <<<"${source_after}")" \
+  --arg source "${source_kind}" --arg source_generation "$(jq -r '.generation' < <(stream_shell_value "${source_after}"))" \
   --arg source_snapshot_sha "${source_snapshot_sha256}" --arg requested_at "${transition_requested_at}" \
   --argjson expected_source_connections "${EXPECTED_CONNECTIONS}" \
   '{schema:$schema,challenge:$challenge,operation:$operation,destination:$destination,
@@ -340,7 +342,7 @@ proof_received_ms="$(epoch_millis)"
 python3 "${DEPLOYMENT_CONTRACT}" validate-destination-proof \
   "${DESTINATION_PROOF}" "${proof_challenge}" "${OPERATION}" \
   "${destination_kind}" "${destination_generation}" "${source_kind}" \
-  "$(jq -r '.generation' <<<"${source_after}")" "${source_snapshot_sha256}" \
+  "$(jq -r '.generation' < <(stream_shell_value "${source_after}"))" "${source_snapshot_sha256}" \
   "${EXPECTED_CONNECTIONS}" "${transition_requested_at}" \
   "${proof_received_at}"
 activated_at="$(jq -r '.observed_at' "${DESTINATION_PROOF}")"
@@ -350,9 +352,9 @@ destination_after="$(supervisor_snapshot "${destination_kind}")"
 jq -e --arg generation "${destination_generation}" --argjson before "${destination_before}" \
   '.generation == $generation and .public_connections >= ($before.public_connections + 1) and
    .generation_connections >= ($before.generation_connections + 1) and .inactive_connections == 0' \
-  <<<"${destination_after}" >/dev/null \
+  < <(stream_shell_value "${destination_after}") >/dev/null \
   || die "golden fresh public connection was not correlated to the destination generation"
-destination_connection_delta="$(( $(jq -r '.generation_connections' <<<"${destination_after}") - $(jq -r '.generation_connections' <<<"${destination_before}") ))"
+destination_connection_delta="$(( $(jq -r '.generation_connections' < <(stream_shell_value "${destination_after}")) - $(jq -r '.generation_connections' < <(stream_shell_value "${destination_before}")) ))"
 legacy_restarts_after="$(service_restarts legacy)"
 legacy_oom_after="$(service_oom_kills legacy)"
 slot_restarts_after="$(service_restarts "${active_migration_slot}")"


### PR DESCRIPTION
## Summary

- replace here-string input in every local GCP deploy phase with a concurrent process-substitution stream
- share one shell-value stream primitive across provisioning, preflight, migration, rollback, retirement, and publish paths
- cover a nested command substitution with 2 MB JSON on macOS Bash

## Verification

- exact staging instance-group and backend queries that previously wedged now return immediately
- `bash -n` and `shellcheck -x` on every changed script
- `go test ./...`
- regression commit `b7e0552` is red before fix and green after `c8bdd64`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788370162&installation_model_id=21920&pr_number=136&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F136&signature=9c80b0554f7b3f1c16d6f8d5292be278dd0771423dae3c16a63fed74a9500240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace here-strings in local GCP deploy scripts with a streamed process-substitution helper to prevent macOS Bash deadlocks and safely handle large JSON. Staging instance-group and backend queries that previously wedged now return immediately.

- **Bug Fixes**
  - Stream shell values via `stream_shell_value` to avoid Bash here-string deadlocks on macOS; adds a test that streams nested 2 MB JSON to validate.

- **Refactors**
  - Centralized input handling in `deploy/gcp/stream-shell-value.sh` and switched provisioning, preflight, migration, rollback, retirement, and publish scripts to use it.

<sup>Written for commit c8bdd640ddc69b8d20fe5b4d26cbef0afd0d66fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

