### PR TITLE
Verify propagated migration routes and clean abandoned samplers

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -3392,6 +3392,23 @@ func (r *goldenRunner) startActivationSession(
 	directConfigPath, teamConfigPath string,
 	hostedOrigin, localOrigin *url.URL,
 ) (*goldenSession, error) {
+	return r.startActivationSessionWithTransport(
+		ctx, label, route, "websocket", clientPath, authData, cloud,
+		directConfigPath, teamConfigPath, hostedOrigin, localOrigin,
+	)
+}
+
+func (r *goldenRunner) startActivationSessionWithTransport(
+	ctx context.Context,
+	label string,
+	route string,
+	transport string,
+	clientPath string,
+	authData []byte,
+	cloud goldenCloudConfig,
+	directConfigPath, teamConfigPath string,
+	hostedOrigin, localOrigin *url.URL,
+) (*goldenSession, error) {
 	upstream := hostedOrigin
 	if route == "local-egress" {
 		upstream = localOrigin
@@ -3402,7 +3419,7 @@ func (r *goldenRunner) startActivationSession(
 	}
 	return r.startFreshSession(
 		ctx, clientPath, authData, cloud, directConfigPath, teamConfigPath,
-		observation, label, route, "websocket",
+		observation, label, route, transport,
 	)
 }
 
@@ -4409,12 +4426,18 @@ func validateGoldenSummary(summary goldenSummary, testMode bool) error {
 		}
 		expected["migration-"+suffix] = struct{ route, transport string }{route: route, transport: transport}
 	}
