### PR TITLE
Fix health-check-pinned migration retries

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -212,6 +212,24 @@ func TestGCPCanarySecurityPolicyRequiresAnAuthenticatedHeader(t *testing.T) {
 	if err := json.Unmarshal(policyBody, &policyJSON); err != nil {
 		t.Fatal(err)
 	}
+	updatedPolicy := filepath.Join(t.TempDir(), "updated-policy.json")
+	if output, err := exec.Command(
+		mustLookPath(t, "python3"), helper, "render", updatedPolicy, name, host,
+		"--token-file", tokenPath, "--fingerprint", "existing-fingerprint==",
+	).CombinedOutput(); err != nil {
+		t.Fatalf("render existing canary security policy: %v\n%s", err, output)
+	}
+	updatedBody, err := os.ReadFile(updatedPolicy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var updatedJSON map[string]any
+	if err := json.Unmarshal(updatedBody, &updatedJSON); err != nil {
+		t.Fatal(err)
+	}
+	if updatedJSON["fingerprint"] != "existing-fingerprint==" {
+		t.Fatalf("existing policy fingerprint was not preserved: %#v", updatedJSON["fingerprint"])
+	}
 	rules := policyJSON["rules"].([]any)
 	hostExpression := `has(request.headers['host']) && request.headers['host'].lower() == 'front-canary.staging.sr.cmux.internal'`
 	allowExpression := rules[0].(map[string]any)["match"].(map[string]any)["expr"].(map[string]any)["expression"].(string)

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -2417,6 +2417,21 @@ exit 0
 	if err := os.WriteFile(frontActiveMarker, nil, 0o600); err != nil {
 		t.Fatal(err)
 	}
+	pinnedFrontStatus := `{"active":{"id":"slot-a"},"backends":[{"id":"slot-a","connections":13}]}`
+	output, runErr, contextErr = run("0", "0", pinnedFrontStatus)
+	if runErr == nil || contextErr != nil {
+		t.Fatalf("mismatched topology with pinned connections was not rejected safely: err=%v context=%v\n%s", runErr, contextErr, output)
+	}
+	if !strings.Contains(string(output), "refusing to replace stale front topology with 13 pinned connection(s)") {
+		t.Fatalf("mismatched pinned topology returned the wrong failure:\n%s", output)
+	}
+	logBody, err = os.ReadFile(systemctlLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(logBody), "disable --now") {
+		t.Fatalf("mismatched pinned topology allowed a service stop:\n%s", logBody)
+	}
 	for path, target := range map[string]string{
 		filepath.Join(frontRoot, "subrouter"):       controlRelease,
 		filepath.Join(controlRoot, "subrouter"):     controlRelease,
@@ -2428,6 +2443,23 @@ exit 0
 		if err := os.Symlink(target, path); err != nil {
 			t.Fatal(err)
 		}
+	}
+	if err := os.WriteFile(systemctlLog, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output, runErr, contextErr = run("0", "0", pinnedFrontStatus)
+	if runErr != nil || contextErr != nil {
+		t.Fatalf("exact active topology with load-balancer connections was not reused: err=%v context=%v\n%s", runErr, contextErr, output)
+	}
+	if !strings.Contains(string(output), "reusing active migration topology with 13 pinned connection(s)") {
+		t.Fatalf("exact pinned topology did not report reuse:\n%s", output)
+	}
+	logBody, err = os.ReadFile(systemctlLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(logBody), "disable --now") {
+		t.Fatalf("exact pinned topology stopped a serving unit:\n%s", logBody)
 	}
 	if err := os.WriteFile(systemctlLog, nil, 0o600); err != nil {
 		t.Fatal(err)

--- a/deploy/gcp/canary-security-policy.py
+++ b/deploy/gcp/canary-security-policy.py
@@ -25,6 +25,7 @@ POLICY_DESCRIPTION = "Subrouter front migration canary access boundary"
 ALLOW_DESCRIPTION = "allow authenticated Subrouter front migration canary"
 DENY_DESCRIPTION = "deny unauthenticated Subrouter front migration canary"
 TOKEN = re.compile(r"[0-9a-f]{64}")
+FINGERPRINT = re.compile(r"[A-Za-z0-9+/=_-]{8,256}")
 NAME = re.compile(r"[a-z][a-z0-9-]{0,62}")
 HOST = re.compile(r"[a-z0-9](?:[a-z0-9.-]{0,251}[a-z0-9])?")
 MAX_POLICY_BYTES = 2 * 1024 * 1024
@@ -72,8 +73,8 @@ def redaction_action() -> dict[str, Any]:
     }
 
 
-def policy_document(name: str, host: str, token: str) -> dict[str, Any]:
-    return {
+def policy_document(name: str, host: str, token: str, fingerprint: str | None = None) -> dict[str, Any]:
+    document = {
         "name": name,
         "description": POLICY_DESCRIPTION,
         "type": "CLOUD_ARMOR",
@@ -96,6 +97,9 @@ def policy_document(name: str, host: str, token: str) -> dict[str, Any]:
             default_rule(),
         ],
     }
+    if fingerprint is not None:
+        document["fingerprint"] = fingerprint
+    return document
 
 
 def read_document(source: str) -> dict[str, Any]:
@@ -232,6 +236,7 @@ def main() -> None:
     render.add_argument("name")
     render.add_argument("host")
     render.add_argument("--token-file", type=Path, required=True)
+    render.add_argument("--fingerprint")
     verify = commands.add_parser("assert-ready")
     verify.add_argument("source")
     verify.add_argument("name")
@@ -243,7 +248,12 @@ def main() -> None:
     if args.command == "render":
         if token is None:
             fail("render requires a canary token")
-        write_document(args.destination, policy_document(args.name, args.host, token))
+        if args.fingerprint is not None and FINGERPRINT.fullmatch(args.fingerprint) is None:
+            fail("security policy fingerprint is invalid")
+        write_document(
+            args.destination,
+            policy_document(args.name, args.host, token, args.fingerprint),
+        )
         return
     token = validate_ready(read_document(args.source), args.name, args.host, token)
     json.dump(

--- a/deploy/gcp/install-front-slots.sh
+++ b/deploy/gcp/install-front-slots.sh
@@ -65,6 +65,12 @@ atomic_symlink() {
   mv -Tf -- "${temporary}" "${destination}"
 }
 
+binary_matches() {
+  local installed="$1" expected="$2"
+  [[ -x "${installed}" && -x "${expected}" ]] || return 1
+  [[ "$(sha256sum "${installed}" | awk '{print $1}')" == "$(sha256sum "${expected}" | awk '{print $1}')" ]]
+}
+
 wait_endpoint() {
   local url="$1"
   local service="$2"
@@ -299,6 +305,20 @@ ensure_migration_topology() {
     active_slot="$(jq -r '.active.id' <<<"${status}")"
     connections="$(jq -r '[.backends[].connections] | add // 0' <<<"${status}")"
     [[ "${connections}" =~ ^[0-9]+$ ]] || die "front returned an invalid connection total"
+
+    # A prepared load-balancer backend keeps health-check connections pinned to
+    # the front. Reuse an exact active topology so a retry neither drops those
+    # connections nor mistakes healthy prewarming for stale state. Any binary
+    # mismatch still fails closed while connections exist.
+    if (( connections > 0 )) \
+      && systemctl is-active --quiet "subrouter-slot@${active_slot}.service" \
+      && binary_matches "${FRONT_ROOT}/subrouter" "${control_binary}" \
+      && binary_matches "${CONTROL_ROOT}/subrouter" "${control_binary}" \
+      && binary_matches "${SLOT_ROOT}/${active_slot}/worker" "${worker_binary}"
+    then
+      log "reusing active migration topology with ${connections} pinned connection(s)"
+      return
+    fi
 
     (( connections == 0 )) \
       || die "refusing to replace stale front topology with ${connections} pinned connection(s)"

--- a/deploy/gcp/migrate-to-front-slots.sh
+++ b/deploy/gcp/migrate-to-front-slots.sh
@@ -238,19 +238,26 @@ canary_token_file=""
 canary_policy_config_file=""
 
 install_canary_access_boundary() {
-  local policy_exists=0 current_policy expected_policy_url policy_json backend_policy_json token_sha
+  local policy_exists=0 current_policy expected_policy_url policy_json backend_policy_json token_sha policy_fingerprint=""
   canary_token_file="$(mktemp "${ARTIFACT_DIR}/.front-canary-token.XXXXXX")"
   chmod 0600 "${canary_token_file}"
   python3 -c 'import secrets, sys; print(secrets.token_hex(32), file=sys.stdout)' >"${canary_token_file}"
   canary_policy_config_file="$(mktemp "${ARTIFACT_DIR}/.front-canary-policy.XXXXXX.json")"
   chmod 0600 "${canary_policy_config_file}"
-  python3 "${CANARY_SECURITY_POLICY_HELPER}" render \
-    "${canary_policy_config_file}" "${CANARY_SECURITY_POLICY}" "${CANARY_HOST}" \
-    --token-file "${canary_token_file}"
-  if "${GCLOUD_BINARY}" compute security-policies describe "${CANARY_SECURITY_POLICY}" \
-    --project "${PROJECT_ID}" --global --format=json >/dev/null 2>&1
+  if policy_json="$("${GCLOUD_BINARY}" compute security-policies describe "${CANARY_SECURITY_POLICY}" \
+    --project "${PROJECT_ID}" --global --format=json 2>/dev/null)"
   then
     policy_exists=1
+    policy_fingerprint="$(jq -er '.fingerprint | select(type=="string" and length>0)' \
+      < <(stream_shell_value "${policy_json}"))" \
+      || die "existing canary security policy has no update fingerprint"
+    python3 "${CANARY_SECURITY_POLICY_HELPER}" render \
+      "${canary_policy_config_file}" "${CANARY_SECURITY_POLICY}" "${CANARY_HOST}" \
+      --token-file "${canary_token_file}" --fingerprint "${policy_fingerprint}"
+  else
+    python3 "${CANARY_SECURITY_POLICY_HELPER}" render \
+      "${canary_policy_config_file}" "${CANARY_SECURITY_POLICY}" "${CANARY_HOST}" \
+      --token-file "${canary_token_file}"
   fi
   if [[ "${policy_exists}" == 1 ]]; then
     "${GCLOUD_BINARY}" compute security-policies import "${CANARY_SECURITY_POLICY}" \


### PR DESCRIPTION
Staging migration retries can encounter load-balancer health-check connections on an already-prepared front topology. The installer currently treats those connections as stale and refuses to resume.

This change reuses the topology only when the active front, control binary, active slot worker, and active slot service exactly match the requested immutable releases. Mismatched topology still fails without stopping a service.

Commits are split test-first: `cec4d71` reproduces the failure, then `a39c123` fixes it.

Tests:
- `go test ./cmd/subrouter -run TestFrontSlotInstallerSafelyBeginsDormantStaleMigrationReconciliation -count=1`
- `go test ./cmd/subrouter`
- `go test -p 1 ./...`
- `bash -n deploy/gcp/install-front-slots.sh`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788512299&installation_model_id=21920&pr_number=168&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F168&signature=2735e20ad5d47777cee811682293c4d6cfc372a3739dedb3327e325a5fb99120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes migration retries blocked by load-balancer health-check connections by reusing the exact active topology when binaries match. Also preserves the Cloud Armor canary policy fingerprint during updates to avoid import conflicts.

- **Bug Fixes**
  - In `deploy/gcp/install-front-slots.sh`, reuse the active migration topology when the running `front`, `control`, and `worker` binaries match the requested releases; otherwise fail closed without stopping services.
  - Preserve Cloud Armor canary policy fingerprint: `deploy/gcp/canary-security-policy.py` adds `--fingerprint` support and validation; `deploy/gcp/migrate-to-front-slots.sh` reads the existing policy fingerprint and passes it through to keep imports idempotent.
  - Expanded `cmd/subrouter/deploy_scripts_test.go` to cover both pinned-topology reuse/rejection and fingerprint preservation.

<sup>Written for commit 1ff14bb336bd1ac8f579ec3747ba9e66453c5f18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud Armor policy rendering now supports preserving existing policy fingerprints during updates.
  * Deployment migration reuses active topologies only when running components match the expected releases.

* **Bug Fixes**
  * Improved safeguards prevent service shutdown or topology replacement when pinned connections are present and compatibility checks fail.
  * Added validation for policy fingerprint formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->