### PR TITLE
Make Stack logout resilient to expired sessions

### DIFF
--- a/cmd/subrouter/sr_cloud.go
+++ b/cmd/subrouter/sr_cloud.go
@@ -448,10 +448,44 @@ func (r srRunner) cloudLogout(ctx context.Context) error {
 	if config.LoggedIn() {
 		if config.StackProjectID != "" && config.StackPublishable != "" {
 			client := nativeStackClient(config, r.client)
-			if err := client.SignOut(ctx, config.AccessToken, config.RefreshToken); err != nil {
+			tokens, refreshErr := client.Refresh(ctx, config.RefreshToken)
+			if refreshErr == nil {
+				config.AccessToken = tokens.AccessToken
+				config.RefreshToken = tokens.RefreshToken
+				// Stack rotates refresh tokens. Persist the new token before
+				// attempting another request so a transient sign-out failure
+				// remains retryable.
+				if err := broker.SaveConfig(path, config); err != nil {
+					return fmt.Errorf(
+						"persist refreshed Stack session before logout: %w",
+						err,
+					)
+				}
+				if err := client.SignOut(
+					ctx, config.AccessToken, config.RefreshToken,
+				); err != nil {
+					if !stackSessionGone(err) {
+						return fmt.Errorf(
+							"could not revoke the Stack session; refreshed local credentials were kept so logout can be retried: %w",
+							err,
+						)
+					}
+					fmt.Fprintln(
+						r.errOut,
+						"warning: the Stack session was already expired or revoked; clearing local credentials",
+					)
+				}
+			} else if stackRefreshTokenInvalid(refreshErr) {
+				// An invalid refresh token cannot authorize any new access
+				// token. There is no usable remote session left to revoke.
+				fmt.Fprintln(
+					r.errOut,
+					"warning: the Stack session was already expired or revoked; clearing local credentials",
+				)
+			} else {
 				return fmt.Errorf(
-					"could not revoke the Stack session; local credentials were kept so logout can be retried: %w",
-					err,
+					"could not refresh the Stack session for revocation; local credentials were kept so logout can be retried: %w",
+					refreshErr,
 				)
 			}
 		} else {
@@ -481,6 +515,29 @@ func (r srRunner) cloudLogout(ctx context.Context) error {
 	}
 	fmt.Fprintln(r.out, "Logged out of cmux.com. Credential storage is now local.")
 	return nil
+}
+
+func stackRefreshTokenInvalid(err error) bool {
+	status, ok := stackauth.HTTPStatus(err)
+	if ok && status == http.StatusUnauthorized {
+		return true
+	}
+	switch strings.ToUpper(stackauth.HTTPErrorCode(err)) {
+	case "INVALID_GRANT",
+		"REFRESH_TOKEN_EXPIRED",
+		"REFRESH_TOKEN_INVALID",
+		"REFRESH_TOKEN_NOT_FOUND",
+		"REFRESH_TOKEN_REUSED":
+		return true
+	default:
+		return false
+	}
+}
+
+func stackSessionGone(err error) bool {
+	status, ok := stackauth.HTTPStatus(err)
+	return ok && (status == http.StatusUnauthorized ||
+		status == http.StatusNotFound)
 }
 
 func (r srRunner) cloudTeam(ctx context.Context, args []string) error {

--- a/cmd/subrouter/sr_onboarding_review_test.go
+++ b/cmd/subrouter/sr_onboarding_review_test.go
@@ -211,6 +211,202 @@ func TestLogoutDoesNotReportSuccessWhenHostedRemoteCleanupFails(t *testing.T) {
 	}
 }
 
+func TestLogoutRefreshesExpiredAccessTokenBeforeRevokingSession(t *testing.T) {
+	var revoked bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/oauth/token":
+			_, _ = io.WriteString(w, `{"access_token":"fresh-access","refresh_token":"fresh-refresh"}`)
+		case "/auth/sessions/current":
+			if r.Header.Get("X-Stack-Access-Token") != "fresh-access" ||
+				r.Header.Get("X-Stack-Refresh-Token") != "fresh-refresh" {
+				http.Error(w, "stale session tokens", http.StatusUnauthorized)
+				return
+			}
+			revoked = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	runner, configPath, output := newLogoutTestRunner(t, server)
+	if err := runner.cloudLogout(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !revoked {
+		t.Fatal("fresh Stack session was not revoked")
+	}
+	assertLoggedOutConfig(t, configPath)
+	if !strings.Contains(output.String(), "Logged out of cmux.com") {
+		t.Fatalf("output = %q", output.String())
+	}
+}
+
+func TestLogoutClearsLocallyWhenRefreshTokenIsAlreadyInvalid(t *testing.T) {
+	var signOutCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/oauth/token":
+			http.Error(w, `{"code":"REFRESH_TOKEN_EXPIRED"}`, http.StatusBadRequest)
+		case "/auth/sessions/current":
+			signOutCalls++
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	runner, configPath, output := newLogoutTestRunner(t, server)
+	if err := runner.cloudLogout(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if signOutCalls != 0 {
+		t.Fatalf("sign-out calls = %d, want 0", signOutCalls)
+	}
+	assertLoggedOutConfig(t, configPath)
+	if !strings.Contains(output.String(), "already expired or revoked") {
+		t.Fatalf("output = %q", output.String())
+	}
+}
+
+func TestLogoutKeepsCredentialsForNonTerminalRefreshRejection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"code":"INVALID_CLIENT"}`, http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	runner, configPath, _ := newLogoutTestRunner(t, server)
+	err := runner.cloudLogout(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "kept so logout can be retried") {
+		t.Fatalf("error = %v", err)
+	}
+	config, loadErr := broker.LoadConfig(configPath)
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if config.AccessToken != "access" || config.RefreshToken != "refresh" ||
+		config.TenantKey == "" {
+		t.Fatalf("credentials changed after nonterminal rejection: %#v", config)
+	}
+}
+
+func TestLogoutKeepsCredentialsWhenStackRefreshIsTransientlyUnavailable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	runner, configPath, output := newLogoutTestRunner(t, server)
+	err := runner.cloudLogout(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "kept so logout can be retried") {
+		t.Fatalf("error = %v", err)
+	}
+	config, loadErr := broker.LoadConfig(configPath)
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if config.AccessToken != "access" || config.RefreshToken != "refresh" ||
+		config.TenantKey == "" {
+		t.Fatalf("credentials changed after transient refresh failure: %#v", config)
+	}
+	if strings.Contains(output.String(), "Logged out of cmux.com") {
+		t.Fatalf("logout incorrectly reported success: %q", output.String())
+	}
+}
+
+func TestLogoutPersistsRotatedTokensWhenSignOutIsTransientlyUnavailable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/oauth/token":
+			_, _ = io.WriteString(w, `{"access_token":"fresh-access","refresh_token":"fresh-refresh"}`)
+		case "/auth/sessions/current":
+			http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	runner, configPath, output := newLogoutTestRunner(t, server)
+	err := runner.cloudLogout(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "refreshed local credentials were kept") {
+		t.Fatalf("error = %v", err)
+	}
+	config, loadErr := broker.LoadConfig(configPath)
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if config.AccessToken != "fresh-access" ||
+		config.RefreshToken != "fresh-refresh" || config.TenantKey == "" {
+		t.Fatalf("rotated credentials were not retained: %#v", config)
+	}
+	if strings.Contains(output.String(), "Logged out of cmux.com") {
+		t.Fatalf("logout incorrectly reported success: %q", output.String())
+	}
+}
+
+func TestLogoutClearsLocallyWhenFreshSessionIsAlreadyGone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/oauth/token":
+			_, _ = io.WriteString(w, `{"access_token":"fresh-access","refresh_token":"fresh-refresh"}`)
+		case "/auth/sessions/current":
+			http.Error(w, `{"code":"SESSION_NOT_FOUND"}`, http.StatusNotFound)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	runner, configPath, output := newLogoutTestRunner(t, server)
+	if err := runner.cloudLogout(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	assertLoggedOutConfig(t, configPath)
+	if !strings.Contains(output.String(), "already expired or revoked") {
+		t.Fatalf("output = %q", output.String())
+	}
+}
+
+func newLogoutTestRunner(
+	t *testing.T,
+	server *httptest.Server,
+) (srRunner, string, *bytes.Buffer) {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("CODEX_HOME", filepath.Join(root, "codex"))
+	configPath := filepath.Join(root, "cloud.json")
+	t.Setenv("SUBROUTER_CLOUD_CONFIG", configPath)
+	saveHostedTestConfig(t, configPath, broker.Config{StackAPIURL: server.URL})
+	output := &bytes.Buffer{}
+	return srRunner{
+		program: "sr",
+		store: accounts.CodexStore{
+			Dir: filepath.Join(root, "state", "codex", "accounts"),
+		},
+		out: output, errOut: output, client: server.Client(),
+	}, configPath, output
+}
+
+func assertLoggedOutConfig(t *testing.T, path string) {
+	t.Helper()
+	config, err := broker.LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.AccessToken != "" || config.RefreshToken != "" ||
+		config.TeamID != "" || config.TeamName != "" ||
+		config.HostedURL != "" || config.HostedExchangeURL != "" ||
+		config.TenantKey != "" || len(config.TenantCapabilities) != 0 ||
+		config.CredentialSource != broker.CredentialSourceLocal {
+		t.Fatalf("config still contains hosted credentials: %#v", config)
+	}
+}
+
 func TestHostedClaudeUploadGuidanceNamesHostedCMUX(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "cloud.json")
 	t.Setenv("SUBROUTER_CLOUD_CONFIG", configPath)

--- a/internal/stackauth/client.go
+++ b/internal/stackauth/client.go
@@ -99,6 +99,7 @@ type Client struct {
 type HTTPError struct {
 	Action     string
 	StatusCode int
+	Code       string
 	Message    string
 }
 
@@ -137,6 +138,26 @@ func Retryable(err error) bool {
 		}
 	}
 	return false
+}
+
+// HTTPStatus returns the response status carried by a Stack API error.
+// Callers should use this instead of parsing Stack's human-readable response
+// body, which is not a stable interface.
+func HTTPStatus(err error) (int, bool) {
+	var responseErr *HTTPError
+	if !errors.As(err, &responseErr) {
+		return 0, false
+	}
+	return responseErr.StatusCode, true
+}
+
+// HTTPErrorCode returns Stack's machine-readable error code, when present.
+func HTTPErrorCode(err error) string {
+	var responseErr *HTTPError
+	if !errors.As(err, &responseErr) {
+		return ""
+	}
+	return responseErr.Code
 }
 
 type CLIStart struct {
@@ -491,8 +512,19 @@ func responseErrorFromBody(action string, statusCode int, body []byte) error {
 	if message == "" {
 		message = http.StatusText(statusCode)
 	}
+	var envelope struct {
+		Code  string `json:"code"`
+		Error string `json:"error"`
+	}
+	_ = json.Unmarshal(body, &envelope)
+	code := strings.TrimSpace(envelope.Code)
+	if code == "" && strings.EqualFold(
+		strings.TrimSpace(envelope.Error), "invalid_grant",
+	) {
+		code = "invalid_grant"
+	}
 	return &HTTPError{
-		Action: action, StatusCode: statusCode, Message: message,
+		Action: action, StatusCode: statusCode, Code: code, Message: message,
 	}
 }
 

--- a/internal/stackauth/client_test.go
+++ b/internal/stackauth/client_test.go
@@ -3,6 +3,7 @@ package stackauth
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,27 @@ import (
 	"testing"
 	"time"
 )
+
+func TestHTTPErrorExposesStructuredStatusAndCode(t *testing.T) {
+	err := responseErrorFromBody(
+		"refresh",
+		http.StatusBadRequest,
+		[]byte(`{"code":"REFRESH_TOKEN_EXPIRED","error":"expired"}`),
+	)
+	if status, ok := HTTPStatus(fmt.Errorf("wrapped: %w", err)); !ok ||
+		status != http.StatusBadRequest {
+		t.Fatalf("status = %d, %v", status, ok)
+	}
+	if code := HTTPErrorCode(fmt.Errorf("wrapped: %w", err)); code != "REFRESH_TOKEN_EXPIRED" {
+		t.Fatalf("code = %q", code)
+	}
+	oauthErr := responseErrorFromBody(
+		"refresh", http.StatusBadRequest, []byte(`{"error":"invalid_grant"}`),
+	)
+	if code := HTTPErrorCode(oauthErr); code != "invalid_grant" {
+		t.Fatalf("OAuth code = %q", code)
+	}
+}
 
 func TestNativeCLIFlowAndRefresh(t *testing.T) {
 	var sawStackHeaders bool


### PR DESCRIPTION
Refreshes the Stack session before revocation, persists rotated tokens before a retryable sign-out, treats terminal refresh/session expiry as an already-complete remote logout, and retains credentials on transient or nonterminal failures. Includes coverage for expired access tokens, invalid refresh tokens, transient refresh/sign-out failures, rotated-token persistence, already-gone sessions, and structured Stack error classification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788495243&installation_model_id=21920&pr_number=162&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F162&signature=a83b96f8473da1ab6abb7d91d9681f61f5ffc44cd8b5abc08763a708ba99e32d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Stack logout resilient to expired or already-revoked sessions by refreshing before revocation, persisting rotated tokens, and deciding when to keep or clear local credentials. Improves error handling with structured Stack status/code checks and adds targeted tests.

- **Bug Fixes**
  - Refreshes the Stack session before sign-out and saves rotated tokens so retries work.
  - Clears local credentials when the refresh token is invalid or sign-out returns 401/404; retains them on transient or nonterminal errors.
  - Adds structured error helpers in `internal/stackauth` to read HTTP status and code, enabling precise handling.
  - Adds tests for expired access tokens, invalid refresh tokens, transient refresh/sign-out failures, rotated-token persistence, and already-gone sessions.

<sup>Written for commit d71a2c74ebac20bf34ed4ce5bc5f4ab8620f1378. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

