### PR TITLE
Show hosted usage dashboard by default

### DIFF
--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -747,7 +747,7 @@ func (r srRunner) status(ctx context.Context) error {
 		return err
 	}
 	switch config.EffectiveCredentialSource() {
-	case broker.CredentialSourceTeam:
+	case broker.CredentialSourceTeam, broker.CredentialSourceHosted:
 		return r.cloudStatus(ctx)
 	case broker.CredentialSourceLegacy:
 		if server, ok, err := r.defaultRemoteServer(); err != nil {
@@ -827,7 +827,7 @@ func (r srRunner) defaultInteractive(ctx context.Context, opts srSwitchOptions) 
 		return err
 	}
 	switch config.EffectiveCredentialSource() {
-	case broker.CredentialSourceTeam:
+	case broker.CredentialSourceTeam, broker.CredentialSourceHosted:
 		return r.cloudStatus(ctx)
 	case broker.CredentialSourceLegacy:
 		if server, ok, err := r.defaultRemoteServer(); err != nil {

--- a/cmd/subrouter/sr_hosted_login_test.go
+++ b/cmd/subrouter/sr_hosted_login_test.go
@@ -226,6 +226,64 @@ func TestHostedCodexAddUsesTemporaryHomeAndUploadsCredential(t *testing.T) {
 	}
 }
 
+func TestHostedDefaultOutputUsesUsageDashboard(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("COLUMNS", "160")
+	tenantKey := "srt_0123456789abcdef0123456789abcdef"
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Method != http.MethodGet || r.URL.Path != "/t/"+tenantKey+"/_subrouter/usage-status" {
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]broker.UsageStatus{{
+			ID: "hosted@example.com", Provider: accounts.ProviderCodex,
+			AuthMode: accounts.AuthModeOAuth, Email: "hosted@example.com",
+			AuthChecked: true, AuthValid: true, PlanType: "pro",
+			Windows: []accounts.UsageWindow{{
+				Name: "weekly", UsedPercent: 25,
+				LimitWindowSeconds: int64((7 * 24 * time.Hour) / time.Second),
+			}},
+		}})
+	}))
+	defer server.Close()
+
+	configPath := filepath.Join(t.TempDir(), "cloud.json")
+	t.Setenv("SUBROUTER_CLOUD_CONFIG", configPath)
+	if err := broker.SaveConfig(configPath, broker.Config{
+		Version: 1, BaseURL: "https://cmux.com",
+		AccessToken: "access", RefreshToken: "refresh",
+		TeamID: "team-1", TeamName: "Hosted team",
+		CredentialSource: broker.CredentialSourceHosted,
+		HostedURL:        server.URL, TenantKey: tenantKey,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	runner := srRunner{
+		program: "sr", store: accounts.CodexStore{Dir: t.TempDir()},
+		out: &output, errOut: &output,
+	}
+	if err := runner.run(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 1 {
+		t.Fatalf("usage requests = %d, want 1", requests)
+	}
+	for _, want := range []string{
+		"Credential storage: hosted cmux (Hosted team, team-1)",
+		"Codex accounts",
+		"hosted@example.com",
+		"75% left",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("hosted dashboard missing %q:\n%s", want, output.String())
+		}
+	}
+}
+
 func TestHostedAndLocalEgressStorageAliasesStayDistinct(t *testing.T) {
 	for _, value := range []string{"hosted", "cmux", "cloud"} {
 		got, err := parseCredentialSource(value, false)


### PR DESCRIPTION
## Summary
- route bare hosted `sr` and `sr status` through the full usage dashboard
- keep `sr-gcp` account-add instructions after the dashboard

## Testing
- `go test ./cmd/subrouter -count=1`
- `go test -p 1 ./... -count=1`
- public staging dashboard smoke against `https://staging.sr.cmux.com`

## Deployment
- Public account upload still requires the safe GCP migration in https://github.com/manaflow-ai/subrouter/pull/164 because staging currently runs the legacy pre-hosted account handler.

## Issues
- Related: https://github.com/manaflow-ai/subrouter/pull/164

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788507743&installation_model_id=21920&pr_number=165&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F165&signature=1e768457fda1b79525aa75b61dc5ab005ca33d80cf3cdc83d731ed64a96ca865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
When using hosted accounts, `sr` and `sr status` now open the full usage dashboard by default. `sr-gcp` account-add instructions are shown after the dashboard.

<sup>Written for commit 3951eb1271c8d271a291e850aab8226fe39ac535. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

