### PR TITLE
Gate hosted tenant credentials by capability

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -302,7 +302,7 @@ func serve(args []string) error {
 	stackProjectID := flags.String("stack-project-id", "", "Stack Auth project ID enabling hosted login; defaults to SUBROUTER_STACK_PROJECT_ID")
 	stackPublishableClientKey := flags.String("stack-publishable-client-key", "", "Stack Auth publishable client key; defaults to SUBROUTER_STACK_PUBLISHABLE_CLIENT_KEY")
 	stackTenantKeySecret := flags.String("stack-tenant-key-secret", "", "local-development override for stable Stack-team tenant keys; deployments use SUBROUTER_STACK_TENANT_KEY_SECRET")
-	stackTenantDeleteToken := flags.String("stack-tenant-delete-token", "", "trusted cmux.com token required for hosted tenant deletion; deployments use SUBROUTER_STACK_TENANT_DELETE_TOKEN")
+	stackTenantDeleteToken := flags.String("stack-tenant-delete-token", "", "trusted cmux.com token required for hosted tenant exchange and deletion; deployments use SUBROUTER_STACK_TENANT_DELETE_TOKEN")
 	bedrockEnable := flags.Bool("bedrock", false, "enable the /bedrock/* AWS SigV4 signing gateway for Claude Code Bedrock mode")
 	bedrockRegion := flags.String("bedrock-region", "us-east-1", "comma-separated AWS regions for the Bedrock signing gateway")
 	bedrockGatewayToken := flags.String("bedrock-gateway-token", "", "optional bearer token clients must present to the Bedrock gateway; defaults to SUBROUTER_BEDROCK_GATEWAY_TOKEN")
@@ -620,6 +620,7 @@ func serve(args []string) error {
 			PublishableClientKey: *stackPublishableClientKey,
 			HTTPClient:           stackHTTPClient,
 		}
+		multiTenantHandler.StackProjectID = *stackProjectID
 		multiTenantHandler.StackTenantKeySecret = []byte(*stackTenantKeySecret)
 		multiTenantHandler.StackTenantDeleteToken = []byte(*stackTenantDeleteToken)
 	}

