### PR TITLE
Hold real golden streams through deployment boundaries

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -1791,6 +1791,7 @@ type runningGoldenObserver struct {
 	events           *os.File
 	stats            *observerStats
 	observation      *observer
+	pacer            *goldenResponsePacer
 	lifecycle        *goldenObserverConnectionLifecycle
 	pid              int
 	done             chan struct{}
@@ -1882,9 +1883,13 @@ func (r *goldenRunner) startObserver(label string, upstream *url.URL) (*runningG
 	}
 	stats := newObserverStats()
 	observation := newObserver(events, stats)
+	var pacer *goldenResponsePacer
+	if !goldenTestHooks.enabled {
+		pacer = newGoldenResponsePacer()
+	}
 	lifecycle := newGoldenObserverConnectionLifecycle()
 	server := &http.Server{
-		Handler:           newObserverHandlerWithObserver(upstream, observation),
+		Handler:           newObserverHandlerWithObserverAndPacer(upstream, observation, pacer),
 		ReadHeaderTimeout: 10 * time.Second,
 		ConnState: func(connection net.Conn, state http.ConnState) {
 			finish := lifecycle.begin(connection, state)
@@ -1896,7 +1901,7 @@ func (r *goldenRunner) startObserver(label string, upstream *url.URL) (*runningG
 	}
 	running := &runningGoldenObserver{
 		label: label, baseURL: "http://" + listener.Addr().String(), server: server,
-		listener: listener, events: events, stats: stats, observation: observation, lifecycle: lifecycle, pid: os.Getpid(), done: make(chan struct{}),
+		listener: listener, events: events, stats: stats, observation: observation, pacer: pacer, lifecycle: lifecycle, pid: os.Getpid(), done: make(chan struct{}),
 		upstream: upstream, upstreamLoopback: isGoldenLoopbackHost(upstream.Hostname()),
 	}
 	r.mu.Lock()
@@ -1925,6 +1930,7 @@ func (r *goldenRunner) requireObserversRunning() error {
 
 func (o *runningGoldenObserver) stop(ctx context.Context) error {
 	o.stopOnce.Do(func() {
+		o.pacer.releasePacing()
 		if o.server != nil {
 			if err := o.server.Shutdown(ctx); err != nil {
 				o.stopErr = fmt.Errorf("%w: %v", failGolden("observer_shutdown_incomplete"), err)
@@ -2803,6 +2809,11 @@ func newGoldenTestStreamReleaseToken() (string, error) {
 }
 
 func releaseGoldenTestSessions(sessions []*goldenSession) error {
+	for _, session := range sessions {
+		if session != nil && session.observer != nil {
+			session.observer.pacer.releasePacing()
+		}
+	}
 	if !goldenTestHooks.enabled {
 		return nil
 	}

--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -1797,7 +1797,7 @@ type runningGoldenObserver struct {
 	events           *os.File
 	stats            *observerStats
 	observation      *observer
-	pacer            *goldenResponsePacer
+	gate             *goldenResponseGate
 	lifecycle        *goldenObserverConnectionLifecycle
 	pid              int
 	done             chan struct{}
@@ -1889,13 +1889,13 @@ func (r *goldenRunner) startObserver(label string, upstream *url.URL) (*runningG
 	}
 	stats := newObserverStats()
 	observation := newObserver(events, stats)
-	var pacer *goldenResponsePacer
+	var gate *goldenResponseGate
 	if !goldenTestHooks.enabled {
-		pacer = newGoldenResponsePacer()
+		gate = newGoldenResponseGate()
 	}
 	lifecycle := newGoldenObserverConnectionLifecycle()
 	server := &http.Server{
-		Handler:           newObserverHandlerWithObserverAndPacer(upstream, observation, pacer),
+		Handler:           newObserverHandlerWithObserverAndGate(upstream, observation, gate),
 		ReadHeaderTimeout: 10 * time.Second,
 		ConnState: func(connection net.Conn, state http.ConnState) {
 			finish := lifecycle.begin(connection, state)
@@ -1907,7 +1907,7 @@ func (r *goldenRunner) startObserver(label string, upstream *url.URL) (*runningG
 	}
 	running := &runningGoldenObserver{
 		label: label, baseURL: "http://" + listener.Addr().String(), server: server,
-		listener: listener, events: events, stats: stats, observation: observation, pacer: pacer, lifecycle: lifecycle, pid: os.Getpid(), done: make(chan struct{}),
+		listener: listener, events: events, stats: stats, observation: observation, gate: gate, lifecycle: lifecycle, pid: os.Getpid(), done: make(chan struct{}),
 		upstream: upstream, upstreamLoopback: isGoldenLoopbackHost(upstream.Hostname()),
 	}
 	r.mu.Lock()
@@ -1936,7 +1936,7 @@ func (r *goldenRunner) requireObserversRunning() error {
 
 func (o *runningGoldenObserver) stop(ctx context.Context) error {
 	o.stopOnce.Do(func() {
-		o.pacer.releasePacing()
+		o.gate.releasePacing()
 		if o.server != nil {
 			if err := o.server.Shutdown(ctx); err != nil {
 				o.stopErr = fmt.Errorf("%w: %v", failGolden("observer_shutdown_incomplete"), err)
@@ -2817,7 +2817,7 @@ func newGoldenTestStreamReleaseToken() (string, error) {
 func releaseGoldenTestSessions(sessions []*goldenSession) error {
 	for _, session := range sessions {
 		if session != nil && session.observer != nil {
-			session.observer.pacer.releasePacing()
+			session.observer.gate.releasePacing()
 		}
 	}
 	if !goldenTestHooks.enabled {

--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -1501,6 +1501,12 @@ func waitGoldenContinuityBoundary(ctx context.Context, monitors []*goldenContinu
 	for {
 		complete := true
 		for _, monitor := range monitors {
+			monitor.mu.Lock()
+			liveErr := monitor.liveErr
+			monitor.mu.Unlock()
+			if liveErr != nil {
+				return liveErr
+			}
 			requests := responseRequests(monitor.session.observer.stats)
 			if len(requests) != 1 || requests[0].RequestID != monitor.requestID || requests[0].ConnectionID == "" {
 				return failGolden("continuity_transport_identity_changed")

--- a/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
@@ -16,7 +16,7 @@ func TestGoldenObserverHoldsRealResponseUntilGateRelease(t *testing.T) {
 	goldenTestHooks.enabled = false
 	t.Cleanup(func() { goldenTestHooks = previousHooks })
 
-	payload := bytes.Repeat([]byte("continuity-payload\n"), 32<<10)
+	payload := []byte("finite response that fits inside one paced transport chunk")
 	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "text/event-stream")
 		_, _ = writer.Write(payload)
@@ -62,7 +62,7 @@ func TestGoldenObserverHoldsRealResponseUntilGateRelease(t *testing.T) {
 	select {
 	case err := <-readDone:
 		t.Fatalf("real response completed before gate release: %v", err)
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(500 * time.Millisecond):
 	}
 
 	if err := releaseGoldenTestSessions([]*goldenSession{{observer: observation}}); err != nil {

--- a/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
@@ -77,3 +77,82 @@ func TestGoldenObserverHoldsRealResponseUntilGateRelease(t *testing.T) {
 		t.Fatal("released response did not drain")
 	}
 }
+
+func TestGoldenObserverIsolatesConcurrentResponseHoldbacks(t *testing.T) {
+	previousHooks := goldenTestHooks
+	goldenTestHooks.enabled = false
+	t.Cleanup(func() { goldenTestHooks = previousHooks })
+
+	upstreamWritten := make(chan string, 2)
+	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		identifier := request.URL.Query().Get("id")
+		writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = writer.Write([]byte(identifier))
+		upstreamWritten <- identifier
+	}))
+	t.Cleanup(upstream.Close)
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &goldenRunner{artifactDir: t.TempDir()}
+	observation, err := runner.startObserver("concurrent-real-stream-pacing", upstreamURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := observation.stop(ctx); err != nil {
+			t.Errorf("stop observer: %v", err)
+		}
+	})
+
+	type responseResult struct {
+		identifier string
+		body       string
+		err        error
+	}
+	results := make(chan responseResult, 2)
+	for _, identifier := range []string{"first-response", "second-response"} {
+		go func(identifier string) {
+			response, err := http.Post(observation.baseURL+"/v1/responses?id="+identifier, "application/json", bytes.NewReader([]byte("{}")))
+			if err != nil {
+				results <- responseResult{identifier: identifier, err: err}
+				return
+			}
+			body, readErr := io.ReadAll(response.Body)
+			closeErr := response.Body.Close()
+			if readErr == nil {
+				readErr = closeErr
+			}
+			results <- responseResult{identifier: identifier, body: string(body), err: readErr}
+		}(identifier)
+	}
+	for range 2 {
+		select {
+		case <-upstreamWritten:
+		case <-time.After(5 * time.Second):
+			t.Fatal("concurrent upstream response was not written")
+		}
+	}
+	time.Sleep(100 * time.Millisecond)
+	if err := releaseGoldenTestSessions([]*goldenSession{{observer: observation}}); err != nil {
+		t.Fatal(err)
+	}
+
+	for range 2 {
+		select {
+		case result := <-results:
+			if result.err != nil {
+				t.Fatalf("%s failed: %v", result.identifier, result.err)
+			}
+			if result.body != result.identifier {
+				t.Fatalf("%s body = %q", result.identifier, result.body)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("concurrent response did not drain")
+		}
+	}
+}

--- a/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestGoldenObserverHoldsRealResponseUntilGateRelease(t *testing.T) {
+	previousHooks := goldenTestHooks
+	goldenTestHooks.enabled = false
+	t.Cleanup(func() { goldenTestHooks = previousHooks })
+
+	payload := bytes.Repeat([]byte("continuity-payload\n"), 32<<10)
+	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = writer.Write(payload)
+	}))
+	t.Cleanup(upstream.Close)
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &goldenRunner{artifactDir: t.TempDir()}
+	observation, err := runner.startObserver("real-stream-pacing", upstreamURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := observation.stop(ctx); err != nil {
+			t.Errorf("stop observer: %v", err)
+		}
+	})
+
+	request, err := http.NewRequest(http.MethodPost, observation.baseURL+"/v1/responses", bytes.NewReader([]byte("{}")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	readDone := make(chan error, 1)
+	go func() {
+		_, readErr := io.Copy(io.Discard, response.Body)
+		closeErr := response.Body.Close()
+		if readErr != nil {
+			readDone <- readErr
+			return
+		}
+		readDone <- closeErr
+	}()
+
+	select {
+	case err := <-readDone:
+		t.Fatalf("real response completed before gate release: %v", err)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	if err := releaseGoldenTestSessions([]*goldenSession{{observer: observation}}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-readDone:
+		if err != nil {
+			t.Fatalf("released response failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("released response did not drain")
+	}
+}

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -37,21 +37,58 @@ const (
 )
 
 type observerDelay interface {
-	wait(context.Context, <-chan struct{}, time.Duration) error
+	wait(context.Context, <-chan struct{}, <-chan struct{}, time.Duration) error
 }
 
 type timerObserverDelay struct{}
 
-func (timerObserverDelay) wait(ctx context.Context, released <-chan struct{}, duration time.Duration) error {
+func (timerObserverDelay) wait(
+	ctx context.Context,
+	gateReleased <-chan struct{},
+	requestReleased <-chan struct{},
+	duration time.Duration,
+) error {
 	timer := time.NewTimer(duration)
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-released:
+	case <-gateReleased:
+		return nil
+	case <-requestReleased:
 		return nil
 	case <-timer.C:
 		return nil
+	}
+}
+
+type goldenResponseGate struct {
+	released chan struct{}
+	release  sync.Once
+}
+
+func newGoldenResponseGate() *goldenResponseGate {
+	return &goldenResponseGate{released: make(chan struct{})}
+}
+
+func (g *goldenResponseGate) releasePacing() {
+	if g == nil {
+		return
+	}
+	g.release.Do(func() { close(g.released) })
+}
+
+func (g *goldenResponseGate) newResponsePacer() *goldenResponsePacer {
+	if g == nil {
+		return nil
+	}
+	return &goldenResponsePacer{
+		chunkBytes:      goldenPacedChunkBytes,
+		holdbackBytes:   goldenPacedHoldbackBytes,
+		interval:        goldenPacedChunkInterval,
+		delay:           timerObserverDelay{},
+		gateReleased:    g.released,
+		requestReleased: make(chan struct{}),
 	}
 }
 
@@ -59,33 +96,24 @@ func (timerObserverDelay) wait(ctx context.Context, released <-chan struct{}, du
 // and retains a response tail so a finite real Codex response cannot complete
 // before the deployment gate explicitly releases it.
 type goldenResponsePacer struct {
-	chunkBytes    int
-	holdbackBytes int
-	interval      time.Duration
-	delay         observerDelay
-	released      chan struct{}
-	release       sync.Once
-	mu            sync.Mutex
-	started       bool
-	pending       []byte
-	sink          func([]byte) (int, error)
+	chunkBytes         int
+	holdbackBytes      int
+	interval           time.Duration
+	delay              observerDelay
+	gateReleased       <-chan struct{}
+	requestReleased    chan struct{}
+	releaseRequestOnce sync.Once
+	mu                 sync.Mutex
+	started            bool
+	pending            []byte
+	sink               func([]byte) (int, error)
 }
 
-func newGoldenResponsePacer() *goldenResponsePacer {
-	return &goldenResponsePacer{
-		chunkBytes:    goldenPacedChunkBytes,
-		holdbackBytes: goldenPacedHoldbackBytes,
-		interval:      goldenPacedChunkInterval,
-		delay:         timerObserverDelay{},
-		released:      make(chan struct{}),
-	}
-}
-
-func (p *goldenResponsePacer) releasePacing() {
+func (p *goldenResponsePacer) releaseRequest() {
 	if p == nil {
 		return
 	}
-	p.release.Do(func() { close(p.released) })
+	p.releaseRequestOnce.Do(func() { close(p.requestReleased) })
 }
 
 func (p *goldenResponsePacer) isReleased() bool {
@@ -93,7 +121,9 @@ func (p *goldenResponsePacer) isReleased() bool {
 		return true
 	}
 	select {
-	case <-p.released:
+	case <-p.gateReleased:
+		return true
+	case <-p.requestReleased:
 		return true
 	default:
 		return false
@@ -118,31 +148,38 @@ func (p *goldenResponsePacer) write(ctx context.Context, payload []byte, write f
 	if flushBytes <= 0 {
 		return len(payload), nil
 	}
-	if err := p.writePacedLocked(ctx, p.pending[:flushBytes]); err != nil {
+	written, err := p.writePacedLocked(ctx, p.pending[:flushBytes])
+	if written < 0 || written > len(p.pending) {
+		return 0, errors.New("golden response pacing writer returned an invalid byte count")
+	}
+	copy(p.pending, p.pending[written:])
+	p.pending = p.pending[:len(p.pending)-written]
+	if err != nil {
 		return 0, err
 	}
-	copy(p.pending, p.pending[flushBytes:])
-	p.pending = p.pending[:len(p.pending)-flushBytes]
+	if written != flushBytes {
+		return 0, io.ErrShortWrite
+	}
 	return len(payload), nil
 }
 
-func (p *goldenResponsePacer) writePacedLocked(ctx context.Context, payload []byte) error {
+func (p *goldenResponsePacer) writePacedLocked(ctx context.Context, payload []byte) (int, error) {
 	total := 0
 	for total < len(payload) {
 		if p.isReleased() {
 			n, err := p.sink(payload[total:])
 			total += n
 			if err != nil {
-				return err
+				return total, err
 			}
 			if total != len(payload) {
-				return io.ErrShortWrite
+				return total, io.ErrShortWrite
 			}
-			return nil
+			return total, nil
 		}
 		if p.started {
-			if err := p.delay.wait(ctx, p.released, p.interval); err != nil {
-				return err
+			if err := p.delay.wait(ctx, p.gateReleased, p.requestReleased, p.interval); err != nil {
+				return total, err
 			}
 			if p.isReleased() {
 				continue
@@ -157,13 +194,13 @@ func (p *goldenResponsePacer) writePacedLocked(ctx context.Context, payload []by
 		n, err := p.sink(payload[total:end])
 		total += n
 		if err != nil {
-			return err
+			return total, err
 		}
 		if total != end {
-			return io.ErrShortWrite
+			return total, io.ErrShortWrite
 		}
 	}
-	return nil
+	return total, nil
 }
 
 func (p *goldenResponsePacer) flushPendingLocked() error {
@@ -174,6 +211,9 @@ func (p *goldenResponsePacer) flushPendingLocked() error {
 		return errors.New("golden response pacing sink is unavailable")
 	}
 	n, err := p.sink(p.pending)
+	if n < 0 || n > len(p.pending) {
+		return errors.New("golden response pacing writer returned an invalid byte count")
+	}
 	p.pending = p.pending[n:]
 	if err != nil {
 		return err
@@ -197,7 +237,10 @@ func (p *goldenResponsePacer) waitAndFlush() error {
 	if p == nil {
 		return nil
 	}
-	<-p.released
+	select {
+	case <-p.gateReleased:
+	case <-p.requestReleased:
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.flushPendingLocked()
@@ -511,7 +554,7 @@ type countingResponseWriter struct {
 func (w *countingResponseWriter) WriteHeader(statusCode int) {
 	if w.pacer != nil && statusCode != http.StatusSwitchingProtocols &&
 		(statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices) {
-		w.pacer.releasePacing()
+		w.pacer.releaseRequest()
 	}
 	w.ResponseWriter.WriteHeader(statusCode)
 	if statusCode >= http.StatusOK || statusCode == http.StatusSwitchingProtocols {
@@ -652,7 +695,7 @@ func (c *countingConn) Write(p []byte) (int, error) {
 func (c *countingConn) Close() error {
 	if c.pacer != nil {
 		if !c.pacer.hasPayload() {
-			c.pacer.releasePacing()
+			c.pacer.releaseRequest()
 		}
 		if err := c.pacer.waitAndFlush(); err != nil {
 			_ = c.Conn.Close()
@@ -675,10 +718,10 @@ func newObserverHandlerWithStats(upstream *url.URL, events io.Writer, stats *obs
 }
 
 func newObserverHandlerWithObserver(upstream *url.URL, observation *observer) http.Handler {
-	return newObserverHandlerWithObserverAndPacer(upstream, observation, nil)
+	return newObserverHandlerWithObserverAndGate(upstream, observation, nil)
 }
 
-func newObserverHandlerWithObserverAndPacer(upstream *url.URL, observation *observer, pacer *goldenResponsePacer) http.Handler {
+func newObserverHandlerWithObserverAndGate(upstream *url.URL, observation *observer, gate *goldenResponseGate) http.Handler {
 	proxy := httputil.NewSingleHostReverseProxy(upstream)
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	dialer := &net.Dialer{}
@@ -691,7 +734,7 @@ func newObserverHandlerWithObserverAndPacer(upstream *url.URL, observation *obse
 		if !ok {
 			return connection, nil
 		}
-		if pacer != nil && (meta.path == "/v1/responses" || meta.path == "/responses") {
+		if gate != nil && (meta.path == "/v1/responses" || meta.path == "/responses") {
 			if tcp, ok := connection.(*net.TCPConn); ok {
 				if err := tcp.SetReadBuffer(goldenPacedReadBuffer); err != nil {
 					_ = connection.Close()
@@ -748,9 +791,9 @@ func newObserverHandlerWithObserverAndPacer(upstream *url.URL, observation *obse
 			request.Body = &countingReadCloser{ReadCloser: request.Body, observer: observation, meta: meta}
 		}
 		request = request.WithContext(context.WithValue(request.Context(), requestEvidenceContextKey{}, meta))
-		responsePacer := pacer
-		if meta.path != "/v1/responses" && meta.path != "/responses" {
-			responsePacer = nil
+		var responsePacer *goldenResponsePacer
+		if meta.path == "/v1/responses" || meta.path == "/responses" {
+			responsePacer = gate.newResponsePacer()
 		}
 		responseWriter := &countingResponseWriter{
 			ResponseWriter: w, observer: observation, meta: meta,
@@ -759,7 +802,7 @@ func newObserverHandlerWithObserverAndPacer(upstream *url.URL, observation *obse
 		proxy.ServeHTTP(responseWriter, request)
 		if responsePacer != nil {
 			if !responsePacer.hasPayload() {
-				responsePacer.releasePacing()
+				responsePacer.releaseRequest()
 			}
 			if err := responsePacer.waitAndFlush(); err != nil {
 				observation.emit(meta.event("proxy_error"))

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -30,7 +30,112 @@ import (
 const (
 	goldenRequestTokenHeader = "X-Subrouter-Golden-Request-Token"
 	goldenRequestStateEnv    = "SUBROUTER_GOLDEN_FAKE_REQUEST_STATE"
+	goldenPacedChunkBytes    = 256
+	goldenPacedChunkInterval = 100 * time.Millisecond
+	goldenPacedReadBuffer    = 64 << 10
 )
+
+type observerDelay interface {
+	wait(context.Context, <-chan struct{}, time.Duration) error
+}
+
+type timerObserverDelay struct{}
+
+func (timerObserverDelay) wait(ctx context.Context, released <-chan struct{}, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-released:
+		return nil
+	case <-timer.C:
+		return nil
+	}
+}
+
+// goldenResponsePacer applies backpressure from the local continuity observer
+// so a finite real Codex response remains connected through the deployment
+// boundary. Releasing it drains the already-verified response at full speed.
+type goldenResponsePacer struct {
+	chunkBytes int
+	interval   time.Duration
+	delay      observerDelay
+	released   chan struct{}
+	release    sync.Once
+	mu         sync.Mutex
+	started    bool
+}
+
+func newGoldenResponsePacer() *goldenResponsePacer {
+	return &goldenResponsePacer{
+		chunkBytes: goldenPacedChunkBytes,
+		interval:   goldenPacedChunkInterval,
+		delay:      timerObserverDelay{},
+		released:   make(chan struct{}),
+	}
+}
+
+func (p *goldenResponsePacer) releasePacing() {
+	if p == nil {
+		return
+	}
+	p.release.Do(func() { close(p.released) })
+}
+
+func (p *goldenResponsePacer) isReleased() bool {
+	if p == nil {
+		return true
+	}
+	select {
+	case <-p.released:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *goldenResponsePacer) write(ctx context.Context, payload []byte, write func([]byte) (int, error)) (int, error) {
+	if p == nil || len(payload) == 0 || p.isReleased() {
+		return write(payload)
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	total := 0
+	for total < len(payload) {
+		if p.isReleased() {
+			n, err := write(payload[total:])
+			total += n
+			if err == nil && total != len(payload) {
+				err = io.ErrShortWrite
+			}
+			return total, err
+		}
+		if p.started {
+			if err := p.delay.wait(ctx, p.released, p.interval); err != nil {
+				return total, err
+			}
+			if p.isReleased() {
+				continue
+			}
+		} else {
+			p.started = true
+		}
+		end := total + p.chunkBytes
+		if end > len(payload) {
+			end = len(payload)
+		}
+		n, err := write(payload[total:end])
+		total += n
+		if err != nil {
+			return total, err
+		}
+		if total != end {
+			return total, io.ErrShortWrite
+		}
+	}
+	return total, nil
+}
 
 type transportEvent struct {
 	Kind         string `json:"kind"`
@@ -333,6 +438,8 @@ type countingResponseWriter struct {
 	observer   *observer
 	meta       requestEvidence
 	statusCode int
+	context    context.Context
+	pacer      *goldenResponsePacer
 }
 
 func (w *countingResponseWriter) WriteHeader(statusCode int) {
@@ -346,14 +453,16 @@ func (w *countingResponseWriter) Write(p []byte) (int, error) {
 	if w.statusCode == 0 {
 		w.recordFinalStatus(http.StatusOK)
 	}
-	n, err := w.ResponseWriter.Write(p)
-	if n > 0 {
-		event := w.meta.event("response_chunk")
-		event.Direction = "upstream_to_client"
-		event.Bytes = int64(n)
-		w.observer.emit(event)
-	}
-	return n, err
+	return w.pacer.write(w.context, p, func(chunk []byte) (int, error) {
+		n, err := w.ResponseWriter.Write(chunk)
+		if n > 0 {
+			event := w.meta.event("response_chunk")
+			event.Direction = "upstream_to_client"
+			event.Bytes = int64(n)
+			w.observer.emit(event)
+		}
+		return n, err
+	})
 }
 
 func (w *countingResponseWriter) recordFinalStatus(statusCode int) {
@@ -397,13 +506,15 @@ func (w *countingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	w.recordFinalStatus(http.StatusSwitchingProtocols)
 	// ReverseProxy writes the HTTP 101 control response through buffered. The
 	// wrapped connection sees only post-handshake WebSocket frame bytes.
-	return &countingConn{Conn: connection, observer: w.observer, meta: w.meta}, buffered, nil
+	return &countingConn{Conn: connection, observer: w.observer, meta: w.meta, context: w.context, pacer: w.pacer}, buffered, nil
 }
 
 type countingConn struct {
 	net.Conn
 	observer *observer
 	meta     requestEvidence
+	context  context.Context
+	pacer    *goldenResponsePacer
 	closed   atomic.Bool
 }
 
@@ -456,14 +567,16 @@ func (c *countingConn) Read(p []byte) (int, error) {
 }
 
 func (c *countingConn) Write(p []byte) (int, error) {
-	n, err := c.Conn.Write(p)
-	if n > 0 {
-		event := c.meta.event("response_chunk")
-		event.Direction = "upstream_to_client"
-		event.Bytes = int64(n)
-		c.observer.emit(event)
-	}
-	return n, err
+	return c.pacer.write(c.context, p, func(chunk []byte) (int, error) {
+		n, err := c.Conn.Write(chunk)
+		if n > 0 {
+			event := c.meta.event("response_chunk")
+			event.Direction = "upstream_to_client"
+			event.Bytes = int64(n)
+			c.observer.emit(event)
+		}
+		return n, err
+	})
 }
 
 func (c *countingConn) Close() error {
@@ -483,6 +596,10 @@ func newObserverHandlerWithStats(upstream *url.URL, events io.Writer, stats *obs
 }
 
 func newObserverHandlerWithObserver(upstream *url.URL, observation *observer) http.Handler {
+	return newObserverHandlerWithObserverAndPacer(upstream, observation, nil)
+}
+
+func newObserverHandlerWithObserverAndPacer(upstream *url.URL, observation *observer, pacer *goldenResponsePacer) http.Handler {
 	proxy := httputil.NewSingleHostReverseProxy(upstream)
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	dialer := &net.Dialer{}
@@ -494,6 +611,14 @@ func newObserverHandlerWithObserver(upstream *url.URL, observation *observer) ht
 		meta, ok := ctx.Value(requestEvidenceContextKey{}).(requestEvidence)
 		if !ok {
 			return connection, nil
+		}
+		if pacer != nil && (meta.path == "/v1/responses" || meta.path == "/responses") {
+			if tcp, ok := connection.(*net.TCPConn); ok {
+				if err := tcp.SetReadBuffer(goldenPacedReadBuffer); err != nil {
+					_ = connection.Close()
+					return nil, err
+				}
+			}
 		}
 		id := goldenSocketEndpointID(connection.LocalAddr().String())
 		event := meta.event("upstream_connection_opened")
@@ -544,7 +669,14 @@ func newObserverHandlerWithObserver(upstream *url.URL, observation *observer) ht
 			request.Body = &countingReadCloser{ReadCloser: request.Body, observer: observation, meta: meta}
 		}
 		request = request.WithContext(context.WithValue(request.Context(), requestEvidenceContextKey{}, meta))
-		responseWriter := &countingResponseWriter{ResponseWriter: w, observer: observation, meta: meta}
+		responsePacer := pacer
+		if meta.path != "/v1/responses" && meta.path != "/responses" {
+			responsePacer = nil
+		}
+		responseWriter := &countingResponseWriter{
+			ResponseWriter: w, observer: observation, meta: meta,
+			context: request.Context(), pacer: responsePacer,
+		}
 		proxy.ServeHTTP(responseWriter, request)
 		responseWriter.finish()
 		observation.emit(meta.event("request_completed"))

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -33,6 +33,7 @@ const (
 	goldenPacedChunkBytes    = 256
 	goldenPacedChunkInterval = 100 * time.Millisecond
 	goldenPacedReadBuffer    = 64 << 10
+	goldenPacedHoldbackBytes = 256
 )
 
 type observerDelay interface {
@@ -55,24 +56,28 @@ func (timerObserverDelay) wait(ctx context.Context, released <-chan struct{}, du
 }
 
 // goldenResponsePacer applies backpressure from the local continuity observer
-// so a finite real Codex response remains connected through the deployment
-// boundary. Releasing it drains the already-verified response at full speed.
+// and retains a response tail so a finite real Codex response cannot complete
+// before the deployment gate explicitly releases it.
 type goldenResponsePacer struct {
-	chunkBytes int
-	interval   time.Duration
-	delay      observerDelay
-	released   chan struct{}
-	release    sync.Once
-	mu         sync.Mutex
-	started    bool
+	chunkBytes    int
+	holdbackBytes int
+	interval      time.Duration
+	delay         observerDelay
+	released      chan struct{}
+	release       sync.Once
+	mu            sync.Mutex
+	started       bool
+	pending       []byte
+	sink          func([]byte) (int, error)
 }
 
 func newGoldenResponsePacer() *goldenResponsePacer {
 	return &goldenResponsePacer{
-		chunkBytes: goldenPacedChunkBytes,
-		interval:   goldenPacedChunkInterval,
-		delay:      timerObserverDelay{},
-		released:   make(chan struct{}),
+		chunkBytes:    goldenPacedChunkBytes,
+		holdbackBytes: goldenPacedHoldbackBytes,
+		interval:      goldenPacedChunkInterval,
+		delay:         timerObserverDelay{},
+		released:      make(chan struct{}),
 	}
 }
 
@@ -96,24 +101,48 @@ func (p *goldenResponsePacer) isReleased() bool {
 }
 
 func (p *goldenResponsePacer) write(ctx context.Context, payload []byte, write func([]byte) (int, error)) (int, error) {
-	if p == nil || len(payload) == 0 || p.isReleased() {
+	if p == nil || len(payload) == 0 {
 		return write(payload)
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.sink = write
+	if p.isReleased() {
+		if err := p.flushPendingLocked(); err != nil {
+			return 0, err
+		}
+		return write(payload)
+	}
+	p.pending = append(p.pending, payload...)
+	flushBytes := len(p.pending) - p.holdbackBytes
+	if flushBytes <= 0 {
+		return len(payload), nil
+	}
+	if err := p.writePacedLocked(ctx, p.pending[:flushBytes]); err != nil {
+		return 0, err
+	}
+	copy(p.pending, p.pending[flushBytes:])
+	p.pending = p.pending[:len(p.pending)-flushBytes]
+	return len(payload), nil
+}
+
+func (p *goldenResponsePacer) writePacedLocked(ctx context.Context, payload []byte) error {
 	total := 0
 	for total < len(payload) {
 		if p.isReleased() {
-			n, err := write(payload[total:])
+			n, err := p.sink(payload[total:])
 			total += n
-			if err == nil && total != len(payload) {
-				err = io.ErrShortWrite
+			if err != nil {
+				return err
 			}
-			return total, err
+			if total != len(payload) {
+				return io.ErrShortWrite
+			}
+			return nil
 		}
 		if p.started {
 			if err := p.delay.wait(ctx, p.released, p.interval); err != nil {
-				return total, err
+				return err
 			}
 			if p.isReleased() {
 				continue
@@ -125,16 +154,53 @@ func (p *goldenResponsePacer) write(ctx context.Context, payload []byte, write f
 		if end > len(payload) {
 			end = len(payload)
 		}
-		n, err := write(payload[total:end])
+		n, err := p.sink(payload[total:end])
 		total += n
 		if err != nil {
-			return total, err
+			return err
 		}
 		if total != end {
-			return total, io.ErrShortWrite
+			return io.ErrShortWrite
 		}
 	}
-	return total, nil
+	return nil
+}
+
+func (p *goldenResponsePacer) flushPendingLocked() error {
+	if len(p.pending) == 0 {
+		return nil
+	}
+	if p.sink == nil {
+		return errors.New("golden response pacing sink is unavailable")
+	}
+	n, err := p.sink(p.pending)
+	p.pending = p.pending[n:]
+	if err != nil {
+		return err
+	}
+	if len(p.pending) != 0 {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+func (p *goldenResponsePacer) hasPayload() bool {
+	if p == nil {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.started || len(p.pending) > 0
+}
+
+func (p *goldenResponsePacer) waitAndFlush() error {
+	if p == nil {
+		return nil
+	}
+	<-p.released
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.flushPendingLocked()
 }
 
 type transportEvent struct {
@@ -443,6 +509,10 @@ type countingResponseWriter struct {
 }
 
 func (w *countingResponseWriter) WriteHeader(statusCode int) {
+	if w.pacer != nil && statusCode != http.StatusSwitchingProtocols &&
+		(statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices) {
+		w.pacer.releasePacing()
+	}
 	w.ResponseWriter.WriteHeader(statusCode)
 	if statusCode >= http.StatusOK || statusCode == http.StatusSwitchingProtocols {
 		w.recordFinalStatus(statusCode)
@@ -580,6 +650,15 @@ func (c *countingConn) Write(p []byte) (int, error) {
 }
 
 func (c *countingConn) Close() error {
+	if c.pacer != nil {
+		if !c.pacer.hasPayload() {
+			c.pacer.releasePacing()
+		}
+		if err := c.pacer.waitAndFlush(); err != nil {
+			_ = c.Conn.Close()
+			return err
+		}
+	}
 	if c.closed.CompareAndSwap(false, true) {
 		c.observer.emit(transportEvent{Kind: "connection_closed", ConnectionID: c.meta.connectionID})
 	}
@@ -678,6 +757,14 @@ func newObserverHandlerWithObserverAndPacer(upstream *url.URL, observation *obse
 			context: request.Context(), pacer: responsePacer,
 		}
 		proxy.ServeHTTP(responseWriter, request)
+		if responsePacer != nil {
+			if !responsePacer.hasPayload() {
+				responsePacer.releasePacing()
+			}
+			if err := responsePacer.waitAndFlush(); err != nil {
+				observation.emit(meta.event("proxy_error"))
+			}
+		}
 		responseWriter.finish()
 		observation.emit(meta.event("request_completed"))
 	})


### PR DESCRIPTION
The production golden gate previously relied on a finite model response remaining open naturally. A fast HTTP response could finish before the first GCP route transition, causing `continuity_boundary_bytes_missing`.

The local observer now applies cancellable backpressure only to golden response streams, bounds the upstream socket buffer, and releases pacing after the verified boundary so the response drains and its exact payload is still validated. Production Subrouter traffic is unchanged.

Verification:
- regression test fails before the fix
- focused test passes under the race detector
- `go test ./...` passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788489175&installation_model_id=21920&pr_number=157&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F157&signature=616f5cc83bde42542a4b62f0224a5555f4cdc24fca593afe45a135291d6b00f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents early completion of real golden response streams across deployment boundaries by pacing chunks and retaining a small tail until the gate releases. Pacing is isolated per request to prevent cross‑stream corruption, and streams drain immediately on release.

- **Bug Fixes**
  - Added a golden response pacer that writes in small timed chunks, holds back 256B, and flushes at full speed on release.
  - Applied pacing only to `/v1/responses` and `/responses`, and bounded the upstream TCP read buffer to 64KiB for these streams.
  - Routed `ResponseWriter` and hijacked connection writes through the pacer; releases pacing on non‑2xx/101, observer shutdown, and in `releaseGoldenTestSessions`.
  - Ensured pending bytes flush after proxy/hijack close to deliver the retained tail.
  - Isolated pacing per request to avoid concurrent response mixing; added tests for early completion and concurrent holdbacks.

<sup>Written for commit 05118c3f4dbf4d5fe31e4904b6dcbfceae601a26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming responses can now be paced in controlled chunks and released when the deployment gate completes.
  * Response handling supports consistent pacing across standard and upgraded connections.

* **Bug Fixes**
  * Monitoring errors are surfaced promptly before response validation.
  * Empty and error responses are handled without unnecessary delays.
  * Improved shutdown behavior ensures pending responses and connections are released cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->