### PR TITLE
Show hosted tenant quota usage in status

### DIFF
--- a/cmd/subrouter/cloud_mode_test.go
+++ b/cmd/subrouter/cloud_mode_test.go
@@ -33,6 +33,24 @@ func saveReadyCloudConfig(t *testing.T) {
 	}
 }
 
+func TestUsageRowsFromHostedStatusesPreservesQuotaWindows(t *testing.T) {
+	rows := usageRowsFromHostedStatuses([]broker.UsageStatus{{
+		ID:        "account-1",
+		Provider:  accounts.ProviderCodex,
+		AuthMode:  accounts.AuthModeOAuth,
+		Email:     "user@example.com",
+		AuthValid: true,
+		Windows: []accounts.UsageWindow{{
+			Name:        "weekly",
+			UsedPercent: 25,
+		}},
+	}})
+	if len(rows) != 1 || rows[0].email != "user@example.com" ||
+		len(rows[0].windows) != 1 || rows[0].windows[0].UsedPercent != 25 {
+		t.Fatalf("usage rows = %#v", rows)
+	}
+}
+
 func TestCloudCodexAlwaysUsesLocalProxy(t *testing.T) {
 	saveReadyCloudConfig(t)
 	local := healthServer(t, 200)

--- a/cmd/subrouter/sr_cloud.go
+++ b/cmd/subrouter/sr_cloud.go
@@ -707,6 +707,20 @@ func (r srRunner) cloudStatus(ctx context.Context) error {
 	if err := r.printCredentialSource(config); err != nil {
 		return err
 	}
+	if config.HostedReady() {
+		statuses, err := client.UsageStatuses(ctx)
+		if err != nil {
+			return err
+		}
+		rows := usageRowsFromHostedStatuses(statuses)
+		if len(rows) == 0 {
+			fmt.Fprintln(r.out, "No shared accounts.")
+			return nil
+		}
+		fmt.Fprintln(r.out)
+		displayUsageRowsPerGroup(r.out, rows)
+		return nil
+	}
 	items, err := client.ListAccounts(ctx)
 	if err != nil {
 		return err
@@ -731,6 +745,29 @@ func (r srRunner) cloudStatus(ctx context.Context) error {
 		)
 	}
 	return nil
+}
+
+func usageRowsFromHostedStatuses(statuses []broker.UsageStatus) []srUsageRow {
+	wire := make([]remoteServerUsageStatus, 0, len(statuses))
+	for _, status := range statuses {
+		wire = append(wire, remoteServerUsageStatus{
+			ID:                 status.ID,
+			Provider:           status.Provider,
+			AuthMode:           status.AuthMode,
+			Email:              status.Email,
+			Source:             status.Source,
+			AuthChecked:        status.AuthChecked,
+			AuthValid:          status.AuthValid,
+			Refreshed:          status.Refreshed,
+			Error:              status.Error,
+			Active:             status.Active,
+			PlanType:           status.PlanType,
+			Windows:            status.Windows,
+			Credits:            status.Credits,
+			ComplimentaryReset: status.ComplimentaryReset,
+		})
+	}
+	return usageRowsFromServerUsageStatuses(wire)
 }
 
 func (r srRunner) cloudAccount(ctx context.Context, args []string) error {

--- a/internal/broker/client.go
+++ b/internal/broker/client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/manaflow-ai/subrouter/account"
+	"github.com/manaflow-ai/subrouter/internal/accounts"
 )
 
 type Team struct {
@@ -157,6 +158,23 @@ type Client struct {
 	leaseRefs  map[string]leaseRef
 }
 
+type UsageStatus struct {
+	ID                 string                           `json:"id"`
+	Provider           accounts.Provider                `json:"provider"`
+	AuthMode           accounts.AuthMode                `json:"auth_mode"`
+	Email              string                           `json:"email,omitempty"`
+	Source             string                           `json:"source"`
+	AuthChecked        bool                             `json:"auth_checked"`
+	AuthValid          bool                             `json:"auth_valid"`
+	Refreshed          bool                             `json:"refreshed,omitempty"`
+	Error              string                           `json:"error,omitempty"`
+	Active             bool                             `json:"active,omitempty"`
+	PlanType           string                           `json:"plan_type,omitempty"`
+	Windows            []accounts.UsageWindow           `json:"windows,omitempty"`
+	Credits            *accounts.CreditsInfo            `json:"credits,omitempty"`
+	ComplimentaryReset *accounts.ComplimentaryResetInfo `json:"complimentary_reset,omitempty"`
+}
+
 type leaseRef struct {
 	AccountID            string
 	CredentialGeneration int
@@ -240,6 +258,23 @@ func (c *Client) ListAccounts(ctx context.Context) ([]SharedAccount, error) {
 		return nil, err
 	}
 	return response.Accounts, nil
+}
+
+func (c *Client) UsageStatuses(ctx context.Context) ([]UsageStatus, error) {
+	if !c.Config.HostedReady() {
+		return nil, errors.New("hosted usage status requires a hosted tenant")
+	}
+	var statuses []UsageStatus
+	if err := c.doHostedJSON(
+		ctx,
+		http.MethodGet,
+		"/_subrouter/usage-status",
+		nil,
+		&statuses,
+	); err != nil {
+		return nil, err
+	}
+	return statuses, nil
 }
 
 func (c *Client) UploadAccount(ctx context.Context, input AccountUpload) (SharedAccount, error) {

--- a/internal/broker/hosted_client_test.go
+++ b/internal/broker/hosted_client_test.go
@@ -105,6 +105,43 @@ func TestHostedClientRepairPreservesTargetAccountID(t *testing.T) {
 	}
 }
 
+func TestHostedClientUsesTenantScopedUsageStatus(t *testing.T) {
+	key := "srt_0123456789abcdef0123456789abcdef"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/t/"+key+"/_subrouter/usage-status" {
+			http.Error(w, "unexpected path", http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{{
+			"id":         "user@example.com",
+			"provider":   "codex",
+			"auth_mode":  "oauth",
+			"email":      "user@example.com",
+			"auth_valid": true,
+			"windows": []map[string]any{{
+				"Name": "weekly", "UsedPercent": 25.0,
+			}},
+		}})
+	}))
+	defer server.Close()
+	client := NewClient(Config{
+		Version: 1, BaseURL: DefaultBaseURL,
+		AccessToken: "access", RefreshToken: "refresh",
+		TeamID: "team", CredentialSource: CredentialSourceHosted,
+		HostedURL: server.URL, TenantKey: key,
+	})
+	client.HTTPClient = server.Client()
+	statuses, err := client.UsageStatuses(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(statuses) != 1 || statuses[0].Email != "user@example.com" ||
+		len(statuses[0].Windows) != 1 ||
+		statuses[0].Windows[0].UsedPercent != 25 {
+		t.Fatalf("usage statuses = %#v", statuses)
+	}
+}
+
 func TestHostedClientRejectsUnknownAPIKeyProvider(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode([]map[string]any{{

--- a/internal/proxy/multitenant.go
+++ b/internal/proxy/multitenant.go
@@ -342,6 +342,7 @@ func (m *MultiTenant) newTenantServer(ctx context.Context, t tenant.Tenant) (*Se
 	// Reaching a tenant handler already proves possession of the tenant key,
 	// so the tenant-visible _subrouter read endpoints need no admin token.
 	server.AdminToken = ""
+	server.AccountImportToken = ""
 	server.tenantAccountImportAuthorized = true
 	server.Transcripts = nil
 	if m.TranscriptDir != "" {

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -66,6 +66,13 @@ func (f fakeStackTeams) ListTeams(context.Context, string) ([]stackauth.Team, er
 // header it received, a legacy single-tenant base Server with one account, and
 // a MultiTenant wrapper over a fresh registry.
 func newMultiTenantFixture(t *testing.T) (*tenant.Registry, http.Handler, func() string) {
+	return newMultiTenantFixtureWithAccountImportToken(t, "")
+}
+
+func newMultiTenantFixtureWithAccountImportToken(
+	t *testing.T,
+	accountImportToken string,
+) (*tenant.Registry, http.Handler, func() string) {
 	t.Helper()
 	var lastAuth string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -89,13 +96,39 @@ func newMultiTenantFixture(t *testing.T) (*tenant.Registry, http.Handler, func()
 			AuthMode: accounts.AuthModeOAuth,
 			Token:    "legacy-token",
 		}},
-		Sessions:     legacySessions,
-		Scheduler:    selectacct.NewScheduler(nil),
-		MaxBodyBytes: 1024,
+		Sessions:           legacySessions,
+		Scheduler:          selectacct.NewScheduler(nil),
+		MaxBodyBytes:       1024,
+		AccountImportToken: accountImportToken,
 	}
 	registry := tenant.NewRegistry(t.TempDir())
 	multi := &MultiTenant{Base: base, Registry: registry}
 	return registry, multi.Handler(base.Handler()), func() string { return lastAuth }
+}
+
+func TestMultiTenantUsageStatusNeedsOnlyTheTenantKey(t *testing.T) {
+	registry, handler, _ := newMultiTenantFixtureWithAccountImportToken(
+		t,
+		"legacy-import-token",
+	)
+	_, key, err := registry.Create("usage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/t/"+key+"/_subrouter/usage-status",
+		nil,
+	)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("usage status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var statuses []AccountUsageStatus
+	if err := json.Unmarshal(response.Body.Bytes(), &statuses); err != nil {
+		t.Fatalf("decode usage status: %v", err)
+	}
 }
 
 func writeTenantAPIKeyAccount(t *testing.T, registry *tenant.Registry, tenantID, email, apiKey string) {


### PR DESCRIPTION
Makes tenant-scoped `/_subrouter/usage-status` reachable with the tenant key even when the global server has a separate account-import token, adds a typed hosted usage client, and renders the normal grouped quota grid for hosted `sr status`/bare `sr`. This lets bare CodeRouter show account usage instead of only account health.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788490268&installation_model_id=21920&pr_number=158&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F158&signature=bd023b42a0bf539295c3eef62e748d0789d6be77119c6cc92209d6411639534c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables hosted tenants to see quota usage in `sr status` and bare `sr` by calling a tenant-scoped `/_subrouter/usage-status` with only the tenant key. Adds a typed hosted usage client and maps results to the normal grouped quota grid.

- **New Features**
  - Tenant-scoped `/_subrouter/usage-status` is accessible with the tenant key even when a global account-import token exists; tenant servers clear `AccountImportToken` for read endpoints.
  - Adds `UsageStatus` and `UsageStatuses()` in `internal/broker`, and converts results in `sr_cloud` to display grouped quota windows.

<sup>Written for commit 72f24c9571b01a1b5f937e154cd4792f765a4c52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

