### PR TITLE
Install and rotate server credentials on non-GCP hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,15 @@ When `SUBROUTER_ADMIN_TOKEN` or `--admin-token` is set, non-loopback requests to
 
 A server with neither credential configured rejects every account import, including `sr add`. That state is reported as `"account_import": "disabled"` by `/_subrouter/health` and logged as a warning at startup, and `sr doctor` runs the same preflight `sr add` runs against the selected server.
 
+`sr server install <name>` provisions those credentials for you and keeps both sides in step. It reaches a GCP instance through gcloud, and any other machine through SSH:
+
+```bash
+sr server add mac-mini --url http://100.64.0.9:31415 --ssh-host worker@mac-mini
+sr server install mac-mini
+```
+
+On the host that resolves to `sudo sr install-systemd` on Linux and `sudo sr install-launchd` on macOS. `install-launchd` provisions credentials into an existing LaunchDaemon rather than creating the service: it writes the tokens to 0600 files owned by the service user, points `SUBROUTER_ADMIN_TOKEN_FILE` and `SUBROUTER_ACCOUNT_IMPORT_TOKEN_FILE` at them, and reloads the job. Every other key in the plist is left alone, so a host keeps its supervisor layout, service user, and per-host flags across a credential rotation. Build the service itself with [deploy/macos/migrate-launchdaemon-to-supervisor.sh](deploy/macos/migrate-launchdaemon-to-supervisor.sh) first.
+
 ## GCP deployment
 
 See [deploy/gcp/README.md](deploy/gcp/README.md) for the small GCP + Tailscale Subrouter deployment flow.

