### PR TITLE
Isolate denied canary from readiness sampling

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -295,10 +295,13 @@ printf '%s\n' '[{"backend":"group-a","status":{"healthStatus":[{"instance":"inst
 		t.Fatal(err)
 	}
 	body := string(captured)
+	authenticatedOffset := strings.Index(body, "X-Subrouter-Canary-Token:")
+	deniedOffset := strings.Index(body, "X-Subrouter-Session: canary-test-1-denied")
 	if strings.Count(body, "--request--") != 2 ||
 		strings.Count(body, "X-Subrouter-Canary-Token:") != 1 ||
 		!strings.Contains(body, "X-Subrouter-Session: canary-test-1-denied") ||
-		!strings.Contains(body, "X-Subrouter-Session: canary-test-1") {
+		!strings.Contains(body, "X-Subrouter-Session: canary-test-1") ||
+		authenticatedOffset < 0 || deniedOffset < 0 || authenticatedOffset > deniedOffset {
 		t.Fatalf("probe did not pair denied and authenticated canaries:\n%s", body)
 	}
 }

--- a/deploy/gcp/probe-front-readiness.sh
+++ b/deploy/gcp/probe-front-readiness.sh
@@ -36,12 +36,12 @@ canary_request() {
     --write-out '%{http_code}' --connect-timeout 5 --max-time 10
 }
 
-unauthorized_code="$(canary_request "${SESSION_ID}-denied" "")" || unauthorized_code=""
-[[ "${unauthorized_code}" == 403 ]] \
-  || { printf 'front-readiness-probe: unprotected public canary returned %s\n' "${unauthorized_code:-no status}" >&2; exit 1; }
 authorized_code="$(canary_request "${SESSION_ID}" "${canary_token}")" || authorized_code=""
 [[ "${authorized_code}" == 400 ]] \
   || { printf 'front-readiness-probe: authenticated public canary returned %s\n' "${authorized_code:-no status}" >&2; exit 1; }
+unauthorized_code="$(canary_request "${SESSION_ID}-denied" "")" || unauthorized_code=""
+[[ "${unauthorized_code}" == 403 ]] \
+  || { printf 'front-readiness-probe: unprotected public canary returned %s\n' "${unauthorized_code:-no status}" >&2; exit 1; }
 
 exec "${GCLOUD_BINARY}" compute backend-services get-health "${FRONT_BACKEND_SERVICE}" \
   --project "${PROJECT_ID}" --global --format=json


### PR DESCRIPTION
Staging showed that Google Cloud Armor can return a transient edge 502 when an authenticated request immediately follows the intentional denied control request. This was isolated to the synthetic canary hostname: 150 authenticated-only requests passed, while the deny-then-auth sequence reproduced the Google-generated 502.\n\nThe probe now checks the authenticated request first and the denied control second. Backend health collection plus the waiter interval separates the next authenticated request without a timing sleep. Every accepted sample still requires an authenticated 400, unauthenticated 403, and fully healthy backend membership.\n\nThe first commit adds the failing request-order regression; the second fixes it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788512044&installation_model_id=21920&pr_number=167&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F167&signature=5c7a6273f744d0b515214008738437259c6cf1869d3fc8da945502b2fe2f2a26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered the front readiness probe to send the authenticated canary before the denied control to avoid transient Google Cloud Armor 502s that falsely mark the service unhealthy. Keeps the same readiness guarantees while isolating the denied canary from sampling.

- **Bug Fixes**
  - Updated `deploy/gcp/probe-front-readiness.sh` to call the authenticated canary first, then the denied control; backend health polling provides natural spacing without sleeps.
  - Strengthened test to assert two requests and that the authenticated request precedes the denied request.

<sup>Written for commit f3278852810b483cac169a22b196e1facee48248. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