--- a/cmd/subrouter/sr_cloud.go
+++ b/cmd/subrouter/sr_cloud.go
@@ -164,8 +164,9 @@ func (r srRunner) cloudLogin(ctx context.Context, args []string) error {
 	exchange, err := stackauth.ExchangeTenant(
 		ctx,
 		httpClient,
-		publicConfig.Subrouter.URL,
+		publicConfig.Subrouter.ExchangeURL,
 		tokens.AccessToken,
+		tokens.RefreshToken,
 		team.ID,
 		team.DisplayName,
 	)
@@ -178,7 +179,9 @@ func (r srRunner) cloudLogin(ctx context.Context, args []string) error {
 	config.TeamName = team.DisplayName
 	config.CredentialSource = broker.CredentialSourceHosted
 	config.HostedURL = publicConfig.Subrouter.URL
+	config.HostedExchangeURL = publicConfig.Subrouter.ExchangeURL
 	config.TenantKey = exchange.TenantKey
+	config.TenantCapabilities = append([]string(nil), exchange.Capabilities...)
 	config.StackAPIURL = publicConfig.Auth.APIURL
 	config.StackProjectID = publicConfig.Auth.ProjectID
 	config.StackPublishable = publicConfig.Auth.PublishableClientKey
@@ -463,7 +466,9 @@ func (r srRunner) cloudLogout(ctx context.Context) error {
 	config.TeamID = ""
 	config.TeamName = ""
 	config.HostedURL = ""
+	config.HostedExchangeURL = ""
 	config.TenantKey = ""
+	config.TenantCapabilities = nil
 	config.CredentialSource = broker.CredentialSourceLocal
 	if err := broker.SaveConfig(path, config); err != nil {
 		return err
@@ -536,7 +541,8 @@ func (r srRunner) cloudTeam(ctx context.Context, args []string) error {
 			return err
 		}
 		exchange, err := stackauth.ExchangeTenant(
-			ctx, r.client, config.HostedURL, tokens.AccessToken,
+			ctx, r.client, hostedExchangeURL(config), tokens.AccessToken,
+			tokens.RefreshToken,
 			team.ID, team.DisplayName,
 		)
 		if err != nil {
@@ -547,6 +553,7 @@ func (r srRunner) cloudTeam(ctx context.Context, args []string) error {
 		config.TeamID = team.ID
 		config.TeamName = team.DisplayName
 		config.TenantKey = exchange.TenantKey
+		config.TenantCapabilities = append([]string(nil), exchange.Capabilities...)
 		config.CredentialSource = broker.CredentialSourceHosted
 		if err := broker.SaveConfig(path, config); err != nil {
 			return err
@@ -559,6 +566,13 @@ func (r srRunner) cloudTeam(ctx context.Context, args []string) error {
 	default:
 		return fmt.Errorf("unknown team command %q; use list, current, or use", args[0])
 	}
+}
+
+func hostedExchangeURL(config broker.Config) string {
+	if value := strings.TrimSpace(config.HostedExchangeURL); value != "" {
+		return value
+	}
+	return strings.TrimRight(config.BaseURL, "/") + "/api/subrouter/exchange"
 }
 
 func nativeStackClient(config broker.Config, httpClient *http.Client) stackauth.Client {

--- a/cmd/subrouter/sr_hosted_login_test.go
+++ b/cmd/subrouter/sr_hosted_login_test.go
@@ -23,6 +23,7 @@ func TestSRLoginNativeStackConfiguresBuiltInCMUXRemote(t *testing.T) {
 		"sub": "user", "project_id": "project", "selected_team_id": "team-1",
 	})
 	var exchangeAuthorization string
+	var exchangeRefreshToken string
 	var pollAttempts int
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +36,10 @@ func TestSRLoginNativeStackConfiguresBuiltInCMUXRemote(t *testing.T) {
 					"publishableClientKey": "pck_test",
 					"confirmUrl":           server.URL + "/handler/cli-auth-confirm",
 				},
-				"subrouter": map[string]string{"url": "https://published.example"},
+				"subrouter": map[string]string{
+					"url":         "https://published.example",
+					"exchangeUrl": server.URL + "/api/subrouter/exchange",
+				},
 			})
 		case "/auth/cli":
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -60,11 +64,13 @@ func TestSRLoginNativeStackConfiguresBuiltInCMUXRemote(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]string{{
 				"id": "team-1", "display_name": "Acme",
 			}}})
-		case "/_subrouter/auth/stack":
+		case "/api/subrouter/exchange":
 			exchangeAuthorization = r.Header.Get("Authorization")
-			_ = json.NewEncoder(w).Encode(map[string]string{
+			exchangeRefreshToken = r.Header.Get("X-Stack-Refresh-Token")
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"tenantId": "team-1", "tenantName": "Acme",
 				"tenantKey": tenantKey, "proxyUrl": server.URL + "/t/" + tenantKey,
+				"capabilities": []string{"use", "manage_accounts"},
 			})
 		default:
 			http.NotFound(w, r)
@@ -113,6 +119,9 @@ func TestSRLoginNativeStackConfiguresBuiltInCMUXRemote(t *testing.T) {
 	}
 	if exchangeAuthorization != "Bearer "+accessToken {
 		t.Fatalf("exchange authorization = %q", exchangeAuthorization)
+	}
+	if exchangeRefreshToken != "rotated" {
+		t.Fatalf("exchange refresh token = %q", exchangeRefreshToken)
 	}
 	if pollAttempts != 2 {
 		t.Fatalf("poll attempts = %d", pollAttempts)

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -95,10 +95,12 @@ sr login
 sr codex
 ```
 
-The browser login uses the same Stack identity as cmux, exchanges it for a
-tenant key at `/_subrouter/auth/stack`, and writes the tenant-scoped public URL
-to the local Codex configuration. `sr remote use cmux-local` keeps the proxy on
-the Mac while leasing short-lived access credentials from the same tenant.
+The browser login uses the same Stack identity as cmux. The cmux.com exchange
+broker enforces team permissions and cutover readiness, then requests a
+capability-scoped tenant key from hosted Subrouter. Direct client exchange is
+rejected. The CLI writes the tenant-scoped public URL to the local Codex
+configuration. `sr remote use cmux-local` keeps the proxy on the Mac while
+leasing short-lived access credentials from the same tenant.
 
 Operators can add a fresh server-owned Codex OAuth account over authenticated
 HTTP when needed:

--- a/internal/broker/config.go
+++ b/internal/broker/config.go
@@ -27,19 +27,21 @@ const (
 )
 
 type Config struct {
-	Version          int              `json:"version"`
-	BaseURL          string           `json:"baseUrl"`
-	AccessToken      string           `json:"accessToken"`
-	RefreshToken     string           `json:"refreshToken"`
-	LocalProxyToken  string           `json:"localProxyToken,omitempty"`
-	TeamID           string           `json:"teamId,omitempty"`
-	TeamName         string           `json:"teamName,omitempty"`
-	CredentialSource CredentialSource `json:"credentialSource,omitempty"`
-	HostedURL        string           `json:"hostedUrl,omitempty"`
-	TenantKey        string           `json:"tenantKey,omitempty"`
-	StackAPIURL      string           `json:"stackApiUrl,omitempty"`
-	StackProjectID   string           `json:"stackProjectId,omitempty"`
-	StackPublishable string           `json:"stackPublishableClientKey,omitempty"`
+	Version            int              `json:"version"`
+	BaseURL            string           `json:"baseUrl"`
+	AccessToken        string           `json:"accessToken"`
+	RefreshToken       string           `json:"refreshToken"`
+	LocalProxyToken    string           `json:"localProxyToken,omitempty"`
+	TeamID             string           `json:"teamId,omitempty"`
+	TeamName           string           `json:"teamName,omitempty"`
+	CredentialSource   CredentialSource `json:"credentialSource,omitempty"`
+	HostedURL          string           `json:"hostedUrl,omitempty"`
+	HostedExchangeURL  string           `json:"hostedExchangeUrl,omitempty"`
+	TenantKey          string           `json:"tenantKey,omitempty"`
+	TenantCapabilities []string         `json:"tenantCapabilities,omitempty"`
+	StackAPIURL        string           `json:"stackApiUrl,omitempty"`
+	StackProjectID     string           `json:"stackProjectId,omitempty"`
+	StackPublishable   string           `json:"stackPublishableClientKey,omitempty"`
 }
 
 func (c Config) LoggedIn() bool {
@@ -112,7 +114,9 @@ func (c Config) Normalized() Config {
 	out.TeamID = strings.TrimSpace(out.TeamID)
 	out.TeamName = strings.TrimSpace(out.TeamName)
 	out.HostedURL = strings.TrimRight(strings.TrimSpace(out.HostedURL), "/")
+	out.HostedExchangeURL = strings.TrimSpace(out.HostedExchangeURL)
 	out.TenantKey = strings.TrimSpace(out.TenantKey)
+	out.TenantCapabilities = normalizeTenantCapabilities(out.TenantCapabilities)
 	out.StackAPIURL = strings.TrimRight(strings.TrimSpace(out.StackAPIURL), "/")
 	out.StackProjectID = strings.TrimSpace(out.StackProjectID)
 	out.StackPublishable = strings.TrimSpace(out.StackPublishable)
@@ -168,7 +172,32 @@ func (c Config) Validate() error {
 			return errors.New("team credential source with a hosted URL requires a valid tenant key")
 		}
 	}
+	if normalized.HostedExchangeURL != "" {
+		exchangeURL, err := url.Parse(normalized.HostedExchangeURL)
+		if err != nil || exchangeURL.Host == "" || exchangeURL.User != nil ||
+			exchangeURL.Fragment != "" {
+			return errors.New("hosted Subrouter exchange URL is invalid")
+		}
+		if exchangeURL.Scheme != "https" &&
+			!(exchangeURL.Scheme == "http" && isLoopbackHost(exchangeURL.Hostname())) {
+			return errors.New("hosted Subrouter exchange URL must use HTTPS, except for loopback")
+		}
+	}
 	return nil
+}
+
+func normalizeTenantCapabilities(values []string) []string {
+	seen := map[string]bool{}
+	for _, value := range values {
+		seen[strings.TrimSpace(value)] = true
+	}
+	out := make([]string, 0, 2)
+	for _, capability := range []string{"manage_accounts", "use"} {
+		if seen[capability] {
+			out = append(out, capability)
+		}
+	}
+	return out
 }
 
 func isLoopbackHost(host string) bool {

--- a/internal/proxy/multitenant.go
+++ b/internal/proxy/multitenant.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -51,6 +52,7 @@ type MultiTenant struct {
 	StackTeams interface {
 		ListTeams(context.Context, string) ([]stackauth.Team, error)
 	}
+	StackProjectID         string
 	StackTenantKeySecret   []byte
 	StackTenantDeleteToken []byte
 	PublicURL              string
@@ -86,13 +88,13 @@ func (m *MultiTenant) Handler(fallback http.Handler) http.Handler {
 			return
 		}
 		if key := tenantKeyFromHeaders(r); key != "" {
-			resolved, ok, err := m.Registry.Resolve(key)
+			resolved, credential, ok, err := m.Registry.ResolveCredential(key)
 			if err != nil {
 				http.Error(w, "tenant registry error", http.StatusInternalServerError)
 				return
 			}
 			if ok {
-				m.serveResolvedTenant(w, r, resolved, r.URL.Path, key)
+				m.serveResolvedTenant(w, r, resolved, credential, r.URL.Path, key)
 				return
 			}
 			// srt_ credentials belong exclusively to tenant routing. Always fail
@@ -141,7 +143,7 @@ func tenantKeyFromHeaders(r *http.Request) string {
 }
 
 func (m *MultiTenant) serveTenant(w http.ResponseWriter, r *http.Request, key, rest string) {
-	resolved, ok, err := m.Registry.Resolve(key)
+	resolved, credential, ok, err := m.Registry.ResolveCredential(key)
 	if err != nil {
 		http.Error(w, "tenant registry error", http.StatusInternalServerError)
 		return
@@ -150,13 +152,14 @@ func (m *MultiTenant) serveTenant(w http.ResponseWriter, r *http.Request, key, r
 		http.Error(w, "unknown tenant key", http.StatusUnauthorized)
 		return
 	}
-	m.serveResolvedTenant(w, r, resolved, rest, key)
+	m.serveResolvedTenant(w, r, resolved, credential, rest, key)
 }
 
 func (m *MultiTenant) serveResolvedTenant(
 	w http.ResponseWriter,
 	r *http.Request,
 	t tenant.Tenant,
+	credential tenant.Key,
 	path string,
 	key string,
 ) {
@@ -166,13 +169,22 @@ func (m *MultiTenant) serveResolvedTenant(
 		return
 	}
 	defer useLock.Close()
-	fresh, ok, err := m.Registry.ResolveFresh(key)
+	fresh, freshCredential, ok, err := m.Registry.ResolveFreshCredential(key)
 	if err != nil {
 		http.Error(w, "tenant registry error", http.StatusInternalServerError)
 		return
 	}
 	if !ok || subtle.ConstantTimeCompare([]byte(fresh.ID), []byte(t.ID)) != 1 {
 		http.Error(w, "unknown tenant key", http.StatusUnauthorized)
+		return
+	}
+	if m.isLegacyStackCredential(fresh.ID, key) {
+		http.Error(w, "unknown tenant key", http.StatusUnauthorized)
+		return
+	}
+	if freshCredential.Hash != credential.Hash ||
+		!tenantCredentialAllows(freshCredential, path, r.Method) {
+		http.Error(w, "tenant key lacks required capability", http.StatusForbidden)
 		return
 	}
 	handler, err := m.handlerFor(r.Context(), t)
@@ -191,6 +203,54 @@ func (m *MultiTenant) serveResolvedTenant(
 	// (Codex forwarding keeps X-Api-Key, logging, transcripts) can see it.
 	stripTenantCredentialHeaders(scoped.Header)
 	handler.ServeHTTP(w, scoped)
+}
+
+func (m *MultiTenant) isLegacyStackCredential(tenantID, key string) bool {
+	if strings.TrimSpace(m.StackProjectID) == "" || len(m.StackTenantKeySecret) < 32 {
+		return false
+	}
+	legacy, err := tenant.DeriveKey(
+		m.StackTenantKeySecret,
+		m.StackProjectID,
+		tenantID,
+	)
+	return err == nil && subtle.ConstantTimeCompare([]byte(legacy), []byte(key)) == 1
+}
+
+func tenantCredentialAllows(key tenant.Key, path, method string) bool {
+	if !key.Restricted {
+		return true
+	}
+	if path == "/_subrouter/health" || path == "/_subrouter/whoami" {
+		return key.Allows(tenant.CapabilityUse) ||
+			key.Allows(tenant.CapabilityManageAccounts)
+	}
+	if path == "/_subrouter/accounts" {
+		if method == http.MethodGet {
+			return key.Allows(tenant.CapabilityUse) ||
+				key.Allows(tenant.CapabilityManageAccounts)
+		}
+		return key.Allows(tenant.CapabilityManageAccounts)
+	}
+	if strings.HasPrefix(path, "/_subrouter/accounts/") ||
+		path == "/_subrouter/account-import" ||
+		path == "/_subrouter/reload-accounts" {
+		return key.Allows(tenant.CapabilityManageAccounts)
+	}
+	if path == "/_subrouter/account-status" ||
+		path == "/_subrouter/usage-status" {
+		return key.Allows(tenant.CapabilityUse) ||
+			key.Allows(tenant.CapabilityManageAccounts)
+	}
+	if path == "/_subrouter/leases" ||
+		strings.HasPrefix(path, "/_subrouter/leases/") ||
+		path == "/_subrouter/sessions" {
+		return key.Allows(tenant.CapabilityUse)
+	}
+	if strings.HasPrefix(path, "/_subrouter/") {
+		return false
+	}
+	return key.Allows(tenant.CapabilityUse)
 }
 
 // stripTenantCredentialHeaders removes key-shaped tenant credentials from the
@@ -380,8 +440,9 @@ func (m *MultiTenant) handleStackAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var input struct {
-		TeamID   string `json:"teamId"`
-		TeamName string `json:"teamName"`
+		TeamID       string   `json:"teamId"`
+		TeamName     string   `json:"teamName"`
+		Capabilities []string `json:"capabilities"`
 	}
 	if err := json.NewDecoder(io.LimitReader(r.Body, tenantAdminMaxBodyBytes)).Decode(&input); err != nil && !errors.Is(err, io.EOF) {
 		http.Error(w, "invalid JSON body", http.StatusBadRequest)
@@ -426,12 +487,27 @@ func (m *MultiTenant) handleStackAuth(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	capabilities, err := stackTenantCapabilities(input.Capabilities)
+	if err != nil {
+		http.Error(w, "tenant capabilities are invalid", http.StatusBadRequest)
+		return
+	}
+	controlToken := strings.TrimSpace(r.Header.Get("X-Subrouter-Stack-Control-Token"))
+	if len(m.StackTenantDeleteToken) < 32 ||
+		subtle.ConstantTimeCompare([]byte(controlToken), m.StackTenantDeleteToken) != 1 {
+		http.Error(w, "trusted service credential required", http.StatusUnauthorized)
+		return
+	}
 	base := strings.TrimRight(strings.TrimSpace(m.PublicURL), "/")
 	if base == "" {
 		http.Error(w, "hosted proxy URL is not configured", http.StatusInternalServerError)
 		return
 	}
-	key, err := tenant.DeriveKey(m.StackTenantKeySecret, claims.ProjectID, teamID)
+	key, err := tenant.DeriveKey(
+		m.StackTenantKeySecret,
+		stackTenantKeyNamespace(claims.ProjectID, capabilities),
+		teamID,
+	)
 	if err != nil {
 		http.Error(w, "tenant key unavailable", http.StatusInternalServerError)
 		return
@@ -443,7 +519,12 @@ func (m *MultiTenant) handleStackAuth(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "team name is invalid", http.StatusBadRequest)
 		return
 	}
-	created, err := m.Registry.EnsureExternal(teamID, teamName, key)
+	created, err := m.Registry.EnsureExternalRestricted(
+		teamID,
+		teamName,
+		key,
+		capabilities,
+	)
 	if err != nil {
 		if errors.Is(err, tenant.ErrTenantRetired) {
 			http.Error(w, "tenant is retired", http.StatusGone)
@@ -457,7 +538,40 @@ func (m *MultiTenant) handleStackAuth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]any{
 		"tenantId": created.ID, "tenantName": created.Name,
 		"tenantKey": key, "proxyUrl": proxyURL,
+		"capabilities": capabilities,
 	})
+}
+
+func stackTenantCapabilities(raw []string) ([]tenant.Capability, error) {
+	seen := map[tenant.Capability]bool{}
+	capabilities := make([]tenant.Capability, 0, len(raw))
+	for _, value := range raw {
+		capability := tenant.Capability(strings.TrimSpace(value))
+		if capability != tenant.CapabilityUse &&
+			capability != tenant.CapabilityManageAccounts {
+			return nil, errors.New("unknown capability")
+		}
+		if !seen[capability] {
+			seen[capability] = true
+			capabilities = append(capabilities, capability)
+		}
+	}
+	if len(capabilities) == 0 {
+		return nil, errors.New("capabilities are required")
+	}
+	slices.Sort(capabilities)
+	return capabilities, nil
+}
+
+func stackTenantKeyNamespace(
+	projectID string,
+	capabilities []tenant.Capability,
+) string {
+	values := make([]string, len(capabilities))
+	for i, capability := range capabilities {
+		values[i] = string(capability)
+	}
+	return strings.TrimSpace(projectID) + "\x00scoped-v1:" + strings.Join(values, ",")
 }
 
 func (m *MultiTenant) handleStackTenantDelete(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -595,6 +595,71 @@ func TestStackLoginCreatesStableTenantAndAcceptsDirectAccountUpload(t *testing.T
 	}
 }
 
+func TestStackLoginRequiresTrustedServiceCredential(t *testing.T) {
+	registry := tenant.NewRegistry(t.TempDir())
+	base := Server{MaxBodyBytes: 1024}
+	handler := (&MultiTenant{
+		Base: base, Registry: registry, PublicURL: "https://sr.example",
+		StackTenantKeySecret:   []byte("0123456789abcdef0123456789abcdef"),
+		StackTenantDeleteToken: []byte(testStackTenantDeleteToken),
+		StackVerifier: fakeStackVerifier{claims: stackauth.Claims{
+			ProjectID: "project", SelectedTeamID: "team-123",
+		}},
+	}).Handler(base.Handler())
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/_subrouter/auth/stack",
+		strings.NewReader(`{"teamId":"team-123","teamName":"Acme","capabilities":["use"]}`),
+	)
+	req.Header.Set("Authorization", "Bearer stack-access")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, req)
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401, body = %s", response.Code, response.Body.String())
+	}
+}
+
+func TestStackUseCredentialCannotManageTenantAccounts(t *testing.T) {
+	registry := tenant.NewRegistry(t.TempDir())
+	base := Server{MaxBodyBytes: 1024}
+	handler := (&MultiTenant{
+		Base: base, Registry: registry, PublicURL: "https://sr.example",
+		StackTenantKeySecret:   []byte("0123456789abcdef0123456789abcdef"),
+		StackTenantDeleteToken: []byte(testStackTenantDeleteToken),
+		StackVerifier: fakeStackVerifier{claims: stackauth.Claims{
+			ProjectID: "project", SelectedTeamID: "team-123",
+		}},
+	}).Handler(base.Handler())
+	exchange := httptest.NewRequest(
+		http.MethodPost,
+		"/_subrouter/auth/stack",
+		strings.NewReader(`{"teamId":"team-123","teamName":"Acme","capabilities":["use"]}`),
+	)
+	exchange.Header.Set("Authorization", "Bearer stack-access")
+	exchange.Header.Set("X-Subrouter-Stack-Control-Token", testStackTenantDeleteToken)
+	exchangeResponse := httptest.NewRecorder()
+	handler.ServeHTTP(exchangeResponse, exchange)
+	if exchangeResponse.Code != http.StatusOK {
+		t.Fatalf("exchange status = %d: %s", exchangeResponse.Code, exchangeResponse.Body.String())
+	}
+	var body struct {
+		TenantKey string `json:"tenantKey"`
+	}
+	if err := json.Unmarshal(exchangeResponse.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	upload := httptest.NewRequest(
+		http.MethodPost,
+		"/t/"+body.TenantKey+"/_subrouter/accounts",
+		strings.NewReader(`{"provider":"openai-apikey","label":"work","apiKey":"sk-test"}`),
+	)
+	uploadResponse := httptest.NewRecorder()
+	handler.ServeHTTP(uploadResponse, upload)
+	if uploadResponse.Code != http.StatusForbidden {
+		t.Fatalf("upload status = %d, want 403: %s", uploadResponse.Code, uploadResponse.Body.String())
+	}
+}
+
 func TestStackTenantDeletionRequiresTrustedServiceCredential(t *testing.T) {
 	registry := tenant.NewRegistry(t.TempDir())
 	key, err := tenant.DeriveKey(

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -524,9 +524,10 @@ func TestStackLoginCreatesStableTenantAndAcceptsDirectAccountUpload(t *testing.T
 		req := httptest.NewRequest(
 			http.MethodPost,
 			"/_subrouter/auth/stack",
-			strings.NewReader(`{"teamId":"team-123","teamName":"Acme"}`),
+			strings.NewReader(`{"teamId":"team-123","teamName":"Acme","capabilities":["manage_accounts"]}`),
 		)
 		req.Header.Set("Authorization", "Bearer stack-access")
+		req.Header.Set("X-Subrouter-Stack-Control-Token", testStackTenantDeleteToken)
 		response := httptest.NewRecorder()
 		handler.ServeHTTP(response, req)
 		if response.Code != http.StatusOK {
@@ -657,6 +658,47 @@ func TestStackUseCredentialCannotManageTenantAccounts(t *testing.T) {
 	handler.ServeHTTP(uploadResponse, upload)
 	if uploadResponse.Code != http.StatusForbidden {
 		t.Fatalf("upload status = %d, want 403: %s", uploadResponse.Code, uploadResponse.Body.String())
+	}
+	listResponse := httptest.NewRecorder()
+	handler.ServeHTTP(
+		listResponse,
+		httptest.NewRequest(
+			http.MethodGet,
+			"/t/"+body.TenantKey+"/_subrouter/accounts",
+			nil,
+		),
+	)
+	if listResponse.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want 200: %s", listResponse.Code, listResponse.Body.String())
+	}
+}
+
+func TestLegacyDirectStackCredentialIsRejected(t *testing.T) {
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	legacyKey, err := tenant.DeriveKey(secret, "project", "team-123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := tenant.NewRegistry(t.TempDir())
+	if _, err := registry.EnsureExternal("team-123", "Acme", legacyKey); err != nil {
+		t.Fatal(err)
+	}
+	base := Server{MaxBodyBytes: 1024}
+	handler := (&MultiTenant{
+		Base: base, Registry: registry, StackProjectID: "project",
+		StackTenantKeySecret: secret,
+	}).Handler(base.Handler())
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(
+		response,
+		httptest.NewRequest(
+			http.MethodGet,
+			"/t/"+legacyKey+"/_subrouter/whoami",
+			nil,
+		),
+	)
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401: %s", response.Code, response.Body.String())
 	}
 }
 
@@ -1232,9 +1274,10 @@ func TestStackTenantDeletionRevokesNewRequestsThenDrainsInFlightTraffic(t *testi
 	reactivate := httptest.NewRequest(
 		http.MethodPost,
 		"/_subrouter/auth/stack",
-		strings.NewReader(`{"teamId":"user-1","teamName":"User One"}`),
+		strings.NewReader(`{"teamId":"user-1","teamName":"User One","capabilities":["use"]}`),
 	)
 	reactivate.Header.Set("Authorization", "Bearer stack-access")
+	reactivate.Header.Set("X-Subrouter-Stack-Control-Token", testStackTenantDeleteToken)
 	reactivateResponse := httptest.NewRecorder()
 	handler.ServeHTTP(reactivateResponse, reactivate)
 	if reactivateResponse.Code != http.StatusGone {
@@ -1612,14 +1655,16 @@ func TestStackLoginAcceptsAnotherTeamAfterMembershipCheck(t *testing.T) {
 		StackTeams: fakeStackTeams{teams: []stackauth.Team{{
 			ID: "requested-team", DisplayName: "Requested Team",
 		}}},
-		StackTenantKeySecret: []byte("0123456789abcdef0123456789abcdef"),
+		StackTenantKeySecret:   []byte("0123456789abcdef0123456789abcdef"),
+		StackTenantDeleteToken: []byte(testStackTenantDeleteToken),
 	}).Handler(base.Handler())
 	req := httptest.NewRequest(
 		http.MethodPost,
 		"/_subrouter/auth/stack",
-		strings.NewReader(`{"teamId":"requested-team"}`),
+		strings.NewReader(`{"teamId":"requested-team","capabilities":["use"]}`),
 	)
 	req.Header.Set("Authorization", "Bearer access")
+	req.Header.Set("X-Subrouter-Stack-Control-Token", testStackTenantDeleteToken)
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, req)
 	if response.Code != http.StatusOK {
@@ -1634,7 +1679,7 @@ func TestStackLoginAcceptsAnotherTeamAfterMembershipCheck(t *testing.T) {
 	}
 	expectedKey, err := tenant.DeriveKey(
 		[]byte("0123456789abcdef0123456789abcdef"),
-		"project",
+		stackTenantKeyNamespace("project", []tenant.Capability{tenant.CapabilityUse}),
 		"requested-team",
 	)
 	if err != nil {
@@ -1653,14 +1698,16 @@ func TestStackLoginRequiresPublicURL(t *testing.T) {
 		StackVerifier: fakeStackVerifier{claims: stackauth.Claims{
 			ProjectID: "project", SelectedTeamID: "team-123",
 		}},
-		StackTenantKeySecret: []byte("0123456789abcdef0123456789abcdef"),
+		StackTenantKeySecret:   []byte("0123456789abcdef0123456789abcdef"),
+		StackTenantDeleteToken: []byte(testStackTenantDeleteToken),
 	}).Handler(base.Handler())
 	req := httptest.NewRequest(
 		http.MethodPost,
 		"/_subrouter/auth/stack",
-		strings.NewReader(`{"teamId":"team-123"}`),
+		strings.NewReader(`{"teamId":"team-123","capabilities":["use"]}`),
 	)
 	req.Header.Set("Authorization", "Bearer access")
+	req.Header.Set("X-Subrouter-Stack-Control-Token", testStackTenantDeleteToken)
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, req)
 	if response.Code != http.StatusInternalServerError ||

--- a/internal/stackauth/client.go
+++ b/internal/stackauth/client.go
@@ -310,6 +310,14 @@ func ExchangeTenant(
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 30 * time.Second}
 	}
+	exchangeClient := &http.Client{
+		Transport: httpClient.Transport,
+		Jar:       httpClient.Jar,
+		Timeout:   httpClient.Timeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 	payload, err := json.Marshal(map[string]string{"teamId": teamID, "teamName": teamName})
 	if err != nil {
 		return TenantExchange{}, err
@@ -327,7 +335,7 @@ func ExchangeTenant(
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("X-Stack-Refresh-Token", refreshToken)
 	req.Header.Set("X-Cmux-Team-Id", teamID)
-	res, err := httpClient.Do(req)
+	res, err := exchangeClient.Do(req)
 	if err != nil {
 		return TenantExchange{}, err
 	}

--- a/internal/stackauth/client.go
+++ b/internal/stackauth/client.go
@@ -326,6 +326,7 @@ func ExchangeTenant(
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("X-Stack-Refresh-Token", refreshToken)
+	req.Header.Set("X-Cmux-Team-Id", teamID)
 	res, err := httpClient.Do(req)
 	if err != nil {
 		return TenantExchange{}, err

--- a/internal/stackauth/client.go
+++ b/internal/stackauth/client.go
@@ -27,26 +27,29 @@ type PublicConfig struct {
 		ConfirmURL           string `json:"confirmUrl"`
 	} `json:"auth"`
 	Subrouter struct {
-		URL string `json:"url"`
+		URL         string `json:"url"`
+		ExchangeURL string `json:"exchangeUrl"`
 	} `json:"subrouter"`
 }
 
 func (c PublicConfig) Validate() error {
 	for name, value := range map[string]string{
-		"Stack API URL":         c.Auth.APIURL,
-		"Stack project ID":      c.Auth.ProjectID,
-		"Stack publishable key": c.Auth.PublishableClientKey,
-		"CLI confirmation URL":  c.Auth.ConfirmURL,
-		"Subrouter URL":         c.Subrouter.URL,
+		"Stack API URL":          c.Auth.APIURL,
+		"Stack project ID":       c.Auth.ProjectID,
+		"Stack publishable key":  c.Auth.PublishableClientKey,
+		"CLI confirmation URL":   c.Auth.ConfirmURL,
+		"Subrouter URL":          c.Subrouter.URL,
+		"Subrouter exchange URL": c.Subrouter.ExchangeURL,
 	} {
 		if strings.TrimSpace(value) == "" {
 			return fmt.Errorf("%s is missing", name)
 		}
 	}
 	for name, raw := range map[string]string{
-		"Stack API URL":        c.Auth.APIURL,
-		"CLI confirmation URL": c.Auth.ConfirmURL,
-		"Subrouter URL":        c.Subrouter.URL,
+		"Stack API URL":          c.Auth.APIURL,
+		"CLI confirmation URL":   c.Auth.ConfirmURL,
+		"Subrouter URL":          c.Subrouter.URL,
+		"Subrouter exchange URL": c.Subrouter.ExchangeURL,
 	} {
 		if err := validateHTTPSOriginOrURL(raw); err != nil {
 			return fmt.Errorf("%s: %w", name, err)
@@ -172,10 +175,11 @@ type SessionTokens struct {
 }
 
 type TenantExchange struct {
-	TenantID   string `json:"tenantId"`
-	TenantName string `json:"tenantName"`
-	TenantKey  string `json:"tenantKey"`
-	ProxyURL   string `json:"proxyUrl"`
+	TenantID     string   `json:"tenantId"`
+	TenantName   string   `json:"tenantName"`
+	TenantKey    string   `json:"tenantKey"`
+	ProxyURL     string   `json:"proxyUrl"`
+	Capabilities []string `json:"capabilities"`
 }
 
 type Team struct {
@@ -297,8 +301,9 @@ func (c Client) SignOut(ctx context.Context, accessToken, refreshToken string) e
 func ExchangeTenant(
 	ctx context.Context,
 	httpClient *http.Client,
-	hostedURL string,
+	exchangeURL string,
 	accessToken string,
+	refreshToken string,
 	teamID string,
 	teamName string,
 ) (TenantExchange, error) {
@@ -312,7 +317,7 @@ func ExchangeTenant(
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodPost,
-		strings.TrimRight(hostedURL, "/")+"/_subrouter/auth/stack",
+		strings.TrimSpace(exchangeURL),
 		bytes.NewReader(payload),
 	)
 	if err != nil {
@@ -320,6 +325,7 @@ func ExchangeTenant(
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("X-Stack-Refresh-Token", refreshToken)
 	res, err := httpClient.Do(req)
 	if err != nil {
 		return TenantExchange{}, err
@@ -332,10 +338,23 @@ func ExchangeTenant(
 	if err := json.NewDecoder(io.LimitReader(res.Body, 1<<20)).Decode(&out); err != nil {
 		return TenantExchange{}, err
 	}
-	if out.TenantID == "" || out.TenantKey == "" || out.ProxyURL == "" {
+	if out.TenantID == "" || out.TenantKey == "" || out.ProxyURL == "" ||
+		!validTenantCapabilities(out.Capabilities) {
 		return TenantExchange{}, errors.New("hosted Subrouter returned an incomplete tenant")
 	}
 	return out, nil
+}
+
+func validTenantCapabilities(values []string) bool {
+	if len(values) == 0 {
+		return false
+	}
+	for _, value := range values {
+		if value != "use" && value != "manage_accounts" {
+			return false
+		}
+	}
+	return true
 }
 
 // ParseClaimsUnverified reads identity hints used to select the user's team in

--- a/internal/stackauth/client_test.go
+++ b/internal/stackauth/client_test.go
@@ -160,6 +160,35 @@ func TestExchangeTenantUsesBrokeredURLAndNativeSessionPair(t *testing.T) {
 	}
 }
 
+func TestExchangeTenantDoesNotForwardRefreshTokenAcrossRedirects(t *testing.T) {
+	var leakedRefreshToken string
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		leakedRefreshToken = r.Header.Get("X-Stack-Refresh-Token")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tenantId": "team-1", "tenantName": "Acme",
+			"tenantKey":    "srt_0123456789abcdef0123456789abcdef",
+			"proxyUrl":     serverURL(r) + "/t/srt_0123456789abcdef0123456789abcdef",
+			"capabilities": []string{"use"},
+		})
+	}))
+	defer target.Close()
+	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+	}))
+	defer redirect.Close()
+
+	_, err := ExchangeTenant(
+		context.Background(), redirect.Client(), redirect.URL,
+		"access", "refresh", "team-1", "Acme",
+	)
+	if err == nil {
+		t.Fatal("cross-origin redirect unexpectedly succeeded")
+	}
+	if leakedRefreshToken != "" {
+		t.Fatal("refresh token was forwarded to the redirect target")
+	}
+}
+
 func serverURL(r *http.Request) string {
 	return "http://" + r.Host
 }

--- a/internal/stackauth/client_test.go
+++ b/internal/stackauth/client_test.go
@@ -132,7 +132,8 @@ func TestExchangeTenantUsesBrokeredURLAndNativeSessionPair(t *testing.T) {
 		}
 		sawRequest = true
 		if r.Header.Get("Authorization") != "Bearer access" ||
-			r.Header.Get("X-Stack-Refresh-Token") != "refresh" {
+			r.Header.Get("X-Stack-Refresh-Token") != "refresh" ||
+			r.Header.Get("X-Cmux-Team-Id") != "team-1" {
 			http.Error(w, "missing native session", http.StatusUnauthorized)
 			return
 		}

--- a/internal/stackauth/client_test.go
+++ b/internal/stackauth/client_test.go
@@ -122,3 +122,43 @@ func TestFetchPublicConfigExplainsUnavailableCLIAuth(t *testing.T) {
 		t.Fatalf("provider leaked through public error: %v", err)
 	}
 }
+
+func TestExchangeTenantUsesBrokeredURLAndNativeSessionPair(t *testing.T) {
+	var sawRequest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/subrouter/exchange" {
+			http.NotFound(w, r)
+			return
+		}
+		sawRequest = true
+		if r.Header.Get("Authorization") != "Bearer access" ||
+			r.Header.Get("X-Stack-Refresh-Token") != "refresh" {
+			http.Error(w, "missing native session", http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tenantId": "team-1", "tenantName": "Acme",
+			"tenantKey":    "srt_0123456789abcdef0123456789abcdef",
+			"proxyUrl":     serverURL(r) + "/t/srt_0123456789abcdef0123456789abcdef",
+			"capabilities": []string{"use"},
+		})
+	}))
+	defer server.Close()
+
+	exchange, err := ExchangeTenant(
+		context.Background(), server.Client(),
+		server.URL+"/api/subrouter/exchange",
+		"access", "refresh", "team-1", "Acme",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sawRequest || len(exchange.Capabilities) != 1 ||
+		exchange.Capabilities[0] != "use" {
+		t.Fatalf("exchange = %#v", exchange)
+	}
+}
+
+func serverURL(r *http.Request) string {
+	return "http://" + r.Host
+}

--- a/internal/tenant/tenant.go
+++ b/internal/tenant/tenant.go
@@ -26,9 +26,25 @@ const keyRandomBytes = 16
 const keyDisplayPrefixLen = len(KeyPrefix) + 8
 
 type Key struct {
-	Hash      string    `json:"hash"`
-	Prefix    string    `json:"prefix"`
-	CreatedAt time.Time `json:"createdAt"`
+	Hash         string       `json:"hash"`
+	Prefix       string       `json:"prefix"`
+	CreatedAt    time.Time    `json:"createdAt"`
+	Restricted   bool         `json:"restricted,omitempty"`
+	Capabilities []Capability `json:"capabilities,omitempty"`
+}
+
+type Capability string
+
+const (
+	CapabilityUse            Capability = "use"
+	CapabilityManageAccounts Capability = "manage_accounts"
+)
+
+func (k Key) Allows(capability Capability) bool {
+	if !k.Restricted {
+		return true
+	}
+	return slices.Contains(k.Capabilities, capability)
 }
 
 type Tenant struct {
@@ -220,6 +236,12 @@ func copyRegistryFile(file registryFile) registryFile {
 	out := registryFile{Tenants: make([]Tenant, len(file.Tenants))}
 	for i, t := range file.Tenants {
 		t.Keys = append([]Key(nil), t.Keys...)
+		for keyIndex := range t.Keys {
+			t.Keys[keyIndex].Capabilities = append(
+				[]Capability(nil),
+				t.Keys[keyIndex].Capabilities...,
+			)
+		}
 		out.Tenants[i] = t
 	}
 	return out
@@ -320,6 +342,38 @@ func (r *Registry) Create(name string) (Tenant, string, error) {
 // repeated logins return the same client configuration without accumulating
 // registry keys.
 func (r *Registry) EnsureExternal(id, name, plaintextKey string) (Tenant, error) {
+	return r.ensureExternal(id, name, plaintextKey, nil, false)
+}
+
+// EnsureExternalRestricted creates or updates an externally owned tenant key
+// whose authority is limited to the supplied capabilities.
+func (r *Registry) EnsureExternalRestricted(
+	id,
+	name,
+	plaintextKey string,
+	capabilities []Capability,
+) (Tenant, error) {
+	if len(capabilities) == 0 {
+		return Tenant{}, errors.New("restricted external tenant key requires capabilities")
+	}
+	canonical := append([]Capability(nil), capabilities...)
+	slices.Sort(canonical)
+	canonical = slices.Compact(canonical)
+	for _, capability := range canonical {
+		if capability != CapabilityUse && capability != CapabilityManageAccounts {
+			return Tenant{}, fmt.Errorf("invalid tenant key capability %q", capability)
+		}
+	}
+	return r.ensureExternal(id, name, plaintextKey, canonical, true)
+}
+
+func (r *Registry) ensureExternal(
+	id,
+	name,
+	plaintextKey string,
+	capabilities []Capability,
+	restricted bool,
+) (Tenant, error) {
 	id = strings.TrimSpace(id)
 	name = strings.TrimSpace(name)
 	if !ValidExternalID(id) {
@@ -363,16 +417,24 @@ func (r *Registry) EnsureExternal(id, name, plaintextKey string) (Tenant, error)
 			changed = true
 		}
 		found := false
-		for _, key := range file.Tenants[i].Keys {
+		for keyIndex := range file.Tenants[i].Keys {
+			key := &file.Tenants[i].Keys[keyIndex]
 			if key.Hash == hash {
 				found = true
+				if key.Restricted != restricted ||
+					!slices.Equal(key.Capabilities, capabilities) {
+					key.Restricted = restricted
+					key.Capabilities = append([]Capability(nil), capabilities...)
+					changed = true
+				}
 				break
 			}
 		}
 		if !found {
 			file.Tenants[i].Keys = append(file.Tenants[i].Keys, Key{
 				Hash: hash, Prefix: plaintextKey[:keyDisplayPrefixLen],
-				CreatedAt: time.Now().UTC(),
+				CreatedAt: time.Now().UTC(), Restricted: restricted,
+				Capabilities: append([]Capability(nil), capabilities...),
 			})
 			changed = true
 		}
@@ -390,7 +452,8 @@ func (r *Registry) EnsureExternal(id, name, plaintextKey string) (Tenant, error)
 		ID: id, Name: name, CreatedAt: time.Now().UTC(),
 		Keys: []Key{{
 			Hash: hash, Prefix: plaintextKey[:keyDisplayPrefixLen],
-			CreatedAt: time.Now().UTC(),
+			CreatedAt: time.Now().UTC(), Restricted: restricted,
+			Capabilities: append([]Capability(nil), capabilities...),
 		}},
 	}
 	if err := os.MkdirAll(filepath.Join(r.Dir(id), "codex", "accounts"), 0o700); err != nil {
@@ -699,38 +762,48 @@ func (r *Registry) RevokeKey(tenantID, keyRef string) (int, error) {
 // Resolve maps a plaintext tenant key to its tenant. A revoked or unknown key
 // returns ok=false.
 func (r *Registry) Resolve(key string) (Tenant, bool, error) {
+	t, _, ok, err := r.ResolveCredential(key)
+	return t, ok, err
+}
+
+func (r *Registry) ResolveCredential(key string) (Tenant, Key, bool, error) {
 	if !ValidKeyFormat(key) {
-		return Tenant{}, false, nil
+		return Tenant{}, Key{}, false, nil
 	}
 	hash := HashKey(key)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	file, err := r.load()
 	if err != nil {
-		return Tenant{}, false, err
+		return Tenant{}, Key{}, false, err
 	}
 	for _, t := range file.Tenants {
 		for _, k := range t.Keys {
 			if k.Hash == hash {
-				return t, true, nil
+				return t, k, true, nil
 			}
 		}
 	}
-	return Tenant{}, false, nil
+	return Tenant{}, Key{}, false, nil
 }
 
 // ResolveFresh bypasses the metadata cache after a request has acquired its
 // shared use lock. This closes the cross-process race with tenant retirement.
 func (r *Registry) ResolveFresh(key string) (Tenant, bool, error) {
+	t, _, ok, err := r.ResolveFreshCredential(key)
+	return t, ok, err
+}
+
+func (r *Registry) ResolveFreshCredential(key string) (Tenant, Key, bool, error) {
 	if !ValidKeyFormat(key) {
-		return Tenant{}, false, nil
+		return Tenant{}, Key{}, false, nil
 	}
 	hash := HashKey(key)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	file, err := r.loadFresh()
 	if err != nil {
-		return Tenant{}, false, err
+		return Tenant{}, Key{}, false, err
 	}
 	for _, t := range file.Tenants {
 		if t.Retired {
@@ -738,11 +811,11 @@ func (r *Registry) ResolveFresh(key string) (Tenant, bool, error) {
 		}
 		for _, k := range t.Keys {
 			if k.Hash == hash {
-				return t, true, nil
+				return t, k, true, nil
 			}
 		}
 	}
-	return Tenant{}, false, nil
+	return Tenant{}, Key{}, false, nil
 }
 
 // Find matches a tenant by exact ID or case-insensitive name.

--- a/internal/tenant/tenant_test.go
+++ b/internal/tenant/tenant_test.go
@@ -138,6 +138,41 @@ func TestEnsureExternalIsStableAndUpdatesName(t *testing.T) {
 	}
 }
 
+func TestRestrictedExternalKeyPersistsCanonicalCapabilities(t *testing.T) {
+	registry := NewRegistry(t.TempDir())
+	key, err := DeriveKey(
+		[]byte("0123456789abcdef0123456789abcdef"),
+		"stack-project\x00scoped-v1:manage_accounts,use",
+		"team-123",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.EnsureExternalRestricted(
+		"team-123",
+		"Acme",
+		key,
+		[]Capability{CapabilityUse, CapabilityManageAccounts, CapabilityUse},
+	); err != nil {
+		t.Fatal(err)
+	}
+	_, credential, ok, err := registry.ResolveCredential(key)
+	if err != nil || !ok {
+		t.Fatalf("resolve = %v, %v", ok, err)
+	}
+	if !credential.Restricted || !credential.Allows(CapabilityUse) ||
+		!credential.Allows(CapabilityManageAccounts) ||
+		len(credential.Capabilities) != 2 {
+		t.Fatalf("credential = %#v", credential)
+	}
+	reloaded := NewRegistry(registry.stateDir)
+	_, persisted, ok, err := reloaded.ResolveCredential(key)
+	if err != nil || !ok || !persisted.Restricted ||
+		len(persisted.Capabilities) != 2 {
+		t.Fatalf("persisted credential = %#v, %v, %v", persisted, ok, err)
+	}
+}
+
 func TestDeleteRetiredTombstonesAnAbsentTenantDeletionIntent(t *testing.T) {
 	registry := NewRegistry(t.TempDir())
 	deleted, err := registry.DeleteRetired("team-absent")


### PR DESCRIPTION
Hosted Stack exchange now requires the trusted cmux control-plane token and creates deterministic capability-scoped tenant keys. Legacy direct Stack keys are rejected, account mutation requires `manage_accounts`, proxy and lease operations require `use`, and native exchange carries the explicit selected team header.

Regression sequence: test-only commits `5dd8fbd` and `b88efa9` fail before fixes `202666d` and `30f707c`.

Verified: `go test ./...`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788393746&installation_model_id=21920&pr_number=141&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F141&signature=8a2b6ecb84c0a557e0b704c0c845055f93a36cecad70f0c9804338a2d292744f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate hosted tenant credentials by capability and route native exchange through a trusted broker. Exchange blocks redirects to protect refresh tokens; scoped tenant keys enforce `use` and `manage_accounts`, and legacy direct Stack keys are rejected.

- **New Features**
  - Added brokered exchange at `/api/subrouter/exchange`; requires the trusted control-plane token and returns deterministic, capability-scoped tenant keys.
  - Enforced capabilities in the proxy:
    - Account mutations require `manage_accounts`.
    - Proxy, leasing, and sessions require `use`.
    - Health and basic status endpoints allow either.
  - Rejected legacy direct Stack-derived keys; only scoped keys are valid.
  - CLI now uses `subrouter.exchangeUrl`, sends refresh token and `X-Cmux-Team-Id`, disables redirects to avoid leaking the refresh token, and stores `hostedExchangeUrl` and `tenantCapabilities` in config.
  - Registry persists restricted external keys with capabilities; config validation added for `hostedExchangeUrl`.

- **Migration**
  - Set `SUBROUTER_STACK_TENANT_DELETE_TOKEN` for both exchange and deletion, and `SUBROUTER_STACK_PROJECT_ID` to detect legacy keys.
  - Ensure public config includes `subrouter.exchangeUrl`; clients should re-login to receive scoped tenant keys (direct client exchange is no longer accepted).

<sup>Written for commit 01df831dfffb928c9ed328111609fdeafb660977. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure brokered tenant exchange for hosted login and team switching.
  * Added capability-scoped tenant access, supporting separate usage and account-management permissions.
  * Added restricted tenant credentials and improved credential validation.
  * Logout now clears hosted exchange settings and tenant capabilities.

* **Documentation**
  * Updated browser-login guidance to describe brokered exchange and capability-scoped credentials.

* **Bug Fixes**
  * Prevented unauthorized account management and rejection of legacy direct tenant credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->