### PR TITLE
Require release-coherent golden deployment helpers

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -49,7 +49,7 @@ const (
 	goldenPinnedBootstrapTag                  = "v0.1.55"
 	goldenPinnedBootstrapLinuxSHA256          = "6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c"
 	goldenPinnedBootstrapRevision             = "c4ea17e91ef6e9d0ab31cdd2774ca8d5387219bc"
-	goldenPinnedCandidateTag                  = "v0.1.56"
+	goldenPinnedCandidateTag                  = "v0.1.58"
 	goldenFakeStreamReleaseTokenEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_TOKEN"
 	goldenFakeStreamReleaseStateEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_STATE"
 )

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-func TestGoldenOptionsRequireV0156Candidate(t *testing.T) {
+func TestGoldenOptionsRequireV0158Candidate(t *testing.T) {
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = false
 	t.Cleanup(func() { goldenTestHooks = previousHooks })
@@ -19,7 +19,7 @@ func TestGoldenOptionsRequireV0156Candidate(t *testing.T) {
 	args := []string{
 		"--predecessor-version", "v0.1.51",
 		"--predecessor-sha256", goldenPinnedPredecessorSHA256,
-		"--candidate-tag", "v0.1.56",
+		"--candidate-tag", "v0.1.58",
 		"--candidate-sha256", strings.Repeat("b", 64),
 		"--candidate-revision", strings.Repeat("c", 40),
 		"--deploy-evidence-validator", "validator",
@@ -32,16 +32,16 @@ func TestGoldenOptionsRequireV0156Candidate(t *testing.T) {
 		"--old-generation-check", "true",
 	}
 	if _, err := parseGoldenArgs(args); err != nil {
-		t.Fatalf("v0.1.56 candidate was rejected: %v", err)
+		t.Fatalf("v0.1.58 candidate was rejected: %v", err)
 	}
 	for index := range args {
-		if args[index] == "v0.1.56" {
-			args[index] = "v0.1.55"
+		if args[index] == "v0.1.58" {
+			args[index] = "v0.1.57"
 			break
 		}
 	}
 	if _, err := parseGoldenArgs(args); err == nil {
-		t.Fatal("superseded v0.1.55 candidate was accepted")
+		t.Fatal("superseded v0.1.57 candidate was accepted")
 	}
 }
 

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -960,6 +960,45 @@ esac
 	}
 }
 
+func TestGoldenReleaseHelperCoherenceRejectsDrift(t *testing.T) {
+	requireDeployScriptTools(t, "bash")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	verifier := filepath.Join(repoRoot, "deploy", "gcp", "verify-release-helper-coherence.sh")
+	checkoutDir := t.TempDir()
+	releaseDir := t.TempDir()
+	helpers := []string{"deployment-contract.py", "install-front-slots.sh"}
+	checkoutPaths := make([]string, 0, len(helpers))
+	for _, name := range helpers {
+		body := []byte("verified helper " + name + "\n")
+		checkoutPath := filepath.Join(checkoutDir, name)
+		if err := os.WriteFile(checkoutPath, body, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(releaseDir, name), body, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		checkoutPaths = append(checkoutPaths, checkoutPath)
+	}
+	run := func() ([]byte, error) {
+		t.Helper()
+		args := append([]string{verifier, releaseDir}, checkoutPaths...)
+		return exec.Command(mustLookPath(t, "bash"), args...).CombinedOutput()
+	}
+	if output, err := run(); err != nil || len(output) != 0 {
+		t.Fatalf("matching release helpers were rejected: %v\n%s", err, output)
+	}
+	if err := os.WriteFile(filepath.Join(releaseDir, helpers[0]), []byte("stale release helper\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	output, err := run()
+	if err == nil {
+		t.Fatalf("mismatched release helper was accepted:\n%s", output)
+	}
+	if !strings.Contains(string(output), helpers[0]) || !strings.Contains(string(output), "cut and pin a new release") {
+		t.Fatalf("mismatch was not localized:\n%s", output)
+	}
+}
+
 func TestReleaseMainVerificationStreamsLargeComparison(t *testing.T) {
 	requireDeployScriptTools(t, "bash", "jq", "python3")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify the immutable v0.1.51/v0.1.55/v0.1.56 release inputs, then run the complete
+# Verify the immutable v0.1.51/v0.1.55/v0.1.58 release inputs, then run the complete
 # legacy-to-front migration and slot-upgrade continuity gate from a local Mac.
 set -euo pipefail
 umask 077
@@ -16,8 +16,8 @@ bootstrap_tag="v0.1.55"
 bootstrap_version="0.1.55"
 bootstrap_revision="c4ea17e91ef6e9d0ab31cdd2774ca8d5387219bc"
 bootstrap_linux_sha="6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c"
-candidate_tag="v0.1.56"
-candidate_version="0.1.56"
+candidate_tag="v0.1.58"
+candidate_version="0.1.58"
 
 usage() {
   cat <<'EOF'
@@ -215,7 +215,7 @@ if ! gh release view "${candidate_tag}" --repo "${repository}" --json tagName,is
       '.tagName == $tag and (.isDraft | not) and (.isPrerelease | not) and .isImmutable == true and
        (.publishedAt | type == "string" and length > 0)' \
       >/dev/null; then
-  echo "v0.1.56 is not a published immutable release" >&2
+  echo "v0.1.58 is not a published immutable release" >&2
   exit 1
 fi
 candidate_revision="$(require_release_revision_on_main "${candidate_tag}")"
@@ -257,6 +257,9 @@ jq -e --arg tag "${candidate_tag}" --arg revision "${candidate_revision}" \
    .tag == $tag and .source_revision == $revision and .tag_on_main == true' \
   "${candidate_dir}/SOURCE_PROVENANCE.json" >/dev/null \
   || { echo "candidate source provenance is invalid" >&2; exit 1; }
+"${root}/deploy/gcp/verify-release-helper-coherence.sh" "${candidate_dir}" \
+  "${root}/deploy/gcp/deployment-contract.py" \
+  "${root}/deploy/gcp/install-front-slots.sh"
 candidate_linux="${candidate_dir}/${candidate_linux_asset}"
 chmod 0700 "${candidate_linux}"
 verify_go_release_binary "${candidate_linux}" "${candidate_revision}"

--- a/deploy/gcp/verify-release-helper-coherence.sh
+++ b/deploy/gcp/verify-release-helper-coherence.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Refuse to run a golden deployment with release helpers that differ from the
+# checkout whose observer and deployment actions will consume them.
+set -euo pipefail
+
+if (( $# < 2 )); then
+  echo "usage: $0 <release-asset-dir> <checkout-helper> [...]" >&2
+  exit 2
+fi
+
+release_dir="$1"
+shift
+[[ -d "${release_dir}" && ! -L "${release_dir}" ]] || {
+  echo "candidate release asset directory is missing or unsafe" >&2
+  exit 1
+}
+
+for checkout_helper in "$@"; do
+  helper_name="$(basename "${checkout_helper}")"
+  release_helper="${release_dir}/${helper_name}"
+  [[ -f "${checkout_helper}" && ! -L "${checkout_helper}" ]] || {
+    echo "checkout release helper is missing or unsafe: ${helper_name}" >&2
+    exit 1
+  }
+  [[ -f "${release_helper}" && ! -L "${release_helper}" ]] || {
+    echo "candidate release helper is missing or unsafe: ${helper_name}" >&2
+    exit 1
+  }
+  cmp -s -- "${checkout_helper}" "${release_helper}" || {
+    echo "candidate release helper differs from checkout: ${helper_name}; cut and pin a new release before running golden continuity" >&2
+    exit 1
+  }
+done


### PR DESCRIPTION
The hosted continuity gate mixed current observer logic with stale immutable deployment helpers from v0.1.56. This advances the candidate to v0.1.58 and rejects any release helper that differs from the checkout before staging or production mutation.\n\nTests: go test ./...\n\nRegression history: fb946fb adds the failing tests, ac0ccda implements the guard.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788482043&installation_model_id=21920&pr_number=153&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F153&signature=6a2b1c6042845d1e247e6f4a19e8689d5a0a29ff14bf086fbbe1e0f8c2ff16c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent golden deployments from using stale release helpers by enforcing helper coherence with the checked-out code, and bump the pinned candidate to v0.1.58 to match the observer logic.

- **Bug Fixes**
  - Added a verifier script to reject golden runs when release helpers differ from the checkout.
  - Updated the local continuity script to use v0.1.58 and run the helper coherence check.
  - Pinned the observer’s golden candidate tag to v0.1.58.
  - Added tests for helper drift rejection and for requiring the v0.1.58 candidate.

<sup>Written for commit ac0ccdabdad1c484379569984486dc8e0d31d237. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-deployment verification to ensure release helpers match their checked-out counterparts.
  * Deployment continuity checks now validate the release deployment contract and installer before proceeding.
* **Bug Fixes**
  * Updated deployment workflows to use candidate release v0.1.58.
  * Improved error reporting when release helper files are inconsistent.
* **Tests**
  * Added coverage confirming mismatched release helpers are rejected with actionable guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->