### PR TITLE
Bound golden GitHub ancestry responses

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -1688,11 +1688,27 @@ func verifyGoldenPredecessorProvenance(
 		} `json:"merge_base_commit"`
 	}
 	if err := getGoldenGitHubJSON(ctx, httpClient,
-		"https://api.github.com/repos/manaflow-ai/subrouter/compare/"+revision+"...main", &comparison); err != nil ||
+		goldenGitHubComparisonURL(revision), &comparison); err != nil ||
 		(comparison.Status != "ahead" && comparison.Status != "identical") || comparison.MergeBaseCommit.SHA != revision {
 		return "", false, failGolden("predecessor_not_on_main")
 	}
 	return revision, true, nil
+}
+
+func goldenGitHubComparisonURL(revision string) string {
+	comparison := url.URL{
+		Scheme: "https",
+		Host:   "api.github.com",
+		Path:   "/repos/manaflow-ai/subrouter/compare/" + revision + "...main",
+	}
+	query := comparison.Query()
+	// GitHub includes every changed file only on page one. The ancestry fields
+	// are repeated on later pages, so page two keeps the response bounded even
+	// after years of changes following the pinned predecessor.
+	query.Set("per_page", "1")
+	query.Set("page", "2")
+	comparison.RawQuery = query.Encode()
+	return comparison.String()
 }
 
 func getGoldenGitHubJSON(ctx context.Context, client *http.Client, rawURL string, target any) error {

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -107,6 +108,22 @@ func TestGoldenGitHubJSONDoesNotSendAuthenticationToUntrustedURL(t *testing.T) {
 	}
 	if response.SHA != "anonymous" {
 		t.Fatalf("sha = %q, want anonymous", response.SHA)
+	}
+}
+
+func TestGoldenGitHubComparisonURLRequestsMetadataOnlyPage(t *testing.T) {
+	const revision = "5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8"
+	comparisonURL, err := url.Parse(goldenGitHubComparisonURL(revision))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if comparisonURL.Scheme != "https" || comparisonURL.Host != "api.github.com" ||
+		comparisonURL.Path != "/repos/manaflow-ai/subrouter/compare/"+revision+"...main" {
+		t.Fatalf("comparison URL target = %q", comparisonURL.String())
+	}
+	query := comparisonURL.Query()
+	if query.Get("per_page") != "1" || query.Get("page") != "2" || len(query) != 2 {
+		t.Fatalf("comparison URL query = %q", comparisonURL.RawQuery)
 	}
 }
 


### PR DESCRIPTION
The pinned predecessor comparison crossed the verifier's 1 MiB JSON cap because GitHub included 160 irrelevant file diffs. Request page 2 with one commit per page so GitHub returns the same ancestry metadata without file diffs.\n\nFocused tests pass. The full observer package twice hit the existing process_sampling_gap timing test under local load; GitHub CI is the exact clean-run gate.\n\nRegression history: 209f32f adds the failing test, 503dee3 implements pagination.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788483377&installation_model_id=21920&pr_number=154&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F154&signature=242af7b39c3075263fffc75c96de191898dcb6f7f3753f112f2f5deb2b3b40d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the GitHub compare request for golden predecessor checks to a metadata-only page to avoid large JSON payloads. This prevents verifier failures from file diff bloat and keeps the check stable over time.

- **Bug Fixes**
  - Request compare page 2 with `per_page=1` so GitHub returns ancestry fields without file diffs.
  - Replace the hardcoded compare URL with a helper that builds the paginated URL.
  - Add a unit test to assert the URL targets the correct endpoint and queries only `per_page=1&page=2`.

<sup>Written for commit 503dee3d3083d81168ff66b09e73eb9697bc44ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

