### PR TITLE
Validate migration session IDs portably

### DIFF
--- a/deploy/gcp/switch-front-migration.sh
+++ b/deploy/gcp/switch-front-migration.sh
@@ -139,7 +139,7 @@ proof_attempt_path() {
 }
 destination_session_observed() {
   local session_id="$1" service
-  [[ "${session_id}" =~ ^[A-Za-z0-9._:-]{1,256}$ ]] || return 1
+  [[ -n "${session_id}" && "${#session_id}" -le 256 && "${session_id}" =~ ^[A-Za-z0-9._:-]+$ ]] || return 1
   if [[ "${destination_kind}" == front ]]; then
     service="$(metric_service "${active_migration_slot}")"
   else
@@ -363,7 +363,7 @@ while (( proof_attempt <= proof_max_attempts )); do
     "${EXPECTED_CONNECTIONS}" "${transition_requested_at}" \
     "${proof_received_at}"
   destination_session_id="$(jq -r '.session_id // empty' "${proof_path}")"
-  [[ "${destination_session_id}" =~ ^[A-Za-z0-9._:-]{1,256}$ ]] \
+  [[ -n "${destination_session_id}" && "${#destination_session_id}" -le 256 && "${destination_session_id}" =~ ^[A-Za-z0-9._:-]+$ ]] \
     || die "golden destination proof session ID is invalid"
   if destination_session_observed "${destination_session_id}"; then
     destination_correlated=true


### PR DESCRIPTION
Replace the Bash ERE repetition bound with explicit non-empty and byte-length checks. GNU Bash rejects `{1,256}` because its repetition ceiling is 255.

Verified with both macOS system Bash and the GNU Bash 5 runner used by the hosted continuity gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788479924&installation_model_id=21920&pr_number=151&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F151&signature=e61f541e39ec2955a3983970105831645becf08e1733d556442172446a7764f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make migration session ID validation portable by replacing `{1,256}` with explicit checks (non-empty, byte-length ≤ 256, allowed charset) in `deploy/gcp/switch-front-migration.sh`. Fixes false rejections on GNU Bash (max repetition 255) and aligns behavior across macOS and CI runners.

<sup>Written for commit 2b4cb2878251e3dbbfd998f49820c41a60d65039. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

