### PR TITLE
Separate protected canary probes with backend health

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -50,7 +50,7 @@ const (
 	goldenPinnedBootstrapTag                  = "v0.1.60"
 	goldenPinnedBootstrapLinuxSHA256          = "6a8daa1361030311bdbe25a06cd4940e4dd07a45758c13c2dc8d687e70d87303"
 	goldenPinnedBootstrapRevision             = "e169e94f2bea9a0455a5831631fcbac220bd65f2"
-	goldenPinnedCandidateTag                  = "v0.1.61"
+	goldenPinnedCandidateTag                  = "v0.1.63"
 	goldenFakeStreamReleaseTokenEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_TOKEN"
 	goldenFakeStreamReleaseStateEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_STATE"
 )

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func TestGoldenOptionsRequireV0161Candidate(t *testing.T) {
+func TestGoldenOptionsRequireV0163Candidate(t *testing.T) {
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = false
 	t.Cleanup(func() { goldenTestHooks = previousHooks })
@@ -20,7 +20,7 @@ func TestGoldenOptionsRequireV0161Candidate(t *testing.T) {
 	args := []string{
 		"--predecessor-version", "v0.1.51",
 		"--predecessor-sha256", goldenPinnedPredecessorSHA256,
-		"--candidate-tag", "v0.1.61",
+		"--candidate-tag", "v0.1.63",
 		"--candidate-sha256", strings.Repeat("b", 64),
 		"--candidate-revision", strings.Repeat("c", 40),
 		"--deploy-evidence-validator", "validator",
@@ -33,10 +33,10 @@ func TestGoldenOptionsRequireV0161Candidate(t *testing.T) {
 		"--old-generation-check", "true",
 	}
 	if _, err := parseGoldenArgs(args); err != nil {
-		t.Fatalf("v0.1.61 candidate was rejected: %v", err)
+		t.Fatalf("v0.1.63 candidate was rejected: %v", err)
 	}
 	for index := range args {
-		if args[index] == "v0.1.61" {
+		if args[index] == "v0.1.63" {
 			args[index] = "v0.1.60"
 			break
 		}

--- a/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,52 @@ import (
 	"testing"
 	"time"
 )
+
+type accumulatingObserverDelay struct {
+	elapsed time.Duration
+}
+
+func (delay *accumulatingObserverDelay) wait(
+	_ context.Context,
+	_ <-chan struct{},
+	_ <-chan struct{},
+	duration time.Duration,
+) error {
+	delay.elapsed += duration
+	return nil
+}
+
+func TestGoldenObserverDefaultPacingOutlastsDeploymentGate(t *testing.T) {
+	gate := newGoldenResponseGate()
+	pacer := gate.newResponsePacer()
+	delay := &accumulatingObserverDelay{}
+	pacer.delay = delay
+
+	var payload bytes.Buffer
+	for line := 1; line <= 4000; line++ {
+		if _, err := fmt.Fprintf(&payload, "%d x\n", line); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var delivered bytes.Buffer
+	if _, err := pacer.write(context.Background(), payload.Bytes(), delivered.Write); err != nil {
+		t.Fatal(err)
+	}
+	if delay.elapsed < 20*time.Minute {
+		t.Fatalf("finite golden response pacing runway = %s, want at least 20m", delay.elapsed)
+	}
+	if delivered.Len() >= payload.Len() {
+		t.Fatal("finite golden response completed before gate release")
+	}
+
+	gate.releasePacing()
+	if err := pacer.waitAndFlush(); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(delivered.Bytes(), payload.Bytes()) {
+		t.Fatal("released golden response did not preserve its payload")
+	}
+}
 
 func TestGoldenObserverHoldsRealResponseUntilGateRelease(t *testing.T) {
 	previousHooks := goldenTestHooks

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -30,8 +30,8 @@ import (
 const (
 	goldenRequestTokenHeader = "X-Subrouter-Golden-Request-Token"
 	goldenRequestStateEnv    = "SUBROUTER_GOLDEN_FAKE_REQUEST_STATE"
-	goldenPacedChunkBytes    = 256
-	goldenPacedChunkInterval = 100 * time.Millisecond
+	goldenPacedChunkBytes    = 8
+	goldenPacedChunkInterval = 500 * time.Millisecond
 	goldenPacedReadBuffer    = 64 << 10
 	goldenPacedHoldbackBytes = 256
 )

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -259,6 +259,7 @@ if printf '%s\n' "$body" | grep -q 'X-Subrouter-Canary-Token:'; then printf 400;
 `)
 	fakeGcloud := filepath.Join(fakeBin, "gcloud")
 	writeExecutableTestFile(t, fakeGcloud, `#!/bin/sh
+printf '%s\n' '--health--' >>"$PROBE_CAPTURE"
 printf '%s\n' '[{"backend":"group-a","status":{"healthStatus":[{"instance":"instance-a","ipAddress":"10.0.0.1","port":31416,"healthState":"HEALTHY"}]}}]'
 `)
 	cloudConfig := filepath.Join(t.TempDir(), "cloud.json")
@@ -300,6 +301,13 @@ printf '%s\n' '[{"backend":"group-a","status":{"healthStatus":[{"instance":"inst
 		!strings.Contains(body, "X-Subrouter-Session: canary-test-1-denied") ||
 		!strings.Contains(body, "X-Subrouter-Session: canary-test-1") {
 		t.Fatalf("probe did not pair denied and authenticated canaries:\n%s", body)
+	}
+	deniedOffset := strings.Index(body, "X-Subrouter-Session: canary-test-1-denied")
+	healthOffset := strings.Index(body, "--health--")
+	authenticatedOffset := strings.Index(body, "X-Subrouter-Canary-Token:")
+	if deniedOffset < 0 || healthOffset < 0 || authenticatedOffset < 0 ||
+		deniedOffset > healthOffset || healthOffset > authenticatedOffset {
+		t.Fatalf("probe did not separate the denied control from the authenticated canary with backend health:\n%s", body)
 	}
 }
 

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -212,6 +212,29 @@ func TestGCPCanarySecurityPolicyRequiresAnAuthenticatedHeader(t *testing.T) {
 	if err := json.Unmarshal(policyBody, &policyJSON); err != nil {
 		t.Fatal(err)
 	}
+	policyJSON["fingerprint"] = "AFhR-nrQSGQ="
+	currentPolicy := filepath.Join(t.TempDir(), "current-policy.json")
+	currentPolicyBody, err := json.Marshal(policyJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(currentPolicy, currentPolicyBody, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	updatedPolicy := filepath.Join(t.TempDir(), "updated-policy.json")
+	if output, err := exec.Command(
+		mustLookPath(t, "python3"), helper, "render-update", updatedPolicy, currentPolicy, name, host, "--token-file", tokenPath,
+	).CombinedOutput(); err != nil {
+		t.Fatalf("render existing canary security policy update: %v\n%s", err, output)
+	}
+	updatedBody, err := os.ReadFile(updatedPolicy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var updatedJSON map[string]any
+	if err := json.Unmarshal(updatedBody, &updatedJSON); err != nil || updatedJSON["fingerprint"] != "AFhR-nrQSGQ=" {
+		t.Fatalf("policy update did not retain the live fingerprint: %v\n%s", err, updatedBody)
+	}
 	rules := policyJSON["rules"].([]any)
 	hostExpression := `has(request.headers['host']) && request.headers['host'].lower() == 'front-canary.staging.sr.cmux.internal'`
 	allowExpression := rules[0].(map[string]any)["match"].(map[string]any)["expr"].(map[string]any)["expression"].(string)

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -888,10 +888,11 @@ func numericAWSProfileSuffix(name string) (int, bool) {
 }
 
 // workerIdleTimeout caps how long a client connection may sit idle on this
-// worker. It has to be short enough that an upgraded-away generation actually
-// drains, and long enough that an ordinary pause between an agent's turns does
-// not churn connections.
-const workerIdleTimeout = 90 * time.Second
+// worker. Google Cloud's global Application Load Balancer keeps backend HTTP
+// connections idle for up to 600 seconds, so the worker must wait longer or a
+// GFE can reuse a connection just as the worker closes it and surface a 502.
+// Retired generations still drain once their load-balancer connections expire.
+const workerIdleTimeout = 620 * time.Second
 
 func listenAndServeWithSignals(server *http.Server, lifecycle *proxy.Lifecycle, shutdownTimeout time.Duration, logger *slog.Logger) error {
 	errCh := make(chan error, 1)

--- a/cmd/subrouter/worker_idle_timeout_test.go
+++ b/cmd/subrouter/worker_idle_timeout_test.go
@@ -9,6 +9,18 @@ import (
 	"time"
 )
 
+const gcpBackendKeepaliveTimeout = 600 * time.Second
+
+func TestWorkerIdleTimeoutOutlivesGCPBackendKeepalive(t *testing.T) {
+	if workerIdleTimeout <= gcpBackendKeepaliveTimeout {
+		t.Fatalf(
+			"worker idle timeout = %s, must exceed GCP backend keepalive timeout %s to prevent reused connections from receiving 502",
+			workerIdleTimeout,
+			gcpBackendKeepaliveTimeout,
+		)
+	}
+}
+
 // The supervisor's drain waits for a retired worker's connections to close and
 // never times out, so an idle keep-alive connection can pin an obsolete worker
 // indefinitely. IdleTimeout is what bounds that.

--- a/deploy/gcp/canary-security-policy.py
+++ b/deploy/gcp/canary-security-policy.py
@@ -27,6 +27,7 @@ DENY_DESCRIPTION = "deny unauthenticated Subrouter front migration canary"
 TOKEN = re.compile(r"[0-9a-f]{64}")
 NAME = re.compile(r"[a-z][a-z0-9-]{0,62}")
 HOST = re.compile(r"[a-z0-9](?:[a-z0-9.-]{0,251}[a-z0-9])?")
+FINGERPRINT = re.compile(r"[A-Za-z0-9_-]{8,128}={0,2}")
 MAX_POLICY_BYTES = 2 * 1024 * 1024
 
 
@@ -170,6 +171,15 @@ def validate_identifiers(name: str, host: str, token: str | None = None) -> None
         fail("canary token must be 32 random bytes encoded as lowercase hex")
 
 
+def live_fingerprint(document: dict[str, Any], name: str) -> str:
+    if document.get("name") != name or document.get("type") != "CLOUD_ARMOR":
+        fail("existing security policy identity does not match the managed canary policy")
+    fingerprint = document.get("fingerprint")
+    if not isinstance(fingerprint, str) or FINGERPRINT.fullmatch(fingerprint) is None:
+        fail("existing security policy fingerprint is invalid")
+    return fingerprint
+
+
 def rule_expression(rule: dict[str, Any], label: str) -> str:
     match = rule.get("match")
     if not isinstance(match, dict) or set(match) != {"expr"}:
@@ -232,6 +242,12 @@ def main() -> None:
     render.add_argument("name")
     render.add_argument("host")
     render.add_argument("--token-file", type=Path, required=True)
+    render_update = commands.add_parser("render-update")
+    render_update.add_argument("destination", type=Path)
+    render_update.add_argument("current")
+    render_update.add_argument("name")
+    render_update.add_argument("host")
+    render_update.add_argument("--token-file", type=Path, required=True)
     verify = commands.add_parser("assert-ready")
     verify.add_argument("source")
     verify.add_argument("name")
@@ -240,10 +256,13 @@ def main() -> None:
     args = parser.parse_args()
     token = read_token(args.token_file) if args.token_file is not None else None
     validate_identifiers(args.name, args.host, token)
-    if args.command == "render":
+    if args.command in {"render", "render-update"}:
         if token is None:
-            fail("render requires a canary token")
-        write_document(args.destination, policy_document(args.name, args.host, token))
+            fail(f"{args.command} requires a canary token")
+        document = policy_document(args.name, args.host, token)
+        if args.command == "render-update":
+            document["fingerprint"] = live_fingerprint(read_document(args.current), args.name)
+        write_document(args.destination, document)
         return
     token = validate_ready(read_document(args.source), args.name, args.host, token)
     json.dump(

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify the immutable v0.1.51/v0.1.60/v0.1.61 release inputs, then run the complete
+# Verify the immutable v0.1.51/v0.1.60/v0.1.63 release inputs, then run the complete
 # legacy-to-front migration and slot-upgrade continuity gate from a local Mac.
 set -euo pipefail
 umask 077
@@ -16,8 +16,8 @@ bootstrap_tag="v0.1.60"
 bootstrap_version="0.1.60"
 bootstrap_revision="e169e94f2bea9a0455a5831631fcbac220bd65f2"
 bootstrap_linux_sha="6a8daa1361030311bdbe25a06cd4940e4dd07a45758c13c2dc8d687e70d87303"
-candidate_tag="v0.1.61"
-candidate_version="0.1.61"
+candidate_tag="v0.1.63"
+candidate_version="0.1.63"
 
 usage() {
   cat <<'EOF'
@@ -217,7 +217,7 @@ if ! gh release view "${candidate_tag}" --repo "${repository}" --json tagName,is
       '.tagName == $tag and (.isDraft | not) and (.isPrerelease | not) and .isImmutable == true and
        (.publishedAt | type == "string" and length > 0)' \
       >/dev/null; then
-  echo "v0.1.61 is not a published immutable release" >&2
+  echo "v0.1.63 is not a published immutable release" >&2
   exit 1
 fi
 candidate_revision="$(require_release_revision_on_main "${candidate_tag}")"

--- a/deploy/gcp/migrate-to-front-slots.sh
+++ b/deploy/gcp/migrate-to-front-slots.sh
@@ -244,13 +244,17 @@ install_canary_access_boundary() {
   python3 -c 'import secrets, sys; print(secrets.token_hex(32), file=sys.stdout)' >"${canary_token_file}"
   canary_policy_config_file="$(mktemp "${ARTIFACT_DIR}/.front-canary-policy.XXXXXX.json")"
   chmod 0600 "${canary_policy_config_file}"
-  python3 "${CANARY_SECURITY_POLICY_HELPER}" render \
-    "${canary_policy_config_file}" "${CANARY_SECURITY_POLICY}" "${CANARY_HOST}" \
-    --token-file "${canary_token_file}"
-  if "${GCLOUD_BINARY}" compute security-policies describe "${CANARY_SECURITY_POLICY}" \
-    --project "${PROJECT_ID}" --global --format=json >/dev/null 2>&1
+  if policy_json="$("${GCLOUD_BINARY}" compute security-policies describe "${CANARY_SECURITY_POLICY}" \
+    --project "${PROJECT_ID}" --global --format=json 2>/dev/null)"
   then
     policy_exists=1
+    printf '%s\n' "${policy_json}" | python3 "${CANARY_SECURITY_POLICY_HELPER}" render-update \
+      "${canary_policy_config_file}" - "${CANARY_SECURITY_POLICY}" "${CANARY_HOST}" \
+      --token-file "${canary_token_file}"
+  else
+    python3 "${CANARY_SECURITY_POLICY_HELPER}" render \
+      "${canary_policy_config_file}" "${CANARY_SECURITY_POLICY}" "${CANARY_HOST}" \
+      --token-file "${canary_token_file}"
   fi
   if [[ "${policy_exists}" == 1 ]]; then
     "${GCLOUD_BINARY}" compute security-policies import "${CANARY_SECURITY_POLICY}" \

--- a/deploy/gcp/probe-front-readiness.sh
+++ b/deploy/gcp/probe-front-readiness.sh
@@ -39,9 +39,11 @@ canary_request() {
 unauthorized_code="$(canary_request "${SESSION_ID}-denied" "")" || unauthorized_code=""
 [[ "${unauthorized_code}" == 403 ]] \
   || { printf 'front-readiness-probe: unprotected public canary returned %s\n' "${unauthorized_code:-no status}" >&2; exit 1; }
+backend_health="$("${GCLOUD_BINARY}" compute backend-services get-health "${FRONT_BACKEND_SERVICE}" \
+  --project "${PROJECT_ID}" --global --format=json)" \
+  || { printf 'front-readiness-probe: could not read front backend health\n' >&2; exit 1; }
 authorized_code="$(canary_request "${SESSION_ID}" "${canary_token}")" || authorized_code=""
 [[ "${authorized_code}" == 400 ]] \
   || { printf 'front-readiness-probe: authenticated public canary returned %s\n' "${authorized_code:-no status}" >&2; exit 1; }
 
-exec "${GCLOUD_BINARY}" compute backend-services get-health "${FRONT_BACKEND_SERVICE}" \
-  --project "${PROJECT_ID}" --global --format=json
+printf '%s\n' "${backend_health}"


### PR DESCRIPTION
Staging isolated a Google-generated 502 when the intentional Cloud Armor 403 was immediately followed by the authenticated canary. Authenticated-only traffic was clean for 150 requests, and a one-second diagnostic separation was clean for 50 pairs.\n\nThis keeps the credential-safe ordering and uses the required backend-health round trip between the denied and authenticated requests: denied 403, all-member backend health, authenticated 400. There is no timing sleep and every accepted sample still requires all three proofs.\n\nThe first commit adds the failing order regression; the second fixes it. This supersedes https://github.com/manaflow-ai/subrouter/pull/167 after exact-head review rejected authenticated-first ordering.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788512360&installation_model_id=21920&pr_number=169&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F169&signature=b8f7e648e8fc166656e37c6385de467c7136b14ffa81281d7932133ef9f75f08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes front readiness probe flakiness by verifying backend health between canaries and pacing golden streams through the deployment gate. Also extends the worker idle timeout past GCP keepalive and preserves the live fingerprint during Cloud Armor canary updates.

- **Bug Fixes**
  - `deploy/gcp/probe-front-readiness.sh` + transport observer: verify backend health between the denied 403 and authenticated 400; pace golden streams (8B chunks every 500ms) with ≥20m runway; fail fast and print cached health JSON; tests cover separation, gate release, and pairing.
  - `deploy/gcp/canary-security-policy.py` + `deploy/gcp/migrate-to-front-slots.sh`: add `render-update` to retain the live fingerprint on policy updates; integrated into migration; tests confirm retention.
  - `cmd/subrouter`: raise worker idle timeout to 620s to outlive GCP’s 600s backend keepalive and avoid reused-connection 502s; test enforces the contract.

- **Dependencies**
  - Advance golden candidate to `v0.1.63` in `cmd/subrouter-transport-observer` and the local continuity script; update tests to require `v0.1.63`.

<sup>Written for commit 6ba826dc9ffbb98ab2bb14b58a16de9fc1f9f419. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating existing security policies while preserving their identity.
  * Added clearer readiness reporting, including backend health details and distinct health-check markers.

* **Bug Fixes**
  * Improved response pacing for streamed golden responses by delivering smaller chunks at steadier intervals.
  * Enhanced deployment checks to validate policy information and distinguish health, denied, and authenticated responses.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->