-	for _, label := range []string{
+	migrationDestinationLabels := make([]string, 0, 3)
+	for _, baseLabel := range []string{
 		"migration-candidate-front-rehearsal-destination-direct",
 		"migration-candidate-legacy-rollback-destination-direct",
 		"migration-candidate-front-final-destination-direct",
 	} {
-		expected[label] = struct{ route, transport string }{route: "direct-hosted", transport: "websocket"}
+		label, err := goldenMigrationDestinationSessionLabel(summary.Sessions, baseLabel)
+		if err != nil {
+			return err
+		}
+		migrationDestinationLabels = append(migrationDestinationLabels, label)
+		expected[label] = struct{ route, transport string }{route: "direct-hosted", transport: "http"}
 	}
 	for _, cycle := range []string{"rehearsal", "final"} {
 		expected[cycle+"-direct-websocket"] = struct{ route, transport string }{route: "direct-hosted", transport: "websocket"}
@@ -4488,11 +4511,7 @@ func validateGoldenSummary(summary goldenSummary, testMode bool) error {
 	}
 	requiredProcessEvidence["migration-before-rehearsal-cutover\x00local-daemon"] = false
 	requiredProcessEvidence["migration-after-final-cutover\x00local-daemon"] = false
-	for _, label := range []string{
-		"migration-candidate-front-rehearsal-destination-direct",
-		"migration-candidate-legacy-rollback-destination-direct",
-		"migration-candidate-front-final-destination-direct",
-	} {
+	for _, label := range migrationDestinationLabels {
 		requiredProcessEvidence["migration-after-final-cutover\x00"+label] = false
 	}
 	for _, cycle := range []string{"rehearsal", "final"} {
@@ -4583,6 +4602,27 @@ func validateGoldenSummary(summary goldenSummary, testMode bool) error {
 		return failGolden("local_daemon_rss_missing")
 	}
 	return nil
+}
+
+func goldenMigrationDestinationSessionLabel(sessions []goldenSessionSummary, base string) (string, error) {
+	found := ""
+	for _, session := range sessions {
+		allowed := session.Label == base
+		for attempt := 2; !allowed && attempt <= goldenDestinationProofMaxAttempts; attempt++ {
+			allowed = session.Label == fmt.Sprintf("%s-attempt-%d", base, attempt)
+		}
+		if !allowed {
+			continue
+		}
+		if found != "" {
+			return "", fmt.Errorf("%w: multiple sessions for %q", failGolden("session_evidence_incomplete"), base)
+		}
+		found = session.Label
+	}
+	if found == "" {
+		return "", fmt.Errorf("%w: missing session for %q", failGolden("session_evidence_incomplete"), base)
+	}
+	return found, nil
 }
 
 func validateGoldenCleanupSummary(action goldenActionSummary, expectedGenerationHash string) error {

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -491,6 +491,7 @@ func validGoldenMigrationTransitionEvidence(mode, priorType, priorSHA, preparati
 	}
 	evidence.DestinationProof = goldenMigrationDestinationProof{
 		SHA256: strings.Repeat("8", 64), Challenge: strings.Repeat("9", 32), ConnectionID: strings.Repeat("a", 64),
+		SessionID:                  "golden-session",
 		OriginalContinuityVerified: true, FreshPublicConnection: true,
 		ObservedAt: "2026-08-02T00:00:01Z", ReceivedAt: "2026-08-02T00:00:01.5Z",
 	}
@@ -600,9 +601,9 @@ func validGoldenAcceptanceSummary() goldenSummary {
 	labels = append(labels,
 		struct{ label, route, transport string }{"migration-direct-websocket", "direct-hosted", "websocket"},
 		struct{ label, route, transport string }{"migration-direct-http", "direct-hosted", "http"},
-		struct{ label, route, transport string }{"migration-candidate-front-rehearsal-destination-direct", "direct-hosted", "websocket"},
-		struct{ label, route, transport string }{"migration-candidate-legacy-rollback-destination-direct", "direct-hosted", "websocket"},
-		struct{ label, route, transport string }{"migration-candidate-front-final-destination-direct", "direct-hosted", "websocket"},
+		struct{ label, route, transport string }{"migration-candidate-front-rehearsal-destination-direct", "direct-hosted", "http"},
+		struct{ label, route, transport string }{"migration-candidate-legacy-rollback-destination-direct", "direct-hosted", "http"},
+		struct{ label, route, transport string }{"migration-candidate-front-final-destination-direct", "direct-hosted", "http"},
 	)
 	for _, cycle := range []string{"rehearsal", "final"} {
 		labels = append(labels,

--- a/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
+++ b/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
@@ -213,6 +213,7 @@ esac
 	t.Setenv(goldenFakeStreamReleaseStateEnv, streamReleaseState)
 	t.Setenv("SUBROUTER_GOLDEN_FAKE_PROCESS_STATE", processState)
 	t.Setenv("SUBROUTER_GOLDEN_FAKE_PROCESS_PARENT_OWNED", "1")
+	t.Setenv("SUBROUTER_GOLDEN_FAKE_MIGRATION_RETRY_ONCE", "1")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	artifacts := filepath.Join(root, "artifacts")
 	err = runGolden([]string{

--- a/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
+++ b/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
@@ -253,6 +253,15 @@ esac
 		!result.ReleaseChecksumVerified || result.ReleasedVersion != "9.9.9" || len(result.Sessions) != 17 {
 		t.Fatalf("incomplete result: %#v", result)
 	}
+	retryAccepted := false
+	rejectedPresent := false
+	for _, session := range result.Sessions {
+		retryAccepted = retryAccepted || session.Label == "migration-candidate-front-rehearsal-destination-direct-attempt-2"
+		rejectedPresent = rejectedPresent || session.Label == "migration-candidate-front-rehearsal-destination-direct"
+	}
+	if !retryAccepted || rejectedPresent {
+		t.Fatalf("retry summary accepted=%t rejected_present=%t", retryAccepted, rejectedPresent)
+	}
 	allEvidence := readGoldenArtifacts(t, artifacts)
 	for _, forbidden := range []string{
 		"ACCESS_TOKEN_SECRET", "REFRESH_TOKEN_SECRET", "LOCAL_PROXY_SECRET", "CODEX_AUTH_SECRET",

--- a/cmd/subrouter-transport-observer/golden_migration_evidence.go
+++ b/cmd/subrouter-transport-observer/golden_migration_evidence.go
@@ -98,6 +98,7 @@ type goldenMigrationDestinationProof struct {
 	SHA256                     string `json:"sha256"`
 	Challenge                  string `json:"challenge"`
 	ConnectionID               string `json:"connection_id"`
+	SessionID                  string `json:"session_id"`
 	OriginalContinuityVerified bool   `json:"original_continuity_verified"`
 	FreshPublicConnection      bool   `json:"fresh_public_connection"`
 	ObservedAt                 string `json:"observed_at"`
@@ -324,7 +325,8 @@ func validateGoldenMigrationTransition(evidence *goldenMigrationEvidence, expect
 	if proofErr != nil || emittedErr != nil || observedErr != nil || proofObserved != activated ||
 		proofReceived.Before(activated) || emitted.Before(proofReceived) || proofReceived.Sub(requested) >= goldenActivationLimit ||
 		!validGoldenSHA256(evidence.DestinationProof.SHA256) || !validGoldenChallenge(evidence.DestinationProof.Challenge) ||
-		!validGoldenSHA256(evidence.DestinationProof.ConnectionID) || !evidence.DestinationProof.OriginalContinuityVerified ||
+		!validGoldenSHA256(evidence.DestinationProof.ConnectionID) || !validGoldenOpaqueID(evidence.DestinationProof.SessionID) ||
+		!evidence.DestinationProof.OriginalContinuityVerified ||
 		!evidence.DestinationProof.FreshPublicConnection {
 		return failGolden("migration_destination_proof_invalid")
 	}

--- a/cmd/subrouter-transport-observer/golden_migration_transition.go
+++ b/cmd/subrouter-transport-observer/golden_migration_transition.go
@@ -15,6 +15,7 @@ import (
 const (
 	goldenDestinationProofRequestSchema = "subrouter.gcp.destination-proof-request/v1"
 	goldenDestinationProofSchema        = "subrouter.gcp.destination-proof/v1"
+	goldenDestinationProofMaxAttempts   = 4
 )
 
 type goldenDestinationProofRequest struct {
@@ -43,6 +44,7 @@ type goldenDestinationProof struct {
 	OriginalContinuityVerified bool   `json:"original_continuity_verified"`
 	FreshPublicConnection      bool   `json:"fresh_public_connection"`
 	ConnectionID               string `json:"connection_id"`
+	SessionID                  string `json:"session_id"`
 	ObservedAt                 string `json:"observed_at"`
 }
 
@@ -73,13 +75,16 @@ func (r *goldenRunner) runMigrationTransitionWithProof(
 			return goldenActionSummary{}, nil, failGolden("migration_handshake_path_exists")
 		}
 	}
+	actionEnvironment := map[string]string{
+		"SUBROUTER_EXPECTED_MIGRATION_CONNECTIONS": strconv.FormatInt(expectedConnections, 10),
+	}
 	command, err := r.startGoldenEvidenceCommand(ctx, r.options.migrationSwitch, []string{
 		"--operation", operation,
 		"--prior-evidence", filepath.Join(r.artifactDir, prior.EvidenceFile),
 		"--destination-proof-request", requestPath,
 		"--destination-proof", proofPath,
 		"--evidence-json", evidencePath,
-	}, map[string]string{"SUBROUTER_EXPECTED_MIGRATION_CONNECTIONS": strconv.FormatInt(expectedConnections, 10)})
+	}, actionEnvironment)
 	if err != nil {
 		return goldenActionSummary{}, nil, err
 	}
@@ -89,67 +94,98 @@ func (r *goldenRunner) runMigrationTransitionWithProof(
 			command.stop()
 		}
 	}()
-	requestData, err := waitGoldenHandshakeFile(ctx, requestPath, command.done)
-	if err != nil {
-		return goldenActionSummary{}, nil, err
-	}
 	var request goldenDestinationProofRequest
-	if err := json.Unmarshal(requestData, &request); err != nil || request.Schema != goldenDestinationProofRequestSchema ||
-		!validGoldenChallenge(request.Challenge) || request.Operation != operation || request.Source != source ||
-		request.Destination != destination || !validGoldenOpaqueID(request.SourceGeneration) ||
-		!validGoldenOpaqueID(request.DestinationGeneration) || request.SourceGeneration == request.DestinationGeneration ||
-		!validGoldenSHA256(request.SourceSnapshotSHA256) || request.ExpectedSourceConnections != expectedConnections {
-		return goldenActionSummary{}, nil, failGolden("migration_destination_proof_request_invalid")
+	var proof goldenDestinationProof
+	var proofDigest [sha256.Size]byte
+	var destinationSession *goldenSession
+	for attempt := 1; attempt <= goldenDestinationProofMaxAttempts; attempt++ {
+		attemptRequestPath := goldenMigrationAttemptPath(requestPath, attempt)
+		attemptProofPath := goldenMigrationAttemptPath(proofPath, attempt)
+		requestData, err := waitGoldenHandshakeFile(ctx, attemptRequestPath, command.done)
+		if err != nil {
+			return goldenActionSummary{}, nil, err
+		}
+		request = goldenDestinationProofRequest{}
+		if err := json.Unmarshal(requestData, &request); err != nil || request.Schema != goldenDestinationProofRequestSchema ||
+			!validGoldenChallenge(request.Challenge) || request.Operation != operation || request.Source != source ||
+			request.Destination != destination || !validGoldenOpaqueID(request.SourceGeneration) ||
+			!validGoldenOpaqueID(request.DestinationGeneration) || request.SourceGeneration == request.DestinationGeneration ||
+			!validGoldenSHA256(request.SourceSnapshotSHA256) || request.ExpectedSourceConnections != expectedConnections {
+			return goldenActionSummary{}, nil, failGolden("migration_destination_proof_request_invalid")
+		}
+		requested, err := parseGoldenEvidenceTime(request.TransitionRequestedAt)
+		if err != nil || time.Since(requested) >= goldenActivationLimit {
+			return goldenActionSummary{}, nil, failGolden("migration_destination_proof_request_invalid")
+		}
+		if err := waitGoldenContinuityBoundary(ctx, monitors, requested); err != nil {
+			return goldenActionSummary{}, nil, err
+		}
+		if err := requireSessionsRunning(sourceSessions, "migration_"+operation); err != nil {
+			return goldenActionSummary{}, nil, err
+		}
+		if err := r.requireGoldenSamplingStable(sourceSessions); err != nil {
+			return goldenActionSummary{}, nil, err
+		}
+		observedAt := time.Now().UTC()
+		sessionLabel := label + "-destination-direct"
+		if attempt > 1 {
+			sessionLabel = fmt.Sprintf("%s-attempt-%d", sessionLabel, attempt)
+		}
+		candidateSession, err := r.startActivationSessionWithTransport(
+			ctx, sessionLabel, "direct-hosted", "http", inputs.clientPath, inputs.authData,
+			inputs.cloud, inputs.directConfigPath, inputs.teamConfigPath, inputs.hostedOrigin, inputs.localOrigin,
+		)
+		if err != nil {
+			return goldenActionSummary{}, nil, err
+		}
+		if err := waitGoldenSessionChunks(ctx, candidateSession, goldenBaselineChunkSamples); err != nil {
+			return goldenActionSummary{}, nil, err
+		}
+		if err := requireGoldenSessionStartsAfter(candidateSession, observedAt); err != nil {
+			return goldenActionSummary{}, nil, err
+		}
+		if err := waitGoldenContinuityBoundary(ctx, monitors, observedAt); err != nil {
+			return goldenActionSummary{}, nil, err
+		}
+		requestEvent, _, err := goldenSessionRequestWindow(candidateSession)
+		sessionID := goldenSessionThreadID(candidateSession)
+		if err != nil || !validGoldenSHA256(requestEvent.ConnectionID) || !validGoldenOpaqueID(sessionID) {
+			return goldenActionSummary{}, nil, failGolden("migration_destination_connection_missing")
+		}
+		proof = goldenDestinationProof{
+			Schema: goldenDestinationProofSchema, Challenge: request.Challenge, Operation: operation,
+			Destination: request.Destination, DestinationGeneration: request.DestinationGeneration,
+			Source: request.Source, SourceGeneration: request.SourceGeneration,
+			SourceSnapshotSHA256: request.SourceSnapshotSHA256, ExpectedSourceConnections: expectedConnections,
+			OriginalContinuityVerified: true, FreshPublicConnection: true,
+			ConnectionID: requestEvent.ConnectionID, SessionID: sessionID, ObservedAt: observedAt.Format(time.RFC3339Nano),
+		}
+		proofData, err := json.Marshal(proof)
+		proofFileData := append(proofData, '\n')
+		proofDigest = sha256.Sum256(proofFileData)
+		if err != nil || time.Since(requested) >= goldenActivationLimit || writePrivateFile(attemptProofPath, proofFileData) != nil {
+			return goldenActionSummary{}, nil, failGolden("migration_destination_proof_write_failed")
+		}
+		retry, err := waitGoldenMigrationAttemptOutcome(
+			ctx, goldenMigrationAttemptPath(requestPath, attempt+1), command.done,
+		)
+		if err != nil {
+			return goldenActionSummary{}, nil, err
+		}
+		if retry {
+			_ = r.evidence.write(map[string]any{
+				"kind": "migration_destination_retry", "timestamp": time.Now().UTC().Format(time.RFC3339Nano),
+				"operation": operation, "attempt": attempt, "session_id": sessionID,
+			})
+			stopGoldenMigrationRejectedSession(candidateSession)
+			continue
+		}
+		destinationSession = candidateSession
+		break
 	}
-	requested, err := parseGoldenEvidenceTime(request.TransitionRequestedAt)
-	if err != nil || time.Since(requested) >= goldenActivationLimit {
-		return goldenActionSummary{}, nil, failGolden("migration_destination_proof_request_invalid")
+	if destinationSession == nil {
+		return goldenActionSummary{}, nil, failGolden("migration_destination_retry_limit")
 	}
-	if err := waitGoldenContinuityBoundary(ctx, monitors, requested); err != nil {
-		return goldenActionSummary{}, nil, err
-	}
-	if err := requireSessionsRunning(sourceSessions, "migration_"+operation); err != nil {
-		return goldenActionSummary{}, nil, err
-	}
-	if err := r.requireGoldenSamplingStable(sourceSessions); err != nil {
-		return goldenActionSummary{}, nil, err
-	}
-	observedAt := time.Now().UTC()
-	destinationSession, err := r.startActivationSession(
-		ctx, label+"-destination-direct", "direct-hosted", inputs.clientPath, inputs.authData,
-		inputs.cloud, inputs.directConfigPath, inputs.teamConfigPath, inputs.hostedOrigin, inputs.localOrigin,
-	)
-	if err != nil {
-		return goldenActionSummary{}, nil, err
-	}
-	if err := waitGoldenSessionChunks(ctx, destinationSession, goldenBaselineChunkSamples); err != nil {
-		return goldenActionSummary{}, nil, err
-	}
-	if err := requireGoldenSessionStartsAfter(destinationSession, observedAt); err != nil {
-		return goldenActionSummary{}, nil, err
-	}
-	if err := waitGoldenContinuityBoundary(ctx, monitors, observedAt); err != nil {
-		return goldenActionSummary{}, nil, err
-	}
-	requestEvent, _, err := goldenSessionRequestWindow(destinationSession)
-	if err != nil || !validGoldenSHA256(requestEvent.ConnectionID) {
-		return goldenActionSummary{}, nil, failGolden("migration_destination_connection_missing")
-	}
-	proof := goldenDestinationProof{
-		Schema: goldenDestinationProofSchema, Challenge: request.Challenge, Operation: operation,
-		Destination: request.Destination, DestinationGeneration: request.DestinationGeneration,
-		Source: request.Source, SourceGeneration: request.SourceGeneration,
-		SourceSnapshotSHA256: request.SourceSnapshotSHA256, ExpectedSourceConnections: expectedConnections,
-		OriginalContinuityVerified: true, FreshPublicConnection: true,
-		ConnectionID: requestEvent.ConnectionID, ObservedAt: observedAt.Format(time.RFC3339Nano),
-	}
-	proofData, err := json.Marshal(proof)
-	proofFileData := append(proofData, '\n')
-	proofDigest := sha256.Sum256(proofFileData)
-	if err != nil || time.Since(requested) >= goldenActivationLimit || writePrivateFile(proofPath, proofFileData) != nil {
-		return goldenActionSummary{}, nil, failGolden("migration_destination_proof_write_failed")
-	}
-	<-command.done
 	waited = true
 	result := command.result()
 	result.EvidenceType, result.EvidenceFile = expectedEvidence, evidenceName
@@ -166,11 +202,68 @@ func (r *goldenRunner) runMigrationTransitionWithProof(
 	if evidence.PriorEvidenceSHA256 != prior.EvidenceSHA256 || evidence.Routing.Before != source ||
 		evidence.Routing.After != destination || evidence.Timestamps.TransitionRequestedAt != request.TransitionRequestedAt ||
 		evidence.Timestamps.ActivatedAt != proof.ObservedAt || evidence.DestinationProof.SHA256 != fmt.Sprintf("%x", proofDigest[:]) ||
-		evidence.DestinationProof.Challenge != proof.Challenge || evidence.DestinationProof.ConnectionID != proof.ConnectionID {
+		evidence.DestinationProof.Challenge != proof.Challenge || evidence.DestinationProof.ConnectionID != proof.ConnectionID ||
+		evidence.DestinationProof.SessionID != proof.SessionID {
 		return result, nil, failGolden("migration_destination_proof_evidence_mismatch")
 	}
 	if sessionDone(destinationSession) {
 		return result, nil, failGolden("migration_destination_connection_not_held")
 	}
 	return result, destinationSession, nil
+}
+
+func goldenMigrationAttemptPath(base string, attempt int) string {
+	if attempt <= 1 {
+		return base
+	}
+	return fmt.Sprintf("%s.attempt-%d", base, attempt)
+}
+
+func goldenSessionThreadID(session *goldenSession) string {
+	if session == nil {
+		return ""
+	}
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	return session.threadID
+}
+
+func waitGoldenMigrationAttemptOutcome(ctx context.Context, nextRequestPath string, commandDone <-chan struct{}) (bool, error) {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		info, err := os.Lstat(nextRequestPath)
+		if err == nil {
+			if !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > goldenActionEvidenceLimit {
+				return false, failGolden("deployment_handshake_file_invalid")
+			}
+			return true, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return false, failGolden("deployment_handshake_file_invalid")
+		}
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-commandDone:
+			return false, nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func stopGoldenMigrationRejectedSession(session *goldenSession) {
+	if session == nil || session.command == nil || sessionDone(session) {
+		return
+	}
+	interruptCommand(session.command)
+	select {
+	case <-session.done:
+	case <-time.After(time.Second):
+		killProcessGroup(session.command)
+		select {
+		case <-session.done:
+		case <-time.After(2 * time.Second):
+		}
+	}
 }

--- a/cmd/subrouter-transport-observer/golden_migration_transition.go
+++ b/cmd/subrouter-transport-observer/golden_migration_transition.go
@@ -177,7 +177,9 @@ func (r *goldenRunner) runMigrationTransitionWithProof(
 				"kind": "migration_destination_retry", "timestamp": time.Now().UTC().Format(time.RFC3339Nano),
 				"operation": operation, "attempt": attempt, "session_id": sessionID,
 			})
-			stopGoldenMigrationRejectedSession(candidateSession)
+			if err := r.stopGoldenMigrationRejectedSession(candidateSession); err != nil {
+				return goldenActionSummary{}, nil, err
+			}
 			continue
 		}
 		destinationSession = candidateSession
@@ -252,9 +254,9 @@ func waitGoldenMigrationAttemptOutcome(ctx context.Context, nextRequestPath stri
 	}
 }
 
-func stopGoldenMigrationRejectedSession(session *goldenSession) {
+func (r *goldenRunner) stopGoldenMigrationRejectedSession(session *goldenSession) error {
 	if session == nil || session.command == nil || sessionDone(session) {
-		return
+		return failGolden("migration_rejected_session_cleanup_failed")
 	}
 	interruptCommand(session.command)
 	select {
@@ -266,4 +268,17 @@ func stopGoldenMigrationRejectedSession(session *goldenSession) {
 		case <-time.After(2 * time.Second):
 		}
 	}
+	if !sessionDone(session) {
+		return failGolden("migration_rejected_session_cleanup_failed")
+	}
+	r.mu.Lock()
+	for index, running := range r.sessions {
+		if running != session {
+			continue
+		}
+		r.sessions = append(r.sessions[:index], r.sessions[index+1:]...)
+		break
+	}
+	r.mu.Unlock()
+	return nil
 }

--- a/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
+++ b/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
@@ -155,10 +155,33 @@ func fakeAction(args []string) {
 			Schema       string `json:"schema"`
 			Challenge    string `json:"challenge"`
 			ConnectionID string `json:"connection_id"`
+			SessionID    string `json:"session_id"`
 			ObservedAt   string `json:"observed_at"`
 		}
-		if json.Unmarshal(proofData, &proof) != nil || proof.Schema != "subrouter.gcp.destination-proof/v1" || proof.Challenge != challenge {
+		if json.Unmarshal(proofData, &proof) != nil || proof.Schema != "subrouter.gcp.destination-proof/v1" ||
+			proof.Challenge != challenge || proof.SessionID == "" {
 			os.Exit(9)
+		}
+		if os.Getenv("SUBROUTER_GOLDEN_FAKE_MIGRATION_RETRY_ONCE") == "1" && migrationOperation == "rehearsal-cutover" {
+			challenge = strings.Repeat("6", 32)
+			proofRequest["challenge"] = challenge
+			requestPath += ".attempt-2"
+			proofPath += ".attempt-2"
+			if fakeWriteJSON(requestPath, proofRequest) != nil {
+				os.Exit(9)
+			}
+			proofData, err = fakeWaitFile(proofPath, time.Second)
+			proof = struct {
+				Schema       string `json:"schema"`
+				Challenge    string `json:"challenge"`
+				ConnectionID string `json:"connection_id"`
+				SessionID    string `json:"session_id"`
+				ObservedAt   string `json:"observed_at"`
+			}{}
+			if err != nil || json.Unmarshal(proofData, &proof) != nil || proof.Schema != "subrouter.gcp.destination-proof/v1" ||
+				proof.Challenge != challenge || proof.SessionID == "" {
+				os.Exit(9)
+			}
 		}
 		activated, err = time.Parse(time.RFC3339Nano, proof.ObservedAt)
 		if err != nil {
@@ -190,7 +213,8 @@ func fakeAction(args []string) {
 			"legacy": legacy, "front": front,
 			"timestamps": map[string]any{"transition_requested_at": requested.Format(time.RFC3339Nano), "activated_at": activated.Format(time.RFC3339Nano), "evidence_emitted_at": time.Now().UTC().Format(time.RFC3339Nano)},
 			"destination_proof": map[string]any{
-				"sha256": fmt.Sprintf("%x", proofDigest[:]), "challenge": challenge, "connection_id": proof.ConnectionID,
+				"sha256": fmt.Sprintf("%x", proofDigest[:]), "challenge": challenge,
+				"connection_id": proof.ConnectionID, "session_id": proof.SessionID,
 				"original_continuity_verified": true, "fresh_public_connection": true,
 				"observed_at": activated.Format(time.RFC3339Nano), "received_at": proofReceived.Format(time.RFC3339Nano),
 			},

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -1309,7 +1309,7 @@ func TestDeploymentContractValidatesGoldenTransitionProofs(t *testing.T) {
 	}
 
 	proof := filepath.Join(t.TempDir(), "proof.json")
-	proofBody := `{"schema":"subrouter.gcp.destination-proof/v1","challenge":"challenge","operation":"final-cutover","destination":"front","destination_generation":"generation-b","source":"legacy","source_generation":"generation-a","source_snapshot_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","expected_source_connections":2,"original_continuity_verified":true,"fresh_public_connection":true,"connection_id":"connection","observed_at":"2026-08-03T10:00:29.999Z"}`
+	proofBody := `{"schema":"subrouter.gcp.destination-proof/v1","challenge":"challenge","operation":"final-cutover","destination":"front","destination_generation":"generation-b","source":"legacy","source_generation":"generation-a","source_snapshot_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","expected_source_connections":2,"original_continuity_verified":true,"fresh_public_connection":true,"connection_id":"connection","session_id":"session-id","observed_at":"2026-08-03T10:00:29.999Z"}`
 	if err := os.WriteFile(proof, []byte(proofBody), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -1322,6 +1322,12 @@ func TestDeploymentContractValidatesGoldenTransitionProofs(t *testing.T) {
 	}
 	if output, err := run(proofArgs...); err == nil {
 		t.Fatalf("empty destination connection succeeded: %s", output)
+	}
+	if err := os.WriteFile(proof, []byte(strings.Replace(proofBody, `"session_id":"session-id"`, `"session_id":""`, 1)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if output, err := run(proofArgs...); err == nil {
+		t.Fatalf("empty destination session succeeded: %s", output)
 	}
 }
 

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -604,6 +604,51 @@ while :; do sleep 1; done
 	}
 }
 
+func TestDeployLockOwnerCleanupRemovesRunScopedSamplerSentinel(t *testing.T) {
+	requireDeployScriptTools(t, "awk", "bash", "chmod", "grep", "kill", "mkfifo", "mktemp", "rmdir", "sleep", "unlink")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	helper := filepath.Join(repoRoot, "deploy", "gcp", "deploy-lock.sh")
+	fakeBin := t.TempDir()
+	sentinel := filepath.Join(t.TempDir(), "subrouter-rss-owner-cleanup-front.running")
+	lockLog := filepath.Join(t.TempDir(), "deploy-lock.log")
+	if err := os.WriteFile(sentinel, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fakeGcloud := filepath.Join(fakeBin, "gcloud")
+	writeExecutableTestFile(t, fakeGcloud, `#!/usr/bin/env bash
+set -euo pipefail
+remote_command="$*"
+cleanup() {
+  if [[ "${remote_command}" == *"subrouter-rss-owner-cleanup-*.running"* ]]; then
+    unlink "${REMOTE_SAMPLER_SENTINEL}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+printf 'LOCKED\n'
+while IFS= read -r heartbeat; do printf 'ACK %s\n' "$heartbeat"; done
+`)
+
+	harness := `
+set -euo pipefail
+source "$1"
+subrouter_acquire_deploy_lock "$2" "$3" instance project zone /run/lock/subrouter-deploy.lock owner-cleanup
+subrouter_release_deploy_lock
+`
+	command := exec.Command(mustLookPath(t, "bash"), "-c", harness, "deploy-lock-cleanup-test", helper, lockLog, fakeGcloud)
+	command.Env = append(os.Environ(),
+		"REMOTE_SAMPLER_SENTINEL="+sentinel,
+		"SUBROUTER_DEPLOY_LOCK_HEARTBEAT_INTERVAL_SECONDS=0.05",
+		"SUBROUTER_DEPLOY_LOCK_ACK_TIMEOUT_SECONDS=1",
+		"SUBROUTER_DEPLOY_LOCK_HEARTBEAT_TIMEOUT_SECONDS=2",
+	)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("deploy lock cleanup harness: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatalf("run-scoped sampler sentinel survived lock release: %v", err)
+	}
+}
+
 func TestCreateVMTempFilesSurviveInterruptedAndRepeatedMacOSRuns(t *testing.T) {
 	requireDeployScriptTools(t, "bash", "dd", "tr")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/deploy/gcp/deploy-live-upgrade.sh
+++ b/deploy/gcp/deploy-live-upgrade.sh
@@ -416,7 +416,7 @@ slot_absence_latency_ms=""
 
 acquire_deploy_lock() {
   subrouter_acquire_deploy_lock "${ARTIFACT_DIR}/deploy-lock.log" \
-    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" \
+    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" "${RUN_LABEL}" \
     || die "could not acquire ${DEPLOY_LOCK_FILE}"
 }
 

--- a/deploy/gcp/deploy-lock.sh
+++ b/deploy/gcp/deploy-lock.sh
@@ -48,11 +48,12 @@ subrouter_acquire_deploy_lock() {
   local project_id="$4"
   local zone="$5"
   local deploy_lock_file="$6"
+  local owner_cleanup_label="${7:-}"
   local heartbeat_interval="${SUBROUTER_DEPLOY_LOCK_HEARTBEAT_INTERVAL_SECONDS:-10}"
   local heartbeat_ack_timeout="${SUBROUTER_DEPLOY_LOCK_ACK_TIMEOUT_SECONDS:-30}"
   local heartbeat_timeout="${SUBROUTER_DEPLOY_LOCK_HEARTBEAT_TIMEOUT_SECONDS:-300}"
   local owner_pid="$$"
-  local attempt heartbeat_ack_attempts required_command
+  local attempt heartbeat_ack_attempts owner_cleanup_command required_command
 
   [[ -z "${lock_holder_pid}" && -z "${lock_heartbeat_pid}" ]] || {
     echo "deployment lock is already held by this process" >&2
@@ -60,6 +61,10 @@ subrouter_acquire_deploy_lock() {
   }
   [[ "${deploy_lock_file}" =~ ^/[A-Za-z0-9._/-]+$ ]] || {
     echo "deployment lock path is invalid" >&2
+    return 1
+  }
+  [[ -z "${owner_cleanup_label}" || "${owner_cleanup_label}" =~ ^[A-Za-z0-9._-]+$ ]] || {
+    echo "deployment lock owner cleanup label is invalid" >&2
     return 1
   }
   [[ "${heartbeat_interval}" =~ ^[0-9]+([.][0-9]+)?$ &&
@@ -105,9 +110,14 @@ subrouter_acquire_deploy_lock() {
     return 1
   fi
 
+  owner_cleanup_command=""
+  if [[ -n "${owner_cleanup_label}" ]]; then
+    owner_cleanup_command="trap \"rm -f -- /tmp/subrouter-rss-${owner_cleanup_label}-*.running /tmp/install-front-slots-${owner_cleanup_label}.sh /tmp/deployment-contract-${owner_cleanup_label}.py\" EXIT;"
+  fi
+
   "${gcloud_binary}" compute ssh "${instance}" \
     --project "${project_id}" --zone "${zone}" --tunnel-through-iap --quiet \
-    --command "sudo flock -x -w 300 '${deploy_lock_file}' bash -c 'echo LOCKED; while IFS= read -r -t ${heartbeat_timeout} heartbeat; do echo ACK \"\${heartbeat}\"; done'" \
+    --command "sudo flock -x -w 300 '${deploy_lock_file}' bash -c '${owner_cleanup_command} echo LOCKED; while IFS= read -r -t ${heartbeat_timeout} heartbeat; do echo ACK \"\${heartbeat}\"; done'" \
     <"${lock_pipe_path}" >"${log_file}" 2>&1 &
   lock_holder_pid=$!
   exec 9>"${lock_pipe_path}"

--- a/deploy/gcp/deployment-contract.py
+++ b/deploy/gcp/deployment-contract.py
@@ -419,6 +419,9 @@ def command_validate_destination_proof(args: argparse.Namespace) -> None:
     connection_id = document.get("connection_id")
     if not isinstance(connection_id, str) or not connection_id:
         fail("destination proof connection_id must be a non-empty string")
+    session_id = document.get("session_id")
+    if not isinstance(session_id, str) or re.fullmatch(r"[A-Za-z0-9._:-]{1,256}", session_id) is None:
+        fail("destination proof session_id is invalid")
     requested = parse_timestamp(args.requested_at, "transition requested time")
     observed = parse_timestamp(document.get("observed_at"), "destination proof observed time")
     received = parse_timestamp(args.received_at, "destination proof received time")

--- a/deploy/gcp/finalize-legacy-retirement.sh
+++ b/deploy/gcp/finalize-legacy-retirement.sh
@@ -136,7 +136,7 @@ stop_legacy_sampler() {
 lock_holder_pid=""
 acquire_lock() {
   subrouter_acquire_deploy_lock "${ARTIFACT_DIR}/deploy-lock.log" \
-    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" \
+    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" "${RUN_LABEL}" \
     || die "could not acquire ${DEPLOY_LOCK_FILE}"
 }
 release_lock() {

--- a/deploy/gcp/finalize-slot-retirement.sh
+++ b/deploy/gcp/finalize-slot-retirement.sh
@@ -169,7 +169,7 @@ stop_retirement_sampler() {
 lock_holder_pid=""
 acquire_lock() {
   subrouter_acquire_deploy_lock "${ARTIFACT_DIR}/deploy-lock.log" \
-    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" \
+    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" "${RUN_LABEL}" \
     || die "could not acquire ${DEPLOY_LOCK_FILE}"
 }
 release_lock() {

--- a/deploy/gcp/migrate-to-front-slots.sh
+++ b/deploy/gcp/migrate-to-front-slots.sh
@@ -173,7 +173,7 @@ gcloud_scp() {
 lock_holder_pid=""
 acquire_deploy_lock() {
   subrouter_acquire_deploy_lock "${ARTIFACT_DIR}/deploy-lock.log" \
-    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" \
+    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" "${RUN_LABEL}" \
     || die "could not acquire ${DEPLOY_LOCK_FILE}"
 }
 

--- a/deploy/gcp/normalize-staging-predecessor.sh
+++ b/deploy/gcp/normalize-staging-predecessor.sh
@@ -100,7 +100,7 @@ normalization_started=0
 normalization_committed=0
 acquire_lock() {
   subrouter_acquire_deploy_lock "${ARTIFACT_DIR}/deploy-lock.log" \
-    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" \
+    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" "${RUN_LABEL}" \
     || die "could not acquire ${DEPLOY_LOCK_FILE}"
 }
 release_lock() {

--- a/deploy/gcp/rollback-slot.sh
+++ b/deploy/gcp/rollback-slot.sh
@@ -189,7 +189,7 @@ stop_all_rss_samplers() {
 lock_holder_pid=""
 acquire_lock() {
   subrouter_acquire_deploy_lock "${ARTIFACT_DIR}/deploy-lock.log" \
-    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" \
+    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" "${RUN_LABEL}" \
     || die "could not acquire ${DEPLOY_LOCK_FILE}"
 }
 

--- a/deploy/gcp/switch-front-migration.sh
+++ b/deploy/gcp/switch-front-migration.sh
@@ -133,6 +133,24 @@ gcloud_scp() {
 }
 utc_now() { python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z"))'; }
 epoch_millis() { python3 -c 'import time; print(time.time_ns() // 1_000_000)'; }
+proof_attempt_path() {
+  local base="$1" attempt="$2"
+  if [[ "${attempt}" == 1 ]]; then printf '%s\n' "${base}"; else printf '%s.attempt-%s\n' "${base}" "${attempt}"; fi
+}
+destination_session_observed() {
+  local session_id="$1" service
+  [[ "${session_id}" =~ ^[A-Za-z0-9._:-]{1,256}$ ]] || return 1
+  if [[ "${destination_kind}" == front ]]; then
+    service="$(metric_service "${active_migration_slot}")"
+  else
+    service="$(metric_service legacy)"
+  fi
+  printf '%s\n' "${session_id}" | \
+    "${GCLOUD_BINARY}" compute ssh "${INSTANCE}" \
+      --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet \
+      --command "set -eu; IFS= read -r session_id; sudo journalctl --unit='${service}' --since='@${transition_requested_epoch}' --no-pager --output=cat | grep -F 'INFO proxy request agent=codex' | grep -F 'method=POST path=/v1/responses' | grep -F -e \"session=\${session_id} \" -e \"session=\${session_id}:\" -e \"session=\\\"\${session_id}\\\" \" -e \"session=\\\"\${session_id}:\" >/dev/null" \
+    >/dev/null 2>&1
+}
 
 metric_service() {
   case "$1" in
@@ -225,7 +243,7 @@ transition_committed=0
 before_yaml=""
 acquire_lock() {
   subrouter_acquire_deploy_lock "${ARTIFACT_DIR}/deploy-lock.log" \
-    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" \
+    "${GCLOUD_BINARY}" "${INSTANCE}" "${PROJECT_ID}" "${ZONE}" "${DEPLOY_LOCK_FILE}" "${RUN_LABEL}" \
     || die "could not acquire ${DEPLOY_LOCK_FILE}"
 }
 release_lock() {
@@ -286,6 +304,7 @@ destination_before="$(supervisor_snapshot "${destination_kind}")"
 
 transition_requested_at="$(utc_now)"
 transition_requested_ms="$(epoch_millis)"
+transition_requested_epoch=$((transition_requested_ms / 1000))
 transition_started=1
 "${GCLOUD_BINARY}" compute url-maps import "${URL_MAP}" --project "${PROJECT_ID}" --global \
   --source "${candidate_yaml}" --quiet
@@ -303,41 +322,61 @@ if [[ "${destination_kind}" == front ]]; then
 else
   destination_generation="$(jq -r '.generation' < <(stream_shell_value "${legacy_json}"))"
 fi
-proof_challenge="$(python3 -c 'import secrets; print(secrets.token_hex(16))')"
-proof_request_tmp="$(mktemp "${DESTINATION_PROOF_REQUEST}.tmp.XXXXXX")"
-jq -n --arg schema 'subrouter.gcp.destination-proof-request/v1' \
-  --arg challenge "${proof_challenge}" --arg operation "${OPERATION}" \
-  --arg destination "${destination_kind}" --arg generation "${destination_generation}" \
-  --arg source "${source_kind}" --arg source_generation "$(jq -r '.generation' < <(stream_shell_value "${source_after}"))" \
-  --arg source_snapshot_sha "${source_snapshot_sha256}" --arg requested_at "${transition_requested_at}" \
-  --argjson expected_source_connections "${EXPECTED_CONNECTIONS}" \
-  '{schema:$schema,challenge:$challenge,operation:$operation,destination:$destination,
-    destination_generation:$generation,source:$source,source_generation:$source_generation,
-    source_snapshot_sha256:$source_snapshot_sha,
-    expected_source_connections:$expected_source_connections,
-    transition_requested_at:$requested_at}' \
-  >"${proof_request_tmp}"
-chmod 0600 "${proof_request_tmp}"
-mv -f -- "${proof_request_tmp}" "${DESTINATION_PROOF_REQUEST}"
+proof_max_attempts=4
+proof_attempt=1
+destination_correlated=false
+while (( proof_attempt <= proof_max_attempts )); do
+  proof_request_path="$(proof_attempt_path "${DESTINATION_PROOF_REQUEST}" "${proof_attempt}")"
+  proof_path="$(proof_attempt_path "${DESTINATION_PROOF}" "${proof_attempt}")"
+  [[ ! -e "${proof_request_path}" && ! -L "${proof_request_path}" && ! -e "${proof_path}" && ! -L "${proof_path}" ]] \
+    || die "destination proof attempt path already exists"
+  proof_challenge="$(python3 -c 'import secrets; print(secrets.token_hex(16))')"
+  proof_request_tmp="$(mktemp "${proof_request_path}.tmp.XXXXXX")"
+  jq -n --arg schema 'subrouter.gcp.destination-proof-request/v1' \
+    --arg challenge "${proof_challenge}" --arg operation "${OPERATION}" \
+    --arg destination "${destination_kind}" --arg generation "${destination_generation}" \
+    --arg source "${source_kind}" --arg source_generation "$(jq -r '.generation' < <(stream_shell_value "${source_after}"))" \
+    --arg source_snapshot_sha "${source_snapshot_sha256}" --arg requested_at "${transition_requested_at}" \
+    --argjson expected_source_connections "${EXPECTED_CONNECTIONS}" \
+    '{schema:$schema,challenge:$challenge,operation:$operation,destination:$destination,
+      destination_generation:$generation,source:$source,source_generation:$source_generation,
+      source_snapshot_sha256:$source_snapshot_sha,
+      expected_source_connections:$expected_source_connections,
+      transition_requested_at:$requested_at}' \
+    >"${proof_request_tmp}"
+  chmod 0600 "${proof_request_tmp}"
+  mv -f -- "${proof_request_tmp}" "${proof_request_path}"
 
-while [[ ! -f "${DESTINATION_PROOF}" || -L "${DESTINATION_PROOF}" ]]; do
-  (( $(epoch_millis) - transition_requested_ms < 30000 )) \
-    || die "golden destination proof was not observed strictly before 30 seconds"
-  sleep 0.05
+  while [[ ! -f "${proof_path}" || -L "${proof_path}" ]]; do
+    (( $(epoch_millis) - transition_requested_ms < 30000 )) \
+      || die "golden destination proof was not observed strictly before 30 seconds"
+    sleep 0.05
+  done
+  proof_received_at="$(utc_now)"
+  proof_received_ms="$(epoch_millis)"
+  (( proof_received_ms - transition_requested_ms < 30000 )) \
+    || die "golden destination proof arrived at or after 30 seconds"
+  python3 "${DEPLOYMENT_CONTRACT}" validate-destination-proof \
+    "${proof_path}" "${proof_challenge}" "${OPERATION}" \
+    "${destination_kind}" "${destination_generation}" "${source_kind}" \
+    "$(jq -r '.generation' < <(stream_shell_value "${source_after}"))" "${source_snapshot_sha256}" \
+    "${EXPECTED_CONNECTIONS}" "${transition_requested_at}" \
+    "${proof_received_at}"
+  destination_session_id="$(jq -r '.session_id // empty' "${proof_path}")"
+  [[ "${destination_session_id}" =~ ^[A-Za-z0-9._:-]{1,256}$ ]] \
+    || die "golden destination proof session ID is invalid"
+  if destination_session_observed "${destination_session_id}"; then
+    destination_correlated=true
+    activated_at="$(jq -r '.observed_at' "${proof_path}")"
+    destination_proof_sha256="$(sha256sum "${proof_path}" | awk '{print $1}')"
+    destination_connection_id="$(jq -r '.connection_id' "${proof_path}")"
+    break
+  fi
+  log "destination proof attempt ${proof_attempt} remained on ${source_kind}; retrying while original connections stay pinned"
+  proof_attempt=$((proof_attempt + 1))
 done
-proof_received_at="$(utc_now)"
-proof_received_ms="$(epoch_millis)"
-(( proof_received_ms - transition_requested_ms < 30000 )) \
-  || die "golden destination proof arrived at or after 30 seconds"
-python3 "${DEPLOYMENT_CONTRACT}" validate-destination-proof \
-  "${DESTINATION_PROOF}" "${proof_challenge}" "${OPERATION}" \
-  "${destination_kind}" "${destination_generation}" "${source_kind}" \
-  "$(jq -r '.generation' < <(stream_shell_value "${source_after}"))" "${source_snapshot_sha256}" \
-  "${EXPECTED_CONNECTIONS}" "${transition_requested_at}" \
-  "${proof_received_at}"
-activated_at="$(jq -r '.observed_at' "${DESTINATION_PROOF}")"
-destination_proof_sha256="$(sha256sum "${DESTINATION_PROOF}" | awk '{print $1}')"
-destination_connection_id="$(jq -r '.connection_id' "${DESTINATION_PROOF}")"
+[[ "${destination_correlated}" == true ]] \
+  || die "golden fresh public session did not reach the destination within ${proof_max_attempts} attempts"
 destination_after="$(supervisor_snapshot "${destination_kind}")"
 jq -e --arg generation "${destination_generation}" --argjson before "${destination_before}" \
   '.generation == $generation and .public_connections >= ($before.public_connections + 1) and
@@ -383,7 +422,8 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type "${evi
   --arg requested_at "${transition_requested_at}" --arg activated_at "${activated_at}" \
   --arg proof_received_at "${proof_received_at}" --arg emitted_at "${evidence_emitted_at}" \
   --arg proof_sha "${destination_proof_sha256}" --arg challenge "${proof_challenge}" \
-  --arg connection_id "${destination_connection_id}" --argjson before "${source_before}" \
+  --arg connection_id "${destination_connection_id}" --arg session_id "${destination_session_id}" \
+  --argjson before "${source_before}" \
   --argjson after "${source_after}" --argjson expected "${EXPECTED_CONNECTIONS}" \
   --argjson destination_before "${destination_before}" --argjson destination_after "${destination_after}" \
   --argjson destination_delta "${destination_connection_delta}" \
@@ -407,6 +447,7 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type "${evi
     timestamps:{transition_requested_at:$requested_at,activated_at:$activated_at,
       evidence_emitted_at:$emitted_at},
     destination_proof:{sha256:$proof_sha,challenge:$challenge,connection_id:$connection_id,
+      session_id:$session_id,
       original_continuity_verified:true,fresh_public_connection:true,
       observed_at:$activated_at,received_at:$proof_received_at},
     destination:{before:$destination_before,after:$destination_after,

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -734,6 +734,7 @@ def validate_front_migration_transition(document: dict[str, Any], expected: str)
     if not re.fullmatch(r"[0-9a-f]{32}", challenge):
         fail("destination_proof.challenge must be a 128-bit lowercase hex challenge")
     text(field(proof, "connection_id", "destination_proof"), "destination_proof.connection_id")
+    text(field(proof, "session_id", "destination_proof"), "destination_proof.session_id")
     exact(
         boolean(field(proof, "fresh_public_connection", "destination_proof"),
                 "destination_proof.fresh_public_connection"),

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -734,7 +734,9 @@ def validate_front_migration_transition(document: dict[str, Any], expected: str)
     if not re.fullmatch(r"[0-9a-f]{32}", challenge):
         fail("destination_proof.challenge must be a 128-bit lowercase hex challenge")
     text(field(proof, "connection_id", "destination_proof"), "destination_proof.connection_id")
-    text(field(proof, "session_id", "destination_proof"), "destination_proof.session_id")
+    session_id = text(field(proof, "session_id", "destination_proof"), "destination_proof.session_id")
+    if re.fullmatch(r"[A-Za-z0-9._:-]{1,256}", session_id) is None:
+        fail("destination_proof.session_id is invalid")
     exact(
         boolean(field(proof, "fresh_public_connection", "destination_proof"),
                 "destination_proof.fresh_public_connection"),


### PR DESCRIPTION
Fix the production continuity gate after GCP URL-map updates.

- retry fresh HTTP Codex sessions while original streams remain pinned
- bind success to the exact Codex thread in the destination service journal
- stop rejected proof sessions before retrying
- remove run-scoped RSS sentinels when the remote lock owner exits

Tests:
- go test ./cmd/subrouter-transport-observer -count=1
- focused deploy lock and deployment contract tests
- bash syntax, Python compile, and git diff checks

The full local suite also hit two pre-existing short-deadline macOS flakes that reproduce unchanged on the merged base.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788478293&installation_model_id=21920&pr_number=150&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F150&signature=444b9e9ef643159264c9d3b1146e54d53449b1380b04a4a97433822a46c90007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verify propagated migration routes by correlating destination proofs to the exact Codex session with safe, multi-attempt retries; also clean up run-scoped samplers when the deploy lock owner exits and unregister rejected proof sessions.

- **New Features**
  - Add `session_id` to destination proof and evidence; validate end-to-end.
  - Correlate proofs to the destination service journal before accepting cutover.
  - Retry destination proof up to 4 times while original streams stay pinned; label attempts.
  - Start destination candidate over HTTP to ensure a fresh public connection.

- **Bug Fixes**
  - Unregister and stop rejected destination-proof sessions to avoid leaked connections and stale runner state.
  - Remove run-scoped RSS sentinels and temp files when the remote deploy lock owner exits; all deploy scripts pass `RUN_LABEL` to `subrouter_acquire_deploy_lock`.
  - Update golden and contract validators to accept attempt-suffixed labels, expect HTTP for destination-direct sessions, and require a single well-formed `session_id`.

<sup>Written for commit a2eb11f09970e7016ac0bba01b50894706185142. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migration transitions now support transport-aware destination sessions and up to four proof attempts.
  * Migration evidence includes validated session identifiers for stronger destination verification.
  * Deployment locks now support run-specific cleanup of temporary artifacts.

* **Bug Fixes**
  * Improved handling of numbered migration attempts, rejected sessions, and retry exhaustion.
  * Added validation to prevent incomplete or mismatched migration evidence.
  * Improved cleanup when deployment locks are released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->