### PR TITLE
Report when a server cannot accept account imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ sr server add team --url http://100.64.0.1:31415 --admin-token "$TOKEN" --defaul
 
 When `SUBROUTER_ADMIN_TOKEN` or `--admin-token` is set, non-loopback requests to sensitive `/_subrouter/*` endpoints must send `Authorization: Bearer <token>` or `X-Subrouter-Admin-Token: <token>`. Loopback stays trusted for ordinary admin endpoints. Account onboarding uses a distinct `SUBROUTER_ACCOUNT_IMPORT_TOKEN`; that token authorizes only `GET` and `POST /_subrouter/account-import` and cannot access admin APIs or proxy traffic.
 
+A server with neither credential configured rejects every account import, including `sr add`. That state is reported as `"account_import": "disabled"` by `/_subrouter/health` and logged as a warning at startup, and `sr doctor` runs the same preflight `sr add` runs against the selected server.
+
 ## GCP deployment
 
 See [deploy/gcp/README.md](deploy/gcp/README.md) for the small GCP + Tailscale Subrouter deployment flow.

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -603,6 +603,18 @@ func serve(args []string) error {
 		slog.Info("sr auto-switch disabled because usage fetching is disabled", "interval", srSwitchInterval.String())
 	}
 
+	// A server with no import credential rejects every `sr add`, and no other
+	// signal reports it: ordinary admin reads stay open, health stays green, and
+	// the accounts already on disk keep serving traffic. Say it once at startup
+	// so the gap is visible when it appears rather than when someone next needs
+	// to onboard an account.
+	if !*multiTenant && server.AccountImportState() == proxy.AccountImportDisabled {
+		slog.Warn(
+			"account import is disabled: no admin or account-import credential is configured, so this server rejects every sr add",
+			"fix", "set SUBROUTER_ACCOUNT_IMPORT_TOKEN_FILE and SUBROUTER_ADMIN_TOKEN_FILE, or run sr server install <name>",
+		)
+	}
+
 	tenantRegistry := tenant.NewRegistry(storepath.StateDir())
 	multiTenantHandler := &proxy.MultiTenant{
 		Base:          server,

--- a/cmd/subrouter/sr_doctor_account_import_test.go
+++ b/cmd/subrouter/sr_doctor_account_import_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+// writeDoctorServerFile points a store's servers.json at one default server.
+func writeDoctorServerFile(t *testing.T, store accounts.CodexStore, server srServerConfig) {
+	t.Helper()
+	file := srServerFile{Servers: []srServerConfig{server}, Default: server.Name}
+	body, err := json.Marshal(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(store.StoreDir(), "servers.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDoctorFailsWhenServerEntryHasNoImportCredential(t *testing.T) {
+	isolateCloudConfig(t)
+	local := healthServer(t, http.StatusOK)
+	t.Setenv("SUBROUTER_LOCAL_BASE_URL", local.URL+"/v1")
+	t.Setenv("SUBROUTER_CODEX_SERVER", "")
+
+	store := emptyStore(t)
+	writeDoctorServerFile(t, store, srServerConfig{
+		Name: "mac-mini",
+		URL:  "http://127.0.0.1:31415",
+	})
+
+	var out bytes.Buffer
+	_ = runDoctorWith(context.Background(), &fakeController{present: true}, nil, store, &out)
+	if !strings.Contains(out.String(), "FAIL  server account import") {
+		t.Fatalf("expected a failing account import check:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "no protected HTTP account-import credential") {
+		t.Fatalf("expected the fix to name the missing credential:\n%s", out.String())
+	}
+}
+
+func TestDoctorFailsWhenServerRejectsImportCredential(t *testing.T) {
+	isolateCloudConfig(t)
+	local := healthServer(t, http.StatusOK)
+	t.Setenv("SUBROUTER_LOCAL_BASE_URL", local.URL+"/v1")
+	t.Setenv("SUBROUTER_CODEX_SERVER", "")
+
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "protected account import credential required", http.StatusUnauthorized)
+	}))
+	t.Cleanup(remote.Close)
+
+	store := emptyStore(t)
+	writeDoctorServerFile(t, store, srServerConfig{
+		Name:               "mac-mini",
+		URL:                remote.URL,
+		AccountImportToken: "stale-token",
+	})
+
+	var out bytes.Buffer
+	_ = runDoctorWith(context.Background(), &fakeController{present: true}, nil, store, &out)
+	if !strings.Contains(out.String(), "FAIL  server account import") {
+		t.Fatalf("expected a failing account import check:\n%s", out.String())
+	}
+}
+
+func TestDoctorPassesWhenServerAcceptsImports(t *testing.T) {
+	isolateCloudConfig(t)
+	local := healthServer(t, http.StatusOK)
+	t.Setenv("SUBROUTER_LOCAL_BASE_URL", local.URL+"/v1")
+	t.Setenv("SUBROUTER_CODEX_SERVER", "")
+
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != serverAccountImportPath {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer import-token" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(remote.Close)
+
+	store := emptyStore(t)
+	writeDoctorServerFile(t, store, srServerConfig{
+		Name:               "mac-mini",
+		URL:                remote.URL,
+		AccountImportToken: "import-token",
+	})
+
+	var out bytes.Buffer
+	_ = runDoctorWith(context.Background(), &fakeController{present: true}, nil, store, &out)
+	if !strings.Contains(out.String(), "ok    server account import") {
+		t.Fatalf("expected a passing account import check:\n%s", out.String())
+	}
+}

--- a/cmd/subrouter/sr_setup.go
+++ b/cmd/subrouter/sr_setup.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -413,6 +414,8 @@ func runDoctorWith(ctx context.Context, controller serviceController, controller
 			}
 		}
 
