### PR TITLE
Preserve predecessor sessions in the golden gate

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -657,7 +657,7 @@ func writeGoldenConfig(path string, source map[string]any, credentialSource, hos
 }
 
 func goldenPredecessorDirectCredentialSource() string {
-	return "hosted"
+	return "legacy"
 }
 
 func (r *goldenRunner) run(ctx context.Context) (runErr error) {

--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -656,6 +656,10 @@ func writeGoldenConfig(path string, source map[string]any, credentialSource, hos
 	return writePrivateFile(path, data)
 }
 
+func goldenPredecessorDirectCredentialSource() string {
+	return "hosted"
+}
+
 func (r *goldenRunner) run(ctx context.Context) (runErr error) {
 	for _, command := range []string{"lsof", "pgrep", "ps", r.options.codexBinary} {
 		if _, err := exec.LookPath(command); err != nil {
@@ -721,7 +725,7 @@ func (r *goldenRunner) run(ctx context.Context) (runErr error) {
 	}()
 	directConfigPath := filepath.Join(r.privateRoot, "hosted-cloud.json")
 	teamConfigPath := filepath.Join(r.privateRoot, "team-cloud.json")
-	if err := writeGoldenConfig(directConfigPath, cloudConfig.Raw, "hosted", cloudConfig.HostedURL, cloudConfig.BrokerURL); err != nil {
+	if err := writeGoldenConfig(directConfigPath, cloudConfig.Raw, goldenPredecessorDirectCredentialSource(), cloudConfig.HostedURL, cloudConfig.BrokerURL); err != nil {
 		return failGolden("private_config_write_failed")
 	}
 	if err := writeGoldenConfig(teamConfigPath, cloudConfig.Raw, "team", cloudConfig.HostedURL, leaseObserver.baseURL); err != nil {

--- a/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
+++ b/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
@@ -263,6 +263,12 @@ esac
 	}
 }
 
+func TestGoldenPredecessorDirectConfigUsesLegacyCredentialSource(t *testing.T) {
+	if got := goldenPredecessorDirectCredentialSource(); got != "legacy" {
+		t.Fatalf("predecessor direct credential source = %q, want legacy", got)
+	}
+}
+
 func loadGoldenFakeProcessTable(directory string, pids []int) (goldenProcessTable, error) {
 	requested := make(map[int]bool, len(pids))
 	for _, pid := range pids {

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -336,25 +336,40 @@ type countingResponseWriter struct {
 }
 
 func (w *countingResponseWriter) WriteHeader(statusCode int) {
-	if w.statusCode == 0 {
-		w.statusCode = statusCode
-	}
 	w.ResponseWriter.WriteHeader(statusCode)
+	if statusCode >= http.StatusOK || statusCode == http.StatusSwitchingProtocols {
+		w.recordFinalStatus(statusCode)
+	}
 }
 
 func (w *countingResponseWriter) Write(p []byte) (int, error) {
 	if w.statusCode == 0 {
-		w.statusCode = http.StatusOK
+		w.recordFinalStatus(http.StatusOK)
 	}
 	n, err := w.ResponseWriter.Write(p)
 	if n > 0 {
 		event := w.meta.event("response_chunk")
 		event.Direction = "upstream_to_client"
 		event.Bytes = int64(n)
-		event.StatusCode = w.statusCode
 		w.observer.emit(event)
 	}
 	return n, err
+}
+
+func (w *countingResponseWriter) recordFinalStatus(statusCode int) {
+	if w.statusCode != 0 {
+		return
+	}
+	w.statusCode = statusCode
+	event := w.meta.event("response_status")
+	event.StatusCode = statusCode
+	w.observer.emit(event)
+}
+
+func (w *countingResponseWriter) finish() {
+	if w.statusCode == 0 {
+		w.recordFinalStatus(http.StatusOK)
+	}
 }
 
 func (w *countingResponseWriter) Flush() {
@@ -379,6 +394,7 @@ func (w *countingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	w.recordFinalStatus(http.StatusSwitchingProtocols)
 	// ReverseProxy writes the HTTP 101 control response through buffered. The
 	// wrapped connection sees only post-handshake WebSocket frame bytes.
 	return &countingConn{Conn: connection, observer: w.observer, meta: w.meta}, buffered, nil
@@ -528,7 +544,9 @@ func newObserverHandlerWithObserver(upstream *url.URL, observation *observer) ht
 			request.Body = &countingReadCloser{ReadCloser: request.Body, observer: observation, meta: meta}
 		}
 		request = request.WithContext(context.WithValue(request.Context(), requestEvidenceContextKey{}, meta))
-		proxy.ServeHTTP(&countingResponseWriter{ResponseWriter: w, observer: observation, meta: meta}, request)
+		responseWriter := &countingResponseWriter{ResponseWriter: w, observer: observation, meta: meta}
+		proxy.ServeHTTP(responseWriter, request)
+		responseWriter.finish()
 		observation.emit(meta.event("request_completed"))
 	})
 }

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -42,6 +42,7 @@ type transportEvent struct {
 	ConnectionID string `json:"connection_id,omitempty"`
 	Direction    string `json:"direction,omitempty"`
 	Bytes        int64  `json:"bytes,omitempty"`
+	StatusCode   int    `json:"status_code,omitempty"`
 }
 
 type eventRecorder struct {
@@ -329,16 +330,28 @@ func (r *countingReadCloser) Read(p []byte) (int, error) {
 
 type countingResponseWriter struct {
 	http.ResponseWriter
-	observer *observer
-	meta     requestEvidence
+	observer   *observer
+	meta       requestEvidence
+	statusCode int
+}
+
+func (w *countingResponseWriter) WriteHeader(statusCode int) {
+	if w.statusCode == 0 {
+		w.statusCode = statusCode
+	}
+	w.ResponseWriter.WriteHeader(statusCode)
 }
 
 func (w *countingResponseWriter) Write(p []byte) (int, error) {
+	if w.statusCode == 0 {
+		w.statusCode = http.StatusOK
+	}
 	n, err := w.ResponseWriter.Write(p)
 	if n > 0 {
 		event := w.meta.event("response_chunk")
 		event.Direction = "upstream_to_client"
 		event.Bytes = int64(n)
+		event.StatusCode = w.statusCode
 		w.observer.emit(event)
 	}
 	return n, err

--- a/cmd/subrouter-transport-observer/main_test.go
+++ b/cmd/subrouter-transport-observer/main_test.go
@@ -135,7 +135,7 @@ func TestObserverRecordsActualHTTPAndWebSocketHandshakesWithoutHeaderValues(t *t
 
 func TestObserverRecordsResponseStatusWithoutBodyContent(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, "response-body-must-not-appear", http.StatusServiceUnavailable)
+		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 	defer upstream.Close()
 	upstreamURL, err := url.Parse(upstream.URL)
@@ -154,12 +154,47 @@ func TestObserverRecordsResponseStatusWithoutBodyContent(t *testing.T) {
 		if err := decoder.Decode(&event); err != nil {
 			t.Fatal(err)
 		}
-		if event["kind"] == "response_chunk" && event["status_code"] == float64(http.StatusServiceUnavailable) {
+		if event["kind"] == "response_status" && event["status_code"] == float64(http.StatusServiceUnavailable) {
 			statusRecorded = true
 		}
 	}
 	if !statusRecorded {
 		t.Fatalf("response status missing from observer evidence:\n%s", events.String())
+	}
+	if strings.Contains(events.String(), "body") {
+		t.Fatal("observer evidence recorded response body content")
+	}
+}
+
+func TestObserverRecordsFinalResponseStatusAfterInformationalStatus(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusEarlyHints)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("response-body-must-not-appear"))
+	}))
+	defer upstream.Close()
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var events bytes.Buffer
+	handler := newObserverHandler(upstreamURL, &events)
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "http://observer/v1/responses", nil))
+
+	var statuses []int
+	decoder := json.NewDecoder(&events)
+	for decoder.More() {
+		var event map[string]any
+		if err := decoder.Decode(&event); err != nil {
+			t.Fatal(err)
+		}
+		if event["kind"] == "response_status" {
+			statuses = append(statuses, int(event["status_code"].(float64)))
+		}
+	}
+	if len(statuses) != 1 || statuses[0] != http.StatusServiceUnavailable {
+		t.Fatalf("recorded response statuses = %v, want [%d]\n%s", statuses, http.StatusServiceUnavailable, events.String())
 	}
 	if strings.Contains(events.String(), "response-body-must-not-appear") {
 		t.Fatal("observer evidence recorded response body content")

--- a/cmd/subrouter-transport-observer/main_test.go
+++ b/cmd/subrouter-transport-observer/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -129,6 +130,39 @@ func TestObserverRecordsActualHTTPAndWebSocketHandshakesWithoutHeaderValues(t *t
 		if strings.Contains(got, secret) {
 			t.Fatalf("observer events leaked %q:\n%s", secret, got)
 		}
+	}
+}
+
+func TestObserverRecordsResponseStatusWithoutBodyContent(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "response-body-must-not-appear", http.StatusServiceUnavailable)
+	}))
+	defer upstream.Close()
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var events bytes.Buffer
+	handler := newObserverHandler(upstreamURL, &events)
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "http://observer/v1/responses", nil))
+
+	statusRecorded := false
+	decoder := json.NewDecoder(&events)
+	for decoder.More() {
+		var event map[string]any
+		if err := decoder.Decode(&event); err != nil {
+			t.Fatal(err)
+		}
+		if event["kind"] == "response_chunk" && event["status_code"] == float64(http.StatusServiceUnavailable) {
+			statusRecorded = true
+		}
+	}
+	if !statusRecorded {
+		t.Fatalf("response status missing from observer evidence:\n%s", events.String())
+	}
+	if strings.Contains(events.String(), "response-body-must-not-appear") {
+		t.Fatal("observer evidence recorded response body content")
 	}
 }
 


### PR DESCRIPTION
The production continuity gate now launches v0.1.51 direct sessions with its supported legacy credential source. Observer evidence records response status codes without response bodies, headers, URLs, or credentials.

Regression coverage failed before the fix and passes after it. `go test ./...` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788371180&installation_model_id=21920&pr_number=137&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F137&signature=d77fc32c27172a1c9b0e53a8f66351e0e2e13335eac57d96ec717129fbc895d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves predecessor golden sessions by using the legacy credential source for direct v0.1.51 sessions. The observer now records only the final HTTP status for each response and never captures bodies, headers, URLs, or credentials.

- **Bug Fixes**
  - Use `legacy` direct credential source in the production continuity gate to maintain predecessor compatibility.
  - Emit a single `response_status` event with the final status code (after any 1xx and for WebSocket 101), instead of adding status to `response_chunk`.

<sup>Written for commit 795d171b5514378c0c43fc2d84894c41cb34ff3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transport events now report upstream HTTP response status codes, including successful responses and WebSocket handshakes.
  * Response bodies are not captured in status reporting.
* **Bug Fixes**
  * Informational HTTP statuses are excluded, and only the final response status is recorded.
  * Direct hosted configurations now use the legacy credential source for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->