### PR TITLE
Clean up hosted deployment actions after gate failures

### DIFF
--- a/cmd/subrouter-transport-observer/golden_deploy_evidence.go
+++ b/cmd/subrouter-transport-observer/golden_deploy_evidence.go
@@ -196,7 +196,7 @@ func (r *goldenRunner) runEvidenceAction(ctx context.Context, options goldenEvid
 	}
 	argv = append(argv, "--evidence-json", evidencePath)
 	command := exec.CommandContext(ctx, argv[0], argv[1:]...)
-	configureProcessGroup(command)
+	configureGoldenDeploymentAction(command)
 	command.Stdin = os.Stdin
 	if r.testMode {
 		command.Stdout = io.Discard

--- a/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
+++ b/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
@@ -1,0 +1,72 @@
+//go:build !windows
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGoldenMigrationValidationFailureRunsDeploymentActionCleanup(t *testing.T) {
+	root := t.TempDir()
+	requestPath := filepath.Join(root, "request-path")
+	cleanupPath := filepath.Join(root, "cleanup-ran")
+	sentinelPath := filepath.Join(root, "remote-lock-sentinel")
+	actionPath := filepath.Join(root, "migration-action")
+	script := fmt.Sprintf(`#!/bin/sh
+set -eu
+request_path=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --destination-proof-request)
+      request_path="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+cleanup() {
+  rm -f %q
+  : > %q
+}
+trap cleanup EXIT INT TERM
+: > %q
+printf '{}\n' > "$request_path"
+while :; do sleep 300; done
+`, sentinelPath, cleanupPath, sentinelPath)
+	writeGoldenExecutable(t, actionPath, script)
+
+	runner := &goldenRunner{
+		privateRoot: root,
+		artifactDir: root,
+		testMode:    true,
+		options: goldenOptions{
+			migrationSwitch: []string{actionPath},
+		},
+	}
+	prior := goldenActionSummary{
+		EvidenceFile:   filepath.Base(requestPath),
+		EvidenceSHA256: strings.Repeat("a", 64),
+		EvidenceValid:  true,
+	}
+	source := &goldenSession{}
+	_, _, err := runner.runMigrationTransitionWithProof(
+		context.Background(), "rehearsal-cutover", "migration-cleanup", prior,
+		goldenCycleInputs{}, []*goldenSession{source}, []*goldenContinuityMonitor{{}},
+	)
+	if got := fixedGoldenFailure(err); got != "migration_destination_proof_request_invalid" {
+		t.Fatalf("failure = %q, want migration_destination_proof_request_invalid", got)
+	}
+	if _, err := os.Stat(cleanupPath); err != nil {
+		t.Fatalf("deployment action cleanup did not run: %v", err)
+	}
+	if _, err := os.Stat(sentinelPath); !os.IsNotExist(err) {
+		t.Fatalf("deployment lock sentinel survived cleanup: %v", err)
+	}
+}

--- a/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
+++ b/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
@@ -4,11 +4,16 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"io"
 	"os"
+	"os/exec"
+	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 func TestGoldenMigrationValidationFailureRunsDeploymentActionCleanup(t *testing.T) {
@@ -18,47 +23,19 @@ func TestGoldenMigrationValidationFailureRunsDeploymentActionCleanup(t *testing.
 	sentinelPath := filepath.Join(root, "remote-lock-sentinel")
 	childPath := filepath.Join(root, "child.pid")
 	childReadyPath := filepath.Join(root, "child.ready")
-	actionPath := filepath.Join(root, "migration-action")
-	script := fmt.Sprintf(`#!/bin/bash
-set -eu
-request_path=""
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --destination-proof-request)
-      request_path="$2"
-      shift 2
-      ;;
-    *)
-      shift
-      ;;
-  esac
-done
-cleanup() {
-  status=$?
-  trap - EXIT INT TERM
-  rm -f %q
-  : > %q
-  exit "$status"
-}
-trap cleanup EXIT INT TERM
-: > %q
-(trap '' HUP INT TERM; : > %q; exec sleep 300) &
-child=$!
-disown "$child"
-printf '%%s\n' "$child" > %q
-while [ ! -e %q ]; do sleep 0.01; done
-printf '{}\n' > "${request_path}.tmp"
-mv "${request_path}.tmp" "$request_path"
-while :; do sleep 300; done
-`, sentinelPath, cleanupPath, sentinelPath, childReadyPath, childPath, childReadyPath)
-	writeGoldenExecutable(t, actionPath, script)
-
+	action := []string{
+		os.Args[0], "-test.run=^TestGoldenDeploymentActionLifecycleHelper$", "--",
+		"--helper-cleanup", cleanupPath,
+		"--helper-sentinel", sentinelPath,
+		"--helper-child-pid", childPath,
+		"--helper-child-ready", childReadyPath,
+	}
 	runner := &goldenRunner{
 		privateRoot: root,
 		artifactDir: root,
 		testMode:    true,
 		options: goldenOptions{
-			migrationSwitch: []string{actionPath},
+			migrationSwitch: action,
 		},
 	}
 	prior := goldenActionSummary{
@@ -87,4 +64,88 @@ while :; do sleep 300; done
 	}
 	t.Cleanup(func() { _ = childProcess.Kill() })
 	waitGoldenLifecycleProcessGone(t, childPID)
+}
+
+func TestGoldenDeploymentActionLifecycleHelper(t *testing.T) {
+	cleanupPath := goldenLifecycleArgument("--helper-cleanup")
+	if cleanupPath == "" {
+		t.Skip("deployment action helper")
+	}
+	sentinelPath := goldenLifecycleArgument("--helper-sentinel")
+	childPath := goldenLifecycleArgument("--helper-child-pid")
+	childReadyPath := goldenLifecycleArgument("--helper-child-ready")
+	requestPath := goldenLifecycleArgument("--destination-proof-request")
+	if sentinelPath == "" || childPath == "" || childReadyPath == "" || requestPath == "" {
+		t.Fatal("deployment action helper arguments are incomplete")
+	}
+
+	termination := make(chan os.Signal, 1)
+	signal.Notify(termination, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(termination)
+	if err := os.WriteFile(sentinelPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	child := exec.Command(
+		os.Args[0], "-test.run=^TestGoldenDeploymentActionLifecycleResistantChild$", "--",
+		"--helper-child-ready", childReadyPath,
+	)
+	child.Stdout, child.Stderr = io.Discard, io.Discard
+	if err := child.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(childPath, []byte(strconv.Itoa(child.Process.Pid)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitGoldenLifecycleFile(t, childReadyPath)
+	requestTemporary := requestPath + ".tmp"
+	if err := os.WriteFile(requestTemporary, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(requestTemporary, requestPath); err != nil {
+		t.Fatal(err)
+	}
+	<-termination
+	if err := os.Remove(sentinelPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cleanupPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGoldenDeploymentActionLifecycleResistantChild(t *testing.T) {
+	readyPath := goldenLifecycleArgument("--helper-child-ready")
+	if readyPath == "" {
+		t.Skip("deployment action resistant child")
+	}
+	signal.Ignore(os.Interrupt, syscall.SIGHUP, syscall.SIGTERM)
+	if err := os.WriteFile(readyPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	select {}
+}
+
+func goldenLifecycleArgument(name string) string {
+	for index := 0; index+1 < len(os.Args); index++ {
+		if os.Args[index] == name {
+			return os.Args[index+1]
+		}
+	}
+	return ""
+}
+
+func waitGoldenLifecycleFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", path)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }

--- a/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
+++ b/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
@@ -41,7 +41,7 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 : > %q
-(trap '' TERM; while :; do sleep 300; done) &
+(trap '' HUP INT TERM; while :; do sleep 300; done) &
 child=$!
 printf '%%s\n' "$child" > %q
 printf '{}\n' > "${request_path}.tmp"

--- a/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
+++ b/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
@@ -17,7 +17,7 @@ func TestGoldenMigrationValidationFailureRunsDeploymentActionCleanup(t *testing.
 	cleanupPath := filepath.Join(root, "cleanup-ran")
 	sentinelPath := filepath.Join(root, "remote-lock-sentinel")
 	actionPath := filepath.Join(root, "migration-action")
-	script := fmt.Sprintf(`#!/bin/sh
+	script := fmt.Sprintf(`#!/bin/bash
 set -eu
 request_path=""
 while [ "$#" -gt 0 ]; do
@@ -32,12 +32,16 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 cleanup() {
+  status=$?
+  trap - EXIT INT TERM
   rm -f %q
   : > %q
+  exit "$status"
 }
 trap cleanup EXIT INT TERM
 : > %q
-printf '{}\n' > "$request_path"
+printf '{}\n' > "${request_path}.tmp"
+mv "${request_path}.tmp" "$request_path"
 while :; do sleep 300; done
 `, sentinelPath, cleanupPath, sentinelPath)
 	writeGoldenExecutable(t, actionPath, script)

--- a/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
+++ b/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
@@ -17,7 +17,15 @@ func TestGoldenMigrationValidationFailureRunsDeploymentActionCleanup(t *testing.
 	cleanupPath := filepath.Join(root, "cleanup-ran")
 	sentinelPath := filepath.Join(root, "remote-lock-sentinel")
 	childPath := filepath.Join(root, "child.pid")
+	childReadyPath := filepath.Join(root, "child.ready")
+	resistantChildPath := filepath.Join(root, "resistant-child")
 	actionPath := filepath.Join(root, "migration-action")
+	resistantChild := fmt.Sprintf(`#!/bin/bash
+trap '' HUP INT TERM
+: > %q
+exec sleep 300
+`, childReadyPath)
+	writeGoldenExecutable(t, resistantChildPath, resistantChild)
 	script := fmt.Sprintf(`#!/bin/bash
 set -eu
 request_path=""
@@ -41,13 +49,14 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 : > %q
-(trap '' HUP INT TERM; while :; do sleep 300; done) &
+%q &
 child=$!
 printf '%%s\n' "$child" > %q
+while [ ! -e %q ]; do sleep 0.01; done
 printf '{}\n' > "${request_path}.tmp"
 mv "${request_path}.tmp" "$request_path"
 while :; do sleep 300; done
-`, sentinelPath, cleanupPath, sentinelPath, childPath)
+`, sentinelPath, cleanupPath, sentinelPath, resistantChildPath, childPath, childReadyPath)
 	writeGoldenExecutable(t, actionPath, script)
 
 	runner := &goldenRunner{

--- a/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
+++ b/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
@@ -122,7 +122,9 @@ func TestGoldenDeploymentActionLifecycleResistantChild(t *testing.T) {
 	if err := os.WriteFile(readyPath, nil, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	select {}
+	for {
+		time.Sleep(time.Hour)
+	}
 }
 
 func goldenLifecycleArgument(name string) string {

--- a/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
+++ b/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
@@ -21,10 +21,11 @@ func TestGoldenMigrationValidationFailureRunsDeploymentActionCleanup(t *testing.
 	resistantChildPath := filepath.Join(root, "resistant-child")
 	actionPath := filepath.Join(root, "migration-action")
 	resistantChild := fmt.Sprintf(`#!/bin/bash
-trap '' HUP INT TERM
+(trap '' HUP INT TERM; exec sleep 300) &
+child=$!
+printf '%%s\n' "$child" > %q
 : > %q
-exec sleep 300
-`, childReadyPath)
+`, childPath, childReadyPath)
 	writeGoldenExecutable(t, resistantChildPath, resistantChild)
 	script := fmt.Sprintf(`#!/bin/bash
 set -eu
@@ -49,14 +50,12 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 : > %q
-%q &
-child=$!
-printf '%%s\n' "$child" > %q
+%q
 while [ ! -e %q ]; do sleep 0.01; done
 printf '{}\n' > "${request_path}.tmp"
 mv "${request_path}.tmp" "$request_path"
 while :; do sleep 300; done
-`, sentinelPath, cleanupPath, sentinelPath, resistantChildPath, childPath, childReadyPath)
+`, sentinelPath, cleanupPath, sentinelPath, resistantChildPath, childReadyPath)
 	writeGoldenExecutable(t, actionPath, script)
 
 	runner := &goldenRunner{

--- a/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
+++ b/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
@@ -16,6 +16,7 @@ func TestGoldenMigrationValidationFailureRunsDeploymentActionCleanup(t *testing.
 	requestPath := filepath.Join(root, "request-path")
 	cleanupPath := filepath.Join(root, "cleanup-ran")
 	sentinelPath := filepath.Join(root, "remote-lock-sentinel")
+	childPath := filepath.Join(root, "child.pid")
 	actionPath := filepath.Join(root, "migration-action")
 	script := fmt.Sprintf(`#!/bin/bash
 set -eu
@@ -40,10 +41,13 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 : > %q
+(trap '' TERM; while :; do sleep 300; done) &
+child=$!
+printf '%%s\n' "$child" > %q
 printf '{}\n' > "${request_path}.tmp"
 mv "${request_path}.tmp" "$request_path"
 while :; do sleep 300; done
-`, sentinelPath, cleanupPath, sentinelPath)
+`, sentinelPath, cleanupPath, sentinelPath, childPath)
 	writeGoldenExecutable(t, actionPath, script)
 
 	runner := &goldenRunner{
@@ -73,4 +77,11 @@ while :; do sleep 300; done
 	if _, err := os.Stat(sentinelPath); !os.IsNotExist(err) {
 		t.Fatalf("deployment lock sentinel survived cleanup: %v", err)
 	}
+	childPID := readGoldenLifecyclePID(t, childPath)
+	childProcess, err := os.FindProcess(childPID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = childProcess.Kill() })
+	waitGoldenLifecycleProcessGone(t, childPID)
 }

--- a/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
+++ b/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
@@ -18,15 +18,7 @@ func TestGoldenMigrationValidationFailureRunsDeploymentActionCleanup(t *testing.
 	sentinelPath := filepath.Join(root, "remote-lock-sentinel")
 	childPath := filepath.Join(root, "child.pid")
 	childReadyPath := filepath.Join(root, "child.ready")
-	resistantChildPath := filepath.Join(root, "resistant-child")
 	actionPath := filepath.Join(root, "migration-action")
-	resistantChild := fmt.Sprintf(`#!/bin/bash
-(trap '' HUP INT TERM; exec sleep 300) &
-child=$!
-printf '%%s\n' "$child" > %q
-: > %q
-`, childPath, childReadyPath)
-	writeGoldenExecutable(t, resistantChildPath, resistantChild)
 	script := fmt.Sprintf(`#!/bin/bash
 set -eu
 request_path=""
@@ -50,12 +42,15 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 : > %q
-%q
+(trap '' HUP INT TERM; : > %q; exec sleep 300) &
+child=$!
+disown "$child"
+printf '%%s\n' "$child" > %q
 while [ ! -e %q ]; do sleep 0.01; done
 printf '{}\n' > "${request_path}.tmp"
 mv "${request_path}.tmp" "$request_path"
 while :; do sleep 300; done
-`, sentinelPath, cleanupPath, sentinelPath, resistantChildPath, childReadyPath)
+`, sentinelPath, cleanupPath, sentinelPath, childReadyPath, childPath, childReadyPath)
 	writeGoldenExecutable(t, actionPath, script)
 
 	runner := &goldenRunner{

--- a/cmd/subrouter-transport-observer/golden_migration_evidence.go
+++ b/cmd/subrouter-transport-observer/golden_migration_evidence.go
@@ -605,7 +605,7 @@ func (r *goldenRunner) runMigrationEvidenceAction(ctx context.Context, options g
 	}
 	argv = append(argv, "--evidence-json", evidencePath)
 	command := exec.CommandContext(ctx, argv[0], argv[1:]...)
-	configureProcessGroup(command)
+	configureGoldenDeploymentAction(command)
 	command.Stdin = os.Stdin
 	if r.testMode {
 		command.Stdout, command.Stderr = io.Discard, io.Discard

--- a/cmd/subrouter-transport-observer/golden_migration_transition.go
+++ b/cmd/subrouter-transport-observer/golden_migration_transition.go
@@ -86,8 +86,7 @@ func (r *goldenRunner) runMigrationTransitionWithProof(
 	waited := false
 	defer func() {
 		if !waited {
-			killProcessGroup(command.command)
-			<-command.done
+			command.stop()
 		}
 	}()
 	requestData, err := waitGoldenHandshakeFile(ctx, requestPath, command.done)

--- a/cmd/subrouter-transport-observer/golden_process_unix.go
+++ b/cmd/subrouter-transport-observer/golden_process_unix.go
@@ -25,6 +25,13 @@ func interruptProcessGroup(command *exec.Cmd) {
 	}
 }
 
+func terminateProcessGroup(command *exec.Cmd) {
+	if command != nil && command.Process != nil {
+		_ = syscall.Kill(-command.Process.Pid, syscall.SIGTERM)
+		_ = command.Process.Signal(syscall.SIGTERM)
+	}
+}
+
 func killProcessGroup(command *exec.Cmd) {
 	if command != nil && command.Process != nil {
 		_ = syscall.Kill(-command.Process.Pid, syscall.SIGKILL)

--- a/cmd/subrouter-transport-observer/golden_process_windows.go
+++ b/cmd/subrouter-transport-observer/golden_process_windows.go
@@ -21,6 +21,12 @@ func interruptProcessGroup(command *exec.Cmd) {
 	}
 }
 
+func terminateProcessGroup(command *exec.Cmd) {
+	if command != nil && command.Process != nil {
+		_ = command.Process.Signal(os.Interrupt)
+	}
+}
+
 func killProcessGroup(command *exec.Cmd) {
 	if command != nil && command.Process != nil {
 		_ = command.Process.Kill()

--- a/cmd/subrouter-transport-observer/golden_process_windows.go
+++ b/cmd/subrouter-transport-observer/golden_process_windows.go
@@ -23,7 +23,9 @@ func interruptProcessGroup(command *exec.Cmd) {
 
 func terminateProcessGroup(command *exec.Cmd) {
 	if command != nil && command.Process != nil {
-		_ = command.Process.Signal(os.Interrupt)
+		if err := command.Process.Signal(os.Interrupt); err != nil {
+			_ = command.Process.Kill()
+		}
 	}
 }
 

--- a/cmd/subrouter-transport-observer/golden_slot_activation.go
+++ b/cmd/subrouter-transport-observer/golden_slot_activation.go
@@ -64,6 +64,37 @@ type runningGoldenEvidenceCommand struct {
 	finished time.Time
 }
 
+const goldenDeploymentActionShutdownLimit = 2 * time.Minute
+
+func configureGoldenDeploymentAction(command *exec.Cmd) {
+	configureProcessGroup(command)
+	command.Cancel = func() error {
+		terminateProcessGroup(command)
+		return nil
+	}
+	command.WaitDelay = goldenDeploymentActionShutdownLimit
+}
+
+func (r *runningGoldenEvidenceCommand) stop() {
+	if r == nil || r.command == nil {
+		return
+	}
+	select {
+	case <-r.done:
+		return
+	default:
+	}
+	terminateProcessGroup(r.command)
+	timer := time.NewTimer(goldenDeploymentActionShutdownLimit)
+	defer timer.Stop()
+	select {
+	case <-r.done:
+	case <-timer.C:
+		killProcessGroup(r.command)
+		<-r.done
+	}
+}
+
 func (r *goldenRunner) runSlotActivationWithAck(
 	ctx context.Context,
 	intent string,
@@ -102,8 +133,7 @@ func (r *goldenRunner) runSlotActivationWithAck(
 	waited := false
 	defer func() {
 		if !waited {
-			killProcessGroup(command.command)
-			<-command.done
+			command.stop()
 		}
 	}()
 	requestData, err := waitGoldenHandshakeFile(ctx, requestPath, command.done)
@@ -279,7 +309,7 @@ func (r *goldenRunner) startGoldenEvidenceCommand(
 	}
 	argv := append(append([]string(nil), base...), controlled...)
 	command := exec.CommandContext(ctx, argv[0], argv[1:]...)
-	configureProcessGroup(command)
+	configureGoldenDeploymentAction(command)
 	command.Stdin = os.Stdin
 	if r.testMode {
 		command.Stdout, command.Stderr = io.Discard, io.Discard

--- a/cmd/subrouter-transport-observer/golden_slot_activation.go
+++ b/cmd/subrouter-transport-observer/golden_slot_activation.go
@@ -81,6 +81,7 @@ func (r *runningGoldenEvidenceCommand) stop() {
 	}
 	select {
 	case <-r.done:
+		killProcessGroup(r.command)
 		return
 	default:
 	}
@@ -89,6 +90,7 @@ func (r *runningGoldenEvidenceCommand) stop() {
 	defer timer.Stop()
 	select {
 	case <-r.done:
+		killProcessGroup(r.command)
 	case <-timer.C:
 		killProcessGroup(r.command)
 		<-r.done


### PR DESCRIPTION
The hosted continuity gate currently kills a failed deployment action before its shell trap can remove the remote deploy-lock sentinel. This PR makes action shutdown graceful and bounded so staging or production cannot retain a stale lock after an evidence failure.

Regression history intentionally lands the failing lifecycle test before the fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788428792&installation_model_id=21920&pr_number=147&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F147&signature=373d0663fb318da3a55c1dcee1233e89ef8486a141946e3bc151169b4e2d8137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Give deployment actions a 2-minute graceful shutdown so cleanup traps run, deploy-lock sentinels are cleared, and stubborn child process groups are reaped. Standardizes stop across Unix and Windows via `configureGoldenDeploymentAction`, which sends a soft terminate and waits for slot activation, migration transitions, and evidence actions before a forced kill.

- **Tests**
  - Added Unix lifecycle tests that model a detached, signal-resistant child and a long-lived helper; force a migration proof failure and verify soft terminate, bounded wait, then forced kill.
  - Assert cleanup ran, the deploy-lock sentinel was removed, and helper and child process groups were reaped.

<sup>Written for commit c7a87e1cffa4756c48ff636a43cdab2a28c0784b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Unix-specific coverage verifying cleanup after deployment migration validation failures.
  * Confirmed remote lock markers are removed and the expected failure code is reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->