### PR TITLE
Gate hosted cutover on stable front readiness

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -35,6 +35,7 @@ const (
 	goldenActionEvidenceLimit                 = 256 << 10
 	goldenActivationLimit                     = 30 * time.Second
 	goldenMigrationPropagationLimit           = 5 * time.Minute
+	goldenBackendHealthStabilityLimit         = 5 * time.Minute
 	goldenRetirementLimit                     = 30 * time.Second
 	goldenChunkGapFloor                       = 5 * time.Second
 	goldenRSSLimitBytes                 int64 = 192 << 20
@@ -46,9 +47,9 @@ const (
 	goldenPinnedPredecessorVersion            = "0.1.51"
 	goldenPinnedPredecessorSHA256             = "74f4bfbbf6b8dcbe0509eaaa9f63b1eb688358a749ed3b451066e146591d2582"
 	goldenPinnedPredecessorRevision           = "5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8"
-	goldenPinnedBootstrapTag                  = "v0.1.55"
-	goldenPinnedBootstrapLinuxSHA256          = "6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c"
-	goldenPinnedBootstrapRevision             = "c4ea17e91ef6e9d0ab31cdd2774ca8d5387219bc"
+	goldenPinnedBootstrapTag                  = "v0.1.60"
+	goldenPinnedBootstrapLinuxSHA256          = "6a8daa1361030311bdbe25a06cd4940e4dd07a45758c13c2dc8d687e70d87303"
+	goldenPinnedBootstrapRevision             = "e169e94f2bea9a0455a5831631fcbac220bd65f2"
 	goldenPinnedCandidateTag                  = "v0.1.61"
 	goldenFakeStreamReleaseTokenEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_TOKEN"
 	goldenFakeStreamReleaseStateEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_STATE"

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -148,6 +148,17 @@ func TestGoldenMigrationPreparationRequiresCompatibleBootstrapAndStableBackendHe
 		t.Fatal("Python validator accepted a negative backend health sample gap")
 	}
 
+	impossibleSpan := clone(valid)
+	impossibleHealth := impossibleSpan["front"].(map[string]any)["backend_health"].(map[string]any)
+	impossibleHealth["healthy_samples"] = 21
+	impossibleHealth["max_sample_gap_ms"] = 5_000
+	if err := validateGo(impossibleSpan); err == nil {
+		t.Fatal("Go validator accepted samples that cannot span the claimed readiness duration")
+	}
+	if err := validatePython(impossibleSpan); err == nil {
+		t.Fatal("Python validator accepted samples that cannot span the claimed readiness duration")
+	}
+
 	oldBootstrap := clone(valid)
 	oldBootstrap["bootstrap"] = map[string]any{
 		"tag":                  "v0.1.55",

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -38,6 +40,118 @@ func TestGoldenMigrationUsesBoundedRoutePropagationWindow(t *testing.T) {
 	evidence.Timestamps.EvidenceEmittedAt = "2026-08-02T00:05:00.001Z"
 	if err := validateGoldenMigrationTransition(evidence, "front-migration-cutover"); err == nil {
 		t.Fatal("five-minute route propagation boundary was accepted")
+	}
+}
+
+func TestGoldenMigrationPreparationRequiresCompatibleBootstrapAndStableBackendHealth(t *testing.T) {
+	document := func() map[string]any {
+		evidence := validGoldenMigrationPreparationEvidence()
+		evidence.EvidenceEmittedAt = "2026-08-02T00:05:01Z"
+		encoded, err := json.Marshal(evidence)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var result map[string]any
+		if err := json.Unmarshal(encoded, &result); err != nil {
+			t.Fatal(err)
+		}
+		result["bootstrap"] = map[string]any{
+			"tag":                  "v0.1.60",
+			"sha256":               "6a8daa1361030311bdbe25a06cd4940e4dd07a45758c13c2dc8d687e70d87303",
+			"source_revision":      "e169e94f2bea9a0455a5831631fcbac220bd65f2",
+			"tag_on_main":          true,
+			"attestation_verified": true,
+			"immutable":            true,
+		}
+		front := result["front"].(map[string]any)
+		front["worker_checksum"] = "6a8daa1361030311bdbe25a06cd4940e4dd07a45758c13c2dc8d687e70d87303"
+		front["backend_health"] = map[string]any{
+			"all_healthy":     true,
+			"stable_since":    "2026-08-02T00:00:00Z",
+			"verified_at":     "2026-08-02T00:05:00Z",
+			"duration_ms":     300_000,
+			"healthy_samples": 61,
+		}
+		return result
+	}
+	validateGo := func(value map[string]any) error {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		var evidence goldenMigrationEvidence
+		if err := json.Unmarshal(encoded, &evidence); err != nil {
+			return err
+		}
+		return validateGoldenMigrationEvidence(&evidence, "front-migration-preparation")
+	}
+	validatePython := func(value map[string]any) error {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		path := filepath.Join(t.TempDir(), "preparation.json")
+		if err := os.WriteFile(path, encoded, 0o600); err != nil {
+			return err
+		}
+		validator := filepath.Join("..", "..", "deploy", "gcp", "validate-deploy-evidence.py")
+		return exec.Command("python3", validator, "--expect", "front-migration-preparation", path).Run()
+	}
+	clone := func(value map[string]any) map[string]any {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var result map[string]any
+		if err := json.Unmarshal(encoded, &result); err != nil {
+			t.Fatal(err)
+		}
+		return result
+	}
+
+	valid := document()
+	if err := validateGo(valid); err != nil {
+		t.Fatalf("Go validator rejected five minutes of compatible front readiness: %v", err)
+	}
+	if err := validatePython(valid); err != nil {
+		t.Fatalf("Python validator rejected five minutes of compatible front readiness: %v", err)
+	}
+
+	missing := clone(valid)
+	delete(missing["front"].(map[string]any), "backend_health")
+	if err := validateGo(missing); err == nil {
+		t.Fatal("Go validator accepted preparation without backend readiness evidence")
+	}
+	if err := validatePython(missing); err == nil {
+		t.Fatal("Python validator accepted preparation without backend readiness evidence")
+	}
+
+	short := clone(valid)
+	health := short["front"].(map[string]any)["backend_health"].(map[string]any)
+	health["verified_at"] = "2026-08-02T00:04:59.999Z"
+	health["duration_ms"] = 299_999
+	if err := validateGo(short); err == nil {
+		t.Fatal("Go validator accepted a sub-five-minute backend readiness window")
+	}
+	if err := validatePython(short); err == nil {
+		t.Fatal("Python validator accepted a sub-five-minute backend readiness window")
+	}
+
+	oldBootstrap := clone(valid)
+	oldBootstrap["bootstrap"] = map[string]any{
+		"tag":                  "v0.1.55",
+		"sha256":               "6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c",
+		"source_revision":      "c4ea17e91ef6e9d0ab31cdd2774ca8d5387219bc",
+		"tag_on_main":          true,
+		"attestation_verified": true,
+		"immutable":            true,
+	}
+	oldBootstrap["front"].(map[string]any)["worker_checksum"] = "6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c"
+	if err := validateGo(oldBootstrap); err == nil {
+		t.Fatal("Go validator accepted the hosted-tenant-incompatible v0.1.55 bootstrap")
+	}
+	if err := validatePython(oldBootstrap); err == nil {
+		t.Fatal("Python validator accepted the hosted-tenant-incompatible v0.1.55 bootstrap")
 	}
 }
 

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -138,6 +138,15 @@ func TestGoldenMigrationPreparationRequiresCompatibleBootstrapAndStableBackendHe
 		t.Fatal("Python validator accepted a sub-five-minute backend readiness window")
 	}
 
+	negativeGap := clone(valid)
+	negativeGap["front"].(map[string]any)["backend_health"].(map[string]any)["max_sample_gap_ms"] = -1
+	if err := validateGo(negativeGap); err == nil {
+		t.Fatal("Go validator accepted a negative backend health sample gap")
+	}
+	if err := validatePython(negativeGap); err == nil {
+		t.Fatal("Python validator accepted a negative backend health sample gap")
+	}
+
 	oldBootstrap := clone(valid)
 	oldBootstrap["bootstrap"] = map[string]any{
 		"tag":                  "v0.1.55",

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -66,11 +66,12 @@ func TestGoldenMigrationPreparationRequiresCompatibleBootstrapAndStableBackendHe
 		front := result["front"].(map[string]any)
 		front["worker_checksum"] = "6a8daa1361030311bdbe25a06cd4940e4dd07a45758c13c2dc8d687e70d87303"
 		front["backend_health"] = map[string]any{
-			"all_healthy":     true,
-			"stable_since":    "2026-08-02T00:00:00Z",
-			"verified_at":     "2026-08-02T00:05:00Z",
-			"duration_ms":     300_000,
-			"healthy_samples": 61,
+			"all_healthy":       true,
+			"stable_since":      "2026-08-02T00:00:00Z",
+			"verified_at":       "2026-08-02T00:05:00Z",
+			"duration_ms":       300_000,
+			"healthy_samples":   61,
+			"max_sample_gap_ms": 5_000,
 		}
 		return result
 	}
@@ -628,6 +629,10 @@ func validGoldenMigrationBaseEvidence(evidenceType, mode string) *goldenMigratio
 		Front: goldenMigrationFront{
 			Slot: "slot-a", Generation: "front-generation", Checksum: strings.Repeat("b", 64),
 			ControlChecksum: strings.Repeat("b", 64), WorkerChecksum: goldenPinnedBootstrapLinuxSHA256, Ready: true,
+			BackendHealth: goldenMigrationBackendHealth{
+				AllHealthy: true, StableSince: "2026-08-02T00:00:00Z", VerifiedAt: "2026-08-02T00:05:00Z",
+				DurationMillis: 300_000, HealthySamples: 61, MaxSampleGapMillis: 5_000,
+			},
 		},
 	}
 }
