### PR TITLE
Fix golden migration summary propagation window

### DIFF
--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -44,6 +44,28 @@ func TestGoldenMigrationUsesBoundedRoutePropagationWindow(t *testing.T) {
 	}
 }
 
+func TestGoldenMigrationSummaryPreservesRoutePropagationWindow(t *testing.T) {
+	evidence := validGoldenMigrationTransitionEvidence(
+		"final-cutover", "front-migration-rollback", strings.Repeat("1", 64), strings.Repeat("2", 64),
+	)
+	evidence.Timestamps.ActivatedAt = "2026-08-02T00:04:59.000Z"
+	evidence.DestinationProof.ObservedAt = evidence.Timestamps.ActivatedAt
+	evidence.DestinationProof.ReceivedAt = "2026-08-02T00:04:59.500Z"
+	evidence.Timestamps.EvidenceEmittedAt = "2026-08-02T00:04:59.750Z"
+
+	action := goldenActionSummary{}
+	populateGoldenMigrationActionSummary(&action, evidence)
+	if action.RequestedAt != evidence.Timestamps.TransitionRequestedAt ||
+		action.ActivatedAt != evidence.Timestamps.ActivatedAt ||
+		action.PhaseDurationMillis != 299_000 {
+		t.Fatalf(
+			"summary window = %q..%q (%dms), want %q..%q (299000ms)",
+			action.RequestedAt, action.ActivatedAt, action.PhaseDurationMillis,
+			evidence.Timestamps.TransitionRequestedAt, evidence.Timestamps.ActivatedAt,
+		)
+	}
+}
+
 func TestGoldenMigrationTransitionRejectsRetargetedRoutingSelectors(t *testing.T) {
 	evidence := validGoldenMigrationTransitionEvidence(
 		"final-cutover", "front-migration-rollback", strings.Repeat("1", 64), strings.Repeat("2", 64),

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -48,7 +48,7 @@ func TestGoldenMigrationSummaryPreservesRoutePropagationWindow(t *testing.T) {
 	evidence := validGoldenMigrationTransitionEvidence(
 		"final-cutover", "front-migration-rollback", strings.Repeat("1", 64), strings.Repeat("2", 64),
 	)
-	evidence.Timestamps.ActivatedAt = "2026-08-02T00:04:59.000Z"
+	evidence.Timestamps.ActivatedAt = "2026-08-02T00:04:59.123Z"
 	evidence.DestinationProof.ObservedAt = evidence.Timestamps.ActivatedAt
 	evidence.DestinationProof.ReceivedAt = "2026-08-02T00:04:59.500Z"
 	evidence.Timestamps.EvidenceEmittedAt = "2026-08-02T00:04:59.750Z"
@@ -57,9 +57,9 @@ func TestGoldenMigrationSummaryPreservesRoutePropagationWindow(t *testing.T) {
 	populateGoldenMigrationActionSummary(&action, evidence)
 	if action.RequestedAt != evidence.Timestamps.TransitionRequestedAt ||
 		action.ActivatedAt != evidence.Timestamps.ActivatedAt ||
-		action.PhaseDurationMillis != 299_000 {
+		action.PhaseDurationMillis != 299_123 {
 		t.Fatalf(
-			"summary window = %q..%q (%dms), want %q..%q (299000ms)",
+			"summary window = %q..%q (%dms), want %q..%q (299123ms)",
 			action.RequestedAt, action.ActivatedAt, action.PhaseDurationMillis,
 			evidence.Timestamps.TransitionRequestedAt, evidence.Timestamps.ActivatedAt,
 		)
@@ -987,7 +987,9 @@ func validGoldenMigrationAction(evidence *goldenMigrationEvidence, digest, file 
 		StartedAt: "2026-08-02T00:00:00Z", FinishedAt: "2026-08-02T00:00:01Z",
 		DurationMillis: 1_000, ExitCode: 0, EvidenceValid: true, migrationCanonical: evidence,
 	}
-	populateGoldenMigrationActionSummary(&action, evidence)
+	if err := populateGoldenMigrationActionSummary(&action, evidence); err != nil {
+		panic(err)
+	}
 	return action
 }
 

--- a/cmd/subrouter-transport-observer/golden_migration_evidence.go
+++ b/cmd/subrouter-transport-observer/golden_migration_evidence.go
@@ -785,11 +785,13 @@ func (r *goldenRunner) runMigrationEvidenceAction(ctx context.Context, options g
 	}
 	result.ExitCode, result.EvidenceValid, result.EvidenceSHA256 = 0, true, digest
 	result.migrationCanonical = evidence
-	populateGoldenMigrationActionSummary(&result, evidence)
+	if err := populateGoldenMigrationActionSummary(&result, evidence); err != nil {
+		return result, err
+	}
 	return result, nil
 }
 
-func populateGoldenMigrationActionSummary(result *goldenActionSummary, evidence *goldenMigrationEvidence) {
+func populateGoldenMigrationActionSummary(result *goldenActionSummary, evidence *goldenMigrationEvidence) error {
 	result.Mode = evidence.Mode
 	result.ReleaseTag = evidence.Release.Tag
 	result.ReleaseSourceRevision = evidence.Release.SourceRevision
@@ -799,7 +801,14 @@ func populateGoldenMigrationActionSummary(result *goldenActionSummary, evidence 
 		result.FromReleaseSHA256 = evidence.Predecessor.SHA256
 		result.ToReleaseSHA256 = evidence.Bootstrap.SHA256
 	case "front-migration-cutover", "front-migration-rollback":
-		requested, activated, _ := goldenPhaseDuration(evidence.Timestamps.TransitionRequestedAt, evidence.Timestamps.ActivatedAt)
+		requested, activated, err := goldenPhaseDurationWithin(
+			evidence.Timestamps.TransitionRequestedAt,
+			evidence.Timestamps.ActivatedAt,
+			goldenMigrationPropagationLimit,
+		)
+		if err != nil {
+			return err
+		}
 		result.RequestedAt, result.ActivatedAt = requested.Format(time.RFC3339Nano), activated.Format(time.RFC3339Nano)
 		result.PhaseDurationMillis = activated.Sub(requested).Milliseconds()
 		result.LinkedEvidenceSHA256 = evidence.PriorEvidenceSHA256
@@ -824,4 +833,5 @@ func populateGoldenMigrationActionSummary(result *goldenActionSummary, evidence 
 		result.ReportedRetiredWithinMS = *evidence.Retirement.AbsenceLatencyMillis
 		result.ServerRSSBytes = *evidence.Metrics.RunScopedPeakRSSBytes
 	}
+	return nil
 }

--- a/cmd/subrouter-transport-observer/golden_migration_transition.go
+++ b/cmd/subrouter-transport-observer/golden_migration_transition.go
@@ -200,7 +200,9 @@ func (r *goldenRunner) runMigrationTransitionWithProof(
 	}
 	result.EvidenceSHA256, result.EvidenceValid = digest, true
 	result.migrationCanonical = evidence
-	populateGoldenMigrationActionSummary(&result, evidence)
+	if err := populateGoldenMigrationActionSummary(&result, evidence); err != nil {
+		return result, nil, err
+	}
 	if evidence.PriorEvidenceSHA256 != prior.EvidenceSHA256 || evidence.Routing.Before != source ||
 		evidence.Routing.After != destination || evidence.Timestamps.TransitionRequestedAt != request.TransitionRequestedAt ||
 		evidence.Timestamps.ActivatedAt != proof.ObservedAt || evidence.DestinationProof.SHA256 != fmt.Sprintf("%x", proofDigest[:]) ||


### PR DESCRIPTION
## Summary
- preserve the five-minute global route propagation window when migration evidence becomes a golden action summary
- return timestamp validation failures instead of silently writing zero timestamps
- add a red-before-green regression for the 4m59s boundary

## Testing
- `go test ./cmd/subrouter-transport-observer -run "^(TestGoldenMigrationSummaryPreservesRoutePropagationWindow|TestGoldenMigrationUsesBoundedRoutePropagationWindow)$" -count=1`
- `go test ./cmd/subrouter-transport-observer -run "^TestGoldenLocalMacHarnessOrchestratesAllModesWithoutContentEvidence$" -count=1`
- `go test ./...` exposed three existing timing-sensitive failures; each failed test passed alone

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788528677&installation_model_id=21920&pr_number=175&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F175&signature=4db7af7344719919c9c156800d2eec76b9c5773fe442df9f244361cba987f6cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the 5-minute route propagation window in golden migration action summaries and validates timestamps instead of writing zeros. Adds a 4m59s boundary regression test to prevent future timing regressions.

- **Bug Fixes**
  - Bound summary timestamps using `goldenPhaseDurationWithin` with `goldenMigrationPropagationLimit` to keep the 5-minute window and correct phase duration.
  - Made `populateGoldenMigrationActionSummary` return errors on invalid timestamps; callers now propagate failures.
  - Added `TestGoldenMigrationSummaryPreservesRoutePropagationWindow` to cover the 4m59s cutoff.

<sup>Written for commit c32ac58902ed843d2a848071131cb9b0bcabe756. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration action summaries to accurately preserve short route-propagation windows.
  * Corrected duration calculations for migration transitions, including intervals of less than five minutes.
  * Added validation to surface errors when migration summary data cannot be generated successfully.

* **Tests**
  * Added regression coverage to protect route-propagation timing and migration duration reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->