+		checks = append(checks, remoteAccountImportChecks(ctx, store, client)...)
+
 		list, listErr := store.List()
 		switch {
 		case listErr != nil:
@@ -435,6 +438,29 @@ func runDoctorWith(ctx context.Context, controller serviceController, controller
 		return errors.New("doctor found a blocking problem")
 	}
 	return nil
+}
+
+// remoteAccountImportChecks runs the same preflight `sr add` runs, so doctor
+// reports a server that cannot accept accounts before someone discovers it
+// halfway through an OAuth login. Both sides can drift: the client entry can
+// lack a credential, and the server can be configured without one.
+func remoteAccountImportChecks(
+	ctx context.Context,
+	store accounts.CodexStore,
+	client *http.Client,
+) []doctorCheck {
+	runner := srRunner{store: store, client: client, out: io.Discard, errOut: io.Discard}
+	server, ok, err := runner.selectedRemoteServer()
+	if err != nil {
+		return []doctorCheck{{"warn", "server account import", err.Error()}}
+	}
+	if !ok {
+		return nil
+	}
+	if err := runner.ensureServerAccountImportAvailable(ctx, server); err != nil {
+		return []doctorCheck{{"fail", "server account import", err.Error()}}
+	}
+	return []doctorCheck{{"ok", "server account import", server.Name}}
 }
 
 func doctorMark(status string) string {

--- a/internal/proxy/account_import_health_test.go
+++ b/internal/proxy/account_import_health_test.go
@@ -1,0 +1,75 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
+)
+
+func TestHealthReportsAccountImportState(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		adminToken  string
+		importToken string
+		want        string
+	}{
+		{name: "no credential configured", want: AccountImportDisabled},
+		{name: "admin token", adminToken: "secret", want: AccountImportEnabled},
+		{name: "import token", importToken: "secret", want: AccountImportEnabled},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ref := NewAccountRef(accounts.CodexStore{Dir: t.TempDir()}, nil, nil)
+			ref.claudeStore = agentclaude.Store{Dir: t.TempDir()}
+			handler := Server{
+				AccountRef:         ref,
+				AdminToken:         tc.adminToken,
+				AccountImportToken: tc.importToken,
+			}.Handler()
+
+			req := httptest.NewRequest(http.MethodGet, "/_subrouter/health", nil)
+			req.RemoteAddr = "100.64.0.20:4321"
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", resp.Code)
+			}
+			var body struct {
+				OK            bool   `json:"ok"`
+				AccountImport string `json:"account_import"`
+			}
+			if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode health: %v (%s)", err, resp.Body.String())
+			}
+			if !body.OK {
+				t.Fatalf("health ok = false, body = %s", resp.Body.String())
+			}
+			if body.AccountImport != tc.want {
+				t.Fatalf("account_import = %q, want %q", body.AccountImport, tc.want)
+			}
+		})
+	}
+}
+
+// A disabled report must mean the endpoint actually rejects imports, so the
+// health field and the authorization rule cannot drift apart.
+func TestHealthAccountImportStateMatchesAuthorization(t *testing.T) {
+	ref := NewAccountRef(accounts.CodexStore{Dir: t.TempDir()}, nil, nil)
+	ref.claudeStore = agentclaude.Store{Dir: t.TempDir()}
+	server := Server{AccountRef: ref}
+	if server.AccountImportState() != AccountImportDisabled {
+		t.Fatalf("state = %q, want %q", server.AccountImportState(), AccountImportDisabled)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/_subrouter/account-import", nil)
+	req.RemoteAddr = "100.64.0.20:4321"
+	resp := httptest.NewRecorder()
+	server.Handler().ServeHTTP(resp, req)
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("import status = %d, want 401 while state reports disabled", resp.Code)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -35,6 +35,12 @@ import (
 	"github.com/manaflow-ai/subrouter/session"
 )
 
+// Account import states reported by /_subrouter/health.
+const (
+	AccountImportEnabled  = "enabled"
+	AccountImportDisabled = "disabled"
+)
+
 type CredentialBroker interface {
 	Lease(context.Context, broker.LeaseRequest) (broker.Lease, error)
 	Report(context.Context, string, broker.LeaseReport) error
@@ -1027,7 +1033,21 @@ func normalizedCredentialBroker(value CredentialBroker) CredentialBroker {
 }
 
 func (s Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, map[string]any{"ok": true})
+	writeJSON(w, map[string]any{"ok": true, "account_import": s.AccountImportState()})
+}
+
+// AccountImportState reports whether this server can accept `sr add` uploads.
+// Account import denies every request when no credential is configured, and
+// nothing else on the server reflects that, so a host whose binary updated past
+// the credential requirement while its configuration stayed behind looks
+// healthy right up until someone tries to add an account.
+func (s Server) AccountImportState() string {
+	if s.tenantAccountImportAuthorized ||
+		strings.TrimSpace(s.AccountImportToken) != "" ||
+		strings.TrimSpace(s.AdminToken) != "" {
+		return AccountImportEnabled
+	}
+	return AccountImportDisabled
 }
 
 // handleStreamStats reports dropped response streams grouped by which side


### PR DESCRIPTION
## Why

A subrouter with no admin or account-import credential rejects every import, including `sr add`, and nothing reported it. Ordinary admin reads stayed open, `/_subrouter/health` stayed green, and the accounts already on disk kept serving traffic.

`cmux-lawrence` (a launchd Mac host) sat in exactly that state for two days: its worker autoupdates from GitHub releases and picked up #123, which made an unset token mean deny-all, while its LaunchDaemon configuration had no matching update path. The pool could be read and used, just never grown. It surfaced only when someone ran `sr add` and hit the client-side precheck.

## What

- `/_subrouter/health` reports `"account_import": "enabled"|"disabled"`, additive to the existing payload.
- The worker logs a warning at startup when import is disabled, naming the fix.
- `sr doctor` runs the same preflight `sr add` runs against the selected server, so a credential missing on either side is reported before an interactive OAuth login depends on it.

A test asserts the health field and the authorization rule cannot drift: when the state reads `disabled`, the endpoint must actually 401.

## Not in this PR

`sr server install` still only knows gcloud and systemd, so a launchd Mac host has no supported provisioning path and its tokens must be placed by hand. That is the underlying gap and is a separate change.

## Tests

`go test ./internal/proxy/ ./cmd/subrouter/` passes for the touched packages. `TestCreateVMTempFilesSurviveInterruptedAndRepeatedMacOSRuns` fails identically on a clean `origin/main` checkout here (gcloud-dependent, times out at 5s), so it is pre-existing and unrelated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788523392&installation_model_id=21920&pr_number=170&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F170&signature=c32f59d4103c2330c41235eb3d6336f1fe5639e4d81f2f8851574c415170450f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose and warn when a server cannot accept account imports, so misconfigured hosts are visible before `sr add` fails. This makes the capability clear via health, CLI checks, and a startup warning.

- **New Features**
  - `/_subrouter/health` now returns `"account_import": "enabled" | "disabled"`.
  - The worker logs a startup warning when imports are disabled, with a fix hint: set `SUBROUTER_ACCOUNT_IMPORT_TOKEN_FILE` and `SUBROUTER_ADMIN_TOKEN_FILE`, or run `sr server install <name>`.
  - `sr doctor` runs the same preflight as `sr add` against the selected server and reports missing or rejected credentials on either side.

<sup>Written for commit 3f0de87fdb1076842a8a293fe8006c4ddb639fe9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

