### PR TITLE
Authenticate golden GitHub provenance checks

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -1700,6 +1700,9 @@ func getGoldenGitHubJSON(ctx context.Context, client *http.Client, rawURL string
 		return err
 	}
 	request.Header.Set("Accept", "application/vnd.github+json")
+	if token := goldenGitHubToken(ctx); token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
 	response, err := client.Do(request)
 	if err != nil {
 		return err
@@ -1709,6 +1712,19 @@ func getGoldenGitHubJSON(ctx context.Context, client *http.Client, rawURL string
 		return errors.New("github provenance status")
 	}
 	return json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(target)
+}
+
+func goldenGitHubToken(ctx context.Context) string {
+	for _, name := range []string{"GH_TOKEN", "GITHUB_TOKEN"} {
+		if token := strings.TrimSpace(os.Getenv(name)); token != "" {
+			return token
+		}
+	}
+	output, err := exec.CommandContext(ctx, "gh", "auth", "token").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
 }
 
 func downloadGoldenAsset(ctx context.Context, client *http.Client, rawURL string, limit int64) ([]byte, error) {

--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -1700,8 +1700,13 @@ func getGoldenGitHubJSON(ctx context.Context, client *http.Client, rawURL string
 		return err
 	}
 	request.Header.Set("Accept", "application/vnd.github+json")
-	if token := goldenGitHubToken(ctx); token != "" {
-		request.Header.Set("Authorization", "Bearer "+token)
+	trustedGitHubAPI := request.URL.Scheme == "https" &&
+		strings.EqualFold(request.URL.Hostname(), "api.github.com") &&
+		request.URL.Port() == "" && request.URL.User == nil
+	if trustedGitHubAPI {
+		if token := goldenGitHubToken(ctx); token != "" {
+			request.Header.Set("Authorization", "Bearer "+token)
+		}
 	}
 	response, err := client.Do(request)
 	if err != nil {

--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -1725,7 +1725,7 @@ func goldenGitHubToken(ctx context.Context) string {
 			return token
 		}
 	}
-	output, err := exec.CommandContext(ctx, "gh", "auth", "token").Output()
+	output, err := exec.CommandContext(ctx, "gh", "auth", "token", "--hostname", "github.com").Output()
 	if err != nil {
 		return ""
 	}

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -54,13 +55,40 @@ func TestGoldenGitHubJSONUsesLocalGitHubAuthentication(t *testing.T) {
 	}
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+	client := &http.Client{Transport: goldenRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.String() != "https://api.github.com/repos/manaflow-ai/subrouter/commits/v0.1.51" {
+			t.Fatalf("request URL = %q", request.URL.String())
+		}
 		if request.Header.Get("Authorization") != "Bearer golden-test-token" {
-			http.Error(writer, "authentication required", http.StatusForbidden)
-			return
+			t.Fatalf("authorization = %q", request.Header.Get("Authorization"))
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"sha":"authenticated"}`)),
+			Request:    request,
+		}, nil
+	})}
+
+	var response struct {
+		SHA string `json:"sha"`
+	}
+	if err := getGoldenGitHubJSON(context.Background(), client, "https://api.github.com/repos/manaflow-ai/subrouter/commits/v0.1.51", &response); err != nil {
+		t.Fatalf("authenticated GitHub request failed: %v", err)
+	}
+	if response.SHA != "authenticated" {
+		t.Fatalf("sha = %q, want authenticated", response.SHA)
+	}
+}
+
+func TestGoldenGitHubJSONDoesNotSendAuthenticationToUntrustedURL(t *testing.T) {
+	t.Setenv("GH_TOKEN", "golden-test-token")
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if authorization := request.Header.Get("Authorization"); authorization != "" {
+			t.Errorf("authorization leaked to untrusted URL: %q", authorization)
 		}
 		writer.Header().Set("Content-Type", "application/json")
-		_, _ = writer.Write([]byte(`{"sha":"authenticated"}`))
+		_, _ = writer.Write([]byte(`{"sha":"anonymous"}`))
 	}))
 	t.Cleanup(server.Close)
 
@@ -68,9 +96,15 @@ func TestGoldenGitHubJSONUsesLocalGitHubAuthentication(t *testing.T) {
 		SHA string `json:"sha"`
 	}
 	if err := getGoldenGitHubJSON(context.Background(), server.Client(), server.URL, &response); err != nil {
-		t.Fatalf("authenticated GitHub request failed: %v", err)
+		t.Fatalf("anonymous request failed: %v", err)
 	}
-	if response.SHA != "authenticated" {
-		t.Fatalf("sha = %q, want authenticated", response.SHA)
+	if response.SHA != "anonymous" {
+		t.Fatalf("sha = %q, want anonymous", response.SHA)
 	}
+}
+
+type goldenRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function goldenRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
 }

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -1,6 +1,11 @@
 package main
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -36,5 +41,36 @@ func TestGoldenOptionsRequireV0154Candidate(t *testing.T) {
 	}
 	if _, err := parseGoldenArgs(args); err == nil {
 		t.Fatal("superseded v0.1.53 candidate was accepted")
+	}
+}
+
+func TestGoldenGitHubJSONUsesLocalGitHubAuthentication(t *testing.T) {
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	fakeBin := t.TempDir()
+	fakeGH := filepath.Join(fakeBin, "gh")
+	if err := os.WriteFile(fakeGH, []byte("#!/bin/sh\nprintf '%s\\n' golden-test-token\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Authorization") != "Bearer golden-test-token" {
+			http.Error(writer, "authentication required", http.StatusForbidden)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"sha":"authenticated"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var response struct {
+		SHA string `json:"sha"`
+	}
+	if err := getGoldenGitHubJSON(context.Background(), server.Client(), server.URL, &response); err != nil {
+		t.Fatalf("authenticated GitHub request failed: %v", err)
+	}
+	if response.SHA != "authenticated" {
+		t.Fatalf("sha = %q, want authenticated", response.SHA)
 	}
 }

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -50,7 +50,14 @@ func TestGoldenGitHubJSONUsesLocalGitHubAuthentication(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "")
 	fakeBin := t.TempDir()
 	fakeGH := filepath.Join(fakeBin, "gh")
-	if err := os.WriteFile(fakeGH, []byte("#!/bin/sh\nprintf '%s\\n' golden-test-token\n"), 0o700); err != nil {
+	fakeGHScript := "#!/bin/sh\n" +
+		"test \"$#\" -eq 4 || exit 9\n" +
+		"test \"$1\" = auth || exit 9\n" +
+		"test \"$2\" = token || exit 9\n" +
+		"test \"$3\" = --hostname || exit 9\n" +
+		"test \"$4\" = github.com || exit 9\n" +
+		"printf '%s\\n' golden-test-token\n"
+	if err := os.WriteFile(fakeGH, []byte(fakeGHScript), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))


### PR DESCRIPTION
## Summary
Authenticate GitHub API provenance reads in the production continuity harness using an existing CLI or environment token. Fall back to anonymous access when no token is available.

## Verification
- Regression commit `f5d1a31` fails under anonymous rate limiting
- Fix commit `e84cb31` passes the focused regression
- `go test ./...` passes

The token stays in memory and is never placed in process arguments or logs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788389166&installation_model_id=21920&pr_number=140&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F140&signature=e92523cc5f64dfbaf7480fa0183a3d1c3810b2f30abac60e6853567c55c8df5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authenticate GitHub provenance checks using a bearer token from `GH_TOKEN`, `GITHUB_TOKEN`, or `gh auth token --hostname github.com`, and send it only to `https://api.github.com`, with anonymous fallback. This reduces rate-limit failures in the production continuity harness and prevents credential leaks.

- **Bug Fixes**
  - In `getGoldenGitHubJSON`, add `Authorization: Bearer <token>` only for HTTPS requests to `api.github.com`; otherwise send no auth.
  - Bind token discovery to `github.com` and add tests to verify local auth use and that tokens are never forwarded to untrusted URLs; tokens stay in memory and out of args/logs.

<sup>Written for commit c52891e28a6d25bc3f04a5ad7868a7e5654fc062. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