@@ -639,7 +644,7 @@ func validGoldenMigrationPreparationEvidence() *goldenMigrationEvidence {
 		LegacyBackendURL: "https://example.test/legacy", FrontBackendURL: "https://example.test/front",
 		Current: "legacy",
 	}
-	evidence.EvidenceEmittedAt = "2026-08-02T00:00:01Z"
+	evidence.EvidenceEmittedAt = "2026-08-02T00:05:01Z"
 	return evidence
 }
 

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -66,12 +66,13 @@ func TestGoldenMigrationPreparationRequiresCompatibleBootstrapAndStableBackendHe
 		front := result["front"].(map[string]any)
 		front["worker_checksum"] = "6a8daa1361030311bdbe25a06cd4940e4dd07a45758c13c2dc8d687e70d87303"
 		front["backend_health"] = map[string]any{
-			"all_healthy":       true,
-			"stable_since":      "2026-08-02T00:00:00Z",
-			"verified_at":       "2026-08-02T00:05:00Z",
-			"duration_ms":       300_000,
-			"healthy_samples":   61,
-			"max_sample_gap_ms": 5_000,
+			"all_healthy":               true,
+			"stable_since":              "2026-08-02T00:00:00Z",
+			"verified_at":               "2026-08-02T00:05:00Z",
+			"duration_ms":               300_000,
+			"healthy_samples":           61,
+			"max_sample_gap_ms":         5_000,
+			"backend_membership_sha256": strings.Repeat("d", 64),
 		}
 		return result
 	}
@@ -641,6 +642,7 @@ func validGoldenMigrationBaseEvidence(evidenceType, mode string) *goldenMigratio
 			BackendHealth: goldenMigrationBackendHealth{
 				AllHealthy: true, StableSince: "2026-08-02T00:00:00Z", VerifiedAt: "2026-08-02T00:05:00Z",
 				DurationMillis: 300_000, HealthySamples: 61, MaxSampleGapMillis: 5_000,
+				BackendMembershipSHA256: strings.Repeat("d", 64),
 			},
 		},
 	}

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -118,6 +118,16 @@ func TestGoldenMigrationPreparationRequiresCompatibleBootstrapAndStableBackendHe
 	if err := validatePython(valid); err != nil {
 		t.Fatalf("Python validator rejected five minutes of compatible front readiness: %v", err)
 	}
+	fractionalMillisecond := clone(valid)
+	fractionalHealth := fractionalMillisecond["front"].(map[string]any)["backend_health"].(map[string]any)
+	fractionalHealth["verified_at"] = "2026-08-02T00:05:00.001Z"
+	fractionalHealth["duration_ms"] = 300_001
+	if err := validateGo(fractionalMillisecond); err != nil {
+		t.Fatalf("Go validator rejected exact millisecond readiness duration: %v", err)
+	}
+	if err := validatePython(fractionalMillisecond); err != nil {
+		t.Fatalf("Python validator rejected exact millisecond readiness duration: %v", err)
+	}
 
 	missing := clone(valid)
 	delete(missing["front"].(map[string]any), "backend_health")

--- a/cmd/subrouter-transport-observer/golden_migration_evidence.go
+++ b/cmd/subrouter-transport-observer/golden_migration_evidence.go
@@ -263,13 +263,26 @@ func validateGoldenMigrationEvidence(evidence *goldenMigrationEvidence, expected
 		}
 		emittedAt, err := parseGoldenEvidenceTime(evidence.EvidenceEmittedAt)
 		stableDuration := verifiedAt.Sub(stableSince)
+		samplesCoverDuration := false
+		if evidence.Front.BackendHealth.HealthySamples >= 1 &&
+			evidence.Front.BackendHealth.MaxSampleGapMillis >= 0 &&
+			evidence.Front.BackendHealth.MaxSampleGapMillis <= 15_000 {
+			intervalWidth := evidence.Front.BackendHealth.MaxSampleGapMillis + 1
+			requiredIntervals := evidence.Front.BackendHealth.DurationMillis / intervalWidth
+			if evidence.Front.BackendHealth.DurationMillis%intervalWidth != 0 {
+				requiredIntervals++
+			}
+			samplesCoverDuration = evidence.Front.BackendHealth.HealthySamples-1 >= requiredIntervals
+		}
 		if err != nil || !evidence.Front.BackendHealth.AllHealthy || verifiedAt.Before(stableSince) ||
 			stableDuration < goldenBackendHealthStabilityLimit ||
+			stableDuration > 15*time.Minute ||
 			evidence.Front.BackendHealth.DurationMillis != stableDuration.Milliseconds() ||
 			evidence.Front.BackendHealth.DurationMillis < goldenBackendHealthStabilityLimit.Milliseconds() ||
 			evidence.Front.BackendHealth.HealthySamples < 21 ||
 			evidence.Front.BackendHealth.MaxSampleGapMillis < 0 ||
 			evidence.Front.BackendHealth.MaxSampleGapMillis > 15_000 ||
+			!samplesCoverDuration ||
 			!validGoldenSHA256(evidence.Front.BackendHealth.BackendMembershipSHA256) || emittedAt.Before(verifiedAt) {
 			return failGolden("migration_backend_health_invalid")
 		}

