### PR TITLE
Advance golden continuity candidate to v0.1.55

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -44,7 +44,7 @@ const (
 	goldenPinnedPredecessorVersion            = "0.1.51"
 	goldenPinnedPredecessorSHA256             = "74f4bfbbf6b8dcbe0509eaaa9f63b1eb688358a749ed3b451066e146591d2582"
 	goldenPinnedPredecessorRevision           = "5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8"
-	goldenPinnedCandidateTag                  = "v0.1.54"
+	goldenPinnedCandidateTag                  = "v0.1.55"
 	goldenFakeStreamReleaseTokenEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_TOKEN"
 	goldenFakeStreamReleaseStateEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_STATE"
 )

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-func TestGoldenOptionsRequireV0154Candidate(t *testing.T) {
+func TestGoldenOptionsRequireV0155Candidate(t *testing.T) {
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = false
 	t.Cleanup(func() { goldenTestHooks = previousHooks })
@@ -19,7 +19,7 @@ func TestGoldenOptionsRequireV0154Candidate(t *testing.T) {
 	args := []string{
 		"--predecessor-version", "v0.1.51",
 		"--predecessor-sha256", goldenPinnedPredecessorSHA256,
-		"--candidate-tag", "v0.1.54",
+		"--candidate-tag", "v0.1.55",
 		"--candidate-sha256", strings.Repeat("b", 64),
 		"--candidate-revision", strings.Repeat("c", 40),
 		"--deploy-evidence-validator", "validator",
@@ -32,16 +32,16 @@ func TestGoldenOptionsRequireV0154Candidate(t *testing.T) {
 		"--old-generation-check", "true",
 	}
 	if _, err := parseGoldenArgs(args); err != nil {
-		t.Fatalf("v0.1.54 candidate was rejected: %v", err)
+		t.Fatalf("v0.1.55 candidate was rejected: %v", err)
 	}
 	for index := range args {
-		if args[index] == "v0.1.54" {
-			args[index] = "v0.1.53"
+		if args[index] == "v0.1.55" {
+			args[index] = "v0.1.54"
 			break
 		}
 	}
 	if _, err := parseGoldenArgs(args); err == nil {
-		t.Fatal("superseded v0.1.53 candidate was accepted")
+		t.Fatal("superseded v0.1.54 candidate was accepted")
 	}
 }
 

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify the immutable v0.1.51/v0.1.54 release inputs, then run the complete
+# Verify the immutable v0.1.51/v0.1.55 release inputs, then run the complete
 # legacy-to-front migration and slot-upgrade continuity gate from a local Mac.
 set -euo pipefail
 umask 077
@@ -12,8 +12,8 @@ predecessor_version="0.1.51"
 predecessor_revision="5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8"
 predecessor_darwin_sha="74f4bfbbf6b8dcbe0509eaaa9f63b1eb688358a749ed3b451066e146591d2582"
 predecessor_linux_sha="99fcd10d912184c160370eb228b382795101f2b5b2467244f995aa2d10b0c323"
-candidate_tag="v0.1.54"
-candidate_version="0.1.54"
+candidate_tag="v0.1.55"
+candidate_version="0.1.55"
 
 usage() {
   cat <<'EOF'
@@ -168,7 +168,7 @@ if ! gh release view "${candidate_tag}" --repo "${repository}" --json tagName,is
       '.tagName == $tag and (.isDraft | not) and (.isPrerelease | not) and .isImmutable == true and
        (.publishedAt | type == "string" and length > 0)' \
       >/dev/null; then
-  echo "v0.1.54 is not a published immutable release" >&2
+  echo "v0.1.55 is not a published immutable release" >&2
   exit 1
 fi
 candidate_revision="$(require_release_revision_on_main "${candidate_tag}")"


### PR DESCRIPTION
Pins the production continuity harness to the immutable v0.1.55 release that contains capability-scoped tenant credentials and redirect-safe native exchange.

Regression sequence: test-only commit `9f15c41` fails against v0.1.54, then `64574e5` advances the harness.

Verified: `go test ./...`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788395605&installation_model_id=21920&pr_number=142&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F142&signature=7f405c0f1c0ba771534b70a2b5db44aa8957f65c50ca47f7d388a000b3d879a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the golden continuity harness to the immutable v0.1.55 release and update the test and local continuity script to require it. v0.1.55 includes capability-scoped tenant credentials and redirect-safe native exchange; `go test ./...` passes.

<sup>Written for commit 64574e57cbdd4ae399fcdaf65e5c3046e908057c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

