### PR TITLE
Recover bounded golden route migrations

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -34,7 +34,7 @@ const (
 	goldenLocalEgressBindTimeout              = 2 * time.Second
 	goldenActionEvidenceLimit                 = 256 << 10
 	goldenActivationLimit                     = 30 * time.Second
-	goldenMigrationPropagationLimit           = 2 * time.Minute
+	goldenMigrationPropagationLimit           = 5 * time.Minute
 	goldenRetirementLimit                     = 30 * time.Second
 	goldenChunkGapFloor                       = 5 * time.Second
 	goldenRSSLimitBytes                 int64 = 192 << 20

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -24,20 +24,20 @@ func TestGoldenMigrationUsesBoundedRoutePropagationWindow(t *testing.T) {
 	evidence := validGoldenMigrationTransitionEvidence(
 		"final-cutover", "front-migration-rollback", strings.Repeat("1", 64), strings.Repeat("2", 64),
 	)
-	evidence.Timestamps.ActivatedAt = "2026-08-02T00:01:59.000Z"
+	evidence.Timestamps.ActivatedAt = "2026-08-02T00:04:59.000Z"
 	evidence.DestinationProof.ObservedAt = evidence.Timestamps.ActivatedAt
-	evidence.DestinationProof.ReceivedAt = "2026-08-02T00:01:59.500Z"
-	evidence.Timestamps.EvidenceEmittedAt = "2026-08-02T00:01:59.750Z"
+	evidence.DestinationProof.ReceivedAt = "2026-08-02T00:04:59.500Z"
+	evidence.Timestamps.EvidenceEmittedAt = "2026-08-02T00:04:59.750Z"
 	if err := validateGoldenMigrationTransition(evidence, "front-migration-cutover"); err != nil {
-		t.Fatalf("sub-two-minute route propagation was rejected: %v", err)
+		t.Fatalf("sub-five-minute route propagation was rejected: %v", err)
 	}
 
-	evidence.Timestamps.ActivatedAt = "2026-08-02T00:02:00.000Z"
+	evidence.Timestamps.ActivatedAt = "2026-08-02T00:05:00.000Z"
 	evidence.DestinationProof.ObservedAt = evidence.Timestamps.ActivatedAt
 	evidence.DestinationProof.ReceivedAt = evidence.Timestamps.ActivatedAt
-	evidence.Timestamps.EvidenceEmittedAt = "2026-08-02T00:02:00.001Z"
+	evidence.Timestamps.EvidenceEmittedAt = "2026-08-02T00:05:00.001Z"
 	if err := validateGoldenMigrationTransition(evidence, "front-migration-cutover"); err == nil {
-		t.Fatal("two-minute route propagation boundary was accepted")
+		t.Fatal("five-minute route propagation boundary was accepted")
 	}
 }
 

--- a/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
+++ b/cmd/subrouter-transport-observer/golden_deployment_action_lifecycle_unix_test.go
@@ -66,6 +66,48 @@ func TestGoldenMigrationValidationFailureRunsDeploymentActionCleanup(t *testing.
 	waitGoldenLifecycleProcessGone(t, childPID)
 }
 
+func TestTerminateProcessGroupAllowsGracefulCleanup(t *testing.T) {
+	root := t.TempDir()
+	readyPath := filepath.Join(root, "ready")
+	cleanupPath := filepath.Join(root, "cleanup")
+	scriptPath := filepath.Join(root, "cleanup-helper.sh")
+	script := `#!/usr/bin/env bash
+set -euo pipefail
+ready_path="$1"
+cleanup_path="$2"
+cleanup() {
+  trap - TERM
+  sleep 0.25
+  printf 'complete\n' >"${cleanup_path}"
+  exit 0
+}
+trap cleanup TERM
+printf 'ready\n' >"${ready_path}"
+while :; do sleep 1; done
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command(scriptPath, readyPath, cleanupPath)
+	command.Stdout, command.Stderr = io.Discard, io.Discard
+	configureProcessGroup(command)
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		killProcessGroup(command)
+		_ = command.Wait()
+	})
+	waitGoldenLifecycleFile(t, readyPath)
+	terminateProcessGroup(command)
+	if err := command.Wait(); err != nil {
+		t.Fatalf("cleanup helper did not exit gracefully: %v", err)
+	}
+	if _, err := os.Stat(cleanupPath); err != nil {
+		t.Fatalf("graceful cleanup did not complete: %v", err)
+	}
+}
+
 func TestGoldenDeploymentActionLifecycleHelper(t *testing.T) {
 	cleanupPath := goldenLifecycleArgument("--helper-cleanup")
 	if cleanupPath == "" {

--- a/cmd/subrouter-transport-observer/golden_migration_transition.go
+++ b/cmd/subrouter-transport-observer/golden_migration_transition.go
@@ -15,7 +15,7 @@ import (
 const (
 	goldenDestinationProofRequestSchema = "subrouter.gcp.destination-proof-request/v1"
 	goldenDestinationProofSchema        = "subrouter.gcp.destination-proof/v1"
-	goldenDestinationProofMaxAttempts   = 16
+	goldenDestinationProofMaxAttempts   = 64
 )
 
 type goldenDestinationProofRequest struct {

--- a/cmd/subrouter-transport-observer/golden_process_unix.go
+++ b/cmd/subrouter-transport-observer/golden_process_unix.go
@@ -27,8 +27,9 @@ func interruptProcessGroup(command *exec.Cmd) {
 
 func terminateProcessGroup(command *exec.Cmd) {
 	if command != nil && command.Process != nil {
-		_ = syscall.Kill(-command.Process.Pid, syscall.SIGTERM)
-		_ = command.Process.Signal(syscall.SIGTERM)
+		if err := syscall.Kill(-command.Process.Pid, syscall.SIGTERM); err != nil {
+			_ = command.Process.Signal(syscall.SIGTERM)
+		}
 	}
 }
 

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -1356,21 +1356,21 @@ func TestDeploymentContractValidatesGoldenTransitionProofs(t *testing.T) {
 	if output, err := run(proofArgs...); err != nil || len(output) != 0 {
 		t.Fatalf("destination proof result = %q, %v", output, err)
 	}
-	slowProof := strings.Replace(proofBody, "10:00:29.999Z", "10:01:59.999Z", 1)
+	slowProof := strings.Replace(proofBody, "10:00:29.999Z", "10:04:59.999Z", 1)
 	if err := os.WriteFile(proof, []byte(slowProof), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	proofArgs[len(proofArgs)-1] = "2026-08-03T10:01:59.999Z"
+	proofArgs[len(proofArgs)-1] = "2026-08-03T10:04:59.999Z"
 	if output, err := run(proofArgs...); err != nil || len(output) != 0 {
-		t.Fatalf("sub-two-minute destination proof result = %q, %v", output, err)
+		t.Fatalf("sub-five-minute destination proof result = %q, %v", output, err)
 	}
-	lateProof := strings.Replace(proofBody, "10:00:29.999Z", "10:02:00.000Z", 1)
+	lateProof := strings.Replace(proofBody, "10:00:29.999Z", "10:05:00.000Z", 1)
 	if err := os.WriteFile(proof, []byte(lateProof), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	proofArgs[len(proofArgs)-1] = "2026-08-03T10:02:00.000Z"
+	proofArgs[len(proofArgs)-1] = "2026-08-03T10:05:00.000Z"
 	if output, err := run(proofArgs...); err == nil {
-		t.Fatalf("two-minute destination proof boundary succeeded: %s", output)
+		t.Fatalf("five-minute destination proof boundary succeeded: %s", output)
 	}
 	proofArgs[len(proofArgs)-1] = "2026-08-03T10:00:29.999Z"
 	if err := os.WriteFile(proof, []byte(strings.Replace(proofBody, `"connection_id":"connection"`, `"connection_id":""`, 1)), 0o600); err != nil {

--- a/deploy/gcp/deployment-contract.py
+++ b/deploy/gcp/deployment-contract.py
@@ -432,7 +432,7 @@ def command_validate_destination_proof(args: argparse.Namespace) -> None:
         observed,
         received,
         "destination proof",
-        timedelta(minutes=2),
+        timedelta(minutes=5),
     )
 
 

--- a/deploy/gcp/switch-front-migration.sh
+++ b/deploy/gcp/switch-front-migration.sh
@@ -42,7 +42,7 @@ EXPECTED_CONNECTIONS_OVERRIDE="${SUBROUTER_EXPECTED_MIGRATION_CONNECTIONS:-}"
 ARTIFACT_DIR="${SUBROUTER_DEPLOY_ARTIFACT_DIR:-${PWD}/artifacts/gcp-front-transition}"
 RUN_LABEL="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-lb-${OPERATION}-$$"
 RUN_LABEL="${RUN_LABEL//[^a-zA-Z0-9._-]/-}"
-MIGRATION_PROPAGATION_LIMIT_MS=120000
+MIGRATION_PROPAGATION_LIMIT_MS=300000
 REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -323,7 +323,7 @@ if [[ "${destination_kind}" == front ]]; then
 else
   destination_generation="$(jq -r '.generation' < <(stream_shell_value "${legacy_json}"))"
 fi
-proof_max_attempts=16
+proof_max_attempts=64
 proof_attempt=1
 destination_correlated=false
 while (( proof_attempt <= proof_max_attempts )); do
@@ -350,13 +350,13 @@ while (( proof_attempt <= proof_max_attempts )); do
 
   while [[ ! -f "${proof_path}" || -L "${proof_path}" ]]; do
     (( $(epoch_millis) - transition_requested_ms < MIGRATION_PROPAGATION_LIMIT_MS )) \
-      || die "golden destination proof was not observed within the two-minute route propagation window"
+      || die "golden destination proof was not observed within the five-minute route propagation window"
     sleep 0.05
   done
   proof_received_at="$(utc_now)"
   proof_received_ms="$(epoch_millis)"
   (( proof_received_ms - transition_requested_ms < MIGRATION_PROPAGATION_LIMIT_MS )) \
-    || die "golden destination proof arrived outside the two-minute route propagation window"
+    || die "golden destination proof arrived outside the five-minute route propagation window"
   python3 "${DEPLOYMENT_CONTRACT}" validate-destination-proof \
     "${proof_path}" "${proof_challenge}" "${OPERATION}" \
     "${destination_kind}" "${destination_generation}" "${source_kind}" \

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -725,8 +725,8 @@ def validate_front_migration_transition(document: dict[str, Any], expected: str)
     emitted = timestamp(field(timestamps, "evidence_emitted_at", "timestamps"), "timestamps.evidence_emitted_at")
     if not requested <= activated <= emitted:
         fail("migration transition timestamps are out of order")
-    if activated - requested >= dt.timedelta(minutes=2):
-        fail("migration transition exceeded the two-minute route propagation boundary")
+    if activated - requested >= dt.timedelta(minutes=5):
+        fail("migration transition exceeded the five-minute route propagation boundary")
 
     proof = obj(field(document, "destination_proof", "root"), "destination_proof")
     sha(field(proof, "sha256", "destination_proof"), "destination_proof.sha256")
@@ -760,8 +760,8 @@ def validate_front_migration_transition(document: dict[str, Any], expected: str)
     )
     if not activated <= proof_received <= emitted:
         fail("destination proof receipt timestamps are out of order")
-    if proof_received - requested >= dt.timedelta(minutes=2):
-        fail("destination proof exceeded the two-minute route propagation boundary")
+    if proof_received - requested >= dt.timedelta(minutes=5):
+        fail("destination proof exceeded the five-minute route propagation boundary")
 
     source = obj(field(document, "source", "root"), "source")
     before = validate_migration_snapshot(field(source, "before", "source"), "source.before", source_kind)


### PR DESCRIPTION
The staging golden run reached its two-minute route-proof limit while existing Codex streams remained healthy. Google Cloud documents URL-map propagation as taking several minutes. Cleanup then received duplicate SIGTERM delivery and was interrupted before restoring the URL map and releasing the deploy lock.

This keeps migration proof bounded at five minutes, raises the correlated proof-attempt ceiling to use that window, and makes direct process signaling a fallback when process-group signaling fails.

Regression sequence:
- eaa8967 changes boundary and cleanup tests; the old implementation rejects the valid 4:59 proof.
- fddbe82 implements the bounded recovery.

Verified:
- go test ./...
- focused observer tests, 10 repetitions
- focused observer race test
- bash -n deploy/gcp/switch-front-migration.sh

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788493906&installation_model_id=21920&pr_number=160&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F160&signature=d369fff430a289d80d45cd3e15351430ac932aaab8a1fc014b741294727ec7ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the golden-route migration propagation window to 5 minutes and harden cleanup, preventing stuck deploys when URL-map propagation is slow or SIGTERM delivery is flaky.

- **Bug Fixes**
  - Bump migration propagation limit from 2 to 5 minutes in the observer, `deploy/gcp/deployment-contract.py`, `deploy/gcp/validate-deploy-evidence.py`, and `deploy/gcp/switch-front-migration.sh`.
  - Raise destination proof max attempts from 16 to 64 to fit the longer window.
  - Improve termination: try process-group SIGTERM first, then fall back to direct process SIGTERM; add a test to verify graceful cleanup.
  - Update acceptance and deploy script tests to cover the new 5-minute boundary and cleanup behavior.

<sup>Written for commit fddbe82c4310ef6c57eefc252b6c16ee6e4ac1cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended migration propagation and destination-proof acceptance windows from two to five minutes.
  * Increased destination-proof retry capacity from 16 to 64 attempts.
  * Improved process-group termination so graceful shutdown handlers can complete cleanup reliably.

* **Tests**
  * Updated migration timing coverage for the five-minute boundaries.
  * Added validation for graceful process termination and delayed cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->