### PR TITLE
Release deployment locks when their owner dies

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -377,6 +377,91 @@ func TestPublishSubrouterRejectsNonHTTPSManagedURLBeforeMutation(t *testing.T) {
 	}
 }
 
+func TestDeployLockReleasesWhenOwningShellIsKilled(t *testing.T) {
+	requireDeployScriptTools(t, "bash")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	helper := filepath.Join(repoRoot, "deploy", "gcp", "deploy-lock.sh")
+	fakeBin := t.TempDir()
+	holderPID := filepath.Join(t.TempDir(), "holder.pid")
+	remoteLock := filepath.Join(t.TempDir(), "remote.lock")
+	lockLog := filepath.Join(t.TempDir(), "deploy-lock.log")
+	acquired := filepath.Join(t.TempDir(), "acquired")
+	fakeGcloud := filepath.Join(fakeBin, "gcloud")
+	writeExecutableTestFile(t, fakeGcloud, `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$$" >"$HOLDER_PID_FILE"
+: >"$REMOTE_LOCK_FILE"
+cleanup() { unlink "$REMOTE_LOCK_FILE" 2>/dev/null || true; }
+trap cleanup EXIT
+printf 'LOCKED\n'
+while IFS= read -r _; do :; done
+`)
+
+	harness := `
+set -euo pipefail
+source "$1"
+GCLOUD_BINARY="$2"
+INSTANCE=subrouter-staging
+PROJECT_ID=project
+ZONE=us-south1-a
+DEPLOY_LOCK_FILE=/run/lock/subrouter-deploy.lock
+subrouter_acquire_deploy_lock "$3"
+printf 'acquired\n' >"$4"
+while :; do sleep 1; done
+`
+	var output strings.Builder
+	command := exec.Command(mustLookPath(t, "bash"), "-c", harness, "deploy-lock-test", helper, fakeGcloud, lockLog, acquired)
+	command.Env = append(os.Environ(),
+		"HOLDER_PID_FILE="+holderPID,
+		"REMOTE_LOCK_FILE="+remoteLock,
+		"SUBROUTER_DEPLOY_LOCK_HEARTBEAT_INTERVAL_SECONDS=0.05",
+		"SUBROUTER_DEPLOY_LOCK_HEARTBEAT_TIMEOUT_SECONDS=2",
+	)
+	command.Stdout = &output
+	command.Stderr = &output
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- command.Wait() }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, acquiredErr := os.Stat(acquired); acquiredErr == nil {
+			if _, lockErr := os.Stat(remoteLock); lockErr != nil {
+				t.Fatalf("helper reported acquisition without a held lock: %v", lockErr)
+			}
+			break
+		}
+		select {
+		case err := <-done:
+			t.Fatalf("lock owner exited before acquisition: %v\n%s", err, output.String())
+		default:
+		}
+		if time.Now().After(deadline) {
+			_ = command.Process.Kill()
+			<-done
+			t.Fatalf("timed out acquiring fake deployment lock\n%s", output.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := command.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	<-done
+	deadline = time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(remoteLock); os.IsNotExist(err) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("remote lock survived owner death; holder pid file %s\n%s", holderPID, output.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func TestCreateVMTempFilesSurviveInterruptedAndRepeatedMacOSRuns(t *testing.T) {
 	requireDeployScriptTools(t, "bash", "dd", "tr")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -4,12 +4,14 @@ import (
 	"bufio"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -433,8 +435,15 @@ wait
 	}()
 	t.Cleanup(func() {
 		_ = command.Process.Kill()
-		if childPID, err := os.ReadFile(longChildPID); err == nil {
-			_ = exec.Command(mustLookPath(t, "kill"), "-KILL", strings.TrimSpace(string(childPID))).Run()
+		if childPIDBytes, err := os.ReadFile(longChildPID); err == nil {
+			childPID, parseErr := strconv.Atoi(strings.TrimSpace(string(childPIDBytes)))
+			if parseErr != nil {
+				t.Errorf("parse long-lived child pid: %v", parseErr)
+			} else if child, findErr := os.FindProcess(childPID); findErr != nil {
+				t.Errorf("find long-lived child process: %v", findErr)
+			} else if killErr := child.Kill(); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+				t.Errorf("kill long-lived child process: %v", killErr)
+			}
 		}
 		select {
 		case <-done:

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -397,7 +397,7 @@ printf '%s\n' "$$" >"$HOLDER_PID_FILE"
 cleanup() { unlink "$REMOTE_LOCK_FILE" 2>/dev/null || true; }
 trap cleanup EXIT
 printf 'LOCKED\n'
-while IFS= read -r _; do :; done
+while IFS= read -r heartbeat; do printf 'ACK %s\n' "$heartbeat"; done
 `)
 
 	harness := `
@@ -496,6 +496,98 @@ wait
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("remote lock survived owner death; holder pid file %s\n%s", holderPID, output.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestDeployLockTerminatesOwnerWhenHeartbeatAcknowledgementsStop(t *testing.T) {
+	requireDeployScriptTools(t, "awk", "bash", "chmod", "grep", "kill", "mkfifo", "mktemp", "rmdir", "sleep", "unlink")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	helper := filepath.Join(repoRoot, "deploy", "gcp", "deploy-lock.sh")
+	fakeBin := t.TempDir()
+	remoteLock := filepath.Join(t.TempDir(), "remote.lock")
+	lockLog := filepath.Join(t.TempDir(), "deploy-lock.log")
+	acquired := filepath.Join(t.TempDir(), "acquired")
+	fakeGcloud := filepath.Join(fakeBin, "gcloud")
+	writeExecutableTestFile(t, fakeGcloud, `#!/usr/bin/env bash
+set -euo pipefail
+: >"$REMOTE_LOCK_FILE"
+cleanup() { unlink "$REMOTE_LOCK_FILE" 2>/dev/null || true; }
+trap cleanup EXIT
+printf 'LOCKED\n'
+while IFS= read -r _; do :; done
+`)
+
+	harness := `
+set -euo pipefail
+source "$1"
+subrouter_acquire_deploy_lock "$2" "$3" instance project zone /run/lock/subrouter-deploy.lock
+printf 'acquired\n' >"$4"
+while :; do sleep 1; done
+`
+	var output strings.Builder
+	command := exec.Command(mustLookPath(t, "bash"), "-c", harness, "deploy-lock-ack-test", helper, lockLog, fakeGcloud, acquired)
+	command.Env = append(os.Environ(),
+		"REMOTE_LOCK_FILE="+remoteLock,
+		"SUBROUTER_DEPLOY_LOCK_HEARTBEAT_INTERVAL_SECONDS=0.05",
+		"SUBROUTER_DEPLOY_LOCK_ACK_TIMEOUT_SECONDS=1",
+		"SUBROUTER_DEPLOY_LOCK_HEARTBEAT_TIMEOUT_SECONDS=3",
+	)
+	command.Stdout = &output
+	command.Stderr = &output
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	var waitErr error
+	go func() {
+		waitErr = command.Wait()
+		close(done)
+	}()
+	t.Cleanup(func() {
+		_ = command.Process.Kill()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Errorf("unacknowledged deploy lock process tree did not exit\n%s", output.String())
+		}
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, acquiredErr := os.Stat(acquired); acquiredErr == nil {
+			if _, lockErr := os.Stat(remoteLock); lockErr != nil {
+				t.Fatalf("helper reported acquisition without a held lock: %v", lockErr)
+			}
+			break
+		}
+		select {
+		case <-done:
+			t.Fatalf("lock owner exited before acquisition: %v\n%s", waitErr, output.String())
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out acquiring fake deployment lock\n%s", output.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	select {
+	case <-done:
+		if waitErr == nil {
+			t.Fatalf("lock owner exited successfully after acknowledgement loss\n%s", output.String())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("lock owner kept running without remote heartbeat acknowledgements\n%s", output.String())
+	}
+	deadline = time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(remoteLock); os.IsNotExist(err) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("remote lock survived acknowledgement failure\n%s", output.String())
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -383,6 +383,7 @@ func TestDeployLockReleasesWhenOwningShellIsKilled(t *testing.T) {
 	helper := filepath.Join(repoRoot, "deploy", "gcp", "deploy-lock.sh")
 	fakeBin := t.TempDir()
 	holderPID := filepath.Join(t.TempDir(), "holder.pid")
+	longChildPID := filepath.Join(t.TempDir(), "long-child.pid")
 	remoteLock := filepath.Join(t.TempDir(), "remote.lock")
 	lockLog := filepath.Join(t.TempDir(), "deploy-lock.log")
 	acquired := filepath.Join(t.TempDir(), "acquired")
@@ -407,10 +408,12 @@ ZONE=us-south1-a
 DEPLOY_LOCK_FILE=/run/lock/subrouter-deploy.lock
 subrouter_acquire_deploy_lock "$3" "$GCLOUD_BINARY" "$INSTANCE" "$PROJECT_ID" "$ZONE" "$DEPLOY_LOCK_FILE"
 printf 'acquired\n' >"$4"
-while :; do sleep 1; done
+sleep 30 >/dev/null 2>&1 &
+printf '%s\n' "$!" >"$5"
+wait
 `
 	var output strings.Builder
-	command := exec.Command(mustLookPath(t, "bash"), "-c", harness, "deploy-lock-test", helper, fakeGcloud, lockLog, acquired)
+	command := exec.Command(mustLookPath(t, "bash"), "-c", harness, "deploy-lock-test", helper, fakeGcloud, lockLog, acquired, longChildPID)
 	command.Env = append(os.Environ(),
 		"HOLDER_PID_FILE="+holderPID,
 		"REMOTE_LOCK_FILE="+remoteLock,
@@ -430,6 +433,9 @@ while :; do sleep 1; done
 	}()
 	t.Cleanup(func() {
 		_ = command.Process.Kill()
+		if childPID, err := os.ReadFile(longChildPID); err == nil {
+			_ = exec.Command(mustLookPath(t, "kill"), "-KILL", strings.TrimSpace(string(childPID))).Run()
+		}
 		select {
 		case <-done:
 		case <-time.After(10 * time.Second):
@@ -440,6 +446,10 @@ while :; do sleep 1; done
 	deadline := time.Now().Add(5 * time.Second)
 	for {
 		if _, acquiredErr := os.Stat(acquired); acquiredErr == nil {
+			if _, childErr := os.Stat(longChildPID); childErr != nil {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
 			if _, lockErr := os.Stat(remoteLock); lockErr != nil {
 				t.Fatalf("helper reported acquisition without a held lock: %v", lockErr)
 			}

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -389,6 +389,9 @@ func TestDeployLockReleasesWhenOwningShellIsKilled(t *testing.T) {
 	remoteLock := filepath.Join(t.TempDir(), "remote.lock")
 	lockLog := filepath.Join(t.TempDir(), "deploy-lock.log")
 	acquired := filepath.Join(t.TempDir(), "acquired")
+	if err := os.WriteFile(lockLog, []byte("STALE\nLOCKED\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	fakeGcloud := filepath.Join(fakeBin, "gcloud")
 	writeExecutableTestFile(t, fakeGcloud, `#!/usr/bin/env bash
 set -euo pipefail
@@ -420,6 +423,7 @@ wait
 		"HOLDER_PID_FILE="+holderPID,
 		"REMOTE_LOCK_FILE="+remoteLock,
 		"SUBROUTER_DEPLOY_LOCK_HEARTBEAT_INTERVAL_SECONDS=0.05",
+		"SUBROUTER_DEPLOY_LOCK_ACK_TIMEOUT_SECONDS=1",
 		"SUBROUTER_DEPLOY_LOCK_HEARTBEAT_TIMEOUT_SECONDS=2",
 	)
 	command.Stdout = &output
@@ -461,6 +465,13 @@ wait
 			}
 			if _, lockErr := os.Stat(remoteLock); lockErr != nil {
 				t.Fatalf("helper reported acquisition without a held lock: %v", lockErr)
+			}
+			lockOutput, readErr := os.ReadFile(lockLog)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if strings.Contains(string(lockOutput), "STALE") {
+				t.Fatalf("deployment lock accepted a stale acquisition marker:\n%s", lockOutput)
 			}
 			break
 		}
@@ -532,7 +543,7 @@ while :; do sleep 1; done
 		"REMOTE_LOCK_FILE="+remoteLock,
 		"SUBROUTER_DEPLOY_LOCK_HEARTBEAT_INTERVAL_SECONDS=0.05",
 		"SUBROUTER_DEPLOY_LOCK_ACK_TIMEOUT_SECONDS=1",
-		"SUBROUTER_DEPLOY_LOCK_HEARTBEAT_TIMEOUT_SECONDS=3",
+		"SUBROUTER_DEPLOY_LOCK_HEARTBEAT_TIMEOUT_SECONDS=10",
 	)
 	command.Stdout = &output
 	command.Stderr = &output
@@ -578,7 +589,7 @@ while :; do sleep 1; done
 		if waitErr == nil {
 			t.Fatalf("lock owner exited successfully after acknowledgement loss\n%s", output.String())
 		}
-	case <-time.After(3 * time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatalf("lock owner kept running without remote heartbeat acknowledgements\n%s", output.String())
 	}
 	deadline = time.Now().Add(5 * time.Second)

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -405,7 +405,7 @@ INSTANCE=subrouter-staging
 PROJECT_ID=project
 ZONE=us-south1-a
 DEPLOY_LOCK_FILE=/run/lock/subrouter-deploy.lock
-subrouter_acquire_deploy_lock "$3"
+subrouter_acquire_deploy_lock "$3" "$GCLOUD_BINARY" "$INSTANCE" "$PROJECT_ID" "$ZONE" "$DEPLOY_LOCK_FILE"
 printf 'acquired\n' >"$4"
 while :; do sleep 1; done
 `
@@ -608,7 +608,7 @@ case "$*" in
   "config get-value account") printf '%s\n' operator@example.com ;;
   "config get-value project") printf '%s\n' project ;;
   *"instances describe subrouter-team"*) cat "$LIVE_INSTANCE_FIXTURE" ;;
-  *"flock -x -w 300"*) printf '%s\n' LOCKED ;;
+  *"flock -x -w 300"*) printf '%s\n' LOCKED; cat >/dev/null ;;
   *"then echo fresh-prepared"*) printf '%s\n' fresh-prepared ;;
   *"subrouter-verify-fresh-vm"*) cat "$FRESH_TOPOLOGY_FIXTURE" ;;
 esac

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -452,7 +452,11 @@ while :; do sleep 1; done
 		}
 		if time.Now().After(deadline) {
 			_ = command.Process.Kill()
-			<-done
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatalf("timed out acquiring fake deployment lock and its process tree did not exit\n%s", output.String())
+			}
 			t.Fatalf("timed out acquiring fake deployment lock\n%s", output.String())
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -378,7 +378,7 @@ func TestPublishSubrouterRejectsNonHTTPSManagedURLBeforeMutation(t *testing.T) {
 }
 
 func TestDeployLockReleasesWhenOwningShellIsKilled(t *testing.T) {
-	requireDeployScriptTools(t, "bash")
+	requireDeployScriptTools(t, "awk", "bash", "chmod", "grep", "kill", "mkfifo", "mktemp", "rmdir", "sleep", "unlink")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))
 	helper := filepath.Join(repoRoot, "deploy", "gcp", "deploy-lock.sh")
 	fakeBin := t.TempDir()
@@ -422,8 +422,20 @@ while :; do sleep 1; done
 	if err := command.Start(); err != nil {
 		t.Fatal(err)
 	}
-	done := make(chan error, 1)
-	go func() { done <- command.Wait() }()
+	done := make(chan struct{})
+	var waitErr error
+	go func() {
+		waitErr = command.Wait()
+		close(done)
+	}()
+	t.Cleanup(func() {
+		_ = command.Process.Kill()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Errorf("deploy lock process tree did not exit\n%s", output.String())
+		}
+	})
 
 	deadline := time.Now().Add(5 * time.Second)
 	for {
@@ -434,8 +446,8 @@ while :; do sleep 1; done
 			break
 		}
 		select {
-		case err := <-done:
-			t.Fatalf("lock owner exited before acquisition: %v\n%s", err, output.String())
+		case <-done:
+			t.Fatalf("lock owner exited before acquisition: %v\n%s", waitErr, output.String())
 		default:
 		}
 		if time.Now().After(deadline) {
@@ -449,7 +461,11 @@ while :; do sleep 1; done
 	if err := command.Process.Kill(); err != nil {
 		t.Fatal(err)
 	}
-	<-done
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("deploy lock descendants outlived the killed owner; holder pid file %s\n%s", holderPID, output.String())
+	}
 	deadline = time.Now().Add(5 * time.Second)
 	for {
 		if _, err := os.Stat(remoteLock); os.IsNotExist(err) {

--- a/deploy/gcp/deploy-live-upgrade.sh
+++ b/deploy/gcp/deploy-live-upgrade.sh
@@ -82,10 +82,11 @@ RUN_LABEL="${RUN_LABEL//[^a-zA-Z0-9._-]/-}"
 REMOTE_CANDIDATE="/tmp/subrouter-slot-${RUN_LABEL}"
 REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
-REMOTE_LOCK_SENTINEL="/tmp/subrouter-deploy-lock-${RUN_LABEL}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=deploy/gcp/stream-shell-value.sh
 source "${SCRIPT_DIR}/stream-shell-value.sh"
+# shellcheck source=deploy/gcp/deploy-lock.sh
+source "${SCRIPT_DIR}/deploy-lock.sh"
 
 log() { printf 'gcp-slot-deploy: %s\n' "$*"; }
 die() { log "$*" >&2; exit 1; }
@@ -414,25 +415,13 @@ last_connection_closed_ms=""
 slot_absence_latency_ms=""
 
 acquire_deploy_lock() {
-  gcloud_ssh "umask 077; : > '${REMOTE_LOCK_SENTINEL}'; command -v flock >/dev/null"
-  "${GCLOUD_BINARY}" compute ssh "${INSTANCE}" \
-    --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet \
-    --command "sudo flock -x -w 300 '${DEPLOY_LOCK_FILE}' sh -c 'echo LOCKED; while test -e \"${REMOTE_LOCK_SENTINEL}\"; do sleep 1; done'" \
-    >"${ARTIFACT_DIR}/deploy-lock.log" 2>&1 &
-  lock_holder_pid=$!
-  for _ in $(seq 1 3100); do
-    grep -qx LOCKED "${ARTIFACT_DIR}/deploy-lock.log" 2>/dev/null && return 0
-    kill -0 "${lock_holder_pid}" 2>/dev/null || die "remote deployment lock holder exited"
-    sleep 0.1
-  done
-  die "timed out acquiring ${DEPLOY_LOCK_FILE}"
+  subrouter_acquire_deploy_lock "${ARTIFACT_DIR}/deploy-lock.log" \
+    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" \
+    || die "could not acquire ${DEPLOY_LOCK_FILE}"
 }
 
 release_deploy_lock() {
-  [[ -n "${lock_holder_pid}" ]] || return 0
-  gcloud_ssh "rm -f '${REMOTE_LOCK_SENTINEL}'" >/dev/null 2>&1 || true
-  wait "${lock_holder_pid}" || true
-  lock_holder_pid=""
+  subrouter_release_deploy_lock
 }
 
 persist_front_slot() {

--- a/deploy/gcp/deploy-lock.sh
+++ b/deploy/gcp/deploy-lock.sh
@@ -8,6 +8,7 @@ lock_pipe_path=""
 lock_pipe_dir=""
 
 subrouter_release_deploy_lock() {
+  local attempt
   if [[ -n "${lock_heartbeat_pid}" ]]; then
     kill -TERM "${lock_heartbeat_pid}" >/dev/null 2>&1 || true
     wait "${lock_heartbeat_pid}" >/dev/null 2>&1 || true
@@ -18,6 +19,20 @@ subrouter_release_deploy_lock() {
     lock_heartbeat_fd_open=0
   fi
   if [[ -n "${lock_holder_pid}" ]]; then
+    for ((attempt = 0; attempt < 100; attempt++)); do
+      kill -0 "${lock_holder_pid}" >/dev/null 2>&1 || break
+      sleep 0.1
+    done
+    if kill -0 "${lock_holder_pid}" >/dev/null 2>&1; then
+      kill -TERM "${lock_holder_pid}" >/dev/null 2>&1 || true
+      for ((attempt = 0; attempt < 20; attempt++)); do
+        kill -0 "${lock_holder_pid}" >/dev/null 2>&1 || break
+        sleep 0.1
+      done
+    fi
+    if kill -0 "${lock_holder_pid}" >/dev/null 2>&1; then
+      kill -KILL "${lock_holder_pid}" >/dev/null 2>&1 || true
+    fi
     wait "${lock_holder_pid}" >/dev/null 2>&1 || true
     lock_holder_pid=""
   fi
@@ -41,7 +56,7 @@ subrouter_acquire_deploy_lock() {
   local heartbeat_interval="${SUBROUTER_DEPLOY_LOCK_HEARTBEAT_INTERVAL_SECONDS:-10}"
   local heartbeat_timeout="${SUBROUTER_DEPLOY_LOCK_HEARTBEAT_TIMEOUT_SECONDS:-300}"
   local owner_pid="$$"
-  local attempt
+  local attempt required_command
 
   [[ -z "${lock_holder_pid}" && -z "${lock_heartbeat_pid}" && "${lock_heartbeat_fd_open}" == 0 ]] || {
     echo "deployment lock is already held by this process" >&2
@@ -60,12 +75,17 @@ subrouter_acquire_deploy_lock() {
     echo "deployment lock heartbeat timeout is invalid" >&2
     return 1
   }
-  for command in "${gcloud_binary}" chmod grep kill mkfifo mktemp rmdir sleep unlink; do
-    command -v "${command}" >/dev/null 2>&1 || {
-      echo "deployment lock command is unavailable: ${command}" >&2
+  for required_command in "${gcloud_binary}" awk chmod grep kill mkfifo mktemp rmdir sleep unlink; do
+    command -v "${required_command}" >/dev/null 2>&1 || {
+      echo "deployment lock command is unavailable: ${required_command}" >&2
       return 1
     }
   done
+  awk -v interval="${heartbeat_interval}" -v timeout="${heartbeat_timeout}" \
+    'BEGIN { exit !(interval < timeout) }' || {
+    echo "deployment lock heartbeat interval must be shorter than its timeout" >&2
+    return 1
+  }
 
   lock_pipe_dir="$(mktemp -d "${TMPDIR:-/tmp}/subrouter-deploy-lock.XXXXXX")" || return 1
   lock_pipe_path="${lock_pipe_dir}/heartbeat"

--- a/deploy/gcp/deploy-lock.sh
+++ b/deploy/gcp/deploy-lock.sh
@@ -49,9 +49,10 @@ subrouter_acquire_deploy_lock() {
   local zone="$5"
   local deploy_lock_file="$6"
   local heartbeat_interval="${SUBROUTER_DEPLOY_LOCK_HEARTBEAT_INTERVAL_SECONDS:-10}"
+  local heartbeat_ack_timeout="${SUBROUTER_DEPLOY_LOCK_ACK_TIMEOUT_SECONDS:-30}"
   local heartbeat_timeout="${SUBROUTER_DEPLOY_LOCK_HEARTBEAT_TIMEOUT_SECONDS:-300}"
   local owner_pid="$$"
-  local attempt required_command
+  local attempt heartbeat_ack_attempts required_command
 
   [[ -z "${lock_holder_pid}" && -z "${lock_heartbeat_pid}" ]] || {
     echo "deployment lock is already held by this process" >&2
@@ -70,17 +71,32 @@ subrouter_acquire_deploy_lock() {
     echo "deployment lock heartbeat timeout is invalid" >&2
     return 1
   }
+  [[ "${heartbeat_ack_timeout}" =~ ^[0-9]+$ && "${heartbeat_ack_timeout}" != 0 ]] || {
+    echo "deployment lock acknowledgement timeout is invalid" >&2
+    return 1
+  }
   for required_command in "${gcloud_binary}" awk chmod grep kill mkfifo mktemp rmdir sleep unlink; do
     command -v "${required_command}" >/dev/null 2>&1 || {
       echo "deployment lock command is unavailable: ${required_command}" >&2
       return 1
     }
   done
-  awk -v interval="${heartbeat_interval}" -v timeout="${heartbeat_timeout}" \
-    'BEGIN { exit !(interval < timeout) }' || {
-    echo "deployment lock heartbeat interval must be shorter than its timeout" >&2
+  awk -v interval="${heartbeat_interval}" -v ack_timeout="${heartbeat_ack_timeout}" \
+    -v heartbeat_timeout="${heartbeat_timeout}" \
+    'BEGIN { exit !(interval < ack_timeout && ack_timeout < heartbeat_timeout) }' || {
+    echo "deployment lock timing must satisfy heartbeat interval < acknowledgement timeout < remote timeout" >&2
     return 1
   }
+  heartbeat_ack_attempts=$((heartbeat_ack_timeout * 10))
+
+  if [[ -L "${log_file}" ]]; then
+    echo "deployment lock log must not be a symlink: ${log_file}" >&2
+    return 1
+  fi
+  if ! : >"${log_file}" || ! chmod 0600 "${log_file}"; then
+    echo "deployment lock log is not writable: ${log_file}" >&2
+    return 1
+  fi
 
   lock_pipe_dir="$(mktemp -d "${TMPDIR:-/tmp}/subrouter-deploy-lock.XXXXXX")" || return 1
   lock_pipe_path="${lock_pipe_dir}/heartbeat"
@@ -91,7 +107,7 @@ subrouter_acquire_deploy_lock() {
 
   "${gcloud_binary}" compute ssh "${instance}" \
     --project "${project_id}" --zone "${zone}" --tunnel-through-iap --quiet \
-    --command "sudo flock -x -w 300 '${deploy_lock_file}' bash -c 'echo LOCKED; while IFS= read -r -t ${heartbeat_timeout} heartbeat; do :; done'" \
+    --command "sudo flock -x -w 300 '${deploy_lock_file}' bash -c 'echo LOCKED; while IFS= read -r -t ${heartbeat_timeout} heartbeat; do echo ACK \"\${heartbeat}\"; done'" \
     <"${lock_pipe_path}" >"${log_file}" 2>&1 &
   lock_holder_pid=$!
   exec 9>"${lock_pipe_path}"
@@ -108,8 +124,45 @@ subrouter_acquire_deploy_lock() {
       exit 0
     }
     trap stop_heartbeat TERM INT
+    while ! grep -qx LOCKED "${log_file}" 9>&- 2>/dev/null; do
+      if ! kill -0 "${owner_pid}" 2>/dev/null; then
+        exit 0
+      fi
+      if ! kill -0 "${lock_holder_pid}" 2>/dev/null; then
+        kill -TERM "${owner_pid}" >/dev/null 2>&1 || true
+        exit 1
+      fi
+      sleep 0.1 9>&- >/dev/null 2>&1 &
+      heartbeat_sleep_pid=$!
+      wait "${heartbeat_sleep_pid}" >/dev/null 2>&1 || true
+      heartbeat_sleep_pid=""
+    done
+    heartbeat_sequence=0
     while kill -0 "${owner_pid}" 2>/dev/null; do
-      if ! kill -0 "${lock_holder_pid}" 2>/dev/null || ! printf 'heartbeat\n' >&9; then
+      if ! kill -0 "${lock_holder_pid}" 2>/dev/null; then
+        kill -TERM "${owner_pid}" >/dev/null 2>&1 || true
+        exit 1
+      fi
+      heartbeat_sequence=$((heartbeat_sequence + 1))
+      if ! printf '%s\n' "${heartbeat_sequence}" >&9; then
+        kill -TERM "${owner_pid}" >/dev/null 2>&1 || true
+        exit 1
+      fi
+      heartbeat_acknowledged=false
+      for ((ack_attempt = 0; ack_attempt < heartbeat_ack_attempts; ack_attempt++)); do
+        if grep -qx "ACK ${heartbeat_sequence}" "${log_file}" 9>&- 2>/dev/null; then
+          heartbeat_acknowledged=true
+          break
+        fi
+        if ! kill -0 "${lock_holder_pid}" 2>/dev/null; then
+          break
+        fi
+        sleep 0.1 9>&- >/dev/null 2>&1 &
+        heartbeat_sleep_pid=$!
+        wait "${heartbeat_sleep_pid}" >/dev/null 2>&1 || true
+        heartbeat_sleep_pid=""
+      done
+      if [[ "${heartbeat_acknowledged}" != true ]]; then
         kill -TERM "${owner_pid}" >/dev/null 2>&1 || true
         exit 1
       fi

--- a/deploy/gcp/deploy-lock.sh
+++ b/deploy/gcp/deploy-lock.sh
@@ -3,7 +3,6 @@
 
 lock_holder_pid="${lock_holder_pid:-}"
 lock_heartbeat_pid="${lock_heartbeat_pid:-}"
-lock_heartbeat_fd_open=0
 lock_pipe_path=""
 lock_pipe_dir=""
 
@@ -13,10 +12,6 @@ subrouter_release_deploy_lock() {
     kill -TERM "${lock_heartbeat_pid}" >/dev/null 2>&1 || true
     wait "${lock_heartbeat_pid}" >/dev/null 2>&1 || true
     lock_heartbeat_pid=""
-  fi
-  if [[ "${lock_heartbeat_fd_open}" == 1 ]]; then
-    exec 9>&-
-    lock_heartbeat_fd_open=0
   fi
   if [[ -n "${lock_holder_pid}" ]]; then
     for ((attempt = 0; attempt < 100; attempt++)); do
@@ -58,7 +53,7 @@ subrouter_acquire_deploy_lock() {
   local owner_pid="$$"
   local attempt required_command
 
-  [[ -z "${lock_holder_pid}" && -z "${lock_heartbeat_pid}" && "${lock_heartbeat_fd_open}" == 0 ]] || {
+  [[ -z "${lock_holder_pid}" && -z "${lock_heartbeat_pid}" ]] || {
     echo "deployment lock is already held by this process" >&2
     return 1
   }
@@ -100,29 +95,6 @@ subrouter_acquire_deploy_lock() {
     <"${lock_pipe_path}" >"${log_file}" 2>&1 &
   lock_holder_pid=$!
   exec 9>"${lock_pipe_path}"
-  lock_heartbeat_fd_open=1
-  unlink "${lock_pipe_path}"
-  lock_pipe_path=""
-  rmdir "${lock_pipe_dir}"
-  lock_pipe_dir=""
-
-  for ((attempt = 0; attempt < 3100; attempt++)); do
-    if grep -qx LOCKED "${log_file}" 2>/dev/null; then
-      break
-    fi
-    if ! kill -0 "${lock_holder_pid}" 2>/dev/null; then
-      echo "remote deployment lock holder exited before acquisition" >&2
-      subrouter_release_deploy_lock
-      return 1
-    fi
-    sleep 0.1
-  done
-  if ! grep -qx LOCKED "${log_file}" 2>/dev/null; then
-    echo "timed out acquiring ${deploy_lock_file}" >&2
-    subrouter_release_deploy_lock
-    return 1
-  fi
-
   (
     trap '' PIPE
     heartbeat_sleep_pid=""
@@ -148,4 +120,27 @@ subrouter_acquire_deploy_lock() {
     done
   ) &
   lock_heartbeat_pid=$!
+  exec 9>&-
+  unlink "${lock_pipe_path}"
+  lock_pipe_path=""
+  rmdir "${lock_pipe_dir}"
+  lock_pipe_dir=""
+
+  for ((attempt = 0; attempt < 3100; attempt++)); do
+    if grep -qx LOCKED "${log_file}" 2>/dev/null; then
+      break
+    fi
+    if ! kill -0 "${lock_holder_pid}" 2>/dev/null; then
+      echo "remote deployment lock holder exited before acquisition" >&2
+      subrouter_release_deploy_lock
+      return 1
+    fi
+    sleep 0.1
+  done
+  if ! grep -qx LOCKED "${log_file}" 2>/dev/null; then
+    echo "timed out acquiring ${deploy_lock_file}" >&2
+    subrouter_release_deploy_lock
+    return 1
+  fi
+
 }

--- a/deploy/gcp/deploy-lock.sh
+++ b/deploy/gcp/deploy-lock.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Shared deployment lock whose lifetime is tied to the owning local shell.
+
+lock_holder_pid="${lock_holder_pid:-}"
+lock_heartbeat_pid="${lock_heartbeat_pid:-}"
+lock_heartbeat_fd_open=0
+lock_pipe_path=""
+lock_pipe_dir=""
+
+subrouter_release_deploy_lock() {
+  if [[ -n "${lock_heartbeat_pid}" ]]; then
+    kill -TERM "${lock_heartbeat_pid}" >/dev/null 2>&1 || true
+    wait "${lock_heartbeat_pid}" >/dev/null 2>&1 || true
+    lock_heartbeat_pid=""
+  fi
+  if [[ "${lock_heartbeat_fd_open}" == 1 ]]; then
+    exec 9>&-
+    lock_heartbeat_fd_open=0
+  fi
+  if [[ -n "${lock_holder_pid}" ]]; then
+    wait "${lock_holder_pid}" >/dev/null 2>&1 || true
+    lock_holder_pid=""
+  fi
+  if [[ -n "${lock_pipe_path}" && -p "${lock_pipe_path}" ]]; then
+    unlink "${lock_pipe_path}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${lock_pipe_dir}" && -d "${lock_pipe_dir}" ]]; then
+    rmdir "${lock_pipe_dir}" >/dev/null 2>&1 || true
+  fi
+  lock_pipe_path=""
+  lock_pipe_dir=""
+}
+
+subrouter_acquire_deploy_lock() {
+  local log_file="$1"
+  local gcloud_binary="$2"
+  local instance="$3"
+  local project_id="$4"
+  local zone="$5"
+  local deploy_lock_file="$6"
+  local heartbeat_interval="${SUBROUTER_DEPLOY_LOCK_HEARTBEAT_INTERVAL_SECONDS:-10}"
+  local heartbeat_timeout="${SUBROUTER_DEPLOY_LOCK_HEARTBEAT_TIMEOUT_SECONDS:-300}"
+  local owner_pid="$$"
+  local attempt
+
+  [[ -z "${lock_holder_pid}" && -z "${lock_heartbeat_pid}" && "${lock_heartbeat_fd_open}" == 0 ]] || {
+    echo "deployment lock is already held by this process" >&2
+    return 1
+  }
+  [[ "${deploy_lock_file}" =~ ^/[A-Za-z0-9._/-]+$ ]] || {
+    echo "deployment lock path is invalid" >&2
+    return 1
+  }
+  [[ "${heartbeat_interval}" =~ ^[0-9]+([.][0-9]+)?$ &&
+     ! "${heartbeat_interval}" =~ ^0+([.]0+)?$ ]] || {
+    echo "deployment lock heartbeat interval is invalid" >&2
+    return 1
+  }
+  [[ "${heartbeat_timeout}" =~ ^[0-9]+$ && "${heartbeat_timeout}" != 0 ]] || {
+    echo "deployment lock heartbeat timeout is invalid" >&2
+    return 1
+  }
+  for command in "${gcloud_binary}" chmod grep kill mkfifo mktemp rmdir sleep unlink; do
+    command -v "${command}" >/dev/null 2>&1 || {
+      echo "deployment lock command is unavailable: ${command}" >&2
+      return 1
+    }
+  done
+
+  lock_pipe_dir="$(mktemp -d "${TMPDIR:-/tmp}/subrouter-deploy-lock.XXXXXX")" || return 1
+  lock_pipe_path="${lock_pipe_dir}/heartbeat"
+  if ! mkfifo "${lock_pipe_path}" || ! chmod 0600 "${lock_pipe_path}"; then
+    subrouter_release_deploy_lock
+    return 1
+  fi
+
+  "${gcloud_binary}" compute ssh "${instance}" \
+    --project "${project_id}" --zone "${zone}" --tunnel-through-iap --quiet \
+    --command "sudo flock -x -w 300 '${deploy_lock_file}' bash -c 'echo LOCKED; while IFS= read -r -t ${heartbeat_timeout} heartbeat; do :; done'" \
+    <"${lock_pipe_path}" >"${log_file}" 2>&1 &
+  lock_holder_pid=$!
+  exec 9>"${lock_pipe_path}"
+  lock_heartbeat_fd_open=1
+  unlink "${lock_pipe_path}"
+  lock_pipe_path=""
+  rmdir "${lock_pipe_dir}"
+  lock_pipe_dir=""
+
+  for ((attempt = 0; attempt < 3100; attempt++)); do
+    if grep -qx LOCKED "${log_file}" 2>/dev/null; then
+      break
+    fi
+    if ! kill -0 "${lock_holder_pid}" 2>/dev/null; then
+      echo "remote deployment lock holder exited before acquisition" >&2
+      subrouter_release_deploy_lock
+      return 1
+    fi
+    sleep 0.1
+  done
+  if ! grep -qx LOCKED "${log_file}" 2>/dev/null; then
+    echo "timed out acquiring ${deploy_lock_file}" >&2
+    subrouter_release_deploy_lock
+    return 1
+  fi
+
+  (
+    trap '' PIPE
+    heartbeat_sleep_pid=""
+    # shellcheck disable=SC2329 # Invoked by the signal trap below.
+    stop_heartbeat() {
+      trap - TERM INT
+      if [[ -n "${heartbeat_sleep_pid}" ]]; then
+        kill -TERM "${heartbeat_sleep_pid}" >/dev/null 2>&1 || true
+        wait "${heartbeat_sleep_pid}" >/dev/null 2>&1 || true
+      fi
+      exit 0
+    }
+    trap stop_heartbeat TERM INT
+    while kill -0 "${owner_pid}" 2>/dev/null; do
+      if ! kill -0 "${lock_holder_pid}" 2>/dev/null || ! printf 'heartbeat\n' >&9; then
+        kill -TERM "${owner_pid}" >/dev/null 2>&1 || true
+        exit 1
+      fi
+      sleep "${heartbeat_interval}" 9>&- >/dev/null 2>&1 &
+      heartbeat_sleep_pid=$!
+      wait "${heartbeat_sleep_pid}" >/dev/null 2>&1 || true
+      heartbeat_sleep_pid=""
+    done
+  ) &
+  lock_heartbeat_pid=$!
+}

--- a/deploy/gcp/finalize-legacy-retirement.sh
+++ b/deploy/gcp/finalize-legacy-retirement.sh
@@ -34,12 +34,13 @@ DRAIN_TIMEOUT_SECONDS="${SUBROUTER_RETIRE_DRAIN_TIMEOUT_SECONDS:-3600}"
 ARTIFACT_DIR="${SUBROUTER_DEPLOY_ARTIFACT_DIR:-${PWD}/artifacts/gcp-legacy-retirement}"
 RUN_LABEL="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-legacy-retire-$$"
 RUN_LABEL="${RUN_LABEL//[^a-zA-Z0-9._-]/-}"
-REMOTE_LOCK_SENTINEL="/tmp/subrouter-deploy-lock-${RUN_LABEL}"
 REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=deploy/gcp/stream-shell-value.sh
 source "${SCRIPT_DIR}/stream-shell-value.sh"
+# shellcheck source=deploy/gcp/deploy-lock.sh
+source "${SCRIPT_DIR}/deploy-lock.sh"
 
 log() { printf 'gcp-legacy-retirement: %s\n' "$*"; }
 die() { log "$*" >&2; exit 1; }
@@ -134,24 +135,12 @@ stop_legacy_sampler() {
 
 lock_holder_pid=""
 acquire_lock() {
-  gcloud_ssh "umask 077; : > '${REMOTE_LOCK_SENTINEL}'; command -v flock >/dev/null"
-  "${GCLOUD_BINARY}" compute ssh "${INSTANCE}" \
-    --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet \
-    --command "sudo flock -x -w 300 '${DEPLOY_LOCK_FILE}' sh -c 'echo LOCKED; while test -e \"${REMOTE_LOCK_SENTINEL}\"; do sleep 1; done'" \
-    >"${ARTIFACT_DIR}/deploy-lock.log" 2>&1 &
-  lock_holder_pid=$!
-  for _ in $(seq 1 3100); do
-    grep -qx LOCKED "${ARTIFACT_DIR}/deploy-lock.log" 2>/dev/null && return
-    kill -0 "${lock_holder_pid}" 2>/dev/null || die "remote deployment lock holder exited"
-    sleep 0.1
-  done
-  die "timed out acquiring ${DEPLOY_LOCK_FILE}"
+  subrouter_acquire_deploy_lock "${ARTIFACT_DIR}/deploy-lock.log" \
+    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" \
+    || die "could not acquire ${DEPLOY_LOCK_FILE}"
 }
 release_lock() {
-  [[ -n "${lock_holder_pid}" ]] || return 0
-  gcloud_ssh "rm -f '${REMOTE_LOCK_SENTINEL}'" >/dev/null 2>&1 || true
-  wait "${lock_holder_pid}" || true
-  lock_holder_pid=""
+  subrouter_release_deploy_lock
 }
 cleanup() {
   local status=$?

--- a/deploy/gcp/finalize-slot-retirement.sh
+++ b/deploy/gcp/finalize-slot-retirement.sh
@@ -39,10 +39,11 @@ RUN_LABEL="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-retire-$$"
 RUN_LABEL="${RUN_LABEL//[^a-zA-Z0-9._-]/-}"
 REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
-REMOTE_LOCK_SENTINEL="/tmp/subrouter-deploy-lock-${RUN_LABEL}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=deploy/gcp/stream-shell-value.sh
 source "${SCRIPT_DIR}/stream-shell-value.sh"
+# shellcheck source=deploy/gcp/deploy-lock.sh
+source "${SCRIPT_DIR}/deploy-lock.sh"
 
 log() { printf 'gcp-slot-retirement: %s\n' "$*"; }
 die() { log "$*" >&2; exit 1; }
@@ -167,24 +168,12 @@ stop_retirement_sampler() {
 
 lock_holder_pid=""
 acquire_lock() {
-  gcloud_ssh "umask 077; : > '${REMOTE_LOCK_SENTINEL}'; command -v flock >/dev/null"
-  "${GCLOUD_BINARY}" compute ssh "${INSTANCE}" \
-    --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet \
-    --command "sudo flock -x -w 300 '${DEPLOY_LOCK_FILE}' sh -c 'echo LOCKED; while test -e \"${REMOTE_LOCK_SENTINEL}\"; do sleep 1; done'" \
-    >"${ARTIFACT_DIR}/deploy-lock.log" 2>&1 &
-  lock_holder_pid=$!
-  for _ in $(seq 1 3100); do
-    grep -qx LOCKED "${ARTIFACT_DIR}/deploy-lock.log" 2>/dev/null && return
-    kill -0 "${lock_holder_pid}" 2>/dev/null || die "remote deployment lock holder exited"
-    sleep 0.1
-  done
-  die "timed out acquiring ${DEPLOY_LOCK_FILE}"
+  subrouter_acquire_deploy_lock "${ARTIFACT_DIR}/deploy-lock.log" \
+    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" \
+    || die "could not acquire ${DEPLOY_LOCK_FILE}"
 }
 release_lock() {
-  [[ -n "${lock_holder_pid}" ]] || return 0
-  gcloud_ssh "rm -f '${REMOTE_LOCK_SENTINEL}'" >/dev/null 2>&1 || true
-  wait "${lock_holder_pid}" || true
-  lock_holder_pid=""
+  subrouter_release_deploy_lock
 }
 cleanup() {
   local status=$?

--- a/deploy/gcp/migrate-to-front-slots.sh
+++ b/deploy/gcp/migrate-to-front-slots.sh
@@ -60,10 +60,11 @@ REMOTE_CANDIDATE="/tmp/subrouter-front-migration-${RUN_LABEL}"
 REMOTE_WORKER_CANDIDATE="/tmp/subrouter-front-worker-${RUN_LABEL}"
 REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
-REMOTE_LOCK_SENTINEL="/tmp/subrouter-deploy-lock-${RUN_LABEL}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=deploy/gcp/stream-shell-value.sh
 source "${SCRIPT_DIR}/stream-shell-value.sh"
+# shellcheck source=deploy/gcp/deploy-lock.sh
+source "${SCRIPT_DIR}/deploy-lock.sh"
 
 case "${INSTANCE}" in
   subrouter-team)
@@ -171,26 +172,13 @@ gcloud_scp() {
 
 lock_holder_pid=""
 acquire_deploy_lock() {
-  gcloud_ssh "umask 077; : > '${REMOTE_LOCK_SENTINEL}'; command -v flock >/dev/null"
-  "${GCLOUD_BINARY}" compute ssh "${INSTANCE}" \
-    --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet \
-    --command "sudo flock -x -w 300 '${DEPLOY_LOCK_FILE}' sh -c 'echo LOCKED; while test -e \"${REMOTE_LOCK_SENTINEL}\"; do sleep 1; done'" \
-    >"${ARTIFACT_DIR}/deploy-lock.log" 2>&1 &
-  lock_holder_pid=$!
-  for _ in $(seq 1 3100); do
-    grep -qx LOCKED "${ARTIFACT_DIR}/deploy-lock.log" 2>/dev/null && return 0
-    kill -0 "${lock_holder_pid}" 2>/dev/null \
-      || die "remote deployment lock holder exited"
-    sleep 0.1
-  done
-  die "timed out acquiring ${DEPLOY_LOCK_FILE}"
+  subrouter_acquire_deploy_lock "${ARTIFACT_DIR}/deploy-lock.log" \
+    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" \
+    || die "could not acquire ${DEPLOY_LOCK_FILE}"
 }
 
 release_deploy_lock() {
-  [[ -n "${lock_holder_pid}" ]] || return 0
-  gcloud_ssh "rm -f '${REMOTE_LOCK_SENTINEL}'" >/dev/null 2>&1 || true
-  wait "${lock_holder_pid}" || true
-  lock_holder_pid=""
+  subrouter_release_deploy_lock
 }
 
 old_drain_timeout=""

--- a/deploy/gcp/normalize-staging-predecessor.sh
+++ b/deploy/gcp/normalize-staging-predecessor.sh
@@ -39,10 +39,11 @@ RUN_LABEL="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-normalize-$$"
 RUN_LABEL="${RUN_LABEL//[^a-zA-Z0-9._-]/-}"
 REMOTE_CANDIDATE="/tmp/subrouter-v0.1.51-${RUN_LABEL}"
 REMOTE_BACKUP="/tmp/subrouter-pre-normalization-${RUN_LABEL}"
-REMOTE_LOCK_SENTINEL="/tmp/subrouter-deploy-lock-${RUN_LABEL}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=deploy/gcp/stream-shell-value.sh
 source "${SCRIPT_DIR}/stream-shell-value.sh"
+# shellcheck source=deploy/gcp/deploy-lock.sh
+source "${SCRIPT_DIR}/deploy-lock.sh"
 
 log() { printf 'gcp-staging-normalization: %s\n' "$*"; }
 die() { log "$*" >&2; exit 1; }
@@ -98,24 +99,12 @@ lock_holder_pid=""
 normalization_started=0
 normalization_committed=0
 acquire_lock() {
-  gcloud_ssh "umask 077; : > '${REMOTE_LOCK_SENTINEL}'; command -v flock >/dev/null"
-  "${GCLOUD_BINARY}" compute ssh "${INSTANCE}" --project "${PROJECT_ID}" --zone "${ZONE}" \
-    --tunnel-through-iap --quiet \
-    --command "sudo flock -x -w 300 '${DEPLOY_LOCK_FILE}' sh -c 'echo LOCKED; while test -e \"${REMOTE_LOCK_SENTINEL}\"; do sleep 1; done'" \
-    >"${ARTIFACT_DIR}/deploy-lock.log" 2>&1 &
-  lock_holder_pid=$!
-  for _ in $(seq 1 3100); do
-    grep -qx LOCKED "${ARTIFACT_DIR}/deploy-lock.log" 2>/dev/null && return
-    kill -0 "${lock_holder_pid}" 2>/dev/null || die "remote deployment lock holder exited"
-    sleep 0.1
-  done
-  die "timed out acquiring ${DEPLOY_LOCK_FILE}"
+  subrouter_acquire_deploy_lock "${ARTIFACT_DIR}/deploy-lock.log" \
+    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" \
+    || die "could not acquire ${DEPLOY_LOCK_FILE}"
 }
 release_lock() {
-  [[ -n "${lock_holder_pid}" ]] || return 0
-  gcloud_ssh "rm -f '${REMOTE_LOCK_SENTINEL}'" >/dev/null 2>&1 || true
-  wait "${lock_holder_pid}" || true
-  lock_holder_pid=""
+  subrouter_release_deploy_lock
 }
 rollback_normalization() {
   local pre_rollback_status pre_rollback_generation restored_status restored_generation restored_checksum

--- a/deploy/gcp/publish-subrouter.sh
+++ b/deploy/gcp/publish-subrouter.sh
@@ -143,6 +143,12 @@ trap cleanup EXIT INT TERM
 
 subrouter_acquire_deploy_lock "${lock_log}" \
   gcloud "${instance_name}" "${project_id}" "${zone}" "${deploy_lock_file}" || {
+  if [[ -s "${lock_log}" ]]; then
+    echo "Deployment lock output:" >&2
+    while IFS= read -r lock_log_line; do
+      printf '%s\n' "${lock_log_line}" >&2
+    done <"${lock_log}"
+  fi
   echo "Could not acquire ${deploy_lock_file}." >&2
   exit 1
 }

--- a/deploy/gcp/publish-subrouter.sh
+++ b/deploy/gcp/publish-subrouter.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=deploy/gcp/stream-shell-value.sh
 source "${script_dir}/stream-shell-value.sh"
+# shellcheck source=deploy/gcp/deploy-lock.sh
+source "${script_dir}/deploy-lock.sh"
 deployment_contract="$(bash "${script_dir}/resolve-release-contract.sh" "${script_dir}/deployment-contract.py")"
 instance_name="${INSTANCE_NAME:-subrouter-team}"
 server_name="${SERVER_NAME:-team}"
@@ -104,7 +106,6 @@ query_live_instance_identity() {
 deploy_lock_file="${SUBROUTER_DEPLOY_LOCK_FILE:-/run/lock/subrouter-deploy.lock}"
 run_label="publish-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-$$"
 run_label="${run_label//[^a-zA-Z0-9._-]/-}"
-remote_lock_sentinel="/tmp/subrouter-deploy-lock-${run_label}"
 lock_log="$(mktemp "${TMPDIR:-/tmp}/subrouter-publish-lock.XXXXXX")"
 lock_holder_pid=""
 remote_probe=""
@@ -120,11 +121,7 @@ gcloud_ssh() {
 
 # shellcheck disable=SC2329 # Called by the EXIT/signal cleanup trap.
 release_deploy_lock() {
-  if [[ -n "${lock_holder_pid}" ]]; then
-    gcloud_ssh "rm -f '${remote_lock_sentinel}'" >/dev/null 2>&1 || true
-    wait "${lock_holder_pid}" || true
-    lock_holder_pid=""
-  fi
+  subrouter_release_deploy_lock
 }
 
 # shellcheck disable=SC2329 # Called by the EXIT/signal cleanup trap.
@@ -144,22 +141,9 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-gcloud_ssh "umask 077; : > '${remote_lock_sentinel}'; command -v flock >/dev/null"
-gcloud compute ssh "${instance_name}" \
-  --project "${project_id}" --zone "${zone}" --tunnel-through-iap --quiet \
-  --command "sudo flock -x -w 300 '${deploy_lock_file}' sh -c 'echo LOCKED; while test -e \"${remote_lock_sentinel}\"; do sleep 1; done'" \
-  >"${lock_log}" 2>&1 &
-lock_holder_pid=$!
-for _ in $(seq 1 3100); do
-  grep -qx LOCKED "${lock_log}" 2>/dev/null && break
-  kill -0 "${lock_holder_pid}" 2>/dev/null || {
-    echo "Remote deployment lock holder exited." >&2
-    exit 1
-  }
-  sleep 0.1
-done
-grep -qx LOCKED "${lock_log}" 2>/dev/null || {
-  echo "Timed out acquiring ${deploy_lock_file}." >&2
+subrouter_acquire_deploy_lock "${lock_log}" \
+  gcloud "${instance_name}" "${project_id}" "${zone}" "${deploy_lock_file}" || {
+  echo "Could not acquire ${deploy_lock_file}." >&2
   exit 1
 }
 

--- a/deploy/gcp/rollback-slot.sh
+++ b/deploy/gcp/rollback-slot.sh
@@ -39,10 +39,11 @@ RUN_LABEL="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-rollback-$$"
 RUN_LABEL="${RUN_LABEL//[^a-zA-Z0-9._-]/-}"
 REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
-REMOTE_LOCK_SENTINEL="/tmp/subrouter-deploy-lock-${RUN_LABEL}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=deploy/gcp/stream-shell-value.sh
 source "${SCRIPT_DIR}/stream-shell-value.sh"
+# shellcheck source=deploy/gcp/deploy-lock.sh
+source "${SCRIPT_DIR}/deploy-lock.sh"
 
 log() { printf 'gcp-slot-rollback: %s\n' "$*"; }
 die() { log "$*" >&2; exit 1; }
@@ -187,25 +188,13 @@ stop_all_rss_samplers() {
 
 lock_holder_pid=""
 acquire_lock() {
-  gcloud_ssh "umask 077; : > '${REMOTE_LOCK_SENTINEL}'; command -v flock >/dev/null"
-  "${GCLOUD_BINARY}" compute ssh "${INSTANCE}" \
-    --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet \
-    --command "sudo flock -x -w 300 '${DEPLOY_LOCK_FILE}' sh -c 'echo LOCKED; while test -e \"${REMOTE_LOCK_SENTINEL}\"; do sleep 1; done'" \
-    >"${ARTIFACT_DIR}/deploy-lock.log" 2>&1 &
-  lock_holder_pid=$!
-  for _ in $(seq 1 3100); do
-    grep -qx LOCKED "${ARTIFACT_DIR}/deploy-lock.log" 2>/dev/null && return
-    kill -0 "${lock_holder_pid}" 2>/dev/null || die "remote deployment lock holder exited"
-    sleep 0.1
-  done
-  die "timed out acquiring ${DEPLOY_LOCK_FILE}"
+  subrouter_acquire_deploy_lock "${ARTIFACT_DIR}/deploy-lock.log" \
+    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" \
+    || die "could not acquire ${DEPLOY_LOCK_FILE}"
 }
 
 release_lock() {
-  [[ -n "${lock_holder_pid}" ]] || return 0
-  gcloud_ssh "rm -f '${REMOTE_LOCK_SENTINEL}'" >/dev/null 2>&1 || true
-  wait "${lock_holder_pid}" || true
-  lock_holder_pid=""
+  subrouter_release_deploy_lock
 }
 
 transition_started=0

--- a/deploy/gcp/switch-front-migration.sh
+++ b/deploy/gcp/switch-front-migration.sh
@@ -42,12 +42,13 @@ EXPECTED_CONNECTIONS_OVERRIDE="${SUBROUTER_EXPECTED_MIGRATION_CONNECTIONS:-}"
 ARTIFACT_DIR="${SUBROUTER_DEPLOY_ARTIFACT_DIR:-${PWD}/artifacts/gcp-front-transition}"
 RUN_LABEL="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-lb-${OPERATION}-$$"
 RUN_LABEL="${RUN_LABEL//[^a-zA-Z0-9._-]/-}"
-REMOTE_LOCK_SENTINEL="/tmp/subrouter-deploy-lock-${RUN_LABEL}"
 REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=deploy/gcp/stream-shell-value.sh
 source "${SCRIPT_DIR}/stream-shell-value.sh"
+# shellcheck source=deploy/gcp/deploy-lock.sh
+source "${SCRIPT_DIR}/deploy-lock.sh"
 LEGACY_RSS_LIMIT_BYTES="${SUBROUTER_LEGACY_RSS_LIMIT_BYTES:-201326592}"
 
 log() { printf 'gcp-front-transition: %s\n' "$*"; }
@@ -223,24 +224,12 @@ transition_started=0
 transition_committed=0
 before_yaml=""
 acquire_lock() {
-  gcloud_ssh "umask 077; : > '${REMOTE_LOCK_SENTINEL}'; command -v flock >/dev/null"
-  "${GCLOUD_BINARY}" compute ssh "${INSTANCE}" \
-    --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet \
-    --command "sudo flock -x -w 300 '${DEPLOY_LOCK_FILE}' sh -c 'echo LOCKED; while test -e \"${REMOTE_LOCK_SENTINEL}\"; do sleep 1; done'" \
-    >"${ARTIFACT_DIR}/deploy-lock.log" 2>&1 &
-  lock_holder_pid=$!
-  for _ in $(seq 1 3100); do
-    grep -qx LOCKED "${ARTIFACT_DIR}/deploy-lock.log" 2>/dev/null && return
-    kill -0 "${lock_holder_pid}" 2>/dev/null || die "remote deployment lock holder exited"
-    sleep 0.1
-  done
-  die "timed out acquiring ${DEPLOY_LOCK_FILE}"
+  subrouter_acquire_deploy_lock "${ARTIFACT_DIR}/deploy-lock.log" \
+    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" \
+    || die "could not acquire ${DEPLOY_LOCK_FILE}"
 }
 release_lock() {
-  [[ -n "${lock_holder_pid}" ]] || return 0
-  gcloud_ssh "rm -f '${REMOTE_LOCK_SENTINEL}'" >/dev/null 2>&1 || true
-  wait "${lock_holder_pid}" || true
-  lock_holder_pid=""
+  subrouter_release_deploy_lock
 }
 cleanup() {
   local status=$?


### PR DESCRIPTION
A dropped client SSH session left the staging deployment lock held for more than 30 minutes because the remote lock process polled a persistent file sentinel.

Replace all eight GCP deployment lock call sites with one heartbeat-pipe helper. Normal completion closes the pipe immediately. If the owning shell is killed, its monitor closes the pipe; if the client host disappears, the remote read times out. The monitor terminates a still-running owner if the lock channel fails, so a deployment cannot knowingly continue without the lock.

Regression history:
- eff3040 adds a hard-owner-death test that fails without the helper
- d329213 adds the helper and migrates every deploy path

Verified against the real staging VM: lock acquired, owning shell SIGKILLed, lock became available automatically, no sentinel remained.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788445912&installation_model_id=21920&pr_number=149&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F149&signature=cbdce50278633142c772c0de26265f6bf665da4a4970d8c923a952f13c179e01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make GCP deployment locks release when the owner dies and require ACKed heartbeats. Replace file-sentinel polling with a heartbeat pipe so the remote `flock` exits on owner death, disconnect, or timeout.

- **Bug Fixes**
  - Owner death or lost heartbeat ACK frees the lock; the helper kills a still-running owner if the channel/ACK fails.
  - Acquisition and teardown are time-bounded with clearer errors; `publish-subrouter.sh` prints lock output on failure.
  - Heartbeat file descriptor is not inherited by children, preventing descendants from keeping the lock alive.

- **Refactors**
  - Added `deploy/gcp/deploy-lock.sh` with `subrouter_acquire_deploy_lock` and `subrouter_release_deploy_lock`; migrated all GCP deploy scripts to use it.
  - Added tests for owner-death cleanup, shutdown on lost ACKs, bounded acquisition, and rejecting inherited lock handles.

<sup>Written for commit 4cdc7506c1ffa2c1df173a4ac995b750149f541d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Standardized deployment-lock handling across deployment, migration, rollback, and retirement workflows.
  - Added heartbeat monitoring to detect failed lock owners and automatically clean up stale locks.
  - Improved lock acquisition failure and timeout reporting.

- **Bug Fixes**
  - Deployment locks are now reliably released when the owning process terminates.

- **Tests**
  - Added integration coverage for process termination, missed heartbeat acknowledgements, and remote lock cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->