### PR TITLE
Separate URL-map propagation from process activation

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -34,6 +34,7 @@ const (
 	goldenLocalEgressBindTimeout              = 2 * time.Second
 	goldenActionEvidenceLimit                 = 256 << 10
 	goldenActivationLimit                     = 30 * time.Second
+	goldenMigrationPropagationLimit           = 2 * time.Minute
 	goldenRetirementLimit                     = 30 * time.Second
 	goldenChunkGapFloor                       = 5 * time.Second
 	goldenRSSLimitBytes                 int64 = 192 << 20

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -20,6 +20,27 @@ func TestGoldenSummaryRejectsActivationAtOrAboveThirtySeconds(t *testing.T) {
 	}
 }
 
+func TestGoldenMigrationUsesBoundedRoutePropagationWindow(t *testing.T) {
+	evidence := validGoldenMigrationTransitionEvidence(
+		"final-cutover", "front-migration-rollback", strings.Repeat("1", 64), strings.Repeat("2", 64),
+	)
+	evidence.Timestamps.ActivatedAt = "2026-08-02T00:01:59.000Z"
+	evidence.DestinationProof.ObservedAt = evidence.Timestamps.ActivatedAt
+	evidence.DestinationProof.ReceivedAt = "2026-08-02T00:01:59.500Z"
+	evidence.Timestamps.EvidenceEmittedAt = "2026-08-02T00:01:59.750Z"
+	if err := validateGoldenMigrationTransition(evidence, "front-migration-cutover"); err != nil {
+		t.Fatalf("sub-two-minute route propagation was rejected: %v", err)
+	}
+
+	evidence.Timestamps.ActivatedAt = "2026-08-02T00:02:00.000Z"
+	evidence.DestinationProof.ObservedAt = evidence.Timestamps.ActivatedAt
+	evidence.DestinationProof.ReceivedAt = evidence.Timestamps.ActivatedAt
+	evidence.Timestamps.EvidenceEmittedAt = "2026-08-02T00:02:00.001Z"
+	if err := validateGoldenMigrationTransition(evidence, "front-migration-cutover"); err == nil {
+		t.Fatal("two-minute route propagation boundary was accepted")
+	}
+}
+
 func TestGoldenSummaryRejectsStalledOriginalStream(t *testing.T) {
 	summary := validGoldenAcceptanceSummary()
 	for index := range summary.Sessions {

--- a/cmd/subrouter-transport-observer/golden_deploy_evidence.go
+++ b/cmd/subrouter-transport-observer/golden_deploy_evidence.go
@@ -414,6 +414,10 @@ func validateGoldenServerMetrics(metrics goldenDeployServiceMetrics, limit int64
 }
 
 func goldenPhaseDuration(requestedRaw, activatedRaw string) (time.Time, time.Time, error) {
+	return goldenPhaseDurationWithin(requestedRaw, activatedRaw, goldenActivationLimit)
+}
+
+func goldenPhaseDurationWithin(requestedRaw, activatedRaw string, limit time.Duration) (time.Time, time.Time, error) {
 	requested, err := parseGoldenEvidenceTime(requestedRaw)
 	if err != nil {
 		return time.Time{}, time.Time{}, err
@@ -422,7 +426,7 @@ func goldenPhaseDuration(requestedRaw, activatedRaw string) (time.Time, time.Tim
 	if err != nil || activated.Before(requested) {
 		return time.Time{}, time.Time{}, failGolden("action_timing_invalid")
 	}
-	if activated.Sub(requested) >= goldenActivationLimit {
+	if activated.Sub(requested) >= limit {
 		return time.Time{}, time.Time{}, failGolden("activation_duration_exceeded")
 	}
 	return requested, activated, nil

--- a/cmd/subrouter-transport-observer/golden_migration_evidence.go
+++ b/cmd/subrouter-transport-observer/golden_migration_evidence.go
@@ -315,7 +315,9 @@ func validateGoldenMigrationTransition(evidence *goldenMigrationEvidence, expect
 		evidence.Destination.After.PublicConnections < evidence.Destination.Before.PublicConnections+1 {
 		return failGolden("migration_destination_connection_count_invalid")
 	}
-	requested, activated, err := goldenPhaseDuration(evidence.Timestamps.TransitionRequestedAt, evidence.Timestamps.ActivatedAt)
+	requested, activated, err := goldenPhaseDurationWithin(
+		evidence.Timestamps.TransitionRequestedAt, evidence.Timestamps.ActivatedAt, goldenMigrationPropagationLimit,
+	)
 	if err != nil {
 		return err
 	}
@@ -323,7 +325,7 @@ func validateGoldenMigrationTransition(evidence *goldenMigrationEvidence, expect
 	emitted, emittedErr := parseGoldenEvidenceTime(evidence.Timestamps.EvidenceEmittedAt)
 	proofObserved, observedErr := parseGoldenEvidenceTime(evidence.DestinationProof.ObservedAt)
 	if proofErr != nil || emittedErr != nil || observedErr != nil || proofObserved != activated ||
-		proofReceived.Before(activated) || emitted.Before(proofReceived) || proofReceived.Sub(requested) >= goldenActivationLimit ||
+		proofReceived.Before(activated) || emitted.Before(proofReceived) || proofReceived.Sub(requested) >= goldenMigrationPropagationLimit ||
 		!validGoldenSHA256(evidence.DestinationProof.SHA256) || !validGoldenChallenge(evidence.DestinationProof.Challenge) ||
 		!validGoldenSHA256(evidence.DestinationProof.ConnectionID) || !validGoldenOpaqueID(evidence.DestinationProof.SessionID) ||
 		!evidence.DestinationProof.OriginalContinuityVerified ||

--- a/cmd/subrouter-transport-observer/golden_migration_transition.go
+++ b/cmd/subrouter-transport-observer/golden_migration_transition.go
@@ -15,7 +15,7 @@ import (
 const (
 	goldenDestinationProofRequestSchema = "subrouter.gcp.destination-proof-request/v1"
 	goldenDestinationProofSchema        = "subrouter.gcp.destination-proof/v1"
-	goldenDestinationProofMaxAttempts   = 4
+	goldenDestinationProofMaxAttempts   = 16
 )
 
 type goldenDestinationProofRequest struct {
@@ -114,7 +114,7 @@ func (r *goldenRunner) runMigrationTransitionWithProof(
 			return goldenActionSummary{}, nil, failGolden("migration_destination_proof_request_invalid")
 		}
 		requested, err := parseGoldenEvidenceTime(request.TransitionRequestedAt)
-		if err != nil || time.Since(requested) >= goldenActivationLimit {
+		if err != nil || time.Since(requested) >= goldenMigrationPropagationLimit {
 			return goldenActionSummary{}, nil, failGolden("migration_destination_proof_request_invalid")
 		}
 		if err := waitGoldenContinuityBoundary(ctx, monitors, requested); err != nil {
@@ -163,7 +163,7 @@ func (r *goldenRunner) runMigrationTransitionWithProof(
 		proofData, err := json.Marshal(proof)
 		proofFileData := append(proofData, '\n')
 		proofDigest = sha256.Sum256(proofFileData)
-		if err != nil || time.Since(requested) >= goldenActivationLimit || writePrivateFile(attemptProofPath, proofFileData) != nil {
+		if err != nil || time.Since(requested) >= goldenMigrationPropagationLimit || writePrivateFile(attemptProofPath, proofFileData) != nil {
 			return goldenActionSummary{}, nil, failGolden("migration_destination_proof_write_failed")
 		}
 		retry, err := waitGoldenMigrationAttemptOutcome(

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -1317,6 +1317,23 @@ func TestDeploymentContractValidatesGoldenTransitionProofs(t *testing.T) {
 	if output, err := run(proofArgs...); err != nil || len(output) != 0 {
 		t.Fatalf("destination proof result = %q, %v", output, err)
 	}
+	slowProof := strings.Replace(proofBody, "10:00:29.999Z", "10:01:59.999Z", 1)
+	if err := os.WriteFile(proof, []byte(slowProof), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	proofArgs[len(proofArgs)-1] = "2026-08-03T10:01:59.999Z"
+	if output, err := run(proofArgs...); err != nil || len(output) != 0 {
+		t.Fatalf("sub-two-minute destination proof result = %q, %v", output, err)
+	}
+	lateProof := strings.Replace(proofBody, "10:00:29.999Z", "10:02:00.000Z", 1)
+	if err := os.WriteFile(proof, []byte(lateProof), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	proofArgs[len(proofArgs)-1] = "2026-08-03T10:02:00.000Z"
+	if output, err := run(proofArgs...); err == nil {
+		t.Fatalf("two-minute destination proof boundary succeeded: %s", output)
+	}
+	proofArgs[len(proofArgs)-1] = "2026-08-03T10:00:29.999Z"
 	if err := os.WriteFile(proof, []byte(strings.Replace(proofBody, `"connection_id":"connection"`, `"connection_id":""`, 1)), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/deploy/gcp/deployment-contract.py
+++ b/deploy/gcp/deployment-contract.py
@@ -351,11 +351,12 @@ def validate_ordered_window(
     observed: datetime,
     received: datetime,
     label: str,
+    limit: timedelta = timedelta(seconds=30),
 ) -> None:
     if not requested <= intermediate <= observed <= received:
         fail(f"{label} timestamps are out of order")
-    if observed - requested >= timedelta(seconds=30) or received - requested >= timedelta(seconds=30):
-        fail(f"{label} was not completed strictly before 30 seconds")
+    if observed - requested >= limit or received - requested >= limit:
+        fail(f"{label} exceeded its phase boundary")
 
 
 def command_validate_activation_ack(args: argparse.Namespace) -> None:
@@ -425,7 +426,14 @@ def command_validate_destination_proof(args: argparse.Namespace) -> None:
     requested = parse_timestamp(args.requested_at, "transition requested time")
     observed = parse_timestamp(document.get("observed_at"), "destination proof observed time")
     received = parse_timestamp(args.received_at, "destination proof received time")
-    validate_ordered_window(requested, requested, observed, received, "destination proof")
+    validate_ordered_window(
+        requested,
+        requested,
+        observed,
+        received,
+        "destination proof",
+        timedelta(minutes=2),
+    )
 
 
 def add_path(parser: argparse.ArgumentParser, name: str) -> None:

--- a/deploy/gcp/switch-front-migration.sh
+++ b/deploy/gcp/switch-front-migration.sh
@@ -42,6 +42,7 @@ EXPECTED_CONNECTIONS_OVERRIDE="${SUBROUTER_EXPECTED_MIGRATION_CONNECTIONS:-}"
 ARTIFACT_DIR="${SUBROUTER_DEPLOY_ARTIFACT_DIR:-${PWD}/artifacts/gcp-front-transition}"
 RUN_LABEL="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-lb-${OPERATION}-$$"
 RUN_LABEL="${RUN_LABEL//[^a-zA-Z0-9._-]/-}"
+MIGRATION_PROPAGATION_LIMIT_MS=120000
 REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -322,7 +323,7 @@ if [[ "${destination_kind}" == front ]]; then
 else
   destination_generation="$(jq -r '.generation' < <(stream_shell_value "${legacy_json}"))"
 fi
-proof_max_attempts=4
+proof_max_attempts=16
 proof_attempt=1
 destination_correlated=false
 while (( proof_attempt <= proof_max_attempts )); do
@@ -348,14 +349,14 @@ while (( proof_attempt <= proof_max_attempts )); do
   mv -f -- "${proof_request_tmp}" "${proof_request_path}"
 
   while [[ ! -f "${proof_path}" || -L "${proof_path}" ]]; do
-    (( $(epoch_millis) - transition_requested_ms < 30000 )) \
-      || die "golden destination proof was not observed strictly before 30 seconds"
+    (( $(epoch_millis) - transition_requested_ms < MIGRATION_PROPAGATION_LIMIT_MS )) \
+      || die "golden destination proof was not observed within the two-minute route propagation window"
     sleep 0.05
   done
   proof_received_at="$(utc_now)"
   proof_received_ms="$(epoch_millis)"
-  (( proof_received_ms - transition_requested_ms < 30000 )) \
-    || die "golden destination proof arrived at or after 30 seconds"
+  (( proof_received_ms - transition_requested_ms < MIGRATION_PROPAGATION_LIMIT_MS )) \
+    || die "golden destination proof arrived outside the two-minute route propagation window"
   python3 "${DEPLOYMENT_CONTRACT}" validate-destination-proof \
     "${proof_path}" "${proof_challenge}" "${OPERATION}" \
     "${destination_kind}" "${destination_generation}" "${source_kind}" \

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -725,8 +725,8 @@ def validate_front_migration_transition(document: dict[str, Any], expected: str)
     emitted = timestamp(field(timestamps, "evidence_emitted_at", "timestamps"), "timestamps.evidence_emitted_at")
     if not requested <= activated <= emitted:
         fail("migration transition timestamps are out of order")
-    if activated - requested >= dt.timedelta(seconds=30):
-        fail("migration transition exceeded the 30-second phase boundary")
+    if activated - requested >= dt.timedelta(minutes=2):
+        fail("migration transition exceeded the two-minute route propagation boundary")
 
     proof = obj(field(document, "destination_proof", "root"), "destination_proof")
     sha(field(proof, "sha256", "destination_proof"), "destination_proof.sha256")
@@ -760,8 +760,8 @@ def validate_front_migration_transition(document: dict[str, Any], expected: str)
     )
     if not activated <= proof_received <= emitted:
         fail("destination proof receipt timestamps are out of order")
-    if proof_received - requested >= dt.timedelta(seconds=30):
-        fail("destination proof was not received strictly before 30 seconds")
+    if proof_received - requested >= dt.timedelta(minutes=2):
+        fail("destination proof exceeded the two-minute route propagation boundary")
 
     source = obj(field(document, "source", "root"), "source")
     before = validate_migration_snapshot(field(source, "before", "source"), "source.before", source_kind)


### PR DESCRIPTION
Global URL-map propagation remained on the legacy backend beyond the existing 30-second in-process activation bound.

- keep slot activation at 30 seconds
- bound external route propagation separately at two minutes
- retry up to 16 real HTTP Codex proof sessions while original streams remain pinned
- reject the exact two-minute boundary in Go and deployment-contract validation

The staging gate observed two safe legacy attempts before failing closed at the old deadline; existing streams remained active.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788480910&installation_model_id=21920&pr_number=152&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F152&signature=fba4c4059d3ef489ce0fb90608708dfe5b39703e0606012d20654e9655b6ef23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separate URL‑map propagation from process activation to reduce false failures during front migrations. Slot activation stays at 30s, and external route propagation now has its own strict <2‑minute window.

- **Bug Fixes**
  - Add `goldenMigrationPropagationLimit` (2 minutes) and enforce strict “less than” in Go and the deployment contract; reject the exact 2:00 boundary.
  - Keep `goldenActivationLimit` at 30s for in‑process slot activation.
  - Increase destination proof attempts from 4 to 16 while original streams remain pinned.
  - Update `deploy/gcp/deployment-contract.py` and `deploy/gcp/switch-front-migration.sh` to validate and wait within the 2‑minute window with clearer errors.
  - Add tests covering sub‑two‑minute acceptance and boundary rejection.

<sup>Written for commit 64816551345049f8750e06e88fe95ab8e24b4e29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

