### PR TITLE
Bootstrap hosted continuity before team leases

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -44,6 +44,9 @@ const (
 	goldenPinnedPredecessorVersion            = "0.1.51"
 	goldenPinnedPredecessorSHA256             = "74f4bfbbf6b8dcbe0509eaaa9f63b1eb688358a749ed3b451066e146591d2582"
 	goldenPinnedPredecessorRevision           = "5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8"
+	goldenPinnedBootstrapTag                  = "v0.1.55"
+	goldenPinnedBootstrapLinuxSHA256          = "6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c"
+	goldenPinnedBootstrapRevision             = "c4ea17e91ef6e9d0ab31cdd2774ca8d5387219bc"
 	goldenPinnedCandidateTag                  = "v0.1.56"
 	goldenFakeStreamReleaseTokenEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_TOKEN"
 	goldenFakeStreamReleaseStateEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_STATE"
@@ -780,15 +783,6 @@ func (r *goldenRunner) run(ctx context.Context) (runErr error) {
 	if err != nil {
 		return err
 	}
-	if err := requireStableLocalEgress(migration.before, migration.after); err != nil {
-		return err
-	}
-	if err := requireBoundLocalEgress(migration.initial, migration.before); err != nil {
-		return err
-	}
-	if err := requireBoundLocalEgress(migration.initial, migration.after); err != nil {
-		return err
-	}
 	if err := r.requireGoldenLocalDaemonTransportClean(); err != nil {
 		return err
 	}
@@ -811,6 +805,7 @@ func (r *goldenRunner) run(ctx context.Context) (runErr error) {
 		return err
 	}
 	if migration.preparation.migrationCanonical == nil ||
+		migration.preparation.migrationCanonical.Bootstrap.SHA256 != rehearsal.activation.FromReleaseSHA256 ||
 		migration.preparation.migrationCanonical.Release.Tag != rehearsal.activation.ReleaseTag ||
 		migration.preparation.migrationCanonical.Release.SHA256 != rehearsal.activation.ToReleaseSHA256 ||
 		migration.preparation.migrationCanonical.Release.SourceRevision != rehearsal.activation.ReleaseSourceRevision {
@@ -905,14 +900,18 @@ type goldenCycleResult struct {
 	cleanup                 goldenActionSummary
 }
 
-func (r *goldenRunner) startCycleInitialSessions(ctx context.Context, inputs goldenCycleInputs) ([]*goldenSession, error) {
+func (r *goldenRunner) startCycleInitialSessions(ctx context.Context, inputs goldenCycleInputs, includeLocal bool) ([]*goldenSession, error) {
 	specs := []struct {
 		suffix, route, transport string
 	}{
 		{suffix: "direct-websocket", route: "direct-hosted", transport: "websocket"},
 		{suffix: "direct-http", route: "direct-hosted", transport: "http"},
-		{suffix: "local-websocket", route: "local-egress", transport: "websocket"},
-		{suffix: "local-http", route: "local-egress", transport: "http"},
+	}
+	if includeLocal {
+		specs = append(specs,
+			struct{ suffix, route, transport string }{suffix: "local-websocket", route: "local-egress", transport: "websocket"},
+			struct{ suffix, route, transport string }{suffix: "local-http", route: "local-egress", transport: "http"},
+		)
 	}
 	result := make([]*goldenSession, 0, len(specs))
 	for _, spec := range specs {
@@ -974,7 +973,7 @@ func (r *goldenRunner) startCycleInitialSessions(ctx context.Context, inputs gol
 
 func (r *goldenRunner) runRehearsalCycle(ctx context.Context, inputs goldenCycleInputs) (goldenCycleResult, error) {
 	var result goldenCycleResult
-	initial, err := r.startCycleInitialSessions(ctx, inputs)
+	initial, err := r.startCycleInitialSessions(ctx, inputs, true)
 	if err != nil {
 		return result, err
 	}
@@ -1035,7 +1034,7 @@ func (r *goldenRunner) runRehearsalCycle(ctx context.Context, inputs goldenCycle
 	if err := validateGoldenTransitionAction(result.activation, true); err != nil {
 		return result, err
 	}
-	if err := validateGoldenProvenance(r.summary.ReleasedSHA256, result.activation); err != nil {
+	if err := validateGoldenProvenance(r.summary.MigrationPreparation.migrationCanonical.Bootstrap.SHA256, result.activation); err != nil {
 		return result, err
 	}
 	if err := r.validateGoldenSlotCandidate(result.activation); err != nil {
@@ -1137,7 +1136,7 @@ func (r *goldenRunner) runRehearsalCycle(ctx context.Context, inputs goldenCycle
 
 func (r *goldenRunner) runFinalCycle(ctx context.Context, inputs goldenCycleInputs, rehearsal goldenActionSummary) (goldenCycleResult, error) {
 	var result goldenCycleResult
-	initial, err := r.startCycleInitialSessions(ctx, inputs)
+	initial, err := r.startCycleInitialSessions(ctx, inputs, true)
 	if err != nil {
 		return result, err
 	}
@@ -1197,7 +1196,7 @@ func (r *goldenRunner) runFinalCycle(ctx context.Context, inputs goldenCycleInpu
 	if err := validateGoldenTransitionAction(result.activation, true); err != nil {
 		return result, err
 	}
-	if err := validateGoldenProvenance(r.summary.ReleasedSHA256, result.activation); err != nil {
+	if err := validateGoldenProvenance(r.summary.MigrationPreparation.migrationCanonical.Bootstrap.SHA256, result.activation); err != nil {
 		return result, err
 	}
 	if err := r.validateGoldenSlotCandidate(result.activation); err != nil {
@@ -4346,7 +4345,7 @@ func validateGoldenSummary(summary goldenSummary, testMode bool) error {
 	if err := validateGoldenTransitionAction(summary.Activation, true); err != nil {
 		return err
 	}
-	if err := validateGoldenProvenance(summary.ReleasedSHA256, summary.Activation); err != nil {
+	if err := validateGoldenProvenance(summary.MigrationPreparation.migrationCanonical.Bootstrap.SHA256, summary.Activation); err != nil {
 		return err
 	}
 	if err := validateGoldenTransitionAction(summary.Rollback, false); err != nil {
@@ -4355,7 +4354,7 @@ func validateGoldenSummary(summary goldenSummary, testMode bool) error {
 	if err := validateGoldenTransitionAction(summary.FinalActivation, true); err != nil {
 		return err
 	}
-	if err := validateGoldenProvenance(summary.ReleasedSHA256, summary.FinalActivation); err != nil {
+	if err := validateGoldenProvenance(summary.MigrationPreparation.migrationCanonical.Bootstrap.SHA256, summary.FinalActivation); err != nil {
 		return err
 	}
 	if err := validateGoldenRollback(summary.Activation, summary.Rollback); err != nil {
@@ -4390,7 +4389,7 @@ func validateGoldenSummary(summary goldenSummary, testMode bool) error {
 	expected := make(map[string]struct {
 		route, transport string
 	})
-	for _, suffix := range []string{"direct-websocket", "direct-http", "local-websocket", "local-http"} {
+	for _, suffix := range []string{"direct-websocket", "direct-http"} {
 		route := "direct-hosted"
 		if strings.HasPrefix(suffix, "local-") {
 			route = "local-egress"
@@ -4474,7 +4473,7 @@ func validateGoldenSummary(summary goldenSummary, testMode bool) error {
 		return failGolden("process_evidence_incomplete")
 	}
 	requiredProcessEvidence := make(map[string]bool)
-	for _, suffix := range []string{"direct-websocket", "direct-http", "local-websocket", "local-http"} {
+	for _, suffix := range []string{"direct-websocket", "direct-http"} {
 		requiredProcessEvidence["migration-before-rehearsal-cutover\x00migration-"+suffix] = false
 		requiredProcessEvidence["migration-after-final-cutover\x00migration-"+suffix] = false
 	}
@@ -4526,11 +4525,15 @@ func validateGoldenSummary(summary goldenSummary, testMode bool) error {
 				return failGolden("paused_process_detected")
 			}
 		}
-		if !strings.HasPrefix(item.Label, "observer-") && (len(item.DescendantPIDs) == 0 || len(item.SocketIDs) == 0 ||
-			item.RSSBytes <= 0 || item.RSSBytes > goldenRSSLimitBytes) {
+		isObserver := strings.HasPrefix(item.Label, "observer-")
+		isIdleMigrationDaemon := item.Label == "local-daemon" && strings.HasPrefix(item.Phase, "migration-")
+		if !isObserver && (len(item.DescendantPIDs) == 0 || item.RSSBytes <= 0 || item.RSSBytes > goldenRSSLimitBytes) {
 			return failGolden("socket_evidence_incomplete")
 		}
-		if item.Label == "local-daemon" && len(item.RemoteSocketIDs) == 0 {
+		if !isObserver && !isIdleMigrationDaemon && len(item.SocketIDs) == 0 {
+			return failGolden("socket_evidence_incomplete")
+		}
+		if item.Label == "local-daemon" && !strings.HasPrefix(item.Phase, "migration-") && len(item.RemoteSocketIDs) == 0 {
 			return failGolden("egress_evidence_incomplete")
 		}
 		if item.Label == "final-candidate-direct" {

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -158,11 +158,11 @@ func TestGoldenSummaryRejectsRollbackThatDoesNotReverseActivation(t *testing.T) 
 	}
 }
 
-func TestGoldenSummaryBindsDownloadedPredecessorAndCandidate(t *testing.T) {
+func TestGoldenSummaryBindsBootstrapAndCandidate(t *testing.T) {
 	summary := validGoldenAcceptanceSummary()
 	summary.Activation.FromReleaseSHA256 = strings.Repeat("9", 64)
-	if got := fixedGoldenFailure(validateGoldenSummary(summary, false)); got != "deployment_provenance_mismatch" {
-		t.Fatalf("failure = %q, want deployment_provenance_mismatch", got)
+	if got := fixedGoldenFailure(validateGoldenSummary(summary, false)); got != "migration_slot_candidate_mismatch" {
+		t.Fatalf("failure = %q, want migration_slot_candidate_mismatch", got)
 	}
 	summary = validGoldenAcceptanceSummary()
 	summary.FinalActivation.ToReleaseSHA256 = strings.Repeat("8", 64)
@@ -335,7 +335,7 @@ func validGoldenActivationEvidence() *goldenDeployEvidence {
 			TagOnMain: true, AttestationVerified: true, Immutable: true,
 		},
 		Slots:     goldenDeploySlots{Before: "slot-a", Candidate: "slot-b", Final: "slot-b", OldGeneration: "generation-a", CandidateGeneration: "generation-b"},
-		Checksums: goldenDeployChecksums{InstalledBefore: strings.Repeat("a", 64), CandidateInstalled: strings.Repeat("b", 64), InstalledAfter: strings.Repeat("b", 64)},
+		Checksums: goldenDeployChecksums{InstalledBefore: goldenPinnedBootstrapLinuxSHA256, CandidateInstalled: strings.Repeat("b", 64), InstalledAfter: strings.Repeat("b", 64)},
 		Timestamps: goldenDeployTimestamps{
 			UpgradeRequestedAt: "2026-08-02T00:00:00Z", ProvisionalSwitchAt: "2026-08-02T00:00:00.25Z",
 			ActivatedAt: "2026-08-02T00:00:01Z", GoldenAckReceivedAt: "2026-08-02T00:00:01.25Z",
@@ -367,7 +367,7 @@ func validGoldenRollbackEvidence() *goldenDeployEvidence {
 			TagOnMain: true, AttestationVerified: true, Immutable: true,
 		},
 		Slots:       goldenDeploySlots{From: "slot-b", To: "slot-a", Final: "slot-a", FromGeneration: "generation-b", ToGeneration: "generation-a"},
-		Checksums:   goldenDeployChecksums{Candidate: strings.Repeat("b", 64), Restored: strings.Repeat("a", 64)},
+		Checksums:   goldenDeployChecksums{Candidate: strings.Repeat("b", 64), Restored: goldenPinnedBootstrapLinuxSHA256},
 		Timestamps:  goldenDeployTimestamps{RollbackRequestedAt: "2026-08-02T00:00:02Z", ActivatedAt: "2026-08-02T00:00:03Z"},
 		Metrics:     goldenDeployMetrics{RetiringSlot: validGoldenServiceMetrics(goldenRSSLimitBytes), RestoredSlot: validGoldenServiceMetrics(goldenRSSLimitBytes), Front: validGoldenServiceMetrics(goldenFrontRSSLimitBytes)},
 		Connections: goldenDeployConnections{ExpectedExternal: goldenInt64(1), Before: goldenInt64(1), After: goldenInt64(1)},
@@ -395,6 +395,10 @@ func validGoldenMigrationBaseEvidence(evidenceType, mode string) *goldenMigratio
 			Tag: goldenPinnedCandidateTag, SHA256: strings.Repeat("b", 64), SourceRevision: strings.Repeat("c", 40),
 			TagOnMain: true, AttestationVerified: true, Immutable: true,
 		},
+		Bootstrap: goldenDeployRelease{
+			Tag: goldenPinnedBootstrapTag, SHA256: goldenPinnedBootstrapLinuxSHA256,
+			SourceRevision: goldenPinnedBootstrapRevision, TagOnMain: true, AttestationVerified: true, Immutable: true,
+		},
 		Predecessor: goldenMigrationPredecessor{
 			Tag: "v0.1.51", SHA256: goldenPinnedPredecessorLinuxSHA256,
 			SourceRevision: goldenPinnedPredecessorRevision, TagOnMain: true, HardPinVerified: true,
@@ -406,7 +410,7 @@ func validGoldenMigrationBaseEvidence(evidenceType, mode string) *goldenMigratio
 		},
 		Front: goldenMigrationFront{
 			Slot: "slot-a", Generation: "front-generation", Checksum: strings.Repeat("b", 64),
-			ControlChecksum: strings.Repeat("b", 64), WorkerChecksum: goldenPinnedPredecessorLinuxSHA256, Ready: true,
+			ControlChecksum: strings.Repeat("b", 64), WorkerChecksum: goldenPinnedBootstrapLinuxSHA256, Ready: true,
 		},
 	}
 }
@@ -516,6 +520,7 @@ func validGoldenAcceptanceSummary() goldenSummary {
 	stamp := "2026-08-02T00:00:00Z"
 	finished := "2026-08-02T00:00:01Z"
 	releaseA := goldenPinnedPredecessorSHA256
+	bootstrap := goldenPinnedBootstrapLinuxSHA256
 	releaseB := strings.Repeat("b", 64)
 	activationEvidence := validGoldenActivationEvidence()
 	rollbackEvidence := validGoldenRollbackEvidence()
@@ -526,7 +531,7 @@ func validGoldenAcceptanceSummary() goldenSummary {
 		ReleaseTag: goldenPinnedCandidateTag, ReleaseSourceRevision: strings.Repeat("c", 40),
 		FromSlot: "slot-a", ToSlot: "slot-b", ActiveSlot: "slot-b",
 		FromGenerationIDHash: hashGoldenValue("generation-a"), ToGenerationIDHash: hashGoldenValue("generation-b"),
-		ActiveGenerationIDHash: hashGoldenValue("generation-b"), FromReleaseSHA256: releaseA, ToReleaseSHA256: releaseB,
+		ActiveGenerationIDHash: hashGoldenValue("generation-b"), FromReleaseSHA256: bootstrap, ToReleaseSHA256: releaseB,
 		ServerOldPeakRSSBytes: 1 << 20, ServerNewPeakRSSBytes: 1 << 20, ServerFrontPeakRSSBytes: 1 << 20,
 		canonical: activationEvidence,
 	}
@@ -539,7 +544,7 @@ func validGoldenAcceptanceSummary() goldenSummary {
 		ReleaseTag: action.ReleaseTag, ReleaseSourceRevision: action.ReleaseSourceRevision,
 		FromSlot: "slot-b", ToSlot: "slot-a", ActiveSlot: "slot-a",
 		FromGenerationIDHash: action.ToGenerationIDHash, ToGenerationIDHash: action.FromGenerationIDHash,
-		ActiveGenerationIDHash: action.FromGenerationIDHash, FromReleaseSHA256: releaseB, ToReleaseSHA256: releaseA,
+		ActiveGenerationIDHash: action.FromGenerationIDHash, FromReleaseSHA256: releaseB, ToReleaseSHA256: bootstrap,
 		ServerOldPeakRSSBytes: 1 << 20, ServerNewPeakRSSBytes: 1 << 20, ServerFrontPeakRSSBytes: 1 << 20,
 		canonical: rollbackEvidence,
 	}
@@ -560,8 +565,6 @@ func validGoldenAcceptanceSummary() goldenSummary {
 	labels = append(labels,
 		struct{ label, route, transport string }{"migration-direct-websocket", "direct-hosted", "websocket"},
 		struct{ label, route, transport string }{"migration-direct-http", "direct-hosted", "http"},
-		struct{ label, route, transport string }{"migration-local-websocket", "local-egress", "websocket"},
-		struct{ label, route, transport string }{"migration-local-http", "local-egress", "http"},
 		struct{ label, route, transport string }{"migration-candidate-front-rehearsal-destination-direct", "direct-hosted", "websocket"},
 		struct{ label, route, transport string }{"migration-candidate-legacy-rollback-destination-direct", "direct-hosted", "websocket"},
 		struct{ label, route, transport string }{"migration-candidate-front-final-destination-direct", "direct-hosted", "websocket"},
@@ -638,7 +641,7 @@ func validGoldenAcceptanceSummary() goldenSummary {
 	}
 	for _, phase := range []string{"migration-before-rehearsal-cutover", "migration-after-final-cutover"} {
 		migrationLabels := []string{
-			"migration-direct-websocket", "migration-direct-http", "migration-local-websocket", "migration-local-http", "local-daemon",
+			"migration-direct-websocket", "migration-direct-http", "local-daemon",
 		}
 		if phase == "migration-after-final-cutover" {
 			migrationLabels = append(migrationLabels,

--- a/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
+++ b/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
@@ -206,7 +206,7 @@ esac
 	}
 	t.Setenv("DEPLOY_ENV_SECRET", "DEPLOY_ENV_VALUE_SECRET")
 	t.Setenv("ACTION_LOG", actionLog)
-	t.Setenv("FAKE_PREDECESSOR_SHA256", hex.EncodeToString(fakeClientHash[:]))
+	t.Setenv("FAKE_PREDECESSOR_SHA256", goldenPinnedBootstrapLinuxSHA256)
 	t.Setenv("SUBROUTER_GOLDEN_FAKE_SOCKET_STATE", filepath.Join(root, "daemon-sockets"))
 	t.Setenv("SUBROUTER_GOLDEN_FAKE_DAEMON_PID", daemonPIDPath)
 	t.Setenv("SUBROUTER_GOLDEN_FAKE_DAEMON_ADDR", daemonAddressPath)

--- a/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
+++ b/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
@@ -62,7 +62,11 @@ func TestGoldenLocalMacHarnessOrchestratesAllModesWithoutContentEvidence(t *test
 	}))
 	defer release.Close()
 
-	hosted := httptest.NewServer(goldenFakeHostedHandler())
+	actionLog := filepath.Join(root, "actions.log")
+	hosted := httptest.NewServer(goldenFakeHostedHandler(func() bool {
+		actions, err := os.ReadFile(actionLog)
+		return err == nil && strings.Contains(string(actions), "legacy-cleanup\n")
+	}))
 	defer hosted.Close()
 	cloudPath := filepath.Join(root, "cloud.json")
 	tenantKey := "srt_0123456789abcdef0123456789abcdef"
@@ -152,7 +156,6 @@ esac
 	if err := os.WriteFile(filepath.Join(fakeBin, "ps"), []byte(psScript), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	actionLog := filepath.Join(root, "actions.log")
 	processState := filepath.Join(root, "process-state")
 	if err := os.Mkdir(processState, 0o700); err != nil {
 		t.Fatal(err)
@@ -246,7 +249,7 @@ esac
 		t.Fatal(err)
 	}
 	if !result.Passed || !result.PrivateWorkspaceRemoved || !result.FreshLocalLeaseObserved ||
-		!result.ReleaseChecksumVerified || result.ReleasedVersion != "9.9.9" || len(result.Sessions) != 19 {
+		!result.ReleaseChecksumVerified || result.ReleasedVersion != "9.9.9" || len(result.Sessions) != 17 {
 		t.Fatalf("incomplete result: %#v", result)
 	}
 	allEvidence := readGoldenArtifacts(t, artifacts)
@@ -388,7 +391,7 @@ func loadGoldenFakeSocketSnapshot(pid int) ([]byte, error) {
 	return []byte("n127.0.0.1:41000->203.0.113.10:443\n"), nil
 }
 
-func goldenFakeHostedHandler() http.Handler {
+func goldenFakeHostedHandler(leasesReady func() bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/_subrouter/health" || request.URL.Path == "/_subrouter/ready" {
 			w.WriteHeader(http.StatusOK)
@@ -396,6 +399,10 @@ func goldenFakeHostedHandler() http.Handler {
 			return
 		}
 		if request.URL.Path == "/api/subrouter/leases" || strings.HasSuffix(request.URL.Path, "/_subrouter/leases") {
+			if leasesReady != nil && !leasesReady() {
+				http.NotFound(w, request)
+				return
+			}
 			_, _ = io.Copy(io.Discard, request.Body)
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"lease":"response-body-not-recorded"}`))
@@ -599,7 +606,7 @@ func TestGoldenFakeHostedHandlerConsumesRequestBodyBeforeStreaming(t *testing.T)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		goldenFakeHostedHandler().ServeHTTP(recorder, request)
+		goldenFakeHostedHandler(nil).ServeHTTP(recorder, request)
 	}()
 	var releaseOnce sync.Once
 	release := func() { releaseOnce.Do(func() { close(body.release) }) }
@@ -655,7 +662,7 @@ func TestGoldenFakeHostedHandlerRejectsInvalidRequestBodies(t *testing.T) {
 			request := httptest.NewRequest(http.MethodPost, "http://host.test/v1/responses", test.body)
 			request.Header.Set("X-Golden-Short", "1")
 			recorder := httptest.NewRecorder()
-			goldenFakeHostedHandler().ServeHTTP(recorder, request)
+			goldenFakeHostedHandler(nil).ServeHTTP(recorder, request)
 			if recorder.Code != http.StatusBadRequest {
 				t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
 			}
@@ -691,7 +698,7 @@ func TestGoldenFakeHostedHandlerWaitsForSenderCompletionAfterBodyEOF(t *testing.
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		goldenFakeHostedHandler().ServeHTTP(recorder, request)
+		goldenFakeHostedHandler(nil).ServeHTTP(recorder, request)
 	}()
 	var releaseOnce sync.Once
 	release := func() { releaseOnce.Do(func() { close(body.release) }) }
@@ -751,7 +758,7 @@ func TestGoldenFakeHostedHandlerRejectsInvalidSenderCompletion(t *testing.T) {
 				request.Header.Set(goldenRequestTokenHeader, test.token)
 			}
 			recorder := httptest.NewRecorder()
-			goldenFakeHostedHandler().ServeHTTP(recorder, request)
+			goldenFakeHostedHandler(nil).ServeHTTP(recorder, request)
 			if recorder.Code != http.StatusBadRequest {
 				t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
 			}
@@ -771,7 +778,7 @@ func TestGoldenFakeHostedHandlerTimesOutWithoutSenderCompletion(t *testing.T) {
 	request := httptest.NewRequest(http.MethodPost, "http://host.test/v1/responses", strings.NewReader("body"))
 	request.Header.Set(goldenRequestTokenHeader, "0123456789abcdef0123456789abcdef")
 	recorder := httptest.NewRecorder()
-	goldenFakeHostedHandler().ServeHTTP(recorder, request)
+	goldenFakeHostedHandler(nil).ServeHTTP(recorder, request)
 	if recorder.Code != http.StatusGatewayTimeout {
 		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusGatewayTimeout)
 	}

--- a/cmd/subrouter-transport-observer/golden_migration_cycle.go
+++ b/cmd/subrouter-transport-observer/golden_migration_cycle.go
@@ -30,7 +30,7 @@ func (r *goldenRunner) runMigrationCycle(ctx context.Context, inputs goldenCycle
 		return result, err
 	}
 
-	result.initial, err = r.startCycleInitialSessions(ctx, inputs)
+	result.initial, err = r.startCycleInitialSessions(ctx, inputs, false)
 	if err != nil {
 		return result, err
 	}
@@ -39,30 +39,9 @@ func (r *goldenRunner) runMigrationCycle(ctx context.Context, inputs goldenCycle
 		return result, err
 	}
 	result.before = evidenceByLabel(beforeEvidence)
-	if err := requireLocalEgress(beforeEvidence); err != nil {
-		return result, err
-	}
-	if err := requireBoundLocalEgress(result.initial, result.before); err != nil {
-		return result, err
-	}
-	localEgressMonitor, err := startGoldenLocalEgressMonitor(
-		ctx, r, inputs.localDaemonPID, "migration-local-egress-window", result.before["local-daemon"],
-	)
-	if err != nil {
-		return result, err
-	}
-	localEgressMonitorStopped := false
-	defer func() {
-		if !localEgressMonitorStopped {
-			_ = localEgressMonitor.stopAndValidate()
-		}
-	}()
 	initialBaselineEnd := time.Now().UTC()
 	initialMonitors, err := startGoldenContinuityMonitors(r, result.initial, initialBaselineEnd)
 	if err != nil {
-		return result, err
-	}
-	if err := localEgressMonitor.validate(); err != nil {
 		return result, err
 	}
 	initialMonitorsStopped := false
@@ -78,9 +57,6 @@ func (r *goldenRunner) runMigrationCycle(ctx context.Context, inputs goldenCycle
 		inputs, result.initial, initialMonitors,
 	)
 	if err != nil {
-		return result, err
-	}
-	if err := localEgressMonitor.validate(); err != nil {
 		return result, err
 	}
 	result.fresh = append(result.fresh, frontProof)
@@ -100,10 +76,6 @@ func (r *goldenRunner) runMigrationCycle(ctx context.Context, inputs goldenCycle
 		inputs, []*goldenSession{frontProof}, rollbackMonitors,
 	)
 	if err != nil {
-		cancelGoldenContinuityMonitors(frontMonitors)
-		return result, err
-	}
-	if err := localEgressMonitor.validate(); err != nil {
 		cancelGoldenContinuityMonitors(frontMonitors)
 		return result, err
 	}
@@ -134,10 +106,6 @@ func (r *goldenRunner) runMigrationCycle(ctx context.Context, inputs goldenCycle
 		cancelGoldenContinuityMonitors(legacyMonitors)
 		return result, err
 	}
-	if err := localEgressMonitor.validate(); err != nil {
-		cancelGoldenContinuityMonitors(legacyMonitors)
-		return result, err
-	}
 	result.fresh = append(result.fresh, finalFrontProof)
 	if err := validateGoldenMigrationLink(result.rollback, result.finalCutover, "front-migration-rollback"); err != nil {
 		cancelGoldenContinuityMonitors(legacyMonitors)
@@ -160,17 +128,6 @@ func (r *goldenRunner) runMigrationCycle(ctx context.Context, inputs goldenCycle
 	result.after = evidenceByLabel(afterEvidence)
 	if err := requireStableSessionSockets(result.initial, result.before, result.after); err != nil {
 		return result, err
-	}
-	if err := requireStableLocalEgress(result.before, result.after); err != nil {
-		return result, err
-	}
-	if err := requireBoundLocalEgress(result.initial, result.after); err != nil {
-		return result, err
-	}
-	monitorErr := localEgressMonitor.stopAndValidate()
-	localEgressMonitorStopped = true
-	if monitorErr != nil {
-		return result, monitorErr
 	}
 	retiringSessions := append(append([]*goldenSession{}, result.initial...), legacyProof)
 	if err := releaseGoldenTestSessions(retiringSessions); err != nil {
@@ -257,7 +214,10 @@ func (r *goldenRunner) validateGoldenCandidateIdentity(evidence *goldenMigration
 		return nil
 	}
 	if evidence.Release.Tag != r.options.candidateTag || evidence.Release.SHA256 != r.options.candidateSHA256 ||
-		evidence.Release.SourceRevision != r.options.candidateRevision {
+		evidence.Release.SourceRevision != r.options.candidateRevision ||
+		evidence.Bootstrap.Tag != goldenPinnedBootstrapTag ||
+		evidence.Bootstrap.SHA256 != goldenPinnedBootstrapLinuxSHA256 ||
+		evidence.Bootstrap.SourceRevision != goldenPinnedBootstrapRevision {
 		return failGolden("candidate_provenance_mismatch")
 	}
 	return nil

--- a/cmd/subrouter-transport-observer/golden_migration_evidence.go
+++ b/cmd/subrouter-transport-observer/golden_migration_evidence.go
@@ -28,6 +28,7 @@ type goldenMigrationEvidence struct {
 	CutoverEvidenceSHA256     string                          `json:"cutover_evidence_sha256"`
 	Run                       goldenDeployRun                 `json:"run"`
 	Release                   goldenDeployRelease             `json:"release"`
+	Bootstrap                 goldenDeployRelease             `json:"bootstrap"`
 	Predecessor               goldenMigrationPredecessor      `json:"predecessor"`
 	Routing                   goldenMigrationRouting          `json:"routing"`
 	Legacy                    goldenMigrationLegacy           `json:"legacy"`
@@ -237,7 +238,7 @@ func validateGoldenMigrationEvidence(evidence *goldenMigrationEvidence, expected
 			evidence.Legacy.Checksum != goldenPinnedPredecessorLinuxSHA256 || !evidence.Legacy.AcceptingNewPublic ||
 			(evidence.Front.Slot != "slot-a" && evidence.Front.Slot != "slot-b") || evidence.Front.Generation == "" ||
 			evidence.Front.Checksum != evidence.Release.SHA256 || evidence.Front.ControlChecksum != evidence.Release.SHA256 ||
-			evidence.Front.WorkerChecksum != goldenPinnedPredecessorLinuxSHA256 || !evidence.Front.Ready {
+			evidence.Front.WorkerChecksum != evidence.Bootstrap.SHA256 || !evidence.Front.Ready {
 			return failGolden("migration_preparation_invalid")
 		}
 		if _, err := parseGoldenEvidenceTime(evidence.EvidenceEmittedAt); err != nil {
@@ -258,11 +259,17 @@ func validateGoldenMigrationIdentity(evidence *goldenMigrationEvidence) error {
 		evidence.Release.Tag == "" || !validGoldenSHA256(evidence.Release.SHA256) ||
 		!validGoldenRevision(evidence.Release.SourceRevision) || !evidence.Release.TagOnMain ||
 		!evidence.Release.AttestationVerified || !evidence.Release.Immutable ||
+		evidence.Bootstrap.Tag != goldenPinnedBootstrapTag ||
+		evidence.Bootstrap.SHA256 != goldenPinnedBootstrapLinuxSHA256 ||
+		evidence.Bootstrap.SourceRevision != goldenPinnedBootstrapRevision ||
+		!evidence.Bootstrap.TagOnMain || !evidence.Bootstrap.AttestationVerified || !evidence.Bootstrap.Immutable ||
 		evidence.Predecessor.Tag != "v0.1.51" || evidence.Predecessor.SHA256 != goldenPinnedPredecessorLinuxSHA256 ||
 		evidence.Predecessor.SourceRevision != goldenPinnedPredecessorRevision || !evidence.Predecessor.TagOnMain ||
 		!evidence.Predecessor.HardPinVerified || !evidence.Predecessor.SHA256SumsMatch ||
 		!evidence.Predecessor.EmbeddedRevisionVerified || !evidence.Predecessor.LiveWorkerChecksumMatch ||
-		evidence.Release.SHA256 == evidence.Predecessor.SHA256 {
+		evidence.Release.SHA256 == evidence.Predecessor.SHA256 ||
+		evidence.Release.SHA256 == evidence.Bootstrap.SHA256 ||
+		evidence.Bootstrap.SHA256 == evidence.Predecessor.SHA256 {
 		return failGolden("migration_provenance_invalid")
 	}
 	return nil
@@ -423,7 +430,7 @@ func validateGoldenMigrationSummary(summary goldenSummary, testMode bool) error 
 	}
 	if preparation.FromSlot != "legacy" || preparation.ActiveSlot != "legacy" ||
 		preparation.FromReleaseSHA256 != goldenPinnedPredecessorLinuxSHA256 ||
-		preparation.ToReleaseSHA256 == goldenPinnedPredecessorLinuxSHA256 {
+		preparation.ToReleaseSHA256 != goldenPinnedBootstrapLinuxSHA256 {
 		return failGolden("migration_preparation_summary_invalid")
 	}
 
@@ -478,7 +485,8 @@ func validateGoldenMigrationSummary(summary goldenSummary, testMode bool) error 
 	}
 	if preparation.ReleaseTag != summary.Activation.ReleaseTag ||
 		preparation.ReleaseSourceRevision != summary.Activation.ReleaseSourceRevision ||
-		preparation.ToReleaseSHA256 != summary.Activation.ToReleaseSHA256 {
+		preparation.migrationCanonical.Release.SHA256 != summary.Activation.ToReleaseSHA256 ||
+		preparation.ToReleaseSHA256 != summary.Activation.FromReleaseSHA256 {
 		return failGolden("migration_slot_candidate_mismatch")
 	}
 
@@ -519,7 +527,7 @@ func validateGoldenMigrationActionSummary(action goldenActionSummary, expected s
 	}
 	switch expected {
 	case "front-migration-preparation":
-		if action.FromReleaseSHA256 != evidence.Predecessor.SHA256 || action.ToReleaseSHA256 != evidence.Release.SHA256 {
+		if action.FromReleaseSHA256 != evidence.Predecessor.SHA256 || action.ToReleaseSHA256 != evidence.Bootstrap.SHA256 {
 			return failGolden("migration_preparation_summary_invalid")
 		}
 	case "front-migration-cutover", "front-migration-rollback":
@@ -536,7 +544,7 @@ func validateGoldenMigrationActionSummary(action goldenActionSummary, expected s
 			action.ServerFrontPeakRSSBytes != *evidence.Metrics.Front.RunScopedPeakRSSBytes {
 			return failGolden("migration_transition_summary_invalid")
 		}
-		fromRelease, toRelease := evidence.Predecessor.SHA256, evidence.Release.SHA256
+		fromRelease, toRelease := evidence.Predecessor.SHA256, evidence.Bootstrap.SHA256
 		if evidence.Routing.Before == "front" {
 			fromRelease, toRelease = toRelease, fromRelease
 		}
@@ -629,7 +637,7 @@ func populateGoldenMigrationActionSummary(result *goldenActionSummary, evidence 
 	case "front-migration-preparation":
 		result.FromSlot, result.ActiveSlot = "legacy", "legacy"
 		result.FromReleaseSHA256 = evidence.Predecessor.SHA256
-		result.ToReleaseSHA256 = evidence.Release.SHA256
+		result.ToReleaseSHA256 = evidence.Bootstrap.SHA256
 	case "front-migration-cutover", "front-migration-rollback":
 		requested, activated, _ := goldenPhaseDuration(evidence.Timestamps.TransitionRequestedAt, evidence.Timestamps.ActivatedAt)
 		result.RequestedAt, result.ActivatedAt = requested.Format(time.RFC3339Nano), activated.Format(time.RFC3339Nano)
@@ -640,7 +648,7 @@ func populateGoldenMigrationActionSummary(result *goldenActionSummary, evidence 
 		result.ToGenerationIDHash = hashGoldenValue(evidence.Destination.After.Generation)
 		result.ActiveGenerationIDHash = result.ToGenerationIDHash
 		result.FromReleaseSHA256 = evidence.Predecessor.SHA256
-		result.ToReleaseSHA256 = evidence.Release.SHA256
+		result.ToReleaseSHA256 = evidence.Bootstrap.SHA256
 		if evidence.Routing.Before == "front" {
 			result.FromReleaseSHA256, result.ToReleaseSHA256 = result.ToReleaseSHA256, result.FromReleaseSHA256
 		}

--- a/cmd/subrouter-transport-observer/golden_migration_transition.go
+++ b/cmd/subrouter-transport-observer/golden_migration_transition.go
@@ -61,7 +61,7 @@ func (r *goldenRunner) runMigrationTransitionWithProof(
 	} else if operation != "rehearsal-cutover" && operation != "final-cutover" {
 		return goldenActionSummary{}, nil, failGolden("migration_operation_invalid")
 	}
-	if len(monitors) < 4 || len(sourceSessions) == 0 || !prior.EvidenceValid || !validGoldenSHA256(prior.EvidenceSHA256) {
+	if len(sourceSessions) == 0 || len(monitors) < len(sourceSessions) || !prior.EvidenceValid || !validGoldenSHA256(prior.EvidenceSHA256) {
 		return goldenActionSummary{}, nil, failGolden("migration_source_continuity_missing")
 	}
 	requestPath := filepath.Join(r.privateRoot, label+"-destination-proof-request.json")

--- a/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
+++ b/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
@@ -168,7 +168,7 @@ func fakeAction(args []string) {
 		proofDigest := sha256.Sum256(proofData)
 		predecessorLinux := "99fcd10d912184c160370eb228b382795101f2b5b2467244f995aa2d10b0c323"
 		legacy := map[string]any{"service": "subrouter.service", "generation": "legacy-generation", "checksum": predecessorLinux}
-		front := map[string]any{"slot": "slot-a", "generation": "front-generation", "checksum": candidate, "control_checksum": candidate, "worker_checksum": predecessorLinux}
+		front := map[string]any{"slot": "slot-a", "generation": "front-generation", "checksum": candidate, "control_checksum": candidate, "worker_checksum": goldenFakeBootstrapSHA256}
 		snapshot := func(kind, generation string, count int) map[string]any {
 			return map[string]any{"kind": kind, "generation": generation, "public_connections": count, "generation_connections": count, "inactive_connections": 0}
 		}
@@ -179,7 +179,7 @@ func fakeAction(args []string) {
 			"schema": "subrouter.gcp.deploy-evidence/v1", "evidence_type": evidenceType, "mode": mode, "success": true,
 			"prior_evidence_type": priorType, "prior_evidence_sha256": priorSHA, "preparation_evidence_sha256": preparationSHA,
 			"run":     map[string]any{"id": "golden-migration", "project": "test-project", "zone": "test-zone", "instance": "test-instance"},
-			"release": fakeMigrationRelease(candidate, revision), "predecessor": fakeMigrationPredecessor(),
+			"release": fakeMigrationRelease(candidate, revision), "bootstrap": fakeMigrationBootstrap(), "predecessor": fakeMigrationPredecessor(),
 			"routing": map[string]any{
 				"url_map": "test-map", "legacy_backend": "legacy-backend", "front_backend": "front-backend",
 				"legacy_backend_url": "https://legacy.test", "front_backend_url": "https://front.test",
@@ -235,7 +235,7 @@ func fakeAction(args []string) {
 			"schema": "subrouter.gcp.deploy-evidence/v1", "evidence_type": "legacy-retirement", "mode": "final-cutover", "success": true,
 			"cutover_evidence_sha256": fakeFileSHA256(cutoverPath), "preparation_evidence_sha256": preparationSHA,
 			"run":     map[string]any{"id": "golden-migration-cleanup", "project": "test-project", "zone": "test-zone", "instance": "test-instance"},
-			"release": fakeMigrationRelease(candidate, revision), "predecessor": fakeMigrationPredecessor(),
+			"release": fakeMigrationRelease(candidate, revision), "bootstrap": fakeMigrationBootstrap(), "predecessor": fakeMigrationPredecessor(),
 			"routing":     map[string]any{"active": "front", "legacy_backend_retained": true, "accepting_new_public": false},
 			"legacy":      map[string]any{"service": "subrouter.service", "generation": "legacy-generation", "checksum": "99fcd10d912184c160370eb228b382795101f2b5b2467244f995aa2d10b0c323"},
 			"connections": map[string]any{"before": map[string]any{"active": 0, "inactive": 0, "total": 0}, "after": map[string]any{"active": 0, "inactive": 0, "total": 0}},
@@ -445,6 +445,16 @@ func fakeMigrationRelease(candidate, revision string) map[string]any {
 	return map[string]any{"tag": "v1.2.4", "sha256": candidate, "source_revision": revision, "tag_on_main": true, "attestation_verified": true, "immutable": true}
 }
 
+const goldenFakeBootstrapSHA256 = "6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c"
+
+func fakeMigrationBootstrap() map[string]any {
+	return map[string]any{
+		"tag": "v0.1.55", "sha256": goldenFakeBootstrapSHA256,
+		"source_revision": "c4ea17e91ef6e9d0ab31cdd2774ca8d5387219bc", "tag_on_main": true,
+		"attestation_verified": true, "immutable": true,
+	}
+}
+
 func fakeMigrationPredecessor() map[string]any {
 	return map[string]any{
 		"tag": "v0.1.51", "sha256": "99fcd10d912184c160370eb228b382795101f2b5b2467244f995aa2d10b0c323",
@@ -457,7 +467,7 @@ func fakeMigrationPreparation(candidate, revision string) map[string]any {
 	return map[string]any{
 		"schema": "subrouter.gcp.deploy-evidence/v1", "evidence_type": "front-migration-preparation", "mode": "prepare", "success": true,
 		"run":     map[string]any{"id": "golden-migration-prepare", "project": "test-project", "zone": "test-zone", "instance": "test-instance"},
-		"release": fakeMigrationRelease(candidate, revision), "predecessor": fakeMigrationPredecessor(),
+		"release": fakeMigrationRelease(candidate, revision), "bootstrap": fakeMigrationBootstrap(), "predecessor": fakeMigrationPredecessor(),
 		"routing": map[string]any{
 			"url_map": "test-map", "legacy_backend": "legacy-backend", "front_backend": "front-backend",
 			"legacy_backend_url": "https://legacy.test", "front_backend_url": "https://front.test", "current": "legacy",
@@ -467,7 +477,7 @@ func fakeMigrationPreparation(candidate, revision string) map[string]any {
 		},
 		"front": map[string]any{
 			"slot": "slot-a", "generation": "front-generation", "checksum": candidate,
-			"control_checksum": candidate, "worker_checksum": "99fcd10d912184c160370eb228b382795101f2b5b2467244f995aa2d10b0c323", "ready": true,
+			"control_checksum": candidate, "worker_checksum": goldenFakeBootstrapSHA256, "ready": true,
 		},
 		"evidence_emitted_at": time.Now().UTC().Format(time.RFC3339Nano),
 	}

--- a/deploy/gcp/finalize-legacy-retirement.sh
+++ b/deploy/gcp/finalize-legacy-retirement.sh
@@ -62,6 +62,7 @@ python3 "${SCRIPT_DIR}/validate-deploy-evidence.py" --expect front-migration-cut
 cutover_sha256="$(sha256sum "${CUTOVER_EVIDENCE}" | awk '{print $1}')"
 preparation_sha256="$(jq -r '.preparation_evidence_sha256' "${CUTOVER_EVIDENCE}")"
 release_json="$(jq -c '.release' "${CUTOVER_EVIDENCE}")"
+bootstrap_json="$(jq -c '.bootstrap' "${CUTOVER_EVIDENCE}")"
 predecessor_json="$(jq -c '.predecessor' "${CUTOVER_EVIDENCE}")"
 URL_MAP="$(jq -r '.routing.url_map' "${CUTOVER_EVIDENCE}")"
 legacy_backend_url="$(jq -r '.routing.legacy_backend_url' "${CUTOVER_EVIDENCE}")"
@@ -226,7 +227,8 @@ evidence_tmp="$(mktemp "${EVIDENCE_JSON}.tmp.XXXXXX")"
 jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type legacy-retirement \
   --arg cutover_sha "${cutover_sha256}" --arg preparation_sha "${preparation_sha256}" \
   --arg run_id "${RUN_LABEL}" --arg project "${PROJECT_ID}" --arg zone "${ZONE}" --arg instance "${INSTANCE}" \
-  --argjson release "${release_json}" --argjson predecessor "${predecessor_json}" \
+  --argjson release "${release_json}" --argjson bootstrap "${bootstrap_json}" \
+  --argjson predecessor "${predecessor_json}" \
   --arg generation "${legacy_generation}" --arg checksum "${legacy_checksum}" \
   --arg accepting_false_at "${accepting_new_public_false_at}" --arg closed_at "${last_connection_closed_at}" \
   --arg stop_requested_at "${stop_requested_at}" --arg absent_at "${absent_at}" \
@@ -238,7 +240,7 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type legacy
   '{schema:$schema,evidence_type:$evidence_type,mode:"final-cutover",success:true,
     cutover_evidence_sha256:$cutover_sha,preparation_evidence_sha256:$preparation_sha,
     run:{id:$run_id,project:$project,zone:$zone,instance:$instance},release:$release,
-    predecessor:$predecessor,
+    bootstrap:$bootstrap,predecessor:$predecessor,
     routing:{active:"front",legacy_backend_retained:true,accepting_new_public:false},
     legacy:{service:"subrouter.service",generation:$generation,checksum:$checksum},
     connections:{before:$initial_counts,after:{active:0,inactive:0,total:0}},

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify the immutable v0.1.51/v0.1.56 release inputs, then run the complete
+# Verify the immutable v0.1.51/v0.1.55/v0.1.56 release inputs, then run the complete
 # legacy-to-front migration and slot-upgrade continuity gate from a local Mac.
 set -euo pipefail
 umask 077
@@ -12,6 +12,10 @@ predecessor_version="0.1.51"
 predecessor_revision="5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8"
 predecessor_darwin_sha="74f4bfbbf6b8dcbe0509eaaa9f63b1eb688358a749ed3b451066e146591d2582"
 predecessor_linux_sha="99fcd10d912184c160370eb228b382795101f2b5b2467244f995aa2d10b0c323"
+bootstrap_tag="v0.1.55"
+bootstrap_version="0.1.55"
+bootstrap_revision="c4ea17e91ef6e9d0ab31cdd2774ca8d5387219bc"
+bootstrap_linux_sha="6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c"
 candidate_tag="v0.1.56"
 candidate_version="0.1.56"
 
@@ -134,8 +138,9 @@ verify_go_release_binary() {
 }
 
 predecessor_dir="${private_root}/predecessor"
+bootstrap_dir="${private_root}/bootstrap"
 candidate_dir="${private_root}/candidate"
-mkdir -p "${predecessor_dir}" "${candidate_dir}"
+mkdir -p "${predecessor_dir}" "${bootstrap_dir}" "${candidate_dir}"
 
 if ! gh release view "${predecessor_tag}" --repo "${repository}" --json tagName,isDraft,publishedAt \
     | jq -e --arg tag "${predecessor_tag}" \
@@ -163,6 +168,48 @@ chmod 0700 "${predecessor_darwin}" "${predecessor_linux}"
 verify_go_release_binary "${predecessor_darwin}" "${resolved_predecessor_revision}"
 verify_go_release_binary "${predecessor_linux}" "${resolved_predecessor_revision}"
 
+if ! gh release view "${bootstrap_tag}" --repo "${repository}" --json tagName,isDraft,isPrerelease,isImmutable,publishedAt \
+    | jq -e --arg tag "${bootstrap_tag}" \
+      '.tagName == $tag and (.isDraft | not) and (.isPrerelease | not) and .isImmutable == true and
+       (.publishedAt | type == "string" and length > 0)' \
+      >/dev/null; then
+  echo "v0.1.55 is not a published immutable release" >&2
+  exit 1
+fi
+resolved_bootstrap_revision="$(require_release_revision_on_main "${bootstrap_tag}" "${bootstrap_revision}")"
+bootstrap_linux_asset="subrouter_${bootstrap_version}_linux_amd64"
+bootstrap_assets=(SHA256SUMS SOURCE_PROVENANCE.json "${bootstrap_linux_asset}")
+bootstrap_download_args=()
+for asset in "${bootstrap_assets[@]}"; do
+  bootstrap_download_args+=(--pattern "${asset}")
+done
+gh release download "${bootstrap_tag}" --repo "${repository}" --dir "${bootstrap_dir}" "${bootstrap_download_args[@]}"
+bootstrap_manifest="${bootstrap_dir}/SHA256SUMS"
+for asset in "${bootstrap_assets[@]}"; do
+  path="${bootstrap_dir}/${asset}"
+  [[ -f "${path}" && ! -L "${path}" ]] || { echo "bootstrap release asset is missing or unsafe: ${asset}" >&2; exit 1; }
+  gh release verify-asset "${bootstrap_tag}" "${path}" --repo "${repository}" --format json >/dev/null
+  if ! gh attestation verify "${path}" --repo "${repository}" \
+      --signer-workflow "${repository}/.github/workflows/release.yml" \
+      --source-ref "refs/tags/${bootstrap_tag}" --source-digest "${resolved_bootstrap_revision}" \
+      --deny-self-hosted-runners --format json \
+      | jq -e 'length > 0' >/dev/null; then
+    echo "strict bootstrap build attestation verification failed: ${asset}" >&2
+    exit 1
+  fi
+done
+bootstrap_linux="${bootstrap_dir}/${bootstrap_linux_asset}"
+[[ "$(sha256_file "${bootstrap_linux}")" == "${bootstrap_linux_sha}" &&
+   "$(manifest_sha "${bootstrap_manifest}" "${bootstrap_linux_asset}")" == "${bootstrap_linux_sha}" ]] \
+  || { echo "v0.1.55 Linux asset hard pin mismatch" >&2; exit 1; }
+jq -e --arg tag "${bootstrap_tag}" --arg revision "${resolved_bootstrap_revision}" \
+  '(. | keys | sort) == (["source_revision","tag","tag_on_main"] | sort) and
+   .tag == $tag and .source_revision == $revision and .tag_on_main == true' \
+  "${bootstrap_dir}/SOURCE_PROVENANCE.json" >/dev/null \
+  || { echo "bootstrap source provenance is invalid" >&2; exit 1; }
+chmod 0700 "${bootstrap_linux}"
+verify_go_release_binary "${bootstrap_linux}" "${resolved_bootstrap_revision}"
+
 if ! gh release view "${candidate_tag}" --repo "${repository}" --json tagName,isDraft,isPrerelease,isImmutable,publishedAt \
     | jq -e --arg tag "${candidate_tag}" \
       '.tagName == $tag and (.isDraft | not) and (.isPrerelease | not) and .isImmutable == true and
@@ -172,8 +219,9 @@ if ! gh release view "${candidate_tag}" --repo "${repository}" --json tagName,is
   exit 1
 fi
 candidate_revision="$(require_release_revision_on_main "${candidate_tag}")"
-[[ "${candidate_revision}" != "${resolved_predecessor_revision}" ]] \
-  || { echo "candidate and predecessor revisions must differ" >&2; exit 1; }
+[[ "${candidate_revision}" != "${resolved_bootstrap_revision}" &&
+   "${resolved_bootstrap_revision}" != "${resolved_predecessor_revision}" ]] \
+  || { echo "predecessor, bootstrap, and candidate revisions must differ" >&2; exit 1; }
 
 candidate_linux_asset="subrouter_${candidate_version}_linux_amd64"
 candidate_assets=(SHA256SUMS SOURCE_PROVENANCE.json deployment-contract.py install.sh install-front-slots.sh "${candidate_linux_asset}")
@@ -214,6 +262,8 @@ verify_go_release_binary "${candidate_linux}" "${candidate_revision}"
 candidate_linux_sha="${candidate_digests[${candidate_linux_asset}]}"
 [[ "${candidate_linux_sha}" != "${predecessor_linux_sha}" ]] \
   || { echo "candidate and predecessor binaries must differ" >&2; exit 1; }
+[[ "${candidate_linux_sha}" != "${bootstrap_linux_sha}" && "${bootstrap_linux_sha}" != "${predecessor_linux_sha}" ]] \
+  || { echo "predecessor, bootstrap, and candidate binaries must differ" >&2; exit 1; }
 
 release_verification="${private_root}/release-verification.json"
 jq -n --arg schema 'subrouter.release-verification/v1' --arg tag "${candidate_tag}" \
@@ -235,8 +285,10 @@ jq -n --arg schema 'subrouter.release-verification/v1' --arg tag "${candidate_ta
 chmod 0600 "${release_verification}"
 
 candidate_sha_file="${private_root}/candidate-linux.sha256"
+bootstrap_sha_file="${private_root}/bootstrap-linux.sha256"
 predecessor_sha_file="${private_root}/predecessor-linux.sha256"
 printf '%s\n' "${candidate_linux_sha}" >"${candidate_sha_file}"
+printf '%s\n' "${bootstrap_linux_sha}" >"${bootstrap_sha_file}"
 printf '%s\n' "${predecessor_linux_sha}" >"${predecessor_sha_file}"
 
 if [[ -z "${artifact_dir}" ]]; then
@@ -266,6 +318,14 @@ export SUBROUTER_PREDECESSOR_SHA256_FILE="${predecessor_sha_file}"
 export SUBROUTER_PREDECESSOR_SHA256SUMS_FILE="${predecessor_manifest}"
 export SUBROUTER_PREDECESSOR_REVISION="${resolved_predecessor_revision}"
 export SUBROUTER_PREDECESSOR_TAG_ON_MAIN=true
+export SUBROUTER_BOOTSTRAP_TAG="${bootstrap_tag}"
+export SUBROUTER_BOOTSTRAP_BINARY="${bootstrap_linux}"
+export SUBROUTER_BOOTSTRAP_SHA256_FILE="${bootstrap_sha_file}"
+export SUBROUTER_BOOTSTRAP_SHA256SUMS_FILE="${bootstrap_manifest}"
+export SUBROUTER_BOOTSTRAP_REVISION="${resolved_bootstrap_revision}"
+export SUBROUTER_BOOTSTRAP_TAG_ON_MAIN=true
+export SUBROUTER_BOOTSTRAP_ATTESTATION_VERIFIED=true
+export SUBROUTER_BOOTSTRAP_IMMUTABLE=true
 export SUBROUTER_INSTALL_FRONT_SLOTS="${candidate_dir}/install-front-slots.sh"
 export SUBROUTER_DEPLOYMENT_CONTRACT="${candidate_dir}/deployment-contract.py"
 export SUBROUTER_DEPLOY_ARTIFACT_DIR="${private_root}/deploy-internal"

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -220,6 +220,7 @@ if ! gh release view "${candidate_tag}" --repo "${repository}" --json tagName,is
 fi
 candidate_revision="$(require_release_revision_on_main "${candidate_tag}")"
 [[ "${candidate_revision}" != "${resolved_bootstrap_revision}" &&
+   "${candidate_revision}" != "${resolved_predecessor_revision}" &&
    "${resolved_bootstrap_revision}" != "${resolved_predecessor_revision}" ]] \
   || { echo "predecessor, bootstrap, and candidate revisions must differ" >&2; exit 1; }
 

--- a/deploy/gcp/migrate-to-front-slots.sh
+++ b/deploy/gcp/migrate-to-front-slots.sh
@@ -35,6 +35,14 @@ PREDECESSOR_SHA256_FILE="${SUBROUTER_PREDECESSOR_SHA256_FILE:-${PREDECESSOR_BINA
 PREDECESSOR_SHA256SUMS_FILE="${SUBROUTER_PREDECESSOR_SHA256SUMS_FILE:?set SUBROUTER_PREDECESSOR_SHA256SUMS_FILE to the downloaded v0.1.51 checksum manifest}"
 PREDECESSOR_REVISION="${SUBROUTER_PREDECESSOR_REVISION:?set SUBROUTER_PREDECESSOR_REVISION to the verified predecessor tag commit}"
 PREDECESSOR_TAG_ON_MAIN="${SUBROUTER_PREDECESSOR_TAG_ON_MAIN:?set SUBROUTER_PREDECESSOR_TAG_ON_MAIN from the predecessor ancestry gate}"
+BOOTSTRAP_TAG="${SUBROUTER_BOOTSTRAP_TAG:?set SUBROUTER_BOOTSTRAP_TAG}"
+BOOTSTRAP_BINARY="${SUBROUTER_BOOTSTRAP_BINARY:?set SUBROUTER_BOOTSTRAP_BINARY to the verified lease-capable worker asset}"
+BOOTSTRAP_SHA256_FILE="${SUBROUTER_BOOTSTRAP_SHA256_FILE:-${BOOTSTRAP_BINARY}.sha256}"
+BOOTSTRAP_SHA256SUMS_FILE="${SUBROUTER_BOOTSTRAP_SHA256SUMS_FILE:?set SUBROUTER_BOOTSTRAP_SHA256SUMS_FILE}"
+BOOTSTRAP_REVISION="${SUBROUTER_BOOTSTRAP_REVISION:?set SUBROUTER_BOOTSTRAP_REVISION}"
+BOOTSTRAP_TAG_ON_MAIN="${SUBROUTER_BOOTSTRAP_TAG_ON_MAIN:?set SUBROUTER_BOOTSTRAP_TAG_ON_MAIN}"
+BOOTSTRAP_ATTESTATION_VERIFIED="${SUBROUTER_BOOTSTRAP_ATTESTATION_VERIFIED:?set SUBROUTER_BOOTSTRAP_ATTESTATION_VERIFIED}"
+BOOTSTRAP_IMMUTABLE="${SUBROUTER_BOOTSTRAP_IMMUTABLE:?set SUBROUTER_BOOTSTRAP_IMMUTABLE}"
 PUBLIC_BASE_URL="${SUBROUTER_PUBLIC_BASE_URL:?set SUBROUTER_PUBLIC_BASE_URL}"
 DEPLOY_REVISION="${SUBROUTER_DEPLOY_REVISION:?set SUBROUTER_DEPLOY_REVISION to the verified tag commit}"
 TAG_ON_MAIN="${SUBROUTER_RELEASE_TAG_ON_MAIN:?set SUBROUTER_RELEASE_TAG_ON_MAIN from the ancestry gate}"
@@ -107,8 +115,20 @@ manifest_predecessor_sha="$(awk '$2 == "subrouter_0.1.51_linux_amd64" {print $1}
   || die "predecessor SHA256SUMS does not match the hard-pinned Linux asset"
 [[ "$(sha256sum "${PREDECESSOR_BINARY}" | awk '{print $1}')" == "${PREDECESSOR_SHA256}" ]] \
   || die "predecessor binary does not match its verified checksum"
-[[ "${PREDECESSOR_SHA256}" != "${EXPECTED_SHA256}" ]] \
-  || die "predecessor worker must differ from the control release"
+[[ "${BOOTSTRAP_TAG}" == v0.1.55 ]] || die "migration bootstrap must be the operator-pinned v0.1.55 release"
+[[ -x "${BOOTSTRAP_BINARY}" ]] || die "bootstrap binary is not executable: ${BOOTSTRAP_BINARY}"
+[[ -f "${BOOTSTRAP_SHA256_FILE}" ]] || die "bootstrap checksum file is missing: ${BOOTSTRAP_SHA256_FILE}"
+BOOTSTRAP_SHA256="$(tr -d '[:space:]' <"${BOOTSTRAP_SHA256_FILE}")"
+[[ "${BOOTSTRAP_SHA256}" == 6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c ]] \
+  || die "bootstrap Linux bytes do not match the compiled-in v0.1.55 hard pin"
+[[ -f "${BOOTSTRAP_SHA256SUMS_FILE}" ]] || die "bootstrap SHA256SUMS manifest is missing"
+manifest_bootstrap_sha="$(awk '$2 == "subrouter_0.1.55_linux_amd64" {print $1}' "${BOOTSTRAP_SHA256SUMS_FILE}")"
+[[ "${manifest_bootstrap_sha}" == "${BOOTSTRAP_SHA256}" ]] \
+  || die "bootstrap SHA256SUMS does not match the hard-pinned Linux asset"
+[[ "$(sha256sum "${BOOTSTRAP_BINARY}" | awk '{print $1}')" == "${BOOTSTRAP_SHA256}" ]] \
+  || die "bootstrap binary does not match its verified checksum"
+[[ "${PREDECESSOR_SHA256}" != "${BOOTSTRAP_SHA256}" && "${BOOTSTRAP_SHA256}" != "${EXPECTED_SHA256}" && "${PREDECESSOR_SHA256}" != "${EXPECTED_SHA256}" ]] \
+  || die "predecessor, bootstrap worker, and control release must differ"
 [[ "${DEPLOY_REVISION}" =~ ^[0-9a-f]{40}$ ]] || die "SUBROUTER_DEPLOY_REVISION must be a full verified commit"
 bash "${SCRIPT_DIR}/verify-go-release-binary.sh" "${DEPLOY_BINARY}" "${DEPLOY_REVISION}" \
   || die "candidate embedded metadata is invalid"
@@ -117,10 +137,17 @@ bash "${SCRIPT_DIR}/verify-go-release-binary.sh" "${DEPLOY_BINARY}" "${DEPLOY_RE
 bash "${SCRIPT_DIR}/verify-go-release-binary.sh" \
   "${PREDECESSOR_BINARY}" 5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8 \
   || die "predecessor embedded metadata is invalid"
+[[ "${BOOTSTRAP_REVISION}" == c4ea17e91ef6e9d0ab31cdd2774ca8d5387219bc ]] \
+  || die "bootstrap revision does not match the compiled-in v0.1.55 hard pin"
+bash "${SCRIPT_DIR}/verify-go-release-binary.sh" "${BOOTSTRAP_BINARY}" "${BOOTSTRAP_REVISION}" \
+  || die "bootstrap embedded metadata is invalid"
 [[ "${TAG_ON_MAIN}" == true ]] || die "release tag commit was not proven to be on main"
 [[ "${ATTESTATION_VERIFIED}" == true ]] || die "release artifact attestation was not verified"
 [[ "${RELEASE_IMMUTABLE}" == true ]] || die "release was not proven published and immutable"
 [[ "${PREDECESSOR_TAG_ON_MAIN}" == true ]] || die "predecessor tag commit was not proven to be on main"
+[[ "${BOOTSTRAP_TAG_ON_MAIN}" == true ]] || die "bootstrap tag commit was not proven to be on main"
+[[ "${BOOTSTRAP_ATTESTATION_VERIFIED}" == true ]] || die "bootstrap artifact attestation was not verified"
+[[ "${BOOTSTRAP_IMMUTABLE}" == true ]] || die "bootstrap release was not proven published and immutable"
 [[ "${PUBLIC_BASE_URL}" =~ ^https://[^/?#]+/?$ ]] \
   || die "SUBROUTER_PUBLIC_BASE_URL must be an HTTPS origin"
 PUBLIC_BASE_URL="${PUBLIC_BASE_URL%/}"
@@ -229,11 +256,11 @@ front_state="$(gcloud_ssh "if sudo test -S /var/lib/subrouter/front.sock && syst
 case "${front_state}" in
   absent)
     gcloud_scp "${DEPLOY_BINARY}" "${REMOTE_CANDIDATE}"
-    gcloud_scp "${PREDECESSOR_BINARY}" "${REMOTE_WORKER_CANDIDATE}"
+    gcloud_scp "${BOOTSTRAP_BINARY}" "${REMOTE_WORKER_CANDIDATE}"
     gcloud_scp "${INSTALL_FRONT_SLOTS}" "${REMOTE_INSTALLER}"
     gcloud_scp "${DEPLOYMENT_CONTRACT}" "${REMOTE_DEPLOYMENT_CONTRACT}"
     gcloud_ssh "printf '%s  %s\n%s  %s\n' '${INSTALL_FRONT_SLOTS_SHA256}' '${REMOTE_INSTALLER}' '${DEPLOYMENT_CONTRACT_SHA256}' '${REMOTE_DEPLOYMENT_CONTRACT}' | sha256sum -c - >/dev/null"
-    gcloud_ssh "set -e; printf '%s  %s\n%s  %s\n' '${EXPECTED_SHA256}' '${REMOTE_CANDIDATE}' '${PREDECESSOR_SHA256}' '${REMOTE_WORKER_CANDIDATE}' | sha256sum -c - >/dev/null; ${REMOTE_INSTALL_COMMAND} install-release '${RELEASE_TAG}' '${REMOTE_CANDIDATE}' '${EXPECTED_SHA256}'; ${REMOTE_INSTALL_COMMAND} install-release '${PREDECESSOR_TAG}' '${REMOTE_WORKER_CANDIDATE}' '${PREDECESSOR_SHA256}'; ${REMOTE_INSTALL_COMMAND} install-topology '${RELEASE_TAG}' '${PREDECESSOR_TAG}' slot-a"
+    gcloud_ssh "set -e; printf '%s  %s\n%s  %s\n' '${EXPECTED_SHA256}' '${REMOTE_CANDIDATE}' '${BOOTSTRAP_SHA256}' '${REMOTE_WORKER_CANDIDATE}' | sha256sum -c - >/dev/null; ${REMOTE_INSTALL_COMMAND} install-release '${RELEASE_TAG}' '${REMOTE_CANDIDATE}' '${EXPECTED_SHA256}'; ${REMOTE_INSTALL_COMMAND} install-release '${BOOTSTRAP_TAG}' '${REMOTE_WORKER_CANDIDATE}' '${BOOTSTRAP_SHA256}'; ${REMOTE_INSTALL_COMMAND} install-topology '${RELEASE_TAG}' '${BOOTSTRAP_TAG}' slot-a"
     ;;
   active)
     log "resuming an earlier explicit migration with an already healthy front topology"
@@ -242,7 +269,7 @@ case "${front_state}" in
     die "front topology is partially installed; repair it before changing the URL map"
     ;;
 esac
-gcloud_ssh "set -e; status=\$(sudo curl -fsS --unix-socket /var/lib/subrouter/front.sock http://localhost/_subrouter/front-status); slot=\$(printf '%s' \"\${status}\" | jq -r '.active.id // empty'); case \"\${slot}\" in slot-a|slot-b) ;; *) exit 1 ;; esac; test \"\$(sudo sha256sum /opt/subrouter/front/subrouter | awk '{print \$1}')\" = '${EXPECTED_SHA256}'; test \"\$(sudo sha256sum /opt/subrouter/control/subrouter | awk '{print \$1}')\" = '${EXPECTED_SHA256}'; test \"\$(sudo sha256sum /opt/subrouter/slots/\${slot}/worker | awk '{print \$1}')\" = '${PREDECESSOR_SHA256}'; curl -fsS http://127.0.0.1:31416/_subrouter/health >/dev/null; curl -fsS http://127.0.0.1:31416/_subrouter/ready >/dev/null; systemctl is-active --quiet subrouter.service subrouter-front.service subrouter-slot@\${slot}.service; systemctl is-enabled --quiet subrouter-front.service subrouter-slot@\${slot}.service" \
+gcloud_ssh "set -e; status=\$(sudo curl -fsS --unix-socket /var/lib/subrouter/front.sock http://localhost/_subrouter/front-status); slot=\$(printf '%s' \"\${status}\" | jq -r '.active.id // empty'); case \"\${slot}\" in slot-a|slot-b) ;; *) exit 1 ;; esac; test \"\$(sudo sha256sum /opt/subrouter/front/subrouter | awk '{print \$1}')\" = '${EXPECTED_SHA256}'; test \"\$(sudo sha256sum /opt/subrouter/control/subrouter | awk '{print \$1}')\" = '${EXPECTED_SHA256}'; test \"\$(sudo sha256sum /opt/subrouter/slots/\${slot}/worker | awk '{print \$1}')\" = '${BOOTSTRAP_SHA256}'; curl -fsS http://127.0.0.1:31416/_subrouter/health >/dev/null; curl -fsS http://127.0.0.1:31416/_subrouter/ready >/dev/null; systemctl is-active --quiet subrouter.service subrouter-front.service subrouter-slot@\${slot}.service; systemctl is-enabled --quiet subrouter-front.service subrouter-slot@\${slot}.service" \
   || die "front topology does not match the verified migration release"
 
 migration_started=1
@@ -352,7 +379,7 @@ front_checksum="$(gcloud_ssh "sudo sha256sum /opt/subrouter/front/subrouter | aw
 control_checksum="$(gcloud_ssh "sudo sha256sum /opt/subrouter/control/subrouter | awk '{print \$1}'" | tail -n 1)"
 worker_checksum="$(gcloud_ssh "sudo sha256sum /opt/subrouter/slots/${front_slot}/worker | awk '{print \$1}'" | tail -n 1)"
 [[ "${control_checksum}" == "${EXPECTED_SHA256}" ]] || die "slot supervisor control checksum changed after preparation"
-[[ "${worker_checksum}" == "${PREDECESSOR_SHA256}" ]] || die "initial slot worker is not the predecessor release"
+[[ "${worker_checksum}" == "${BOOTSTRAP_SHA256}" ]] || die "initial slot worker is not the lease-capable bootstrap release"
 
 migration_committed=1
 evidence_emitted_at="$(python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z"))')"
@@ -362,6 +389,8 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type front-
   --arg tag "${RELEASE_TAG}" --arg sha "${EXPECTED_SHA256}" --arg revision "${DEPLOY_REVISION}" \
   --arg predecessor_tag "${PREDECESSOR_TAG}" --arg predecessor_sha "${PREDECESSOR_SHA256}" \
   --arg predecessor_revision "${PREDECESSOR_REVISION}" \
+  --arg bootstrap_tag "${BOOTSTRAP_TAG}" --arg bootstrap_sha "${BOOTSTRAP_SHA256}" \
+  --arg bootstrap_revision "${BOOTSTRAP_REVISION}" \
   --arg url_map "${URL_MAP}" --arg legacy_backend "${LEGACY_BACKEND_SERVICE}" \
   --arg front_backend "${FRONT_BACKEND_SERVICE}" --arg legacy_url "${legacy_backend_url}" \
   --arg front_url "${front_backend_url}" --arg legacy_generation "${legacy_generation}" \
@@ -373,6 +402,8 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type front-
     run:{id:$run_id,project:$project,zone:$zone,instance:$instance},
     release:{tag:$tag,sha256:$sha,source_revision:$revision,tag_on_main:true,
       attestation_verified:true,immutable:true},
+    bootstrap:{tag:$bootstrap_tag,sha256:$bootstrap_sha,source_revision:$bootstrap_revision,
+      tag_on_main:true,attestation_verified:true,immutable:true},
     predecessor:{tag:$predecessor_tag,sha256:$predecessor_sha,source_revision:$predecessor_revision,
       tag_on_main:true,hard_pin_verified:true,sha256sums_match:true,
       embedded_revision_verified:true,live_worker_checksum_match:true},

--- a/deploy/gcp/switch-front-migration.sh
+++ b/deploy/gcp/switch-front-migration.sh
@@ -100,6 +100,7 @@ esac
   || die "prior migration evidence target does not match the current GCP target"
 prior_sha256="$(sha256sum "${PRIOR_EVIDENCE}" | awk '{print $1}')"
 release_json="$(jq -c '.release' "${PRIOR_EVIDENCE}")"
+bootstrap_json="$(jq -c '.bootstrap' "${PRIOR_EVIDENCE}")"
 predecessor_json="$(jq -c '.predecessor' "${PRIOR_EVIDENCE}")"
 routing_json="$(jq -c '.routing' "${PRIOR_EVIDENCE}")"
 legacy_json="$(jq -c '.legacy' "${PRIOR_EVIDENCE}")"
@@ -384,7 +385,8 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type "${evi
   --arg mode "${OPERATION}" --arg prior_type "${prior_type}" --arg prior_sha "${prior_sha256}" \
   --arg preparation_sha "${preparation_sha256}" --arg run_id "${RUN_LABEL}" \
   --arg project "${PROJECT_ID}" --arg zone "${ZONE}" --arg instance "${INSTANCE}" \
-  --argjson release "${release_json}" --argjson predecessor "${predecessor_json}" \
+  --argjson release "${release_json}" --argjson bootstrap "${bootstrap_json}" \
+  --argjson predecessor "${predecessor_json}" \
   --argjson routing "${routing_json}" \
   --argjson legacy "${legacy_json}" --argjson front "${front_json}" \
   --arg source "${source_kind}" --arg destination "${destination_kind}" \
@@ -410,7 +412,7 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type "${evi
     prior_evidence_type:$prior_type,prior_evidence_sha256:$prior_sha,
     preparation_evidence_sha256:$preparation_sha,
     run:{id:$run_id,project:$project,zone:$zone,instance:$instance},release:$release,
-    predecessor:$predecessor,
+    bootstrap:$bootstrap,predecessor:$predecessor,
     routing:($routing + {before:$source,after:$destination,source_backend_url:$source_url,
       destination_backend_url:$destination_url}),legacy:$legacy,front:$front,
     timestamps:{transition_requested_at:$requested_at,activated_at:$activated_at,

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -211,6 +211,22 @@ def validate_predecessor(value: Any) -> dict[str, Any]:
     return result
 
 
+def validate_migration_bootstrap(value: Any) -> dict[str, Any]:
+    result = validate_release(value)
+    exact(field(result, "tag", "bootstrap"), "v0.1.55", "bootstrap.tag")
+    exact(
+        sha(field(result, "sha256", "bootstrap"), "bootstrap.sha256"),
+        "6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c",
+        "bootstrap.sha256",
+    )
+    exact(
+        revision(field(result, "source_revision", "bootstrap"), "bootstrap.source_revision"),
+        "c4ea17e91ef6e9d0ab31cdd2774ca8d5387219bc",
+        "bootstrap.source_revision",
+    )
+    return result
+
+
 def validate_snapshot(value: Any, path: str) -> dict[str, Any]:
     result = obj(value, path)
     boolean(field(result, "accepting", path), f"{path}.accepting")
@@ -587,9 +603,10 @@ def validate_front_migration_preparation(document: dict[str, Any]) -> None:
     exact(boolean(field(document, "success", "root"), "success"), True, "success")
     validate_run(field(document, "run", "root"))
     release = validate_release(field(document, "release", "root"))
+    bootstrap = validate_migration_bootstrap(field(document, "bootstrap", "root"))
     predecessor = validate_predecessor(field(document, "predecessor", "root"))
-    if predecessor["sha256"] == release["sha256"]:
-        fail("predecessor worker must differ from the control release")
+    if len({predecessor["sha256"], bootstrap["sha256"], release["sha256"]}) != 3:
+        fail("predecessor, bootstrap worker, and control release must differ")
     routing = obj(field(document, "routing", "root"), "routing")
     for name in ("url_map", "legacy_backend", "front_backend"):
         text(field(routing, name, "routing"), f"routing.{name}")
@@ -619,7 +636,7 @@ def validate_front_migration_preparation(document: dict[str, Any]) -> None:
     )
     exact(
         sha(field(front, "worker_checksum", "front"), "front.worker_checksum"),
-        predecessor["sha256"],
+        bootstrap["sha256"],
         "front.worker_checksum",
     )
     exact(boolean(field(front, "ready", "front"), "front.ready"), True, "front.ready")
@@ -658,9 +675,10 @@ def validate_front_migration_transition(document: dict[str, Any], expected: str)
     sha(field(document, "preparation_evidence_sha256", "root"), "preparation_evidence_sha256")
     validate_run(field(document, "run", "root"))
     release = validate_release(field(document, "release", "root"))
+    bootstrap = validate_migration_bootstrap(field(document, "bootstrap", "root"))
     predecessor = validate_predecessor(field(document, "predecessor", "root"))
-    if predecessor["sha256"] == release["sha256"]:
-        fail("predecessor worker must differ from the control release")
+    if len({predecessor["sha256"], bootstrap["sha256"], release["sha256"]}) != 3:
+        fail("predecessor, bootstrap worker, and control release must differ")
 
     routing = obj(field(document, "routing", "root"), "routing")
     for name in ("url_map", "legacy_backend", "front_backend"):
@@ -694,7 +712,7 @@ def validate_front_migration_transition(document: dict[str, Any], expected: str)
     )
     exact(
         sha(field(front, "worker_checksum", "front"), "front.worker_checksum"),
-        predecessor["sha256"],
+        bootstrap["sha256"],
         "front.worker_checksum",
     )
 
@@ -844,9 +862,10 @@ def validate_legacy_retirement(document: dict[str, Any]) -> None:
     sha(field(document, "preparation_evidence_sha256", "root"), "preparation_evidence_sha256")
     validate_run(field(document, "run", "root"))
     release = validate_release(field(document, "release", "root"))
+    bootstrap = validate_migration_bootstrap(field(document, "bootstrap", "root"))
     predecessor = validate_predecessor(field(document, "predecessor", "root"))
-    if predecessor["sha256"] == release["sha256"]:
-        fail("predecessor worker must differ from the control release")
+    if len({predecessor["sha256"], bootstrap["sha256"], release["sha256"]}) != 3:
+        fail("predecessor, bootstrap worker, and control release must differ")
     routing = obj(field(document, "routing", "root"), "routing")
     exact(field(routing, "active", "routing"), "front", "routing.active")
     exact(


### PR DESCRIPTION
The one-time v0.1.51 migration now installs the immutable v0.1.55 lease-capable worker before any team-leased local sessions start. The golden gate then proves direct legacy sessions survive the topology cutover and local sessions survive the v0.1.55 to v0.1.56 slot deployment.

Migration evidence now pins and carries the v0.1.55 tag, revision, checksum, immutability, and attestation through preparation, cutover, rollback, and retirement.

Tests: `go test ./cmd/subrouter-transport-observer -count=1`; shell and Python syntax checks. The local full suite was attempted twice but unrelated five-second subprocess tests timed out while the shared Mac load exceeded 300; exact-head CI is required before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788424401&installation_model_id=21920&pr_number=146&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F146&signature=7b95cb51d4c93088b52d43c09b5bb300d4d29d5b7e75f70231671b7d7f6c8b50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bootstraps a lease-capable v0.1.55 worker before any team-leased local sessions and binds activation provenance to that bootstrap. Tightens continuity and evidence checks, enforcing unique checksums and source revisions across predecessor, bootstrap, and candidate.

- **New Features**
  - Install immutable `v0.1.55` as the worker for front slots before leases start.
  - Add a `bootstrap` release to migration evidence (tag, revision, checksum, immutability, attestation).
  - Bind activation provenance to the bootstrap (activation From = bootstrap), not the predecessor.
  - Enforce 3-way difference by checksum and source revision among predecessor, bootstrap, and candidate.
  - Relax local egress checks during front migration; start only direct-hosted sessions in that phase.
  - Delay lease issuance in the fake hosted server until legacy cleanup completes.
  - Require monitors >= source sessions for transition continuity checks.

- **Migration**
  - Ensure `v0.1.55` Linux asset is downloaded and verified; export:
    - `SUBROUTER_BOOTSTRAP_TAG`, `SUBROUTER_BOOTSTRAP_BINARY`, `SUBROUTER_BOOTSTRAP_SHA256_FILE`, `SUBROUTER_BOOTSTRAP_SHA256SUMS_FILE`, `SUBROUTER_BOOTSTRAP_REVISION`, `SUBROUTER_BOOTSTRAP_TAG_ON_MAIN`, `SUBROUTER_BOOTSTRAP_ATTESTATION_VERIFIED`, `SUBROUTER_BOOTSTRAP_IMMUTABLE`.
  - Use the updated GCP scripts; they install the bootstrap worker and emit `bootstrap` in evidence.
  - Expect evidence and tests to no longer include local-egress sessions during the front migration cycle.

<sup>Written for commit 83935d1373936c97259a5cd2de96683bd5b7477f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