--- a/cmd/subrouter-transport-observer/golden_migration_evidence.go
+++ b/cmd/subrouter-transport-observer/golden_migration_evidence.go
@@ -80,12 +80,22 @@ type goldenMigrationLegacy struct {
 }
 
 type goldenMigrationFront struct {
-	Slot            string `json:"slot"`
-	Generation      string `json:"generation"`
-	Checksum        string `json:"checksum"`
-	ControlChecksum string `json:"control_checksum"`
-	WorkerChecksum  string `json:"worker_checksum"`
-	Ready           bool   `json:"ready"`
+	Slot            string                       `json:"slot"`
+	Generation      string                       `json:"generation"`
+	Checksum        string                       `json:"checksum"`
+	ControlChecksum string                       `json:"control_checksum"`
+	WorkerChecksum  string                       `json:"worker_checksum"`
+	Ready           bool                         `json:"ready"`
+	BackendHealth   goldenMigrationBackendHealth `json:"backend_health"`
+}
+
+type goldenMigrationBackendHealth struct {
+	AllHealthy         bool   `json:"all_healthy"`
+	StableSince        string `json:"stable_since"`
+	VerifiedAt         string `json:"verified_at"`
+	DurationMillis     int64  `json:"duration_ms"`
+	HealthySamples     int64  `json:"healthy_samples"`
+	MaxSampleGapMillis int64  `json:"max_sample_gap_ms"`
 }
 
 type goldenMigrationTimestamps struct {
@@ -242,8 +252,24 @@ func validateGoldenMigrationEvidence(evidence *goldenMigrationEvidence, expected
 			evidence.Front.WorkerChecksum != evidence.Bootstrap.SHA256 || !evidence.Front.Ready {
 			return failGolden("migration_preparation_invalid")
 		}
-		if _, err := parseGoldenEvidenceTime(evidence.EvidenceEmittedAt); err != nil {
+		stableSince, err := parseGoldenEvidenceTime(evidence.Front.BackendHealth.StableSince)
+		if err != nil {
 			return err
+		}
+		verifiedAt, err := parseGoldenEvidenceTime(evidence.Front.BackendHealth.VerifiedAt)
+		if err != nil {
+			return err
+		}
+		emittedAt, err := parseGoldenEvidenceTime(evidence.EvidenceEmittedAt)
+		stableDuration := verifiedAt.Sub(stableSince)
+		if err != nil || !evidence.Front.BackendHealth.AllHealthy || verifiedAt.Before(stableSince) ||
+			stableDuration < goldenBackendHealthStabilityLimit ||
+			evidence.Front.BackendHealth.DurationMillis != stableDuration.Milliseconds() ||
+			evidence.Front.BackendHealth.DurationMillis < goldenBackendHealthStabilityLimit.Milliseconds() ||
+			evidence.Front.BackendHealth.HealthySamples < 21 ||
+			evidence.Front.BackendHealth.MaxSampleGapMillis < 0 ||
+			evidence.Front.BackendHealth.MaxSampleGapMillis > 15_000 || emittedAt.Before(verifiedAt) {
+			return failGolden("migration_backend_health_invalid")
 		}
 		return nil
 	case "front-migration-cutover", "front-migration-rollback":

--- a/cmd/subrouter-transport-observer/golden_migration_evidence.go
+++ b/cmd/subrouter-transport-observer/golden_migration_evidence.go
@@ -90,12 +90,13 @@ type goldenMigrationFront struct {
 }
 
 type goldenMigrationBackendHealth struct {
-	AllHealthy         bool   `json:"all_healthy"`
-	StableSince        string `json:"stable_since"`
-	VerifiedAt         string `json:"verified_at"`
-	DurationMillis     int64  `json:"duration_ms"`
-	HealthySamples     int64  `json:"healthy_samples"`
-	MaxSampleGapMillis int64  `json:"max_sample_gap_ms"`
+	AllHealthy              bool   `json:"all_healthy"`
+	StableSince             string `json:"stable_since"`
+	VerifiedAt              string `json:"verified_at"`
+	DurationMillis          int64  `json:"duration_ms"`
+	HealthySamples          int64  `json:"healthy_samples"`
+	MaxSampleGapMillis      int64  `json:"max_sample_gap_ms"`
+	BackendMembershipSHA256 string `json:"backend_membership_sha256"`
 }
 
 type goldenMigrationTimestamps struct {
@@ -268,7 +269,8 @@ func validateGoldenMigrationEvidence(evidence *goldenMigrationEvidence, expected
 			evidence.Front.BackendHealth.DurationMillis < goldenBackendHealthStabilityLimit.Milliseconds() ||
 			evidence.Front.BackendHealth.HealthySamples < 21 ||
 			evidence.Front.BackendHealth.MaxSampleGapMillis < 0 ||
-			evidence.Front.BackendHealth.MaxSampleGapMillis > 15_000 || emittedAt.Before(verifiedAt) {
+			evidence.Front.BackendHealth.MaxSampleGapMillis > 15_000 ||
+			!validGoldenSHA256(evidence.Front.BackendHealth.BackendMembershipSHA256) || emittedAt.Before(verifiedAt) {
 			return failGolden("migration_backend_health_invalid")
 		}
 		return nil

--- a/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
+++ b/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
@@ -508,6 +508,7 @@ func fakeMigrationPreparation(candidate, revision string) map[string]any {
 				"all_healthy": true, "stable_since": stableSince.Format(time.RFC3339Nano),
 				"verified_at": verifiedAt.Format(time.RFC3339Nano), "duration_ms": 300_000,
 				"healthy_samples": 61, "max_sample_gap_ms": 5_000,
+				"backend_membership_sha256": strings.Repeat("d", 64),
 			},
 		},
 		"evidence_emitted_at": verifiedAt.Format(time.RFC3339Nano),

--- a/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
+++ b/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
@@ -469,12 +469,12 @@ func fakeMigrationRelease(candidate, revision string) map[string]any {
 	return map[string]any{"tag": "v1.2.4", "sha256": candidate, "source_revision": revision, "tag_on_main": true, "attestation_verified": true, "immutable": true}
 }
 
-const goldenFakeBootstrapSHA256 = "6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c"
+const goldenFakeBootstrapSHA256 = "6a8daa1361030311bdbe25a06cd4940e4dd07a45758c13c2dc8d687e70d87303"
 
 func fakeMigrationBootstrap() map[string]any {
 	return map[string]any{
-		"tag": "v0.1.55", "sha256": goldenFakeBootstrapSHA256,
-		"source_revision": "c4ea17e91ef6e9d0ab31cdd2774ca8d5387219bc", "tag_on_main": true,
+		"tag": "v0.1.60", "sha256": goldenFakeBootstrapSHA256,
+		"source_revision": "e169e94f2bea9a0455a5831631fcbac220bd65f2", "tag_on_main": true,
 		"attestation_verified": true, "immutable": true,
 	}
 }
@@ -488,6 +488,8 @@ func fakeMigrationPredecessor() map[string]any {
 }
 
 func fakeMigrationPreparation(candidate, revision string) map[string]any {
+	verifiedAt := time.Now().UTC()
+	stableSince := verifiedAt.Add(-5 * time.Minute)
 	return map[string]any{
 		"schema": "subrouter.gcp.deploy-evidence/v1", "evidence_type": "front-migration-preparation", "mode": "prepare", "success": true,
 		"run":     map[string]any{"id": "golden-migration-prepare", "project": "test-project", "zone": "test-zone", "instance": "test-instance"},
@@ -502,8 +504,13 @@ func fakeMigrationPreparation(candidate, revision string) map[string]any {
 		"front": map[string]any{
 			"slot": "slot-a", "generation": "front-generation", "checksum": candidate,
 			"control_checksum": candidate, "worker_checksum": goldenFakeBootstrapSHA256, "ready": true,
+			"backend_health": map[string]any{
+				"all_healthy": true, "stable_since": stableSince.Format(time.RFC3339Nano),
+				"verified_at": verifiedAt.Format(time.RFC3339Nano), "duration_ms": 300_000,
+				"healthy_samples": 61, "max_sample_gap_ms": 5_000,
+			},
 		},
-		"evidence_emitted_at": time.Now().UTC().Format(time.RFC3339Nano),
+		"evidence_emitted_at": verifiedAt.Format(time.RFC3339Nano),
 	}
 }
 

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -16,6 +17,81 @@ import (
 	"testing"
 	"time"
 )
+
+func TestGCPBackendHealthRequiresEveryStatusStableAcrossTheWindow(t *testing.T) {
+	requireDeployScriptTools(t, "python3", "sh")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	waiter := filepath.Join(repoRoot, "deploy", "gcp", "wait-for-backend-health.py")
+	fake := filepath.Join(t.TempDir(), "health-command")
+	state := filepath.Join(t.TempDir(), "poll-count")
+	writeExecutableTestFile(t, fake, `#!/bin/sh
+count=0
+if [ -f "$HEALTH_STATE" ]; then count="$(cat "$HEALTH_STATE")"; fi
+count=$((count + 1))
+printf '%s' "$count" >"$HEALTH_STATE"
+case "$count" in
+  1|2) printf '%s\n' '[{"status":{"healthStatus":[{"healthState":"HEALTHY"}]}}]' ;;
+  3) printf '%s\n' '[{"status":{"healthStatus":[{"healthState":"HEALTHY"},{"healthState":"UNHEALTHY"}]}}]' ;;
+  *) printf '%s\n' '[{"status":{"healthStatus":[{"healthState":"HEALTHY"}]}}]' ;;
+esac
+`)
+	command := exec.Command(
+		mustLookPath(t, "python3"), waiter,
+		"--minimum-stable-seconds", "0.03",
+		"--timeout-seconds", "0.5",
+		"--poll-seconds", "0.01",
+		"--", fake,
+	)
+	command.Env = append(os.Environ(), "HEALTH_STATE="+state)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("backend health stabilization failed: %v\n%s", err, output)
+	}
+	var evidence struct {
+		AllHealthy     bool   `json:"all_healthy"`
+		StableSince    string `json:"stable_since"`
+		VerifiedAt     string `json:"verified_at"`
+		DurationMS     int64  `json:"duration_ms"`
+		HealthySamples int64  `json:"healthy_samples"`
+	}
+	if err := json.Unmarshal(output, &evidence); err != nil {
+		t.Fatalf("decode readiness evidence: %v\n%s", err, output)
+	}
+	stableSince, err := time.Parse(time.RFC3339Nano, evidence.StableSince)
+	if err != nil {
+		t.Fatalf("parse stable_since: %v", err)
+	}
+	verifiedAt, err := time.Parse(time.RFC3339Nano, evidence.VerifiedAt)
+	if err != nil {
+		t.Fatalf("parse verified_at: %v", err)
+	}
+	countBody, err := os.ReadFile(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count, err := strconv.Atoi(string(countBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !evidence.AllHealthy || evidence.DurationMS < 30 || evidence.HealthySamples < 3 ||
+		verifiedAt.Sub(stableSince) < 30*time.Millisecond || count < 6 {
+		t.Fatalf("partial health did not reset the stable window: evidence=%+v polls=%d", evidence, count)
+	}
+
+	writeExecutableTestFile(t, fake, `#!/bin/sh
+printf '%s\n' '[{"status":{"healthStatus":[{"healthState":"HEALTHY"},{"healthState":"UNHEALTHY"}]}}]'
+`)
+	command = exec.Command(
+		mustLookPath(t, "python3"), waiter,
+		"--minimum-stable-seconds", "0.02",
+		"--timeout-seconds", "0.06",
+		"--poll-seconds", "0.01",
+		"--", fake,
+	)
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("mixed backend health unexpectedly stabilized:\n%s", output)
+	}
+}
 
 func TestInstallScriptRecordsTheResolvedReleaseVersion(t *testing.T) {
 	requireDeployScriptTools(t, "sh", "curl")

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -37,9 +37,10 @@ esac
 `)
 	command := exec.Command(
 		mustLookPath(t, "python3"), waiter,
-		"--minimum-stable-seconds", "0.03",
-		"--timeout-seconds", "0.5",
+		"--minimum-stable-seconds", "0.15",
+		"--timeout-seconds", "1.5",
 		"--poll-seconds", "0.01",
+		"--maximum-sample-gap-seconds", "0.3",
 		"--", fake,
 	)
 	command.Env = append(os.Environ(), "HEALTH_STATE="+state)
@@ -73,8 +74,8 @@ esac
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !evidence.AllHealthy || evidence.DurationMS < 30 || evidence.HealthySamples < 3 ||
-		verifiedAt.Sub(stableSince) < 30*time.Millisecond || count < 6 {
+	if !evidence.AllHealthy || evidence.DurationMS < 150 || evidence.HealthySamples < 3 ||
+		verifiedAt.Sub(stableSince) < 150*time.Millisecond || count < 6 {
 		t.Fatalf("partial health did not reset the stable window: evidence=%+v polls=%d", evidence, count)
 	}
 
@@ -83,9 +84,10 @@ printf '%s\n' '[{"status":{"healthStatus":[{"healthState":"HEALTHY"},{"healthSta
 `)
 	command = exec.Command(
 		mustLookPath(t, "python3"), waiter,
-		"--minimum-stable-seconds", "0.02",
-		"--timeout-seconds", "0.06",
+		"--minimum-stable-seconds", "0.05",
+		"--timeout-seconds", "0.15",
 		"--poll-seconds", "0.01",
+		"--maximum-sample-gap-seconds", "0.3",
 		"--", fake,
 	)
 	if output, err := command.CombinedOutput(); err == nil {

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -30,9 +30,8 @@ if [ -f "$HEALTH_STATE" ]; then count="$(cat "$HEALTH_STATE")"; fi
 count=$((count + 1))
 printf '%s' "$count" >"$HEALTH_STATE"
 case "$count" in
-  1|2) printf '%s\n' '[{"status":{"healthStatus":[{"healthState":"HEALTHY"}]}}]' ;;
-  3) printf '%s\n' '[{"status":{"healthStatus":[{"healthState":"HEALTHY"},{"healthState":"UNHEALTHY"}]}}]' ;;
-  *) printf '%s\n' '[{"status":{"healthStatus":[{"healthState":"HEALTHY"}]}}]' ;;
+  1|2) printf '%s\n' '[{"backend":"group-a","status":{"healthStatus":[{"instance":"instance-a","ipAddress":"10.0.0.1","port":31416,"healthState":"HEALTHY"}]}}]' ;;
+  *) printf '%s\n' '[{"backend":"group-a","status":{"healthStatus":[{"instance":"instance-b","ipAddress":"10.0.0.2","port":31416,"healthState":"HEALTHY"}]}}]' ;;
 esac
 `)
 	command := exec.Command(
@@ -54,6 +53,7 @@ esac
 		VerifiedAt     string `json:"verified_at"`
 		DurationMS     int64  `json:"duration_ms"`
 		HealthySamples int64  `json:"healthy_samples"`
+		MembershipSHA  string `json:"backend_membership_sha256"`
 	}
 	if err := json.Unmarshal(output, &evidence); err != nil {
 		t.Fatalf("decode readiness evidence: %v\n%s", err, output)
@@ -74,13 +74,13 @@ esac
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !evidence.AllHealthy || evidence.DurationMS < 150 || evidence.HealthySamples < 3 ||
+	if !evidence.AllHealthy || evidence.DurationMS < 150 || evidence.HealthySamples < 3 || len(evidence.MembershipSHA) != 64 ||
 		verifiedAt.Sub(stableSince) < 150*time.Millisecond || count < 6 {
-		t.Fatalf("partial health did not reset the stable window: evidence=%+v polls=%d", evidence, count)
+		t.Fatalf("backend membership change did not reset the stable window: evidence=%+v polls=%d", evidence, count)
 	}
 
 	writeExecutableTestFile(t, fake, `#!/bin/sh
-printf '%s\n' '[{"status":{"healthStatus":[{"healthState":"HEALTHY"},{"healthState":"UNHEALTHY"}]}}]'
+printf '%s\n' '[{"backend":"group-a","status":{"healthStatus":[{"instance":"instance-a","ipAddress":"10.0.0.1","port":31416,"healthState":"HEALTHY"},{"instance":"instance-b","ipAddress":"10.0.0.2","port":31416,"healthState":"UNHEALTHY"}]}}]'
 `)
 	command = exec.Command(
 		mustLookPath(t, "python3"), waiter,

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify the immutable v0.1.51/v0.1.55/v0.1.61 release inputs, then run the complete
+# Verify the immutable v0.1.51/v0.1.60/v0.1.61 release inputs, then run the complete
 # legacy-to-front migration and slot-upgrade continuity gate from a local Mac.
 set -euo pipefail
 umask 077
@@ -12,10 +12,10 @@ predecessor_version="0.1.51"
 predecessor_revision="5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8"
 predecessor_darwin_sha="74f4bfbbf6b8dcbe0509eaaa9f63b1eb688358a749ed3b451066e146591d2582"
 predecessor_linux_sha="99fcd10d912184c160370eb228b382795101f2b5b2467244f995aa2d10b0c323"
-bootstrap_tag="v0.1.55"
-bootstrap_version="0.1.55"
-bootstrap_revision="c4ea17e91ef6e9d0ab31cdd2774ca8d5387219bc"
-bootstrap_linux_sha="6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c"
+bootstrap_tag="v0.1.60"
+bootstrap_version="0.1.60"
+bootstrap_revision="e169e94f2bea9a0455a5831631fcbac220bd65f2"
+bootstrap_linux_sha="6a8daa1361030311bdbe25a06cd4940e4dd07a45758c13c2dc8d687e70d87303"
 candidate_tag="v0.1.61"
 candidate_version="0.1.61"
 
@@ -173,7 +173,7 @@ if ! gh release view "${bootstrap_tag}" --repo "${repository}" --json tagName,is
       '.tagName == $tag and (.isDraft | not) and (.isPrerelease | not) and .isImmutable == true and
        (.publishedAt | type == "string" and length > 0)' \
       >/dev/null; then
-  echo "v0.1.55 is not a published immutable release" >&2
+  echo "v0.1.60 is not a published immutable release" >&2
   exit 1
 fi
 resolved_bootstrap_revision="$(require_release_revision_on_main "${bootstrap_tag}" "${bootstrap_revision}")"
@@ -201,7 +201,7 @@ done
 bootstrap_linux="${bootstrap_dir}/${bootstrap_linux_asset}"
 [[ "$(sha256_file "${bootstrap_linux}")" == "${bootstrap_linux_sha}" &&
    "$(manifest_sha "${bootstrap_manifest}" "${bootstrap_linux_asset}")" == "${bootstrap_linux_sha}" ]] \
-  || { echo "v0.1.55 Linux asset hard pin mismatch" >&2; exit 1; }
+  || { echo "v0.1.60 Linux asset hard pin mismatch" >&2; exit 1; }
 jq -e --arg tag "${bootstrap_tag}" --arg revision "${resolved_bootstrap_revision}" \
   '(. | keys | sort) == (["source_revision","tag","tag_on_main"] | sort) and
    .tag == $tag and .source_revision == $revision and .tag_on_main == true' \

--- a/deploy/gcp/migrate-to-front-slots.sh
+++ b/deploy/gcp/migrate-to-front-slots.sh
@@ -61,6 +61,7 @@ REMOTE_WORKER_CANDIDATE="/tmp/subrouter-front-worker-${RUN_LABEL}"
 REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_HEALTH_WAITER="${SCRIPT_DIR}/wait-for-backend-health.py"
 # shellcheck source=deploy/gcp/stream-shell-value.sh
 source "${SCRIPT_DIR}/stream-shell-value.sh"
 # shellcheck source=deploy/gcp/deploy-lock.sh
@@ -93,6 +94,7 @@ REMOTE_INSTALL_COMMAND="sudo env SUBROUTER_DEPLOYMENT_CONTRACT='${REMOTE_DEPLOYM
 for command in "${GCLOUD_BINARY}" curl go jq python3 sha256sum; do
   command -v "${command}" >/dev/null 2>&1 || die "required command not found: ${command}"
 done
+[[ -f "${BACKEND_HEALTH_WAITER}" ]] || die "backend health waiter is missing"
 INSTALL_FRONT_SLOTS_SHA256="$(sha256sum "${INSTALL_FRONT_SLOTS}" | awk '{print $1}')"
 DEPLOYMENT_CONTRACT_SHA256="$(sha256sum "${DEPLOYMENT_CONTRACT}" | awk '{print $1}')"
 [[ "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] \
@@ -116,14 +118,14 @@ manifest_predecessor_sha="$(awk '$2 == "subrouter_0.1.51_linux_amd64" {print $1}
   || die "predecessor SHA256SUMS does not match the hard-pinned Linux asset"
 [[ "$(sha256sum "${PREDECESSOR_BINARY}" | awk '{print $1}')" == "${PREDECESSOR_SHA256}" ]] \
   || die "predecessor binary does not match its verified checksum"
-[[ "${BOOTSTRAP_TAG}" == v0.1.55 ]] || die "migration bootstrap must be the operator-pinned v0.1.55 release"
+[[ "${BOOTSTRAP_TAG}" == v0.1.60 ]] || die "migration bootstrap must be the operator-pinned v0.1.60 release"
 [[ -x "${BOOTSTRAP_BINARY}" ]] || die "bootstrap binary is not executable: ${BOOTSTRAP_BINARY}"
 [[ -f "${BOOTSTRAP_SHA256_FILE}" ]] || die "bootstrap checksum file is missing: ${BOOTSTRAP_SHA256_FILE}"
 BOOTSTRAP_SHA256="$(tr -d '[:space:]' <"${BOOTSTRAP_SHA256_FILE}")"
-[[ "${BOOTSTRAP_SHA256}" == 6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c ]] \
-  || die "bootstrap Linux bytes do not match the compiled-in v0.1.55 hard pin"
+[[ "${BOOTSTRAP_SHA256}" == 6a8daa1361030311bdbe25a06cd4940e4dd07a45758c13c2dc8d687e70d87303 ]] \
+  || die "bootstrap Linux bytes do not match the compiled-in v0.1.60 hard pin"
 [[ -f "${BOOTSTRAP_SHA256SUMS_FILE}" ]] || die "bootstrap SHA256SUMS manifest is missing"
-manifest_bootstrap_sha="$(awk '$2 == "subrouter_0.1.55_linux_amd64" {print $1}' "${BOOTSTRAP_SHA256SUMS_FILE}")"
+manifest_bootstrap_sha="$(awk '$2 == "subrouter_0.1.60_linux_amd64" {print $1}' "${BOOTSTRAP_SHA256SUMS_FILE}")"
 [[ "${manifest_bootstrap_sha}" == "${BOOTSTRAP_SHA256}" ]] \
   || die "bootstrap SHA256SUMS does not match the hard-pinned Linux asset"
 [[ "$(sha256sum "${BOOTSTRAP_BINARY}" | awk '{print $1}')" == "${BOOTSTRAP_SHA256}" ]] \
@@ -138,8 +140,8 @@ bash "${SCRIPT_DIR}/verify-go-release-binary.sh" "${DEPLOY_BINARY}" "${DEPLOY_RE
 bash "${SCRIPT_DIR}/verify-go-release-binary.sh" \
   "${PREDECESSOR_BINARY}" 5eacb5411c0bd4a24f4e422d6366fa7bfd1843c8 \
   || die "predecessor embedded metadata is invalid"
-[[ "${BOOTSTRAP_REVISION}" == c4ea17e91ef6e9d0ab31cdd2774ca8d5387219bc ]] \
-  || die "bootstrap revision does not match the compiled-in v0.1.55 hard pin"
+[[ "${BOOTSTRAP_REVISION}" == e169e94f2bea9a0455a5831631fcbac220bd65f2 ]] \
+  || die "bootstrap revision does not match the compiled-in v0.1.60 hard pin"
 bash "${SCRIPT_DIR}/verify-go-release-binary.sh" "${BOOTSTRAP_BINARY}" "${BOOTSTRAP_REVISION}" \
   || die "bootstrap embedded metadata is invalid"
 [[ "${TAG_ON_MAIN}" == true ]] || die "release tag commit was not proven to be on main"
@@ -326,20 +328,16 @@ jq -e --arg hc "${FRONT_HEALTH_CHECK}" --arg group "${INSTANCE_GROUP}" \
   < <(stream_shell_value "${front_backend_json}") >/dev/null \
   || die "${FRONT_BACKEND_SERVICE} was not configured atomically"
 
-log "waiting for the fixed-port front health check before routing traffic"
-for _ in $(seq 1 120); do
-  health_json="$("${GCLOUD_BINARY}" compute backend-services get-health "${FRONT_BACKEND_SERVICE}" \
-    --project "${PROJECT_ID}" --global --format=json 2>/dev/null || true)"
-  if jq -e '[.[].status.healthStatus[]? | select(.healthState == "HEALTHY")] | length > 0' \
-      < <(stream_shell_value "${health_json:-[]}") >/dev/null 2>&1; then
-    break
-  fi
-  sleep 1
-done
-health_json="$("${GCLOUD_BINARY}" compute backend-services get-health "${FRONT_BACKEND_SERVICE}" \
-  --project "${PROJECT_ID}" --global --format=json)"
-jq -e '[.[].status.healthStatus[]? | select(.healthState == "HEALTHY")] | length > 0' \
-  < <(stream_shell_value "${health_json}") >/dev/null || die "front did not become healthy in the load balancer"
+log "requiring every front backend health status to remain healthy for five minutes"
+backend_health_json="$(python3 "${BACKEND_HEALTH_WAITER}" \
+  --minimum-stable-seconds 300 --timeout-seconds 900 --poll-seconds 5 \
+  --maximum-sample-gap-seconds 15 -- \
+  "${GCLOUD_BINARY}" compute backend-services get-health "${FRONT_BACKEND_SERVICE}" \
+  --project "${PROJECT_ID}" --global --format=json)" \
+  || die "front did not remain continuously healthy in the load balancer"
+jq -e '.all_healthy == true and .duration_ms >= 300000 and .healthy_samples >= 21 and .max_sample_gap_ms <= 15000' \
+  < <(stream_shell_value "${backend_health_json}") >/dev/null \
+  || die "front backend health evidence is invalid"
 
 legacy_status="$(gcloud_ssh "sudo curl -fsS --unix-socket /var/lib/subrouter/supervisor.sock http://localhost/_subrouter/supervisor-status")"
 jq -e '(.active.id|type)=="string" and (.backends|type)=="array" and ([.backends[].connections] | all(type=="number" and . >= 0))' \
@@ -378,6 +376,7 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type front-
   --arg legacy_checksum "${legacy_checksum}" --arg front_slot "${front_slot}" \
   --arg front_generation "${front_generation}" --arg front_checksum "${front_checksum}" \
   --arg control_checksum "${control_checksum}" --arg worker_checksum "${worker_checksum}" \
+  --argjson backend_health "${backend_health_json}" \
   --arg emitted_at "${evidence_emitted_at}" \
   '{schema:$schema,evidence_type:$evidence_type,mode:"prepare",success:true,
     run:{id:$run_id,project:$project,zone:$zone,instance:$instance},
@@ -393,7 +392,8 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type front-
     legacy:{service:"subrouter.service",generation:$legacy_generation,checksum:$legacy_checksum,
       accepting_new_public:true},
     front:{slot:$front_slot,generation:$front_generation,checksum:$front_checksum,
-      control_checksum:$control_checksum,worker_checksum:$worker_checksum,ready:true},
+      control_checksum:$control_checksum,worker_checksum:$worker_checksum,ready:true,
+      backend_health:$backend_health},
     evidence_emitted_at:$emitted_at}' >"${evidence_tmp}"
 python3 "$(dirname "${BASH_SOURCE[0]}")/validate-deploy-evidence.py" \
   --expect front-migration-preparation "${evidence_tmp}" >/dev/null

--- a/deploy/gcp/migrate-to-front-slots.sh
+++ b/deploy/gcp/migrate-to-front-slots.sh
@@ -335,7 +335,8 @@ backend_health_json="$(python3 "${BACKEND_HEALTH_WAITER}" \
   "${GCLOUD_BINARY}" compute backend-services get-health "${FRONT_BACKEND_SERVICE}" \
   --project "${PROJECT_ID}" --global --format=json)" \
   || die "front did not remain continuously healthy in the load balancer"
-jq -e '.all_healthy == true and .duration_ms >= 300000 and .healthy_samples >= 21 and .max_sample_gap_ms <= 15000' \
+jq -e '.all_healthy == true and .duration_ms >= 300000 and .healthy_samples >= 21 and
+  .max_sample_gap_ms <= 15000 and (.backend_membership_sha256 | test("^[0-9a-f]{64}$"))' \
   < <(stream_shell_value "${backend_health_json}") >/dev/null \
   || die "front backend health evidence is invalid"
 

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -681,8 +681,8 @@ def validate_front_migration_preparation(document: dict[str, Any]) -> None:
     if (
         stable_duration < FRONT_BACKEND_HEALTH_STABILITY
         or stable_duration > dt.timedelta(minutes=15)
-        or duration_ms != int(stable_duration.total_seconds() * 1000)
-        or duration_ms < int(FRONT_BACKEND_HEALTH_STABILITY.total_seconds() * 1000)
+        or duration_ms != stable_duration // dt.timedelta(milliseconds=1)
+        or duration_ms < FRONT_BACKEND_HEALTH_STABILITY // dt.timedelta(milliseconds=1)
         or healthy_samples < 21
         or max_sample_gap_ms > 15_000
         or duration_ms > sample_span_capacity_ms

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -672,6 +672,10 @@ def validate_front_migration_preparation(document: dict[str, Any]) -> None:
         "front.backend_health.max_sample_gap_ms",
         minimum=0,
     )
+    sha(
+        field(backend_health, "backend_membership_sha256", "front.backend_health"),
+        "front.backend_health.backend_membership_sha256",
+    )
     stable_duration = verified_at - stable_since
     if (
         stable_duration < FRONT_BACKEND_HEALTH_STABILITY

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -670,6 +670,7 @@ def validate_front_migration_preparation(document: dict[str, Any]) -> None:
     max_sample_gap_ms = integer(
         field(backend_health, "max_sample_gap_ms", "front.backend_health"),
         "front.backend_health.max_sample_gap_ms",
+        minimum=0,
     )
     stable_duration = verified_at - stable_since
     if (

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -677,12 +677,15 @@ def validate_front_migration_preparation(document: dict[str, Any]) -> None:
         "front.backend_health.backend_membership_sha256",
     )
     stable_duration = verified_at - stable_since
+    sample_span_capacity_ms = (healthy_samples - 1) * (max_sample_gap_ms + 1)
     if (
         stable_duration < FRONT_BACKEND_HEALTH_STABILITY
+        or stable_duration > dt.timedelta(minutes=15)
         or duration_ms != int(stable_duration.total_seconds() * 1000)
         or duration_ms < int(FRONT_BACKEND_HEALTH_STABILITY.total_seconds() * 1000)
         or healthy_samples < 21
         or max_sample_gap_ms > 15_000
+        or duration_ms > sample_span_capacity_ms
     ):
         fail("front.backend_health does not prove five continuous healthy minutes")
     emitted_at = timestamp(field(document, "evidence_emitted_at", "root"), "evidence_emitted_at")

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -36,6 +36,7 @@ TAG = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+(?:[.-][0-9A-Za-z.-]+)?$")
 GCE_INSTANCE_ID = re.compile(r"^[1-9][0-9]{0,19}$")
 SLOTS = {"slot-a", "slot-b"}
 FRESH_VM_MAX_AGE = dt.timedelta(hours=2)
+FRONT_BACKEND_HEALTH_STABILITY = dt.timedelta(minutes=5)
 EXPECTATIONS = {
     "slot-activation",
     "slot-rollback",
@@ -213,15 +214,15 @@ def validate_predecessor(value: Any) -> dict[str, Any]:
 
 def validate_migration_bootstrap(value: Any) -> dict[str, Any]:
     result = validate_release(value)
-    exact(field(result, "tag", "bootstrap"), "v0.1.55", "bootstrap.tag")
+    exact(field(result, "tag", "bootstrap"), "v0.1.60", "bootstrap.tag")
     exact(
         sha(field(result, "sha256", "bootstrap"), "bootstrap.sha256"),
-        "6261bda248a6afc84079ecd22ded35e71d3b4cfb5267a6db2871a35cdcf0bd0c",
+        "6a8daa1361030311bdbe25a06cd4940e4dd07a45758c13c2dc8d687e70d87303",
         "bootstrap.sha256",
     )
     exact(
         revision(field(result, "source_revision", "bootstrap"), "bootstrap.source_revision"),
-        "c4ea17e91ef6e9d0ab31cdd2774ca8d5387219bc",
+        "e169e94f2bea9a0455a5831631fcbac220bd65f2",
         "bootstrap.source_revision",
     )
     return result
@@ -640,7 +641,48 @@ def validate_front_migration_preparation(document: dict[str, Any]) -> None:
         "front.worker_checksum",
     )
     exact(boolean(field(front, "ready", "front"), "front.ready"), True, "front.ready")
-    timestamp(field(document, "evidence_emitted_at", "root"), "evidence_emitted_at")
+    backend_health = obj(field(front, "backend_health", "front"), "front.backend_health")
+    exact(
+        boolean(
+            field(backend_health, "all_healthy", "front.backend_health"),
+            "front.backend_health.all_healthy",
+        ),
+        True,
+        "front.backend_health.all_healthy",
+    )
+    stable_since = timestamp(
+        field(backend_health, "stable_since", "front.backend_health"),
+        "front.backend_health.stable_since",
+    )
+    verified_at = timestamp(
+        field(backend_health, "verified_at", "front.backend_health"),
+        "front.backend_health.verified_at",
+    )
+    duration_ms = integer(
+        field(backend_health, "duration_ms", "front.backend_health"),
+        "front.backend_health.duration_ms",
+    )
+    healthy_samples = integer(
+        field(backend_health, "healthy_samples", "front.backend_health"),
+        "front.backend_health.healthy_samples",
+        minimum=21,
+    )
+    max_sample_gap_ms = integer(
+        field(backend_health, "max_sample_gap_ms", "front.backend_health"),
+        "front.backend_health.max_sample_gap_ms",
+    )
+    stable_duration = verified_at - stable_since
+    if (
+        stable_duration < FRONT_BACKEND_HEALTH_STABILITY
+        or duration_ms != int(stable_duration.total_seconds() * 1000)
+        or duration_ms < int(FRONT_BACKEND_HEALTH_STABILITY.total_seconds() * 1000)
+        or healthy_samples < 21
+        or max_sample_gap_ms > 15_000
+    ):
+        fail("front.backend_health does not prove five continuous healthy minutes")
+    emitted_at = timestamp(field(document, "evidence_emitted_at", "root"), "evidence_emitted_at")
+    if emitted_at < verified_at:
+        fail("evidence_emitted_at predates front backend health verification")
 
 
 def validate_migration_snapshot(value: Any, path: str, kind: str) -> dict[str, Any]:

--- a/deploy/gcp/wait-for-backend-health.py
+++ b/deploy/gcp/wait-for-backend-health.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import hashlib
 import json
 import subprocess
 import sys
@@ -12,24 +13,55 @@ import time
 from typing import Any
 
 
-def all_reported_backends_healthy(value: Any) -> bool:
+def healthy_backend_membership(value: Any) -> tuple[str, ...] | None:
     if not isinstance(value, list) or not value:
-        return False
+        return None
+    identities: list[str] = []
     for backend in value:
         if not isinstance(backend, dict):
-            return False
+            return None
+        backend_id = backend.get("backend")
+        if not isinstance(backend_id, str) or not backend_id:
+            return None
         status = backend.get("status")
         if not isinstance(status, dict):
-            return False
+            return None
         health_statuses = status.get("healthStatus")
         if not isinstance(health_statuses, list) or not health_statuses:
-            return False
-        if any(
-            not isinstance(item, dict) or item.get("healthState") != "HEALTHY"
-            for item in health_statuses
-        ):
-            return False
-    return True
+            return None
+        for item in health_statuses:
+            if not isinstance(item, dict) or item.get("healthState") != "HEALTHY":
+                return None
+            instance = item.get("instance")
+            ip_address = item.get("ipAddress")
+            port = item.get("port")
+            if (
+                not isinstance(instance, str)
+                or not instance
+                or not isinstance(ip_address, str)
+                or not ip_address
+                or isinstance(port, bool)
+                or not isinstance(port, int)
+                or port <= 0
+                or port > 65535
+            ):
+                return None
+            identities.append(
+                json.dumps(
+                    {
+                        "backend": backend_id,
+                        "instance": instance,
+                        "ip_address": ip_address,
+                        "port": port,
+                    },
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+            )
+    membership = tuple(sorted(identities))
+    if not membership or len(set(membership)) != len(membership):
+        return None
+    return membership
 
 
 def timestamp(value: dt.datetime) -> str:
@@ -64,6 +96,7 @@ def main() -> int:
     last_healthy_monotonic: float | None = None
     healthy_samples = 0
     maximum_sample_gap = 0.0
+    stable_membership: tuple[str, ...] | None = None
 
     while time.monotonic() < deadline:
         remaining = deadline - time.monotonic()
@@ -76,19 +109,24 @@ def main() -> int:
                 timeout=max(0.1, min(60.0, remaining)),
             )
             payload = json.loads(completed.stdout) if completed.returncode == 0 else None
-            healthy = all_reported_backends_healthy(payload)
+            membership = healthy_backend_membership(payload)
         except (json.JSONDecodeError, OSError, subprocess.SubprocessError):
-            healthy = False
+            membership = None
 
         observed_monotonic = time.monotonic()
         observed_wall = truncate_to_milliseconds(dt.datetime.now(dt.timezone.utc))
-        if healthy:
+        if membership is not None:
             sample_gap = 0.0
             if last_healthy_monotonic is not None:
                 sample_gap = observed_monotonic - last_healthy_monotonic
-            if stable_started_monotonic is None or sample_gap > args.maximum_sample_gap_seconds:
+            if (
+                stable_started_monotonic is None
+                or membership != stable_membership
+                or sample_gap > args.maximum_sample_gap_seconds
+            ):
                 stable_started_monotonic = observed_monotonic
                 stable_started_wall = observed_wall
+                stable_membership = membership
                 healthy_samples = 1
                 maximum_sample_gap = 0.0
             else:
@@ -109,6 +147,9 @@ def main() -> int:
                     "duration_ms": int(wall_duration.total_seconds() * 1000),
                     "healthy_samples": healthy_samples,
                     "max_sample_gap_ms": int(maximum_sample_gap * 1000),
+                    "backend_membership_sha256": hashlib.sha256(
+                        json.dumps(membership, separators=(",", ":")).encode()
+                    ).hexdigest(),
                 }
                 json.dump(result, sys.stdout, separators=(",", ":"), sort_keys=True)
                 sys.stdout.write("\n")
@@ -119,6 +160,7 @@ def main() -> int:
             last_healthy_monotonic = None
             healthy_samples = 0
             maximum_sample_gap = 0.0
+            stable_membership = None
 
         remaining = deadline - time.monotonic()
         if remaining > 0:

--- a/deploy/gcp/wait-for-backend-health.py
+++ b/deploy/gcp/wait-for-backend-health.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Wait until every reported load-balancer backend is continuously healthy."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+def all_reported_backends_healthy(value: Any) -> bool:
+    if not isinstance(value, list) or not value:
+        return False
+    for backend in value:
+        if not isinstance(backend, dict):
+            return False
+        status = backend.get("status")
+        if not isinstance(status, dict):
+            return False
+        health_statuses = status.get("healthStatus")
+        if not isinstance(health_statuses, list) or not health_statuses:
+            return False
+        if any(
+            not isinstance(item, dict) or item.get("healthState") != "HEALTHY"
+            for item in health_statuses
+        ):
+            return False
+    return True
+
+
+def timestamp(value: dt.datetime) -> str:
+    return value.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def truncate_to_milliseconds(value: dt.datetime) -> dt.datetime:
+    return value.replace(microsecond=(value.microsecond // 1000) * 1000)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--minimum-stable-seconds", type=float, required=True)
+    parser.add_argument("--timeout-seconds", type=float, required=True)
+    parser.add_argument("--poll-seconds", type=float, required=True)
+    parser.add_argument("--maximum-sample-gap-seconds", type=float, required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    command = args.command[1:] if args.command[:1] == ["--"] else args.command
+    if (
+        args.minimum_stable_seconds <= 0
+        or args.timeout_seconds < args.minimum_stable_seconds
+        or args.poll_seconds <= 0
+        or args.maximum_sample_gap_seconds < args.poll_seconds
+        or not command
+    ):
+        parser.error("invalid timing bounds or missing health command")
+
+    deadline = time.monotonic() + args.timeout_seconds
+    stable_started_monotonic: float | None = None
+    stable_started_wall: dt.datetime | None = None
+    last_healthy_monotonic: float | None = None
+    healthy_samples = 0
+    maximum_sample_gap = 0.0
+
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        try:
+            completed = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=max(0.1, min(60.0, remaining)),
+            )
+            payload = json.loads(completed.stdout) if completed.returncode == 0 else None
+            healthy = all_reported_backends_healthy(payload)
+        except (json.JSONDecodeError, OSError, subprocess.SubprocessError):
+            healthy = False
+
+        observed_monotonic = time.monotonic()
+        observed_wall = truncate_to_milliseconds(dt.datetime.now(dt.timezone.utc))
+        if healthy:
+            sample_gap = 0.0
+            if last_healthy_monotonic is not None:
+                sample_gap = observed_monotonic - last_healthy_monotonic
+            if stable_started_monotonic is None or sample_gap > args.maximum_sample_gap_seconds:
+                stable_started_monotonic = observed_monotonic
+                stable_started_wall = observed_wall
+                healthy_samples = 1
+                maximum_sample_gap = 0.0
+            else:
+                healthy_samples += 1
+                maximum_sample_gap = max(maximum_sample_gap, sample_gap)
+            last_healthy_monotonic = observed_monotonic
+
+            monotonic_duration = observed_monotonic - stable_started_monotonic
+            wall_duration = observed_wall - stable_started_wall
+            if (
+                monotonic_duration >= args.minimum_stable_seconds
+                and wall_duration.total_seconds() >= args.minimum_stable_seconds
+            ):
+                result = {
+                    "all_healthy": True,
+                    "stable_since": timestamp(stable_started_wall),
+                    "verified_at": timestamp(observed_wall),
+                    "duration_ms": int(wall_duration.total_seconds() * 1000),
+                    "healthy_samples": healthy_samples,
+                    "max_sample_gap_ms": int(maximum_sample_gap * 1000),
+                }
+                json.dump(result, sys.stdout, separators=(",", ":"), sort_keys=True)
+                sys.stdout.write("\n")
+                return 0
+        else:
+            stable_started_monotonic = None
+            stable_started_wall = None
+            last_healthy_monotonic = None
+            healthy_samples = 0
+            maximum_sample_gap = 0.0
+
+        remaining = deadline - time.monotonic()
+        if remaining > 0:
+            time.sleep(min(args.poll_seconds, remaining))
+
+    print("backend health did not remain continuously healthy before timeout", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/gcp/wait-for-backend-health.py
+++ b/deploy/gcp/wait-for-backend-health.py
@@ -144,7 +144,7 @@ def main() -> int:
                     "all_healthy": True,
                     "stable_since": timestamp(stable_started_wall),
                     "verified_at": timestamp(observed_wall),
-                    "duration_ms": int(wall_duration.total_seconds() * 1000),
+                    "duration_ms": wall_duration // dt.timedelta(milliseconds=1),
                     "healthy_samples": healthy_samples,
                     "max_sample_gap_ms": int(maximum_sample_gap * 1000),
                     "backend_membership_sha256": hashlib.sha256(


### PR DESCRIPTION
The staging golden run found two pre-cutover blockers: the v0.1.55 bootstrap rejects current hosted tenant credentials, and GCP returned a brief public 502 window after reporting one healthy front endpoint.

This pins the migration bootstrap to immutable v0.1.60 and requires every reported front backend health status to remain healthy for five continuous minutes before emitting preparation evidence. The health proof records timestamps, sample count, duration, and maximum observation gap, and both validators fail closed on missing or insufficient evidence.

Regression coverage is split into a red test commit followed by the fix. Focused deployment and golden observer suites pass. The full local suite has one pre-existing macOS-only 5-second timeout in TestCreateVMTempFilesSurviveInterruptedAndRepeatedMacOSRuns; main CI is green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788497398&installation_model_id=21920&pr_number=163&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F163&signature=ce55ee0074a2d6e2aefe261a11442f6040b99c2a5561a329d41017dc8aa1cb68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates front-slot cutover on five continuous minutes of healthy GCP backends tied to a stable backend membership, and records a millisecond-accurate proof in migration evidence. Pins the migration bootstrap to immutable `v0.1.60` to fix hosted-tenant credential issues.

- **New Features**
  - Added `deploy/gcp/wait-for-backend-health.py` to prove 5 minutes of continuous backend health bound to backend membership; emits `all_healthy`, `stable_since`, `verified_at`, `duration_ms`, `healthy_samples`, `max_sample_gap_ms`, and `backend_membership_sha256` with millisecond precision.
  - Integrated the health gate into `migrate-to-front-slots.sh` and preparation evidence; Go/Python validators require a ≥5 min window, samples/gap that can span the window, max gap ≤15s, valid membership SHA, `evidence_emitted_at` ≥ `verified_at`, a ≤15 min cap, and `duration_ms` exactly matching the millisecond diff.

- **Bug Fixes**
  - Pinned migration bootstrap to `v0.1.60` and reject `v0.1.55`; preserved exact millisecond readiness timing to avoid rounding rejects; updated scripts, tests, and the fake client.

<sup>Written for commit 076e9bf8f1cad1693fff5bb81d4e31889199ae1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backend health verification requiring all load-balancer backends to remain healthy continuously for five minutes.
  * Migration evidence now includes health status, verification timing, duration, sample counts, and polling-gap details.
  * Added clear failure handling for unhealthy, incomplete, or invalid health checks.

* **Updates**
  * Updated the verified bootstrap release from v0.1.55 to v0.1.60.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->