### PR TITLE
Keep a macOS client's CLI current

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ Subrouter is a local AI coding-agent proxy. It routes traffic across Codex accou
 
 ## Install
 
+### Keeping the CLI current on macOS
+
+A shared server autoupdates its worker. A laptop does not, so clients drift behind the servers they talk to and hit failures nobody can reproduce. Install the per-user updater once:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/manaflow-ai/subrouter/main/deploy/macos/install-cli-autoupdate.sh | bash
+```
+
+It installs a LaunchAgent that checks daily, compares the release tag against `~/.subrouter/cli-version`, and exits without downloading when they match. Updates go through `install.sh`, so the release checksum is verified, and a missing binary forces a reinstall even when the marker looks current. Logs land in `~/Library/Logs/subrouter-cli-autoupdate.log`. Remove it with `launchctl bootout gui/$(id -u)/ai.manaflow.subrouter-cli-autoupdate`.
+
 ### GCP setup prompt
 
 Paste this into Claude, Codex, or another coding agent with GCP operator access and a local browser for OAuth:

--- a/cmd/subrouter/cli_autoupdate_script_test.go
+++ b/cmd/subrouter/cli_autoupdate_script_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// cliAutoupdateFixture serves one release from disk, so the updater can be
+// exercised without GitHub.
+type cliAutoupdateFixture struct {
+	script      string
+	installDir  string
+	versionFile string
+	env         []string
+}
+
+func newCLIAutoupdateFixture(t *testing.T, tag string) cliAutoupdateFixture {
+	t.Helper()
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assetDir := t.TempDir()
+	version := strings.TrimPrefix(tag, "v")
+	asset := fmt.Sprintf("subrouter_%s_%s_%s", version, runtime.GOOS, releaseArchForTest(runtime.GOARCH))
+	// The updater runs the installed binary with --help, so the fixture release
+	// has to be executable rather than an inert blob.
+	body := []byte("#!/bin/sh\nexit 0\n")
+	if err := os.WriteFile(filepath.Join(assetDir, asset), body, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(body)
+	if err := os.WriteFile(
+		filepath.Join(assetDir, "SHA256SUMS"),
+		[]byte(fmt.Sprintf("%x  %s\n", sum, asset)),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	releaseJSON := filepath.Join(assetDir, "release.json")
+	if err := os.WriteFile(releaseJSON, []byte(fmt.Sprintf(`{"tag_name":%q}`, tag)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	installDir := filepath.Join(t.TempDir(), "bin")
+	versionFile := filepath.Join(t.TempDir(), "cli-version")
+	return cliAutoupdateFixture{
+		script:      filepath.Join(repoRoot, "deploy", "macos", "subrouter-cli-autoupdate.sh"),
+		installDir:  installDir,
+		versionFile: versionFile,
+		env: append(os.Environ(),
+			"SUBROUTER_RELEASE_API_URL=file://"+releaseJSON,
+			"SUBROUTER_INSTALL_URL=file://"+filepath.Join(repoRoot, "install.sh"),
+			"SUBROUTER_DOWNLOAD_BASE=file://"+assetDir,
+			"SUBROUTER_INSTALL_DIR="+installDir,
+			"SUBROUTER_VERSION_FILE="+versionFile,
+		),
+	}
+}
+
+func (f cliAutoupdateFixture) run(t *testing.T) string {
+	t.Helper()
+	command := exec.Command(mustLookPath(t, "bash"), f.script)
+	command.Env = f.env
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cli autoupdate failed: %v\n%s", err, output)
+	}
+	return string(output)
+}
+
+func TestCLIAutoupdateInstallsAndThenStaysQuiet(t *testing.T) {
+	requireDeployScriptTools(t, "bash", "curl", "python3")
+	fixture := newCLIAutoupdateFixture(t, "v0.1.52")
+
+	if output := fixture.run(t); !strings.Contains(output, "updating CLI none -> v0.1.52") {
+		t.Fatalf("first run did not install:\n%s", output)
+	}
+	marker, err := os.ReadFile(fixture.versionFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(marker)) != "v0.1.52" {
+		t.Fatalf("version marker = %q, want v0.1.52", marker)
+	}
+
+	// A second run must not reinstall. Anything that downloads on every tick
+	// makes the agent expensive enough that someone eventually removes it.
+	binary := filepath.Join(fixture.installDir, "subrouter")
+	before, err := os.Stat(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output := fixture.run(t); strings.Contains(output, "updating CLI") {
+		t.Fatalf("second run reinstalled an already current CLI:\n%s", output)
+	}
+	after, err := os.Stat(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Fatal("second run replaced the binary")
+	}
+}
+
+// A marker can outlive the binary it describes: a cleanup script, a new laptop
+// restored from a partial backup, an interrupted install. The updater must fix
+// that rather than trusting the marker and leaving the machine with no CLI.
+func TestCLIAutoupdateReinstallsWhenTheBinaryIsMissing(t *testing.T) {
+	requireDeployScriptTools(t, "bash", "curl", "python3")
+	fixture := newCLIAutoupdateFixture(t, "v0.1.52")
+	fixture.run(t)
+
+	if err := os.Remove(filepath.Join(fixture.installDir, "subrouter")); err != nil {
+		t.Fatal(err)
+	}
+	if output := fixture.run(t); !strings.Contains(output, "updating CLI") {
+		t.Fatalf("updater trusted a stale marker over a missing binary:\n%s", output)
+	}
+	if _, err := os.Stat(filepath.Join(fixture.installDir, "subrouter")); err != nil {
+		t.Fatalf("binary was not restored: %v", err)
+	}
+}

--- a/deploy/macos/install-cli-autoupdate.sh
+++ b/deploy/macos/install-cli-autoupdate.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Install the per-user CLI updater as a LaunchAgent. Run once per machine:
+#
+#   curl -fsSL https://raw.githubusercontent.com/manaflow-ai/subrouter/main/deploy/macos/install-cli-autoupdate.sh | bash
+#
+# After this the machine keeps its own `sr` current, so nobody has to remember
+# to reinstall after a release.
+set -euo pipefail
+
+REPO="${SUBROUTER_REPO:-manaflow-ai/subrouter}"
+LABEL="${SUBROUTER_CLI_UPDATE_LABEL:-ai.manaflow.subrouter-cli-autoupdate}"
+SCRIPT_PATH="${SUBROUTER_CLI_UPDATE_SCRIPT:-$HOME/.subrouter/bin/subrouter-cli-autoupdate.sh}"
+PLIST="$HOME/Library/LaunchAgents/${LABEL}.plist"
+LOG_DIR="${SUBROUTER_CLI_UPDATE_LOG_DIR:-$HOME/Library/Logs}"
+INTERVAL="${SUBROUTER_CLI_UPDATE_INTERVAL:-86400}"
+SCRIPT_URL="${SUBROUTER_CLI_UPDATE_SCRIPT_URL:-https://raw.githubusercontent.com/$REPO/main/deploy/macos/subrouter-cli-autoupdate.sh}"
+
+[ "$(uname -s)" = "Darwin" ] || { echo "macOS only" >&2; exit 1; }
+[ "$(id -u)" != "0" ] || { echo "run as your own user, not root: the agent updates a per-user CLI" >&2; exit 1; }
+
+mkdir -p "$(dirname "$SCRIPT_PATH")" "$LOG_DIR" "$HOME/Library/LaunchAgents"
+if [ -f "${SUBROUTER_CLI_UPDATE_LOCAL_SCRIPT:-}" ]; then
+  install -m 0755 "$SUBROUTER_CLI_UPDATE_LOCAL_SCRIPT" "$SCRIPT_PATH"
+else
+  curl -fsSL "$SCRIPT_URL" -o "$SCRIPT_PATH.new"
+  chmod 0755 "$SCRIPT_PATH.new"
+  mv -f "$SCRIPT_PATH.new" "$SCRIPT_PATH"
+fi
+
+cat >"$PLIST.new" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>${LABEL}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>${SCRIPT_PATH}</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StartInterval</key>
+	<integer>${INTERVAL}</integer>
+	<key>StandardOutPath</key>
+	<string>${LOG_DIR}/subrouter-cli-autoupdate.log</string>
+	<key>StandardErrorPath</key>
+	<string>${LOG_DIR}/subrouter-cli-autoupdate.err.log</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>LowPriorityIO</key>
+	<true/>
+</dict>
+</plist>
+PLIST_EOF
+mv -f "$PLIST.new" "$PLIST"
+plutil -lint "$PLIST" >/dev/null
+
+service="gui/$(id -u)/${LABEL}"
+launchctl bootout "$service" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+
+echo "Installed ${LABEL}; it checks for a new release every $((INTERVAL / 3600))h and logs to ${LOG_DIR}/subrouter-cli-autoupdate.log"

--- a/deploy/macos/subrouter-cli-autoupdate.sh
+++ b/deploy/macos/subrouter-cli-autoupdate.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Pull-based updater for a user's Subrouter CLI. The server autoupdater keeps a
+# shared host current; this keeps the `sr` on a laptop current, so a client and
+# the servers it talks to do not drift apart.
+#
+# Idempotent and cheap: it compares the release tag against a per-user version
+# marker and exits without downloading anything when they match. The install
+# itself is delegated to install.sh, which verifies the release checksum.
+set -euo pipefail
+
+REPO="${SUBROUTER_REPO:-manaflow-ai/subrouter}"
+INSTALL_DIR="${SUBROUTER_INSTALL_DIR:-$HOME/bin}"
+VERSION_FILE="${SUBROUTER_VERSION_FILE:-$HOME/.subrouter/cli-version}"
+INSTALL_URL="${SUBROUTER_INSTALL_URL:-https://raw.githubusercontent.com/$REPO/main/install.sh}"
+RELEASE_API_URL="${SUBROUTER_RELEASE_API_URL:-https://api.github.com/repos/${REPO}/releases/latest}"
+
+log() { echo "subrouter-cli-autoupdate: $*"; }
+
+latest_tag="$(curl -fsSL -H 'Accept: application/vnd.github+json' "$RELEASE_API_URL" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])')"
+[ -n "$latest_tag" ] || { log "could not resolve latest release tag"; exit 1; }
+
+installed=""
+[ -f "$VERSION_FILE" ] && installed="$(sed -n '1p' "$VERSION_FILE" 2>/dev/null || true)"
+
+# The marker can outlive the binary it describes, so treat a missing binary as
+# out of date no matter what the marker says.
+if [ "$latest_tag" = "$installed" ] && [ -x "$INSTALL_DIR/subrouter" ]; then
+  exit 0
+fi
+
+log "updating CLI ${installed:-none} -> ${latest_tag}"
+curl -fsSL "$INSTALL_URL" | env \
+  SUBROUTER_VERSION="$latest_tag" \
+  SUBROUTER_INSTALL_DIR="$INSTALL_DIR" \
+  SUBROUTER_VERSION_FILE="$VERSION_FILE" \
+  ${SUBROUTER_DOWNLOAD_BASE:+SUBROUTER_DOWNLOAD_BASE="$SUBROUTER_DOWNLOAD_BASE"} \
+  sh
+
+# Prove the new binary runs before anyone depends on it. install.sh already
+# rolled back on a failed install; this catches a binary that installs but
+# cannot execute, such as a quarantined or wrong-architecture download.
+"$INSTALL_DIR/subrouter" --help >/dev/null
+log "CLI is now ${latest_tag}"


### PR DESCRIPTION
## Why

A shared server autoupdates its worker through `deploy/macos/subrouter-autoupdate.sh`. A laptop has nothing equivalent, so every client is whatever someone last installed by hand. Checked against the current release on one machine here: the local `sr` hashes to `c0426a88…` while `subrouter_0.1.62_darwin_arm64` is `7d4d856c…`, so that client is running an unreleased hand build against servers on the release.

Drift like that is invisible until a version-dependent failure lands on one machine and cannot be reproduced anywhere else.

## What

`deploy/macos/subrouter-cli-autoupdate.sh` plus a one-command LaunchAgent installer. The agent checks daily, compares the release tag against `~/.subrouter/cli-version`, and exits without downloading when they match, so a tick costs one API call. Updates go through `install.sh`, which verifies the release checksum, and the new binary is run once before the agent reports success.

A missing binary forces a reinstall even when the marker looks current. A marker outlives the binary it describes after a cleanup script, an interrupted install, or a partial restore, and trusting it there would leave a machine with no CLI and no way to notice.

## Tests

Two script tests serve a release from a temp directory over `file://`, so no network is involved: the first run installs and writes the marker, the second is a no-op that does not touch the binary, and a deleted binary triggers reinstall. They skip where `bash`, `curl`, or `python3` is unavailable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788524251&installation_model_id=21920&pr_number=172&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F172&signature=6ce124c0342a383c4a6d7cf8db6796e540a0e9ec8b6f04bbb07aa6952678987c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a per-user macOS LaunchAgent that keeps the Subrouter CLI up to date by checking the latest GitHub release daily and installing when needed. This prevents laptop/client drift from the servers.

- **New Features**
  - `deploy/macos/subrouter-cli-autoupdate.sh`: compares the latest GitHub release tag to `~/.subrouter/cli-version`; exits if current; delegates to `install.sh` (checksum-verified); reinstalls if the binary is missing; runs the CLI once after install; logs to `~/Library/Logs/subrouter-cli-autoupdate.log`.
  - `deploy/macos/install-cli-autoupdate.sh`: installs a per-user LaunchAgent that runs at login and every 24h; configurable via env; validates and bootstraps the plist.
  - Tests and docs: adds `cmd/subrouter/cli_autoupdate_script_test.go` with `file://` fixtures to verify install/no-op/reinstall; README documents setup.

- **Migration**
  - Install: curl -fsSL https://raw.githubusercontent.com/manaflow-ai/subrouter/main/deploy/macos/install-cli-autoupdate.sh | bash
  - Remove: launchctl bootout gui/$(id -u)/ai.manaflow.subrouter-cli-autoupdate

<sup>Written for commit 09e59f888a716a66a45a4bcef2357594323251e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