--- a/cmd/subrouter/install_launchd.go
+++ b/cmd/subrouter/install_launchd.go
@@ -1,0 +1,350 @@
+package main
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	defaultLaunchdServerLabel  = "ai.manaflow.subrouter-team"
+	defaultLaunchdStateDir     = "/var/lib/subrouter"
+	adminTokenFileName         = "admin-token"
+	accountImportTokenFileName = "account-import-token"
+	plistBuddyPath             = "/usr/libexec/PlistBuddy"
+)
+
+// launchdConfig provisions server control credentials into an existing macOS
+// LaunchDaemon. Unlike install-systemd this does not create the service: a
+// shared macOS host is built once (service user, supervisor layout, pf rules,
+// log rotation) and from then on only its credentials change.
+type launchdConfig struct {
+	Label              string
+	PlistPath          string
+	StateDir           string
+	AdminToken         string
+	AccountImportToken string
+	HealthURL          string
+	Start              bool
+	DryRun             bool
+}
+
+func installLaunchd(args []string) error {
+	return installLaunchdWithInput(args, os.Stdin, os.Stdout)
+}
+
+func installLaunchdWithInput(args []string, input io.Reader, out io.Writer) error {
+	config := launchdConfig{}
+	flags := flag.NewFlagSet("install-launchd", flag.ContinueOnError)
+	flags.StringVar(&config.Label, "label", defaultLaunchdServerLabel, "LaunchDaemon label")
+	flags.StringVar(&config.PlistPath, "plist", "", "LaunchDaemon plist path; defaults to /Library/LaunchDaemons/<label>.plist")
+	flags.StringVar(&config.StateDir, "state-dir", defaultLaunchdStateDir, "service state directory that holds the credential files")
+	flags.StringVar(&config.AdminToken, "admin-token", "", "admin token required for non-loopback _subrouter endpoints")
+	adminTokenStdin := flags.Bool("admin-token-stdin", false, "read the admin token from standard input without exposing it in process arguments")
+	flags.StringVar(&config.AccountImportToken, "account-import-token", "", "token limited to protected account import")
+	accountImportTokenStdin := flags.Bool("account-import-token-stdin", false, "read the account import token from standard input without exposing it in process arguments")
+	flags.StringVar(&config.HealthURL, "health-url", "http://127.0.0.1:31415/_subrouter/health", "health endpoint polled after the service reloads")
+	flags.BoolVar(&config.Start, "start", true, "reload the LaunchDaemon so the new credentials take effect")
+	flags.BoolVar(&config.DryRun, "dry-run", false, "print the planned changes without writing files")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *adminTokenStdin && strings.TrimSpace(config.AdminToken) != "" {
+		return errors.New("--admin-token and --admin-token-stdin cannot be used together")
+	}
+	if *accountImportTokenStdin && strings.TrimSpace(config.AccountImportToken) != "" {
+		return errors.New("--account-import-token and --account-import-token-stdin cannot be used together")
+	}
+	requestedTokens := 0
+	if *adminTokenStdin {
+		requestedTokens++
+	}
+	if *accountImportTokenStdin {
+		requestedTokens++
+	}
+	if requestedTokens > 0 {
+		tokens, err := readSystemdTokens(input, requestedTokens)
+		if err != nil {
+			return err
+		}
+		index := 0
+		if *adminTokenStdin {
+			config.AdminToken = tokens[index]
+			index++
+		}
+		if *accountImportTokenStdin {
+			config.AccountImportToken = tokens[index]
+		}
+	}
+	if runtime.GOOS != "darwin" && !config.DryRun {
+		return errors.New("install-launchd is macOS-only")
+	}
+	return installLaunchdWithConfig(config, commandRunner{}, out)
+}
+
+func (c launchdConfig) plistPath() string {
+	if strings.TrimSpace(c.PlistPath) != "" {
+		return c.PlistPath
+	}
+	return filepath.Join("/Library/LaunchDaemons", c.Label+".plist")
+}
+
+func (c launchdConfig) adminTokenPath() string {
+	return filepath.Join(c.StateDir, adminTokenFileName)
+}
+
+func (c launchdConfig) accountImportTokenPath() string {
+	return filepath.Join(c.StateDir, accountImportTokenFileName)
+}
+
+func validateLaunchdConfig(config launchdConfig) error {
+	if strings.TrimSpace(config.Label) == "" {
+		return errors.New("--label is required")
+	}
+	if strings.TrimSpace(config.StateDir) == "" || !filepath.IsAbs(config.StateDir) {
+		return errors.New("--state-dir must be an absolute path")
+	}
+	if strings.TrimSpace(config.AdminToken) == "" {
+		return errors.New("an admin token is required")
+	}
+	if strings.TrimSpace(config.AccountImportToken) == "" {
+		return errors.New("an account import token is required")
+	}
+	return nil
+}
+
+// launchdPlistCommands is the surgical patch applied to an existing plist:
+// point the service at credential files and drop any inline token values, which
+// the server rejects when both a value and a file are set. PlistBuddy edits in
+// place, so every unrelated key (ProgramArguments, UserName, KeepAlive, the
+// Bedrock flags a host may carry) survives untouched.
+func launchdPlistCommands(config launchdConfig) []string {
+	commands := []string{}
+	for _, key := range []string{
+		"SUBROUTER_ADMIN_TOKEN",
+		"SUBROUTER_ACCOUNT_IMPORT_TOKEN",
+		"SUBROUTER_ADMIN_TOKEN_FILE",
+		"SUBROUTER_ACCOUNT_IMPORT_TOKEN_FILE",
+	} {
+		commands = append(commands, "Delete :EnvironmentVariables:"+key)
+	}
+	commands = append(commands,
+		"Add :EnvironmentVariables:SUBROUTER_ADMIN_TOKEN_FILE string "+config.adminTokenPath(),
+		"Add :EnvironmentVariables:SUBROUTER_ACCOUNT_IMPORT_TOKEN_FILE string "+config.accountImportTokenPath(),
+	)
+	return commands
+}
+
+func installLaunchdWithConfig(config launchdConfig, runner commandRunner, out io.Writer) error {
+	if err := validateLaunchdConfig(config); err != nil {
+		return err
+	}
+	plist := config.plistPath()
+	if config.DryRun {
+		fmt.Fprintf(out, "plist %s\n", plist)
+		fmt.Fprintf(out, "%s (0600)\n", config.adminTokenPath())
+		fmt.Fprintf(out, "%s (0600)\n", config.accountImportTokenPath())
+		for _, command := range launchdPlistCommands(config) {
+			fmt.Fprintf(out, "PlistBuddy -c %q\n", command)
+		}
+		return nil
+	}
+	if os.Geteuid() != 0 {
+		return errors.New("install-launchd must run as root; use sudo")
+	}
+	if _, err := os.Stat(plist); err != nil {
+		return fmt.Errorf(
+			"no LaunchDaemon at %s; build the host first with deploy/macos/migrate-launchdaemon-to-supervisor.sh, then rerun: %w",
+			plist, err,
+		)
+	}
+	owner, err := plistServiceUser(plist, runner)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(config.StateDir, 0o750); err != nil {
+		return err
+	}
+	for path, token := range map[string]string{
+		config.adminTokenPath():         config.AdminToken,
+		config.accountImportTokenPath(): config.AccountImportToken,
+	} {
+		if err := writeCredentialFile(path, token, owner, runner); err != nil {
+			return err
+		}
+	}
+	for _, command := range launchdPlistCommands(config) {
+		// Delete fails when the key is absent, which is the normal first run.
+		if strings.HasPrefix(command, "Delete ") {
+			_ = runner.Run(plistBuddyPath, "-c", command, plist)
+			continue
+		}
+		if err := runner.Run(plistBuddyPath, "-c", command, plist); err != nil {
+			return err
+		}
+	}
+	if err := runner.Run("plutil", "-lint", plist); err != nil {
+		return fmt.Errorf("patched plist is invalid: %w", err)
+	}
+	fmt.Fprintf(out, "Provisioned server credentials in %s\n", plist)
+	if !config.Start {
+		fmt.Fprintf(out, "Reload the service to apply them: launchctl bootout system/%s && launchctl bootstrap system %s\n", config.Label, plist)
+		return nil
+	}
+	return reloadLaunchdService(config, runner, out)
+}
+
+// plistServiceUser reads UserName from a LaunchDaemon so credential files land
+// with the same owner the service runs as. An empty result means the daemon
+// runs as root and no chown is needed.
+func plistServiceUser(path string, _ commandRunner) (string, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	user, found, err := plistTopLevelString(body, "UserName")
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w; convert it with 'plutil -convert xml1 %s'", path, err, path)
+	}
+	if !found {
+		return "", nil
+	}
+	return user, nil
+}
+
+// plistTopLevelString returns a string value from the plist's root dictionary.
+// It reads only the root level, so a matching key nested inside
+// EnvironmentVariables or another dictionary is never mistaken for it.
+func plistTopLevelString(body []byte, wanted string) (string, bool, error) {
+	decoder := xml.NewDecoder(bytes.NewReader(body))
+	depth := 0
+	pendingKey := ""
+	currentElement := ""
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return "", false, nil
+		}
+		if err != nil {
+			return "", false, err
+		}
+		switch element := token.(type) {
+		case xml.StartElement:
+			currentElement = element.Name.Local
+			switch element.Name.Local {
+			case "dict", "array":
+				depth++
+			}
+		case xml.EndElement:
+			currentElement = ""
+			switch element.Name.Local {
+			case "dict", "array":
+				depth--
+			}
+		case xml.CharData:
+			if depth != 1 {
+				continue
+			}
+			switch currentElement {
+			case "key":
+				pendingKey = strings.TrimSpace(string(element))
+			case "string":
+				if pendingKey == wanted {
+					return strings.TrimSpace(string(element)), true, nil
+				}
+				pendingKey = ""
+			}
+		}
+	}
+}
+
+// reloadLaunchdService applies the patched plist. launchctl kill reuses the
+// cached job definition, so new EnvironmentVariables need a full
+// bootout/bootstrap. bootout honours ExitTimeOut, and a supervisor drains
+// in-flight streams with its public listener already closed, so waiting for a
+// clean exit can mean minutes of downtime on a busy router. Escalate to SIGKILL
+// after a short grace instead: the streams die either way, and this bounds the
+// outage to seconds.
+func reloadLaunchdService(config launchdConfig, runner commandRunner, out io.Writer) error {
+	service := "system/" + config.Label
+	bootout := exec.Command("launchctl", "bootout", service)
+	if err := bootout.Start(); err != nil {
+		return err
+	}
+	done := make(chan error, 1)
+	go func() { done <- bootout.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(launchdBootoutGrace):
+		fmt.Fprintf(out, "still draining after %s; stopping %s\n", launchdBootoutGrace, config.Label)
+		_ = runner.Run("launchctl", "kill", "KILL", service)
+		<-done
+	}
+	if err := runner.Run("launchctl", "bootstrap", "system", config.plistPath()); err != nil {
+		return fmt.Errorf("bootstrap %s: %w", config.Label, err)
+	}
+	if err := waitForLaunchdHealth(config.HealthURL); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "Reloaded %s\n", config.Label)
+	return nil
+}
+
+const (
+	launchdBootoutGrace = 10 * time.Second
+	launchdHealthWait   = 60 * time.Second
+)
+
+func waitForLaunchdHealth(healthURL string) error {
+	if strings.TrimSpace(healthURL) == "" {
+		return nil
+	}
+	client := &http.Client{Timeout: 2 * time.Second}
+	deadline := time.Now().Add(launchdHealthWait)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		res, err := client.Get(healthURL)
+		if err == nil {
+			_ = res.Body.Close()
+			if res.StatusCode >= 200 && res.StatusCode < 300 {
+				return nil
+			}
+			lastErr = fmt.Errorf("health returned %s", res.Status)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("service did not answer %s within %s: %w", healthURL, launchdHealthWait, lastErr)
+}
+
+// writeCredentialFile writes a token 0600 and hands it to the service user, so
+// the daemon can read it and other local accounts cannot. The file is replaced
+// atomically: a half-written credential would fail closed on the next start.
+func writeCredentialFile(path, token, owner string, runner commandRunner) error {
+	temporary := path + ".new"
+	if err := os.WriteFile(temporary, []byte(strings.TrimSpace(token)+"\n"), 0o600); err != nil {
+		return err
+	}
+	if strings.TrimSpace(owner) != "" {
+		if err := runner.Run("chown", owner, temporary); err != nil {
+			_ = os.Remove(temporary)
+			return err
+		}
+	}
+	if err := os.Rename(temporary, path); err != nil {
+		_ = os.Remove(temporary)
+		return err
+	}
+	return nil
+}

--- a/cmd/subrouter/install_launchd_test.go
+++ b/cmd/subrouter/install_launchd_test.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testLaunchDaemonPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/var/lib/subrouter</string>
+		<key>SUBROUTER_STATE_DIR</key>
+		<string>/var/lib/subrouter</string>
+		<key>UserName</key>
+		<string>decoy-inside-a-nested-dict</string>
+	</dict>
+	<key>KeepAlive</key>
+	<true/>
+	<key>Label</key>
+	<string>ai.manaflow.subrouter-team</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/libexec/subrouter-supervisor</string>
+		<string>supervise</string>
+		<string>--addr</string>
+		<string>0.0.0.0:31415</string>
+		<string>--worker-bin</string>
+		<string>/usr/local/bin/subrouter</string>
+		<string>--</string>
+		<string>--bedrock</string>
+		<string>--bedrock-profiles</string>
+		<string>aw1</string>
+	</array>
+	<key>UserName</key>
+	<string>_subrouter</string>
+</dict>
+</plist>
+`
+
+func TestPlistTopLevelStringIgnoresNestedKeys(t *testing.T) {
+	user, found, err := plistTopLevelString([]byte(testLaunchDaemonPlist), "UserName")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("UserName not found")
+	}
+	if user != "_subrouter" {
+		t.Fatalf("UserName = %q, want _subrouter (the nested value must not win)", user)
+	}
+}
+
+func TestPlistTopLevelStringReportsMissingKey(t *testing.T) {
+	_, found, err := plistTopLevelString([]byte(testLaunchDaemonPlist), "GroupName")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Fatal("GroupName should not be found")
+	}
+}
+
+func TestLaunchdPlistCommandsReplaceInlineTokensWithFiles(t *testing.T) {
+	config := launchdConfig{
+		Label:              defaultLaunchdServerLabel,
+		StateDir:           "/var/lib/subrouter",
+		AdminToken:         "admin",
+		AccountImportToken: "import",
+	}
+	commands := strings.Join(launchdPlistCommands(config), "\n")
+
+	for _, want := range []string{
+		"Delete :EnvironmentVariables:SUBROUTER_ADMIN_TOKEN",
+		"Delete :EnvironmentVariables:SUBROUTER_ACCOUNT_IMPORT_TOKEN",
+		"Add :EnvironmentVariables:SUBROUTER_ADMIN_TOKEN_FILE string /var/lib/subrouter/admin-token",
+		"Add :EnvironmentVariables:SUBROUTER_ACCOUNT_IMPORT_TOKEN_FILE string /var/lib/subrouter/account-import-token",
+	} {
+		if !strings.Contains(commands, want) {
+			t.Fatalf("commands missing %q:\n%s", want, commands)
+		}
+	}
+	// The token values themselves belong in files, never in the plist, which is
+	// world readable.
+	if strings.Contains(commands, "admin") && strings.Contains(commands, "string admin\n") {
+		t.Fatalf("commands leaked a token value:\n%s", commands)
+	}
+}
+
+func TestValidateLaunchdConfigRequiresBothTokens(t *testing.T) {
+	base := launchdConfig{Label: "x", StateDir: "/var/lib/subrouter"}
+	for name, config := range map[string]launchdConfig{
+		"no tokens": base,
+		"admin only": func() launchdConfig {
+			c := base
+			c.AdminToken = "a"
+			return c
+		}(),
+		"import only": func() launchdConfig {
+			c := base
+			c.AccountImportToken = "i"
+			return c
+		}(),
+		"relative state dir": {Label: "x", StateDir: "relative", AdminToken: "a", AccountImportToken: "i"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := validateLaunchdConfig(config); err == nil {
+				t.Fatal("expected validation to fail")
+			}
+		})
+	}
+	full := base
+	full.AdminToken = "a"
+	full.AccountImportToken = "i"
+	if err := validateLaunchdConfig(full); err != nil {
+		t.Fatalf("valid config rejected: %v", err)
+	}
+}
+
+func TestInstallLaunchdDryRunPrintsPlanWithoutTouchingTheHost(t *testing.T) {
+	var out bytes.Buffer
+	config := launchdConfig{
+		Label:              defaultLaunchdServerLabel,
+		PlistPath:          filepath.Join(t.TempDir(), "absent.plist"),
+		StateDir:           "/var/lib/subrouter",
+		AdminToken:         "admin",
+		AccountImportToken: "import",
+		DryRun:             true,
+	}
+	if err := installLaunchdWithConfig(config, commandRunner{}, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "/var/lib/subrouter/account-import-token (0600)") {
+		t.Fatalf("dry run did not describe the credential files:\n%s", out.String())
+	}
+	if _, err := os.Stat(config.PlistPath); !os.IsNotExist(err) {
+		t.Fatal("dry run created the plist")
+	}
+}
+
+// The patch has to be surgical: a host carries flags nobody remembers (Bedrock
+// profiles, KeepAlive, its service user), and losing them on a credential
+// rotation is how a routine change turns into an outage.
+func TestPlistBuddyPatchPreservesEverythingElse(t *testing.T) {
+	if _, err := os.Stat(plistBuddyPath); err != nil {
+		t.Skipf("PlistBuddy unavailable: %v", err)
+	}
+	plist := filepath.Join(t.TempDir(), "ai.manaflow.subrouter-team.plist")
+	if err := os.WriteFile(plist, []byte(testLaunchDaemonPlist), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	config := launchdConfig{
+		Label:              defaultLaunchdServerLabel,
+		PlistPath:          plist,
+		StateDir:           "/var/lib/subrouter",
+		AdminToken:         "admin",
+		AccountImportToken: "import",
+	}
+	runner := commandRunner{}
+	for _, command := range launchdPlistCommands(config) {
+		if strings.HasPrefix(command, "Delete ") {
+			_ = runner.Run(plistBuddyPath, "-c", command, plist)
+			continue
+		}
+		if err := runner.Run(plistBuddyPath, "-c", command, plist); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := runner.Run("plutil", "-lint", plist); err != nil {
+		t.Fatalf("patched plist is invalid: %v", err)
+	}
+
+	patched, err := exec.Command("plutil", "-convert", "xml1", "-o", "-", plist).Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(patched)
+	for _, want := range []string{
+		"SUBROUTER_ADMIN_TOKEN_FILE",
+		"/var/lib/subrouter/admin-token",
+		"SUBROUTER_ACCOUNT_IMPORT_TOKEN_FILE",
+		"/var/lib/subrouter/account-import-token",
+		"--bedrock-profiles",
+		"<string>aw1</string>",
+		"<key>KeepAlive</key>",
+		"<string>_subrouter</string>",
+		"<string>/usr/local/libexec/subrouter-supervisor</string>",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("patched plist lost %q:\n%s", want, body)
+		}
+	}
+	user, found, err := plistTopLevelString(patched, "UserName")
+	if err != nil || !found || user != "_subrouter" {
+		t.Fatalf("service user after patch = %q (found=%v, err=%v)", user, found, err)
+	}
+}
+
+func TestWriteCredentialFileIsPrivateAndAtomic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, adminTokenFileName)
+	if err := writeCredentialFile(path, "  secret\n", "", commandRunner{}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("mode = %o, want 600", info.Mode().Perm())
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "secret\n" {
+		t.Fatalf("body = %q, want the trimmed token", string(body))
+	}
+	if _, err := os.Stat(path + ".new"); !os.IsNotExist(err) {
+		t.Fatal("temporary credential file survived")
+	}
+}

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -160,6 +160,8 @@ func runForProgram(program string, args []string) error {
 		return installDaemon(args[1:])
 	case "install-systemd":
 		return installSystemd(args[1:])
+	case "install-launchd":
+		return installLaunchd(args[1:])
 	case "help", "-h", "--help":
 		usage(program)
 		return nil
@@ -1330,6 +1332,7 @@ Usage:
   %[1]s codex [codex args...]
   %[1]s install-daemon [--start=true]       macOS LaunchAgent
   %[1]s install-systemd [--start=true]      Linux systemd service
+  %[1]s install-launchd [--start=true]      macOS shared-server credentials
 
 Session stickiness:
   Prefer sending X-Subrouter-Session per conversation.

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -67,14 +67,14 @@ This machine's daemon:
 
 Named servers:
   %[1]s list
-  %[1]s add <name> --url <url> [--default] [--admin-token <token>] [--account-import-token <token>] [--tenant-key srt_<hex>] [--gcp-instance <name> --gcp-zone <zone> --gcp-project <project>]
+  %[1]s add <name> --url <url> [--default] [--admin-token <token>] [--account-import-token <token>] [--tenant-key srt_<hex>] [--ssh-host <user@host>] [--gcp-instance <name> --gcp-zone <zone> --gcp-project <project>]
   %[1]s use <name|local> [--no-codex-config]
   %[1]s current
   %[1]s clear-default
   %[1]s rename <old> <new>
   %[1]s remove <name>
   %[1]s status <name>            Usage for a named remote server
-  %[1]s install <name> [--version latest]
+  %[1]s install <name> [--version latest]   Install or rotate credentials over gcloud or --ssh-host
   %[1]s login <name> [--device-auth]
   %[1]s sync <name> [--device-auth] [--all] [--email <email>] [--dry-run] [--yes]
 
@@ -113,6 +113,11 @@ type srServerConfig struct {
 	// AccountImportToken grants only protected HTTP account import. Keeping it
 	// separate prevents a self-service login from gaining administrator access.
 	AccountImportToken string `json:"accountImportToken,omitempty"`
+	// SSHHost installs and rotates credentials on a host that is reachable over
+	// plain SSH rather than through gcloud, such as a macOS worker on a
+	// Tailscale network. It is the install transport only; ordinary traffic and
+	// account import always go through URL.
+	SSHHost string `json:"sshHost,omitempty"`
 	// TenantKey scopes this entry to one tenant on a multi-tenant server:
 	// base URLs gain a /t/<key> prefix, _subrouter reads go through the
 	// tenant-scoped endpoints, and account uploads land in the tenant dir.
@@ -419,7 +424,7 @@ func (r srRunner) serverList(store srServerStore) error {
 func (r srRunner) serverAdd(store srServerStore, args []string) error {
 	command := r.serverCommand()
 	if len(args) == 0 {
-		return fmt.Errorf("usage: %s add <name> --url <url> [--default] [--admin-token <token>] [--account-import-token <token>] [--gcp-instance <name> --gcp-zone <zone> --gcp-project <project>] [--no-codex-config]", command)
+		return fmt.Errorf("usage: %s add <name> --url <url> [--default] [--admin-token <token>] [--account-import-token <token>] [--ssh-host <user@host>] [--gcp-instance <name> --gcp-zone <zone> --gcp-project <project>] [--no-codex-config]", command)
 	}
 	name := args[0]
 	if isBuiltInRemoteName(name) {
@@ -431,6 +436,7 @@ func (r srRunner) serverAdd(store srServerStore, args []string) error {
 	gcpProject := flags.String("gcp-project", "", "GCP project; defaults to current gcloud project")
 	gcpZone := flags.String("gcp-zone", "", "GCP zone")
 	gcpInstance := flags.String("gcp-instance", "", "GCP instance name")
+	sshHost := flags.String("ssh-host", "", "SSH destination used by server install for hosts that are not GCP instances, such as user@mac-mini")
 	adminToken := flags.String("admin-token", "", "admin token for non-loopback _subrouter endpoints")
 	accountImportToken := flags.String("account-import-token", "", "token limited to protected HTTP account import")
 	tenantKey := flags.String("tenant-key", "", "tenant key (srt_...) scoping this entry to one tenant on a multi-tenant server")
@@ -442,7 +448,11 @@ func (r srRunner) serverAdd(store srServerStore, args []string) error {
 	adminTokenSet := false
 	accountImportTokenSet := false
 	tenantKeySet := false
+	sshHostSet := false
 	flags.Visit(func(flag *flag.Flag) {
+		if flag.Name == "ssh-host" {
+			sshHostSet = true
+		}
 		if flag.Name == "admin-token" {
 			adminTokenSet = true
 		}
@@ -471,6 +481,7 @@ func (r srRunner) serverAdd(store srServerStore, args []string) error {
 		GCPProject:         *gcpProject,
 		GCPZone:            *gcpZone,
 		GCPInstance:        *gcpInstance,
+		SSHHost:            strings.TrimSpace(*sshHost),
 		AdminToken:         *adminToken,
 		AccountImportToken: strings.TrimSpace(*accountImportToken),
 		TenantKey:          strings.TrimSpace(*tenantKey),
@@ -487,6 +498,9 @@ func (r srRunner) serverAdd(store srServerStore, args []string) error {
 				}
 				if !tenantKeySet {
 					next.TenantKey = file.Servers[i].TenantKey
+				}
+				if !sshHostSet {
+					next.SSHHost = file.Servers[i].SSHHost
 				}
 				file.Servers[i] = next
 				replaced = true
@@ -1280,12 +1294,19 @@ func (r srRunner) serverInstall(ctx context.Context, store srServerStore, args [
 	if !ok {
 		return fmt.Errorf("server %q not found", name)
 	}
-	if server.GCPInstance == "" || server.GCPZone == "" {
-		return fmt.Errorf("server %s has no GCP target", server.Name)
+	hasGCPTarget := server.GCPInstance != "" && server.GCPZone != ""
+	if !hasGCPTarget && strings.TrimSpace(server.SSHHost) == "" {
+		return fmt.Errorf(
+			"server %s has no install target; add a GCP instance, or an SSH host for a self-managed machine: %s add %s --url %s --ssh-host <user@host>",
+			server.Name, command, server.Name, server.URL,
+		)
 	}
 	server, err = ensureServerControlTokens(store, server)
 	if err != nil {
 		return err
+	}
+	if !hasGCPTarget {
+		return r.installServerOverSSH(ctx, server, *version)
 	}
 	remoteCommand := strings.Join([]string{
 		"set -eu",
@@ -1308,6 +1329,45 @@ func (r srRunner) serverInstall(ctx context.Context, store srServerStore, args [
 	}
 	fmt.Fprintf(r.out, "Installed Subrouter server: %s\n", server.Name)
 	return nil
+}
+
+// installServerOverSSH provisions a self-managed host, such as a macOS worker
+// on a Tailscale network, over plain SSH. The GCP path owns creating a machine;
+// this path owns the part that has to happen repeatedly on a machine that
+// already exists, which is updating the binary and rotating the credentials the
+// server needs before it will accept `sr add`.
+//
+// Both tokens go over stdin so they never appear in remote process arguments.
+func (r srRunner) installServerOverSSH(ctx context.Context, server srServerConfig, version string) error {
+	remoteCommand := serverSSHInstallScript(version)
+	stdin := strings.NewReader(server.AdminToken + "\n" + server.AccountImportToken + "\n")
+	sshArgs := []string{"-o", "BatchMode=yes", server.SSHHost, remoteCommand}
+	if err := r.commandRunner().Run(ctx, "ssh", sshArgs, stdin, r.out, r.errOut); err != nil {
+		return fmt.Errorf("install server %s over ssh: %w", server.Name, err)
+	}
+	fmt.Fprintf(r.out, "Installed Subrouter server: %s\n", server.Name)
+	return nil
+}
+
+// serverSSHInstallScript reads both tokens from stdin, installs the release
+// binary, and hands the tokens to the platform installer without ever writing
+// them to a remote file or argument list.
+func serverSSHInstallScript(version string) string {
+	return strings.Join([]string{
+		"set -eu",
+		"admin_token=''",
+		"account_import_token=''",
+		"read -r admin_token",
+		"read -r account_import_token",
+		"curl -fsSL " + shellQuote(publicInstallScriptURL) + " | sudo env SUBROUTER_VERSION=" + shellQuote(version) + " sh",
+		"case \"$(uname -s)\" in",
+		"Darwin) installer=install-launchd ;;",
+		"*) installer=install-systemd ;;",
+		"esac",
+		"printf '%s\\n%s\\n' \"$admin_token\" \"$account_import_token\" | sudo /usr/local/bin/sr \"$installer\" --admin-token-stdin --account-import-token-stdin",
+		"i=0; until curl -fsS http://127.0.0.1:31415/_subrouter/health >/dev/null 2>&1; do i=$((i+1)); if [ \"$i\" -ge 30 ]; then exit 1; fi; sleep 1; done",
+		"/usr/local/bin/sr --help >/dev/null",
+	}, "\n")
 }
 
 func ensureServerControlTokens(store srServerStore, server srServerConfig) (srServerConfig, error) {

--- a/cmd/subrouter/sr_server_install_ssh_test.go
+++ b/cmd/subrouter/sr_server_install_ssh_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+// stdinCapturingRunner records commands with their standard input, so a test
+// can prove a credential travelled over stdin rather than in argv.
+type stdinCapturingRunner struct {
+	mu       sync.Mutex
+	commands [][]string
+	stdins   []string
+}
+
+func (r *stdinCapturingRunner) Run(ctx context.Context, name string, args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
+	return r.RunWithEnv(ctx, name, args, nil, stdin, stdout, stderr)
+}
+
+func (r *stdinCapturingRunner) RunWithEnv(_ context.Context, name string, args []string, _ []string, stdin io.Reader, _ io.Writer, _ io.Writer) error {
+	body := ""
+	if stdin != nil {
+		raw, _ := io.ReadAll(stdin)
+		body = string(raw)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.commands = append(r.commands, append([]string{name}, args...))
+	r.stdins = append(r.stdins, body)
+	return nil
+}
+
+func (r *stdinCapturingRunner) Output(context.Context, string, []string) ([]byte, error) {
+	return nil, nil
+}
+
+func TestServerInstallWithoutAnyTargetNamesBothOptions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	store := accounts.DefaultCodexStore()
+	if err := defaultSRServerStore(store).save(srServerFile{
+		Servers: []srServerConfig{{Name: "mac-mini", URL: "http://100.64.0.9:31415"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	runner := srRunner{program: "sr", store: store, in: strings.NewReader(""), out: &out, errOut: &out}
+	err := runner.run(context.Background(), []string{"server", "install", "mac-mini"})
+	if err == nil {
+		t.Fatal("expected install to fail without a target")
+	}
+	if !strings.Contains(err.Error(), "--ssh-host") {
+		t.Fatalf("error did not offer the SSH option: %v", err)
+	}
+}
+
+func TestServerInstallOverSSHSendsTokensOnStdin(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	store := accounts.DefaultCodexStore()
+	if err := defaultSRServerStore(store).save(srServerFile{
+		Servers: []srServerConfig{{
+			Name:    "mac-mini",
+			URL:     "http://100.64.0.9:31415",
+			SSHHost: "worker@mac-mini",
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	fake := &stdinCapturingRunner{}
+	runner := srRunner{program: "sr", store: store, in: strings.NewReader(""), out: &out, errOut: &out, cmd: fake}
+	if err := runner.run(context.Background(), []string{"server", "install", "mac-mini"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(fake.commands) != 1 {
+		t.Fatalf("commands = %#v, want one ssh invocation", fake.commands)
+	}
+	command := fake.commands[0]
+	if command[0] != "ssh" {
+		t.Fatalf("command = %q, want ssh", command[0])
+	}
+	if !containsString(command, "worker@mac-mini") {
+		t.Fatalf("ssh destination missing: %#v", command)
+	}
+	script := command[len(command)-1]
+	if !strings.Contains(script, "install-launchd") || !strings.Contains(script, "Darwin)") {
+		t.Fatalf("remote script does not select the macOS installer:\n%s", script)
+	}
+	if !strings.Contains(script, "--admin-token-stdin") || !strings.Contains(script, "--account-import-token-stdin") {
+		t.Fatalf("remote script does not read tokens from stdin:\n%s", script)
+	}
+
+	server, ok, err := defaultSRServerStore(store).find("mac-mini")
+	if err != nil || !ok {
+		t.Fatalf("server lookup failed: %v", err)
+	}
+	if server.AdminToken == "" || server.AccountImportToken == "" {
+		t.Fatal("install did not generate and persist both control tokens")
+	}
+	if server.AdminToken == server.AccountImportToken {
+		t.Fatal("admin and account import tokens must differ")
+	}
+	// The tokens must reach the host over stdin only. Anything in argv is
+	// visible in the remote process list.
+	for _, secret := range []string{server.AdminToken, server.AccountImportToken} {
+		for _, argument := range command {
+			if strings.Contains(argument, secret) {
+				t.Fatalf("token leaked into ssh arguments: %#v", command)
+			}
+		}
+		if !strings.Contains(fake.stdins[0], secret) {
+			t.Fatalf("token was not sent on stdin: %q", fake.stdins[0])
+		}
+	}
+	if strings.Contains(out.String(), server.AdminToken) {
+		t.Fatalf("install printed a token:\n%s", out.String())
+	}
+}
+
+func TestServerAddPreservesSSHHostOnUpdate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	store := accounts.DefaultCodexStore()
+
+	var out bytes.Buffer
+	runner := srRunner{program: "sr", store: store, in: strings.NewReader(""), out: &out, errOut: &out}
+	if err := runner.run(context.Background(), []string{
+		"server", "add", "mac-mini",
+		"--url", "http://100.64.0.9:31415",
+		"--ssh-host", "worker@mac-mini",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := runner.run(context.Background(), []string{
+		"server", "add", "mac-mini",
+		"--url", "http://100.64.0.10:31415",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	server, ok, err := defaultSRServerStore(store).find("mac-mini")
+	if err != nil || !ok {
+		t.Fatalf("server lookup failed: %v", err)
+	}
+	if server.SSHHost != "worker@mac-mini" {
+		t.Fatalf("ssh host = %q, want it preserved across an update", server.SSHHost)
+	}
+	if server.URL != "http://100.64.0.10:31415" {
+		t.Fatalf("url = %q, want the updated value", server.URL)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Why

`sr server install` only knew gcloud and systemd. A self-managed machine, such as a macOS worker on a Tailscale network, failed with `no GCP target` and had to have its credentials placed by hand.

That is the root cause of the outage this pairs with: `cmux-lawrence` autoupdates its worker from GitHub releases and picked up #123, which made an unset token deny every account import, while its LaunchDaemon had no provisioning path that could follow. The binary moved, the configuration could not, and `sr add` was dead for two days.

## What

- `sr server add <name> --ssh-host user@host` records an SSH install transport, preserved across later `add` updates like the other credentials.
- `sr server install` uses SSH when the entry has no GCP instance, and the error when neither is set now names both options instead of only GCP.
- The remote script picks `install-systemd` or `install-launchd` from `uname`. Both tokens travel on stdin, so neither appears in a remote process list; a test asserts they are absent from argv and present on stdin.
- `install-launchd` provisions credentials into an *existing* LaunchDaemon rather than creating the service. A shared macOS host is built once (service user, supervisor layout, pf rules); after that only its credentials change. It writes 0600 token files owned by the service user, points `SUBROUTER_ADMIN_TOKEN_FILE` and `SUBROUTER_ACCOUNT_IMPORT_TOKEN_FILE` at them, and leaves every other plist key alone. With no daemon present it says so and names the migration script.

Reload escalates to `SIGKILL` after ten seconds. `launchctl kill` reuses the cached job definition, so new environment variables need a full bootout/bootstrap, and bootout honours `ExitTimeOut`: a draining supervisor holds its public listener closed for as long as its longest in-flight stream. Waiting politely there is minutes of downtime on a busy router; this bounds it to seconds.

## Verification on a real host

Run against `cmux-lawrence` with `--plist` pointed at a copy of its live LaunchDaemon and `--start=false`:

```
-rw-------  1 _subrouter  wheel  admin-token
-rw-------  1 _subrouter  wheel  account-import-token
<key>SUBROUTER_ACCOUNT_IMPORT_TOKEN_FILE</key>
<key>SUBROUTER_ADMIN_TOKEN_FILE</key>
```

The host's Bedrock arguments, `KeepAlive`, service user, and supervisor `Program` all survived, and the live plist hash was unchanged.

The remote half needs a release that contains `install-launchd`, so `sr server install` end to end over SSH works from the next release onward, not against v0.1.62.

## Tests

`go test ./cmd/... ./internal/...` passes apart from `TestCreateVMTempFilesSurviveInterruptedAndRepeatedMacOSRuns`, which fails identically on a clean `origin/main` checkout here. The PlistBuddy test skips where the tool is absent.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788523995&installation_model_id=21920&pr_number=171&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F171&signature=aa3d0ef369a1fb5e83c4cb109d466f6ce31c51a043818c430227561557090e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add SSH-based server install and macOS `install-launchd` to install and rotate server credentials on non-GCP hosts. This enables macOS/Tailscale workers and prevents outages when binaries update but credentials don’t.

- **New Features**
  - `sr server add --ssh-host user@host` stores an SSH target and preserves it on updates.
  - `sr server install` uses SSH when no GCP instance is set; error now suggests GCP and SSH options.
  - Remote script picks `install-systemd` or `install-launchd` via `uname`; tokens flow over stdin (never in argv).
  - New `install-launchd`: updates an existing LaunchDaemon only—writes 0600 token files (owned by service user), sets `SUBROUTER_*_TOKEN_FILE`, validates plist, reloads, and escalates to SIGKILL after 10s to bound downtime.
  - CLI help and README updated.

- **Migration**
  - For non-GCP hosts: `sr server add <name> --url <url> --ssh-host user@host` then `sr server install <name>`.
  - macOS: the service must already exist; build once with `deploy/macos/migrate-launchdaemon-to-supervisor.sh`. SSH installs work from the next release that includes `install-launchd`.

<sup>Written for commit c920629912d2065e1d40a24a50062c70523db6e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

