### PR TITLE
Preserve trusted legacy Stack exchanges

### DIFF
--- a/internal/proxy/multitenant.go
+++ b/internal/proxy/multitenant.go
@@ -497,15 +497,15 @@ func (m *MultiTenant) handleStackAuth(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	capabilities, err := stackTenantCapabilities(input.Capabilities)
-	if err != nil {
-		http.Error(w, "tenant capabilities are invalid", http.StatusBadRequest)
-		return
-	}
 	controlToken := strings.TrimSpace(r.Header.Get("X-Subrouter-Stack-Control-Token"))
 	if len(m.StackTenantDeleteToken) < 32 ||
 		subtle.ConstantTimeCompare([]byte(controlToken), m.StackTenantDeleteToken) != 1 {
 		http.Error(w, "trusted service credential required", http.StatusUnauthorized)
+		return
+	}
+	capabilities, err := stackTenantCapabilities(input.Capabilities)
+	if err != nil {
+		http.Error(w, "tenant capabilities are invalid", http.StatusBadRequest)
 		return
 	}
 	base := strings.TrimRight(strings.TrimSpace(m.PublicURL), "/")
@@ -553,6 +553,15 @@ func (m *MultiTenant) handleStackAuth(w http.ResponseWriter, r *http.Request) {
 }
 
 func stackTenantCapabilities(raw []string) ([]tenant.Capability, error) {
+	// The first trusted cmux.com exchange broker predates capability-scoped
+	// tenant keys. Preserve that authenticated service boundary during the
+	// rollout; untrusted direct callers are rejected before this fallback.
+	if len(raw) == 0 {
+		return []tenant.Capability{
+			tenant.CapabilityManageAccounts,
+			tenant.CapabilityUse,
+		}, nil
+	}
 	seen := map[tenant.Capability]bool{}
 	capabilities := make([]tenant.Capability, 0, len(raw))
 	for _, value := range raw {

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -524,7 +525,7 @@ func TestStackLoginCreatesStableTenantAndAcceptsDirectAccountUpload(t *testing.T
 		req := httptest.NewRequest(
 			http.MethodPost,
 			"/_subrouter/auth/stack",
-			strings.NewReader(`{"teamId":"team-123","teamName":"Acme","capabilities":["manage_accounts"]}`),
+			strings.NewReader(`{"teamId":"team-123","teamName":"Acme"}`),
 		)
 		req.Header.Set("Authorization", "Bearer stack-access")
 		req.Header.Set("X-Subrouter-Stack-Control-Token", testStackTenantDeleteToken)
@@ -553,6 +554,12 @@ func TestStackLoginCreatesStableTenantAndAcceptsDirectAccountUpload(t *testing.T
 	}
 	if first["proxyUrl"] != "https://sr.example/t/"+key {
 		t.Fatalf("proxy URL = %v", first["proxyUrl"])
+	}
+	if got := first["capabilities"]; !reflect.DeepEqual(
+		got,
+		[]any{"manage_accounts", "use"},
+	) {
+		t.Fatalf("capabilities = %#v", got)
 	}
 
 	upload := httptest.NewRequest(
@@ -697,9 +704,9 @@ func TestLegacyDirectStackCredentialExpiresAfterDeploymentGrace(t *testing.T) {
 		handler.ServeHTTP(
 			response,
 			httptest.NewRequest(
-			http.MethodGet,
-			"/t/"+legacyKey+"/_subrouter/whoami",
-			nil,
+				http.MethodGet,
+				"/t/"+legacyKey+"/_subrouter/whoami",
+				nil,
 			),
 		)
 		return response


### PR DESCRIPTION
Accepts an omitted capability list only after authenticating the trusted Stack control-plane credential, preserving the pre-capability broker during rollout. Explicit capability-scoped exchanges remain unchanged. Adds coverage proving the compatibility exchange receives use and account-management scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788421534&installation_model_id=21920&pr_number=145&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F145&signature=338be1f31c30bd0df28440e24791350330e624bbec20ab4c6aa0805176416757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves legacy trusted Stack exchanges by allowing omitted capability lists only after verifying the control-plane token. For trusted calls without capabilities, we default to manage_accounts and use; explicit capability-scoped exchanges are unchanged.

- **Bug Fixes**
  - Authenticate `X-Subrouter-Stack-Control-Token` before capability parsing to block untrusted fallbacks.
  - Default to ["manage_accounts", "use"] when capabilities are omitted on trusted requests; added tests to confirm the returned capability set.

<sup>Written for commit 4a48c8ca8a89cd9ea71e2bbb1bb0970f38205fab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Stack tenant authentication by validating trusted access before requested capabilities.
  - Login requests without specified capabilities now receive the default `manage_accounts` and `use` capabilities.
  - Explicit capability requests continue to be validated and deduplicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->