### PR TITLE
Separate Codex and server RSS budgets

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -37,6 +37,7 @@ const (
 	goldenRetirementLimit                     = 30 * time.Second
 	goldenChunkGapFloor                       = 5 * time.Second
 	goldenRSSLimitBytes                 int64 = 192 << 20
+	goldenCodexRSSLimitBytes            int64 = 512 << 20
 	goldenBaselineChunkSamples                = 20
 	goldenProcessSampleInterval               = 20 * time.Millisecond
 	goldenProcessSampleMaxGap                 = 100 * time.Millisecond
@@ -2264,7 +2265,7 @@ func (r *goldenRunner) recordGoldenProcessSample(pid int) {
 			if sessionPaused {
 				session.pausedProcessSamples++
 			}
-			if sessionBytes > goldenRSSLimitBytes {
+			if sessionBytes > goldenCodexRSSLimitBytes {
 				session.rssExceeded = true
 			}
 		} else {
@@ -3569,7 +3570,7 @@ func validateGoldenSessions(sessions []*goldenSession, resume bool) error {
 			}
 			return failGolden("codex_transport_issue")
 		}
-		if rssExceeded || peakRSS > goldenRSSLimitBytes {
+		if rssExceeded || peakRSS > goldenCodexRSSLimitBytes {
 			return failGolden("rss_limit_exceeded")
 		}
 		if rssSamples == 0 || peakRSS <= 0 {
@@ -3727,6 +3728,7 @@ func captureProcessEvidenceFromTable(phase, label string, pid int, table goldenP
 	var socketIDs, remoteIDs, states []string
 	var remoteSockets []goldenRemoteSocket
 	var rssBytes int64
+	rssLimit := goldenProcessRSSLimit(label)
 	for _, processID := range pids {
 		sample, ok := table.processes[processID]
 		if !ok {
@@ -3737,7 +3739,7 @@ func captureProcessEvidenceFromTable(phase, label string, pid int, table goldenP
 			return goldenProcessEvidence{}, failGolden("paused_process_detected")
 		}
 		states = append(states, state)
-		if sample.rss > goldenRSSLimitBytes-rssBytes {
+		if sample.rss > rssLimit-rssBytes {
 			return goldenProcessEvidence{}, failGolden("rss_limit_exceeded")
 		}
 		rssBytes += sample.rss
@@ -3777,6 +3779,13 @@ func captureProcessEvidenceFromTable(phase, label string, pid int, table goldenP
 		ProcessID: pid, DescendantPIDs: pids, ProcessStates: states, SocketIDs: deduplicateStrings(socketIDs),
 		RemoteSocketIDs: deduplicateStrings(remoteIDs), RSSBytes: rssBytes, remoteSockets: remoteSockets,
 	}, nil
+}
+
+func goldenProcessRSSLimit(label string) int64 {
+	if label == "local-daemon" {
+		return goldenRSSLimitBytes
+	}
+	return goldenCodexRSSLimitBytes
 }
 
 func goldenProcessTreePIDs(table goldenProcessTable, root int) []int {
@@ -4428,7 +4437,7 @@ func validateGoldenSummary(summary goldenSummary, testMode bool) error {
 			(!strings.Contains(session.Label, "-candidate-") && !session.TransportSocketStable) || session.ResponseBytes <= 0 ||
 			session.MarkerCount != 1 || session.RetryCount != 0 || session.ReconnectCount != 0 ||
 			session.FallbackCount != 0 || session.ErrorCount != 0 || session.NonzeroExitCount != 0 ||
-			session.DuplicateMarkerCount != 0 || session.PeakRSSBytes <= 0 || session.PeakRSSBytes > goldenRSSLimitBytes ||
+			session.DuplicateMarkerCount != 0 || session.PeakRSSBytes <= 0 || session.PeakRSSBytes > goldenCodexRSSLimitBytes ||
 			session.RSSSamples == 0 || session.ProcessSamples == 0 || session.PausedProcessSamples != 0 ||
 			session.MaxProcessSampleGapMS > goldenProcessSampleMaxGap.Milliseconds() ||
 			session.AllowedChunkGapMillis < goldenChunkGapFloor.Milliseconds() ||
@@ -4527,7 +4536,7 @@ func validateGoldenSummary(summary goldenSummary, testMode bool) error {
 		}
 		isObserver := strings.HasPrefix(item.Label, "observer-")
 		isIdleMigrationDaemon := item.Label == "local-daemon" && strings.HasPrefix(item.Phase, "migration-")
-		if !isObserver && (len(item.DescendantPIDs) == 0 || item.RSSBytes <= 0 || item.RSSBytes > goldenRSSLimitBytes) {
+		if !isObserver && (len(item.DescendantPIDs) == 0 || item.RSSBytes <= 0 || item.RSSBytes > goldenProcessRSSLimit(item.Label)) {
 			return failGolden("socket_evidence_incomplete")
 		}
 		if !isObserver && !isIdleMigrationDaemon && len(item.SocketIDs) == 0 {

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -179,20 +179,55 @@ func TestGoldenEvidenceRejectsMissingRetirementLink(t *testing.T) {
 	}
 }
 
-func TestGoldenProcessEvidenceRejectsProcessTreeAbove192MiB(t *testing.T) {
-	bin := t.TempDir()
-	writeGoldenExecutable(t, filepath.Join(bin, "pgrep"), "#!/bin/sh\nexit 1\n")
-	writeGoldenExecutable(t, filepath.Join(bin, "lsof"), "#!/bin/sh\nprintf 'n127.0.0.1:41000->203.0.113.10:443\\n'\n")
-	writeGoldenExecutable(t, filepath.Join(bin, "ps"), `#!/bin/sh
-case "$*" in
-  *state=*) printf 'S\n' ;;
-  *rss=*) printf '200000\n' ;;
-  *) exit 1 ;;
-esac
-`)
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
-	if _, err := captureProcessEvidence("before-activation", "direct-websocket", os.Getpid()); err == nil {
-		t.Fatal("accepted a process tree above 192 MiB RSS")
+func TestGoldenProcessEvidenceAllowsCodexAboveServerSlotLimit(t *testing.T) {
+	const observedCodexRSS int64 = 200_000 << 10
+	pid := os.Getpid()
+	previous := goldenTestHooks
+	goldenTestHooks.enabled = true
+	goldenTestHooks.processTable = func([]int) (goldenProcessTable, error) {
+		return goldenProcessTable{
+			processes: map[int]goldenProcessSample{pid: {parent: 1, state: "S", rss: observedCodexRSS}},
+			children:  map[int][]int{},
+		}, nil
+	}
+	goldenTestHooks.socketSnapshot = func(int) ([]byte, error) {
+		return []byte("n127.0.0.1:41000->203.0.113.10:443\n"), nil
+	}
+	t.Cleanup(func() { goldenTestHooks = previous })
+
+	evidence, err := captureProcessEvidence("before-activation", "direct-websocket", pid)
+	if err != nil {
+		t.Fatalf("rejected ordinary Codex RSS above the server slot limit: %v", err)
+	}
+	if evidence.RSSBytes <= goldenRSSLimitBytes {
+		t.Fatalf("test process RSS = %d, want above server slot limit %d", evidence.RSSBytes, goldenRSSLimitBytes)
+	}
+}
+
+func TestGoldenSummaryUsesSeparateCodexAndServerRSSBudgets(t *testing.T) {
+	const observedCodexRSS int64 = 200_000 << 10
+	if goldenRSSLimitBytes != 192<<20 || observedCodexRSS <= goldenRSSLimitBytes {
+		t.Fatalf("invalid test budgets: server=%d observed Codex=%d", goldenRSSLimitBytes, observedCodexRSS)
+	}
+
+	summary := validGoldenAcceptanceSummary()
+	for index := range summary.Sessions {
+		summary.Sessions[index].PeakRSSBytes = observedCodexRSS
+	}
+	for index := range summary.ProcessSnapshots {
+		item := &summary.ProcessSnapshots[index]
+		if item.Label != "local-daemon" && !strings.HasPrefix(item.Label, "observer-") {
+			item.RSSBytes = observedCodexRSS
+		}
+	}
+	if err := validateGoldenSummary(summary, false); err != nil {
+		t.Fatalf("rejected ordinary Codex RSS above the server slot limit: %v", err)
+	}
+
+	server := validGoldenActivationEvidence()
+	server.Metrics.CandidateSlot.RunScopedPeakRSSBytes = goldenInt64(observedCodexRSS)
+	if err := validateGoldenDeployEvidence(server, "slot-activation"); err == nil {
+		t.Fatal("accepted server slot RSS above its 192 MiB MemoryMax")
 	}
 }
 


### PR DESCRIPTION
The hosted continuity gate reused the 192 MiB server slot limit for Codex client process trees. A clean macOS 26 run measured 200 MiB and aborted before cutover.

Keep the server slot budget at 192 MiB and give bounded Codex process trees a separate 512 MiB ceiling. This remains far below the prior 15 GB runaway-client regression.

Regression history:
- f2a508a adds tests that fail against the shared budget
- cdc327e separates the budgets and makes them pass

Test: `go test ./cmd/subrouter-transport-observer -run 'TestGolden(ProcessEvidenceAllowsCodexAboveServerSlotLimit|SummaryUsesSeparateCodexAndServerRSSBudgets)$' -count=1`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788436097&installation_model_id=21920&pr_number=148&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F148&signature=9076692d8d64c7b45f3848738c4449bafcd583a3f0f483157b43d39e0cfc79f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separate RSS budgets for Codex clients and the server slot to stop false rejections. Server remains capped at 192 MiB; Codex process trees now have a 512 MiB ceiling.

- **Bug Fixes**
  - Added `goldenCodexRSSLimitBytes` (512 MiB) and applied it to non-`local-daemon` processes in sampling, session, summary, and evidence checks.
  - Kept the server slot (`local-daemon`) at 192 MiB and enforced it in deploy validation.
  - Added tests: `TestGoldenProcessEvidenceAllowsCodexAboveServerSlotLimit` and `TestGoldenSummaryUsesSeparateCodexAndServerRSSBudgets`.

<sup>Written for commit cdc327ec334a922b26a31b23e722d66363d00382. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

