### PR TITLE
Fix Cloud Armor canary host expression

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -213,6 +213,12 @@ func TestGCPCanarySecurityPolicyRequiresAnAuthenticatedHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 	rules := policyJSON["rules"].([]any)
+	hostExpression := `has(request.headers['host']) && request.headers['host'].lower() == 'front-canary.staging.sr.cmux.internal'`
+	allowExpression := rules[0].(map[string]any)["match"].(map[string]any)["expr"].(map[string]any)["expression"].(string)
+	denyExpression := rules[1].(map[string]any)["match"].(map[string]any)["expr"].(map[string]any)["expression"].(string)
+	if denyExpression != hostExpression || allowExpression != hostExpression+" && has(request.headers['x-subrouter-canary-token']) && request.headers['x-subrouter-canary-token'] == '"+token+"'" {
+		t.Fatalf("policy did not render an exact Cloud Armor host expression:\nallow: %s\ndeny: %s", allowExpression, denyExpression)
+	}
 	rules[1].(map[string]any)["action"] = "allow"
 	unprotected := filepath.Join(t.TempDir(), "unprotected.json")
 	unprotectedBody, err := json.Marshal(policyJSON)

--- a/deploy/gcp/canary-security-policy.py
+++ b/deploy/gcp/canary-security-policy.py
@@ -51,8 +51,7 @@ def deny_expression(host: str) -> str:
 
 
 def host_expression(host: str) -> str:
-    pattern = "^" + host.replace(".", r"\.") + r"\.?(:[0-9]{1,5})?$"
-    return f"has(request.headers['host']) && request.headers['host'].lower().matches('{pattern}')"
+    return f"has(request.headers['host']) && request.headers['host'].lower() == '{host}'"
 
 
 def default_rule() -> dict[str, Any]:


### PR DESCRIPTION
The production continuity harness reached Cloud Armor policy creation in staging, where Google rejected the host regex because its capture group is unsupported.\n\nThis replaces the regex with Cloud Armor’s documented exact host comparison. The first commit adds the failing generated-policy regression; the second fixes it. A temporary unattached policy was created through the real GCP API, validated, and deleted successfully.\n\nStaging failed before any URL-map cutover and restored the legacy configuration. Production was untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788510411&installation_model_id=21920&pr_number=166&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F166&signature=37c9113aae8a4c79eaecd8c478efc83ef0d09e7482c42e70e765190871cb1707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cloud Armor canary host matching by switching from an unsupported regex to an exact host comparison, so policy creation no longer fails in staging. This unblocks the canary security policy rollout; production was unaffected.

- **Bug Fixes**
  - Replace regex-based host `matches()` with `request.headers['host'].lower() == '{host}'` in the canary policy generator.
  - Strengthen tests to assert exact allow/deny expressions and the required `x-subrouter-canary-token`; validated via a temporary policy created and deleted through the GCP API.

<sup>Written for commit ffb335f262ec943195fba82c0bc257537cb83911. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

