### PR TITLE
Pin production continuity gate to v0.1.61

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -49,7 +49,7 @@ const (
 	goldenPinnedBootstrapTag                  = "v0.1.55"
 	goldenPinnedBootstrapLinuxSHA256          = "6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c"
 	goldenPinnedBootstrapRevision             = "c4ea17e91ef6e9d0ab31cdd2774ca8d5387219bc"
-	goldenPinnedCandidateTag                  = "v0.1.59"
+	goldenPinnedCandidateTag                  = "v0.1.61"
 	goldenFakeStreamReleaseTokenEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_TOKEN"
 	goldenFakeStreamReleaseStateEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_STATE"
 )

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func TestGoldenOptionsRequireV0159Candidate(t *testing.T) {
+func TestGoldenOptionsRequireV0161Candidate(t *testing.T) {
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = false
 	t.Cleanup(func() { goldenTestHooks = previousHooks })
@@ -20,7 +20,7 @@ func TestGoldenOptionsRequireV0159Candidate(t *testing.T) {
 	args := []string{
 		"--predecessor-version", "v0.1.51",
 		"--predecessor-sha256", goldenPinnedPredecessorSHA256,
-		"--candidate-tag", "v0.1.59",
+		"--candidate-tag", "v0.1.61",
 		"--candidate-sha256", strings.Repeat("b", 64),
 		"--candidate-revision", strings.Repeat("c", 40),
 		"--deploy-evidence-validator", "validator",
@@ -33,16 +33,16 @@ func TestGoldenOptionsRequireV0159Candidate(t *testing.T) {
 		"--old-generation-check", "true",
 	}
 	if _, err := parseGoldenArgs(args); err != nil {
-		t.Fatalf("v0.1.59 candidate was rejected: %v", err)
+		t.Fatalf("v0.1.61 candidate was rejected: %v", err)
 	}
 	for index := range args {
-		if args[index] == "v0.1.59" {
-			args[index] = "v0.1.58"
+		if args[index] == "v0.1.61" {
+			args[index] = "v0.1.60"
 			break
 		}
 	}
 	if _, err := parseGoldenArgs(args); err == nil {
-		t.Fatal("superseded v0.1.58 candidate was accepted")
+		t.Fatal("superseded v0.1.60 candidate was accepted")
 	}
 }
 

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify the immutable v0.1.51/v0.1.55/v0.1.59 release inputs, then run the complete
+# Verify the immutable v0.1.51/v0.1.55/v0.1.61 release inputs, then run the complete
 # legacy-to-front migration and slot-upgrade continuity gate from a local Mac.
 set -euo pipefail
 umask 077
@@ -16,8 +16,8 @@ bootstrap_tag="v0.1.55"
 bootstrap_version="0.1.55"
 bootstrap_revision="c4ea17e91ef6e9d0ab31cdd2774ca8d5387219bc"
 bootstrap_linux_sha="6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c"
-candidate_tag="v0.1.59"
-candidate_version="0.1.59"
+candidate_tag="v0.1.61"
+candidate_version="0.1.61"
 
 usage() {
   cat <<'EOF'
@@ -215,7 +215,7 @@ if ! gh release view "${candidate_tag}" --repo "${repository}" --json tagName,is
       '.tagName == $tag and (.isDraft | not) and (.isPrerelease | not) and .isImmutable == true and
        (.publishedAt | type == "string" and length > 0)' \
       >/dev/null; then
-  echo "v0.1.59 is not a published immutable release" >&2
+  echo "v0.1.61 is not a published immutable release" >&2
   exit 1
 fi
 candidate_revision="$(require_release_revision_on_main "${candidate_tag}")"


### PR DESCRIPTION
v0.1.61 contains the merged five-minute GCP propagation contract and single-signal cleanup fix. Pin the production continuity gate to that immutable release so the binary and deployment helpers remain release-coherent.

Regression sequence:
- d78805e requires v0.1.61 and fails against the v0.1.59 pin.
- d362af0 advances the candidate pin.

Verified: go test ./... and focused option tests (10 repetitions).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788494812&installation_model_id=21920&pr_number=161&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F161&signature=5222efd40073bbf1cbfdcc07629914512bb370553e6e010b17e669e80282d17a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the production continuity gate to v0.1.61 to pick up the five-minute GCP propagation contract and the single-signal cleanup fix. Updates golden defaults, tests, and the GCP continuity script to require the immutable v0.1.61 release.

<sup>Written for commit d362af0ff888f0e1a795a6ef4475e2778be120ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

