### PR TITLE
Correlate golden migration proof by session

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -35,6 +35,7 @@ const (
 	goldenActionEvidenceLimit                 = 256 << 10
 	goldenActivationLimit                     = 30 * time.Second
 	goldenMigrationPropagationLimit           = 5 * time.Minute
+	goldenDestinationLivenessLimit            = 10 * time.Second
 	goldenBackendHealthStabilityLimit         = 5 * time.Minute
 	goldenRetirementLimit                     = 30 * time.Second
 	goldenChunkGapFloor                       = 5 * time.Second

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -66,6 +66,33 @@ func TestGoldenMigrationSummaryPreservesRoutePropagationWindow(t *testing.T) {
 	}
 }
 
+func TestGoldenMigrationAllowsConcurrentDestinationConnectionDrain(t *testing.T) {
+	evidence := validGoldenMigrationTransitionEvidence(
+		"final-cutover", "front-migration-rollback", strings.Repeat("1", 64), strings.Repeat("2", 64),
+	)
+	evidence.Destination.Before.PublicConnections = 14
+	evidence.Destination.Before.GenerationConnections = 14
+	evidence.Destination.After.PublicConnections = 10
+	evidence.Destination.After.GenerationConnections = 10
+	evidence.Destination.ConnectionCountDelta = -4
+
+	if err := validateGoldenMigrationTransition(evidence, "front-migration-cutover"); err != nil {
+		t.Fatalf("journal-correlated destination proof was rejected after concurrent drains: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "transition.json")
+	data, err := json.Marshal(evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	validator := filepath.Join("..", "..", "deploy", "gcp", "validate-deploy-evidence.py")
+	if output, err := exec.Command("python3", validator, "--expect", "front-migration-cutover", path).CombinedOutput(); err != nil {
+		t.Fatalf("Python validator rejected journal-correlated destination proof after concurrent drains: %v: %s", err, output)
+	}
+}
+
 func TestGoldenMigrationTransitionRejectsRetargetedRoutingSelectors(t *testing.T) {
 	evidence := validGoldenMigrationTransitionEvidence(
 		"final-cutover", "front-migration-rollback", strings.Repeat("1", 64), strings.Repeat("2", 64),

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -91,6 +91,21 @@ func TestGoldenMigrationAllowsConcurrentDestinationConnectionDrain(t *testing.T)
 	if output, err := exec.Command("python3", validator, "--expect", "front-migration-cutover", path).CombinedOutput(); err != nil {
 		t.Fatalf("Python validator rejected journal-correlated destination proof after concurrent drains: %v: %s", err, output)
 	}
+
+	evidence.DestinationProof.JournalCorrelated = false
+	if err := validateGoldenMigrationTransition(evidence, "front-migration-cutover"); err == nil {
+		t.Fatal("Go validator accepted a destination proof without journal correlation")
+	}
+	data, err = json.Marshal(evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if output, err := exec.Command("python3", validator, "--expect", "front-migration-cutover", path).CombinedOutput(); err == nil {
+		t.Fatalf("Python validator accepted a destination proof without journal correlation: %s", output)
+	}
 }
 
 func TestGoldenMigrationTransitionRejectsRetargetedRoutingSelectors(t *testing.T) {
@@ -958,7 +973,7 @@ func validGoldenMigrationTransitionEvidence(mode, priorType, priorSHA, preparati
 	evidence.DestinationProof = goldenMigrationDestinationProof{
 		SHA256: strings.Repeat("8", 64), Challenge: strings.Repeat("9", 32), ConnectionID: strings.Repeat("a", 64),
 		SessionID:                  "golden-session",
-		OriginalContinuityVerified: true, FreshPublicConnection: true,
+		OriginalContinuityVerified: true, FreshPublicConnection: true, JournalCorrelated: true,
 		ObservedAt: "2026-08-02T00:00:01Z", ReceivedAt: "2026-08-02T00:00:01.5Z",
 	}
 	legacyMetrics := goldenMigrationLegacyMetrics{

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -30,7 +30,10 @@ func TestGoldenMigrationUsesBoundedRoutePropagationWindow(t *testing.T) {
 	evidence.Timestamps.ActivatedAt = "2026-08-02T00:04:59.000Z"
 	evidence.DestinationProof.ObservedAt = evidence.Timestamps.ActivatedAt
 	evidence.DestinationProof.ReceivedAt = "2026-08-02T00:04:59.500Z"
-	evidence.Timestamps.EvidenceEmittedAt = "2026-08-02T00:04:59.750Z"
+	evidence.DestinationProof.PostSnapshotLiveness.RequestedAt = "2026-08-02T00:04:59.600Z"
+	evidence.DestinationProof.PostSnapshotLiveness.ResponseChunkAt = "2026-08-02T00:04:59.700Z"
+	evidence.DestinationProof.PostSnapshotLiveness.ReceivedAt = "2026-08-02T00:04:59.800Z"
+	evidence.Timestamps.EvidenceEmittedAt = "2026-08-02T00:04:59.900Z"
 	if err := validateGoldenMigrationTransition(evidence, "front-migration-cutover"); err != nil {
 		t.Fatalf("sub-five-minute route propagation was rejected: %v", err)
 	}
@@ -38,7 +41,10 @@ func TestGoldenMigrationUsesBoundedRoutePropagationWindow(t *testing.T) {
 	evidence.Timestamps.ActivatedAt = "2026-08-02T00:05:00.000Z"
 	evidence.DestinationProof.ObservedAt = evidence.Timestamps.ActivatedAt
 	evidence.DestinationProof.ReceivedAt = evidence.Timestamps.ActivatedAt
-	evidence.Timestamps.EvidenceEmittedAt = "2026-08-02T00:05:00.001Z"
+	evidence.DestinationProof.PostSnapshotLiveness.RequestedAt = "2026-08-02T00:05:00.001Z"
+	evidence.DestinationProof.PostSnapshotLiveness.ResponseChunkAt = "2026-08-02T00:05:00.002Z"
+	evidence.DestinationProof.PostSnapshotLiveness.ReceivedAt = "2026-08-02T00:05:00.003Z"
+	evidence.Timestamps.EvidenceEmittedAt = "2026-08-02T00:05:00.004Z"
 	if err := validateGoldenMigrationTransition(evidence, "front-migration-cutover"); err == nil {
 		t.Fatal("five-minute route propagation boundary was accepted")
 	}
@@ -51,7 +57,10 @@ func TestGoldenMigrationSummaryPreservesRoutePropagationWindow(t *testing.T) {
 	evidence.Timestamps.ActivatedAt = "2026-08-02T00:04:59.123Z"
 	evidence.DestinationProof.ObservedAt = evidence.Timestamps.ActivatedAt
 	evidence.DestinationProof.ReceivedAt = "2026-08-02T00:04:59.500Z"
-	evidence.Timestamps.EvidenceEmittedAt = "2026-08-02T00:04:59.750Z"
+	evidence.DestinationProof.PostSnapshotLiveness.RequestedAt = "2026-08-02T00:04:59.600Z"
+	evidence.DestinationProof.PostSnapshotLiveness.ResponseChunkAt = "2026-08-02T00:04:59.700Z"
+	evidence.DestinationProof.PostSnapshotLiveness.ReceivedAt = "2026-08-02T00:04:59.800Z"
+	evidence.Timestamps.EvidenceEmittedAt = "2026-08-02T00:04:59.900Z"
 
 	action := goldenActionSummary{}
 	populateGoldenMigrationActionSummary(&action, evidence)
@@ -75,6 +84,7 @@ func TestGoldenMigrationAllowsConcurrentDestinationConnectionDrain(t *testing.T)
 	evidence.Destination.After.PublicConnections = 10
 	evidence.Destination.After.GenerationConnections = 10
 	evidence.Destination.ConnectionCountDelta = -4
+	evidence.DestinationProof.PostSnapshotLiveness.DestinationSnapshotSHA256 = goldenMigrationSnapshotSHA256(evidence.Destination.After)
 
 	if err := validateGoldenMigrationTransition(evidence, "front-migration-cutover"); err != nil {
 		t.Fatalf("journal-correlated destination proof was rejected after concurrent drains: %v", err)
@@ -144,6 +154,43 @@ func TestGoldenMigrationRejectsMissingPostSnapshotConnectionLiveness(t *testing.
 	validator := filepath.Join("..", "..", "deploy", "gcp", "validate-deploy-evidence.py")
 	if output, err := exec.Command("python3", validator, "--expect", "front-migration-cutover", path).CombinedOutput(); err == nil {
 		t.Fatalf("Python validator accepted migration evidence without exact post-snapshot connection liveness: %s", output)
+	}
+}
+
+func TestGoldenMigrationPostSnapshotLivenessUsesExactTransportConnection(t *testing.T) {
+	connectionID := strings.Repeat("a", 64)
+	otherConnectionID := strings.Repeat("b", 64)
+	requestID := "request-1"
+	boundary := time.Now().UTC()
+	stats := newObserverStats()
+	session := &goldenSession{
+		observer: &runningGoldenObserver{stats: stats},
+		done:     make(chan struct{}),
+	}
+	stats.observe(transportEvent{
+		Kind: "request_started", Path: "/v1/responses", RequestID: requestID, ConnectionID: connectionID,
+	})
+	stats.observe(transportEvent{
+		Kind: "response_chunk", Timestamp: boundary.Add(time.Millisecond).Format(time.RFC3339Nano),
+		Path: "/v1/responses", RequestID: requestID, ConnectionID: otherConnectionID, Bytes: 1,
+	})
+	timedContext, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if _, err := waitGoldenConnectionResponseChunkAfter(timedContext, session, connectionID, boundary); err == nil {
+		t.Fatal("post-snapshot liveness accepted a response chunk from a different transport connection")
+	}
+
+	want := boundary.Add(2 * time.Millisecond)
+	stats.observe(transportEvent{
+		Kind: "response_chunk", Timestamp: want.Format(time.RFC3339Nano),
+		Path: "/v1/responses", RequestID: requestID, ConnectionID: connectionID, Bytes: 1,
+	})
+	got, err := waitGoldenConnectionResponseChunkAfter(context.Background(), session, connectionID, boundary)
+	if err != nil {
+		t.Fatalf("exact transport response chunk was rejected: %v", err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("response chunk timestamp = %s, want %s", got, want)
 	}
 }
 
@@ -1014,6 +1061,13 @@ func validGoldenMigrationTransitionEvidence(mode, priorType, priorSHA, preparati
 		SessionID:                  "golden-session",
 		OriginalContinuityVerified: true, FreshPublicConnection: true, JournalCorrelated: true,
 		ObservedAt: "2026-08-02T00:00:01Z", ReceivedAt: "2026-08-02T00:00:01.5Z",
+		PostSnapshotLiveness: goldenMigrationPostSnapshotLiveness{
+			SHA256: strings.Repeat("b", 64), Challenge: strings.Repeat("c", 32),
+			ConnectionID: strings.Repeat("a", 64), SessionID: "golden-session",
+			DestinationSnapshotSHA256: goldenMigrationSnapshotSHA256(evidence.Destination.After),
+			RequestedAt:               "2026-08-02T00:00:01.6Z", ResponseChunkAt: "2026-08-02T00:00:01.7Z",
+			ReceivedAt: "2026-08-02T00:00:01.8Z",
+		},
 	}
 	legacyMetrics := goldenMigrationLegacyMetrics{
 		NRestarts:             goldenDeployCounter{Before: goldenInt64(0), After: goldenInt64(0)},

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -108,6 +108,45 @@ func TestGoldenMigrationAllowsConcurrentDestinationConnectionDrain(t *testing.T)
 	}
 }
 
+func TestGoldenMigrationRejectsMissingPostSnapshotConnectionLiveness(t *testing.T) {
+	evidence := validGoldenMigrationTransitionEvidence(
+		"final-cutover", "front-migration-rollback", strings.Repeat("1", 64), strings.Repeat("2", 64),
+	)
+	data, err := json.Marshal(evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatal(err)
+	}
+	proof, ok := document["destination_proof"].(map[string]any)
+	if !ok {
+		t.Fatal("destination proof is not an object")
+	}
+	delete(proof, "post_snapshot_liveness")
+	data, err = json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var missing goldenMigrationEvidence
+	if err := json.Unmarshal(data, &missing); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateGoldenMigrationTransition(&missing, "front-migration-cutover"); err == nil {
+		t.Fatal("Go validator accepted migration evidence without exact post-snapshot connection liveness")
+	}
+
+	path := filepath.Join(t.TempDir(), "transition.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	validator := filepath.Join("..", "..", "deploy", "gcp", "validate-deploy-evidence.py")
+	if output, err := exec.Command("python3", validator, "--expect", "front-migration-cutover", path).CombinedOutput(); err == nil {
+		t.Fatalf("Python validator accepted migration evidence without exact post-snapshot connection liveness: %s", output)
+	}
+}
+
 func TestGoldenMigrationTransitionRejectsRetargetedRoutingSelectors(t *testing.T) {
 	evidence := validGoldenMigrationTransitionEvidence(
 		"final-cutover", "front-migration-rollback", strings.Repeat("1", 64), strings.Repeat("2", 64),

--- a/cmd/subrouter-transport-observer/golden_migration_evidence.go
+++ b/cmd/subrouter-transport-observer/golden_migration_evidence.go
@@ -145,6 +145,7 @@ type goldenMigrationDestinationProof struct {
 	SessionID                  string `json:"session_id"`
 	OriginalContinuityVerified bool   `json:"original_continuity_verified"`
 	FreshPublicConnection      bool   `json:"fresh_public_connection"`
+	JournalCorrelated          bool   `json:"journal_correlated"`
 	ObservedAt                 string `json:"observed_at"`
 	ReceivedAt                 string `json:"received_at"`
 }
@@ -466,9 +467,8 @@ func validateGoldenMigrationTransition(evidence *goldenMigrationEvidence, expect
 	if evidence.Destination.Before.Generation == "" ||
 		evidence.Destination.Before.Generation != evidence.Destination.After.Generation ||
 		evidence.Destination.Before.InactiveConnections != 0 || evidence.Destination.After.InactiveConnections != 0 ||
-		evidence.Destination.ConnectionCountDelta < 1 ||
 		evidence.Destination.After.GenerationConnections-evidence.Destination.Before.GenerationConnections != evidence.Destination.ConnectionCountDelta ||
-		evidence.Destination.After.PublicConnections < evidence.Destination.Before.PublicConnections+1 {
+		evidence.Destination.After.PublicConnections < 1 || evidence.Destination.After.GenerationConnections < 1 {
 		return failGolden("migration_destination_connection_count_invalid")
 	}
 	requested, activated, err := goldenPhaseDurationWithin(
@@ -485,7 +485,7 @@ func validateGoldenMigrationTransition(evidence *goldenMigrationEvidence, expect
 		!validGoldenSHA256(evidence.DestinationProof.SHA256) || !validGoldenChallenge(evidence.DestinationProof.Challenge) ||
 		!validGoldenSHA256(evidence.DestinationProof.ConnectionID) || !validGoldenOpaqueID(evidence.DestinationProof.SessionID) ||
 		!evidence.DestinationProof.OriginalContinuityVerified ||
-		!evidence.DestinationProof.FreshPublicConnection {
+		!evidence.DestinationProof.FreshPublicConnection || !evidence.DestinationProof.JournalCorrelated {
 		return failGolden("migration_destination_proof_invalid")
 	}
 	if err := validateGoldenMigrationMetrics(evidence); err != nil {

--- a/cmd/subrouter-transport-observer/golden_migration_evidence.go
+++ b/cmd/subrouter-transport-observer/golden_migration_evidence.go
@@ -139,15 +139,27 @@ type goldenMigrationTimestamps struct {
 }
 
 type goldenMigrationDestinationProof struct {
-	SHA256                     string `json:"sha256"`
-	Challenge                  string `json:"challenge"`
-	ConnectionID               string `json:"connection_id"`
-	SessionID                  string `json:"session_id"`
-	OriginalContinuityVerified bool   `json:"original_continuity_verified"`
-	FreshPublicConnection      bool   `json:"fresh_public_connection"`
-	JournalCorrelated          bool   `json:"journal_correlated"`
-	ObservedAt                 string `json:"observed_at"`
-	ReceivedAt                 string `json:"received_at"`
+	SHA256                     string                              `json:"sha256"`
+	Challenge                  string                              `json:"challenge"`
+	ConnectionID               string                              `json:"connection_id"`
+	SessionID                  string                              `json:"session_id"`
+	OriginalContinuityVerified bool                                `json:"original_continuity_verified"`
+	FreshPublicConnection      bool                                `json:"fresh_public_connection"`
+	JournalCorrelated          bool                                `json:"journal_correlated"`
+	ObservedAt                 string                              `json:"observed_at"`
+	ReceivedAt                 string                              `json:"received_at"`
+	PostSnapshotLiveness       goldenMigrationPostSnapshotLiveness `json:"post_snapshot_liveness"`
+}
+
+type goldenMigrationPostSnapshotLiveness struct {
+	SHA256                    string `json:"sha256"`
+	Challenge                 string `json:"challenge"`
+	ConnectionID              string `json:"connection_id"`
+	SessionID                 string `json:"session_id"`
+	DestinationSnapshotSHA256 string `json:"destination_snapshot_sha256"`
+	RequestedAt               string `json:"requested_at"`
+	ResponseChunkAt           string `json:"response_chunk_at"`
+	ReceivedAt                string `json:"received_at"`
 }
 
 type goldenMigrationSnapshot struct {
@@ -488,6 +500,20 @@ func validateGoldenMigrationTransition(evidence *goldenMigrationEvidence, expect
 		!evidence.DestinationProof.FreshPublicConnection || !evidence.DestinationProof.JournalCorrelated {
 		return failGolden("migration_destination_proof_invalid")
 	}
+	liveness := evidence.DestinationProof.PostSnapshotLiveness
+	livenessRequested, requestErr := parseGoldenEvidenceTime(liveness.RequestedAt)
+	livenessChunk, chunkErr := parseGoldenEvidenceTime(liveness.ResponseChunkAt)
+	livenessReceived, receivedErr := parseGoldenEvidenceTime(liveness.ReceivedAt)
+	if requestErr != nil || chunkErr != nil || receivedErr != nil ||
+		!validGoldenSHA256(liveness.SHA256) || !validGoldenChallenge(liveness.Challenge) ||
+		liveness.ConnectionID != evidence.DestinationProof.ConnectionID ||
+		liveness.SessionID != evidence.DestinationProof.SessionID ||
+		liveness.DestinationSnapshotSHA256 != goldenMigrationSnapshotSHA256(evidence.Destination.After) ||
+		livenessRequested.Before(proofReceived) || livenessChunk.Before(livenessRequested) ||
+		livenessReceived.Before(livenessChunk) || emitted.Before(livenessReceived) ||
+		livenessReceived.Sub(livenessRequested) >= goldenDestinationLivenessLimit {
+		return failGolden("migration_destination_liveness_invalid")
+	}
 	if err := validateGoldenMigrationMetrics(evidence); err != nil {
 		return err
 	}
@@ -497,6 +523,21 @@ func validateGoldenMigrationTransition(evidence *goldenMigrationEvidence, expect
 		return failGolden("migration_rollback_metadata_invalid")
 	}
 	return nil
+}
+
+func goldenMigrationSnapshotSHA256(snapshot goldenMigrationSnapshot) string {
+	canonical, err := json.Marshal(map[string]any{
+		"generation":             snapshot.Generation,
+		"generation_connections": snapshot.GenerationConnections,
+		"inactive_connections":   snapshot.InactiveConnections,
+		"kind":                   snapshot.Kind,
+		"public_connections":     snapshot.PublicConnections,
+	})
+	if err != nil {
+		return ""
+	}
+	digest := sha256.Sum256(canonical)
+	return hex.EncodeToString(digest[:])
 }
 
 func validateGoldenMigrationMetrics(evidence *goldenMigrationEvidence) error {

--- a/cmd/subrouter-transport-observer/golden_migration_transition.go
+++ b/cmd/subrouter-transport-observer/golden_migration_transition.go
@@ -250,6 +250,11 @@ func (r *goldenRunner) runMigrationTransitionWithProof(
 		if err != nil || writePrivateFile(attemptLivenessProofPath, livenessProofFileData) != nil {
 			return goldenActionSummary{}, nil, failGolden("migration_destination_liveness_proof_write_failed")
 		}
+		select {
+		case <-ctx.Done():
+			return goldenActionSummary{}, nil, ctx.Err()
+		case <-command.done:
+		}
 		destinationSession = candidateSession
 		break
 	}

--- a/cmd/subrouter-transport-observer/golden_migration_transition.go
+++ b/cmd/subrouter-transport-observer/golden_migration_transition.go
@@ -13,9 +13,11 @@ import (
 )
 
 const (
-	goldenDestinationProofRequestSchema = "subrouter.gcp.destination-proof-request/v1"
-	goldenDestinationProofSchema        = "subrouter.gcp.destination-proof/v1"
-	goldenDestinationProofMaxAttempts   = 64
+	goldenDestinationProofRequestSchema    = "subrouter.gcp.destination-proof-request/v1"
+	goldenDestinationProofSchema           = "subrouter.gcp.destination-proof/v1"
+	goldenDestinationLivenessRequestSchema = "subrouter.gcp.destination-liveness-request/v1"
+	goldenDestinationLivenessProofSchema   = "subrouter.gcp.destination-liveness/v1"
+	goldenDestinationProofMaxAttempts      = 64
 )
 
 type goldenDestinationProofRequest struct {
@@ -46,6 +48,31 @@ type goldenDestinationProof struct {
 	ConnectionID               string `json:"connection_id"`
 	SessionID                  string `json:"session_id"`
 	ObservedAt                 string `json:"observed_at"`
+}
+
+type goldenDestinationLivenessRequest struct {
+	Schema                    string `json:"schema"`
+	Challenge                 string `json:"challenge"`
+	Operation                 string `json:"operation"`
+	Destination               string `json:"destination"`
+	DestinationGeneration     string `json:"destination_generation"`
+	ConnectionID              string `json:"connection_id"`
+	SessionID                 string `json:"session_id"`
+	DestinationSnapshotSHA256 string `json:"destination_snapshot_sha256"`
+	RequestedAt               string `json:"requested_at"`
+}
+
+type goldenDestinationLivenessProof struct {
+	Schema                    string `json:"schema"`
+	Challenge                 string `json:"challenge"`
+	Operation                 string `json:"operation"`
+	Destination               string `json:"destination"`
+	DestinationGeneration     string `json:"destination_generation"`
+	ConnectionID              string `json:"connection_id"`
+	SessionID                 string `json:"session_id"`
+	DestinationSnapshotSHA256 string `json:"destination_snapshot_sha256"`
+	RequestedAt               string `json:"requested_at"`
+	ResponseChunkAt           string `json:"response_chunk_at"`
 }
 
 func (r *goldenRunner) runMigrationTransitionWithProof(
@@ -97,10 +124,15 @@ func (r *goldenRunner) runMigrationTransitionWithProof(
 	var request goldenDestinationProofRequest
 	var proof goldenDestinationProof
 	var proofDigest [sha256.Size]byte
+	var livenessRequest goldenDestinationLivenessRequest
+	var livenessProof goldenDestinationLivenessProof
+	var livenessProofDigest [sha256.Size]byte
 	var destinationSession *goldenSession
 	for attempt := 1; attempt <= goldenDestinationProofMaxAttempts; attempt++ {
 		attemptRequestPath := goldenMigrationAttemptPath(requestPath, attempt)
 		attemptProofPath := goldenMigrationAttemptPath(proofPath, attempt)
+		attemptLivenessRequestPath := attemptProofPath + ".liveness-request"
+		attemptLivenessProofPath := attemptProofPath + ".liveness-proof"
 		requestData, err := waitGoldenHandshakeFile(ctx, attemptRequestPath, command.done)
 		if err != nil {
 			return goldenActionSummary{}, nil, err
@@ -166,8 +198,8 @@ func (r *goldenRunner) runMigrationTransitionWithProof(
 		if err != nil || time.Since(requested) >= goldenMigrationPropagationLimit || writePrivateFile(attemptProofPath, proofFileData) != nil {
 			return goldenActionSummary{}, nil, failGolden("migration_destination_proof_write_failed")
 		}
-		retry, err := waitGoldenMigrationAttemptOutcome(
-			ctx, goldenMigrationAttemptPath(requestPath, attempt+1), command.done,
+		retry, livenessData, err := waitGoldenMigrationAttemptOutcome(
+			ctx, goldenMigrationAttemptPath(requestPath, attempt+1), attemptLivenessRequestPath, command.done,
 		)
 		if err != nil {
 			return goldenActionSummary{}, nil, err
@@ -181,6 +213,42 @@ func (r *goldenRunner) runMigrationTransitionWithProof(
 				return goldenActionSummary{}, nil, err
 			}
 			continue
+		}
+		livenessRequest = goldenDestinationLivenessRequest{}
+		if err := json.Unmarshal(livenessData, &livenessRequest); err != nil ||
+			livenessRequest.Schema != goldenDestinationLivenessRequestSchema ||
+			!validGoldenChallenge(livenessRequest.Challenge) || livenessRequest.Operation != operation ||
+			livenessRequest.Destination != destination ||
+			livenessRequest.DestinationGeneration != request.DestinationGeneration ||
+			livenessRequest.ConnectionID != proof.ConnectionID || livenessRequest.SessionID != proof.SessionID ||
+			!validGoldenSHA256(livenessRequest.DestinationSnapshotSHA256) {
+			return goldenActionSummary{}, nil, failGolden("migration_destination_liveness_request_invalid")
+		}
+		livenessRequested, err := parseGoldenEvidenceTime(livenessRequest.RequestedAt)
+		proofObserved, proofTimeErr := parseGoldenEvidenceTime(proof.ObservedAt)
+		if err != nil || proofTimeErr != nil || livenessRequested.Before(proofObserved) ||
+			time.Since(livenessRequested) >= goldenDestinationLivenessLimit {
+			return goldenActionSummary{}, nil, failGolden("migration_destination_liveness_request_invalid")
+		}
+		responseChunkAt, err := waitGoldenConnectionResponseChunkAfter(
+			ctx, candidateSession, proof.ConnectionID, livenessRequested,
+		)
+		if err != nil {
+			return goldenActionSummary{}, nil, err
+		}
+		livenessProof = goldenDestinationLivenessProof{
+			Schema: goldenDestinationLivenessProofSchema, Challenge: livenessRequest.Challenge,
+			Operation: operation, Destination: destination,
+			DestinationGeneration: request.DestinationGeneration,
+			ConnectionID:          proof.ConnectionID, SessionID: proof.SessionID,
+			DestinationSnapshotSHA256: livenessRequest.DestinationSnapshotSHA256,
+			RequestedAt:               livenessRequest.RequestedAt, ResponseChunkAt: responseChunkAt.Format(time.RFC3339Nano),
+		}
+		livenessProofData, err := json.Marshal(livenessProof)
+		livenessProofFileData := append(livenessProofData, '\n')
+		livenessProofDigest = sha256.Sum256(livenessProofFileData)
+		if err != nil || writePrivateFile(attemptLivenessProofPath, livenessProofFileData) != nil {
+			return goldenActionSummary{}, nil, failGolden("migration_destination_liveness_proof_write_failed")
 		}
 		destinationSession = candidateSession
 		break
@@ -207,7 +275,14 @@ func (r *goldenRunner) runMigrationTransitionWithProof(
 		evidence.Routing.After != destination || evidence.Timestamps.TransitionRequestedAt != request.TransitionRequestedAt ||
 		evidence.Timestamps.ActivatedAt != proof.ObservedAt || evidence.DestinationProof.SHA256 != fmt.Sprintf("%x", proofDigest[:]) ||
 		evidence.DestinationProof.Challenge != proof.Challenge || evidence.DestinationProof.ConnectionID != proof.ConnectionID ||
-		evidence.DestinationProof.SessionID != proof.SessionID {
+		evidence.DestinationProof.SessionID != proof.SessionID ||
+		evidence.DestinationProof.PostSnapshotLiveness.SHA256 != fmt.Sprintf("%x", livenessProofDigest[:]) ||
+		evidence.DestinationProof.PostSnapshotLiveness.Challenge != livenessProof.Challenge ||
+		evidence.DestinationProof.PostSnapshotLiveness.ConnectionID != livenessProof.ConnectionID ||
+		evidence.DestinationProof.PostSnapshotLiveness.SessionID != livenessProof.SessionID ||
+		evidence.DestinationProof.PostSnapshotLiveness.DestinationSnapshotSHA256 != livenessProof.DestinationSnapshotSHA256 ||
+		evidence.DestinationProof.PostSnapshotLiveness.RequestedAt != livenessProof.RequestedAt ||
+		evidence.DestinationProof.PostSnapshotLiveness.ResponseChunkAt != livenessProof.ResponseChunkAt {
 		return result, nil, failGolden("migration_destination_proof_evidence_mismatch")
 	}
 	if sessionDone(destinationSession) {
@@ -232,25 +307,94 @@ func goldenSessionThreadID(session *goldenSession) string {
 	return session.threadID
 }
 
-func waitGoldenMigrationAttemptOutcome(ctx context.Context, nextRequestPath string, commandDone <-chan struct{}) (bool, error) {
+func waitGoldenConnectionResponseChunkAfter(
+	ctx context.Context,
+	session *goldenSession,
+	connectionID string,
+	boundary time.Time,
+) (time.Time, error) {
+	if session == nil || session.observer == nil || session.observer.stats == nil ||
+		!validGoldenSHA256(connectionID) || boundary.IsZero() {
+		return time.Time{}, failGolden("migration_destination_connection_not_held")
+	}
+	waitContext, cancel := context.WithTimeout(ctx, goldenDestinationLivenessLimit)
+	defer cancel()
+	for {
+		requests, chunks, observerErrors := session.observer.stats.snapshot()
+		if observerErrors != 0 {
+			return time.Time{}, failGolden("migration_destination_connection_not_held")
+		}
+		requestIDs := make(map[string]bool)
+		for _, request := range requests {
+			if request.ConnectionID == connectionID &&
+				(request.Path == "/v1/responses" || request.Path == "/responses") {
+				requestIDs[request.RequestID] = true
+			}
+		}
+		for _, chunk := range chunks {
+			if chunk.Kind != "response_chunk" || chunk.ConnectionID != connectionID || chunk.Bytes <= 0 ||
+				!requestIDs[chunk.RequestID] || (chunk.Path != "/v1/responses" && chunk.Path != "/responses") {
+				continue
+			}
+			stamp, err := time.Parse(time.RFC3339Nano, chunk.Timestamp)
+			if err != nil || stamp.IsZero() {
+				return time.Time{}, failGolden("migration_destination_connection_not_held")
+			}
+			if !stamp.Before(boundary) {
+				return stamp, nil
+			}
+		}
+		if sessionDone(session) {
+			return time.Time{}, failGolden("migration_destination_connection_not_held")
+		}
+		select {
+		case <-waitContext.Done():
+			return time.Time{}, failGolden("migration_destination_connection_not_held")
+		case <-session.done:
+			return time.Time{}, failGolden("migration_destination_connection_not_held")
+		case <-session.observer.stats.notify:
+		}
+	}
+}
+
+func waitGoldenMigrationAttemptOutcome(
+	ctx context.Context,
+	nextRequestPath string,
+	livenessRequestPath string,
+	commandDone <-chan struct{},
+) (bool, []byte, error) {
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 	for {
 		info, err := os.Lstat(nextRequestPath)
 		if err == nil {
 			if !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > goldenActionEvidenceLimit {
-				return false, failGolden("deployment_handshake_file_invalid")
+				return false, nil, failGolden("deployment_handshake_file_invalid")
 			}
-			return true, nil
+			return true, nil, nil
 		}
 		if !errors.Is(err, os.ErrNotExist) {
-			return false, failGolden("deployment_handshake_file_invalid")
+			return false, nil, failGolden("deployment_handshake_file_invalid")
+		}
+		info, err = os.Lstat(livenessRequestPath)
+		if err == nil {
+			if !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > goldenActionEvidenceLimit {
+				return false, nil, failGolden("deployment_handshake_file_invalid")
+			}
+			data, readErr := os.ReadFile(livenessRequestPath)
+			if readErr != nil {
+				return false, nil, failGolden("deployment_handshake_file_invalid")
+			}
+			return false, data, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return false, nil, failGolden("deployment_handshake_file_invalid")
 		}
 		select {
 		case <-ctx.Done():
-			return false, ctx.Err()
+			return false, nil, ctx.Err()
 		case <-commandDone:
-			return false, nil
+			return false, nil, failGolden("migration_destination_liveness_request_missing")
 		case <-ticker.C:
 		}
 	}

--- a/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
+++ b/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
@@ -235,7 +235,7 @@ func fakeAction(args []string) {
 			"destination_proof": map[string]any{
 				"sha256": fmt.Sprintf("%x", proofDigest[:]), "challenge": challenge,
 				"connection_id": proof.ConnectionID, "session_id": proof.SessionID,
-				"original_continuity_verified": true, "fresh_public_connection": true,
+				"original_continuity_verified": true, "fresh_public_connection": true, "journal_correlated": true,
 				"observed_at": activated.Format(time.RFC3339Nano), "received_at": proofReceived.Format(time.RFC3339Nano),
 			},
 			"source": map[string]any{

--- a/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
+++ b/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
@@ -203,6 +203,53 @@ func fakeAction(args []string) {
 		}
 		proofReceived := time.Now().UTC()
 		proofDigest := sha256.Sum256(proofData)
+		destinationAfter := map[string]any{
+			"kind": destination, "generation": destinationGeneration,
+			"public_connections": 1, "generation_connections": 1, "inactive_connections": 0,
+		}
+		destinationSnapshotData, err := json.Marshal(destinationAfter)
+		if err != nil {
+			os.Exit(9)
+		}
+		destinationSnapshotDigest := sha256.Sum256(destinationSnapshotData)
+		destinationSnapshotSHA := fmt.Sprintf("%x", destinationSnapshotDigest[:])
+		livenessChallenge := strings.Repeat("7", 32)
+		livenessRequested := time.Now().UTC()
+		livenessRequest := map[string]any{
+			"schema": "subrouter.gcp.destination-liveness-request/v1", "challenge": livenessChallenge,
+			"operation": migrationOperation, "destination": destination,
+			"destination_generation": destinationGeneration, "connection_id": proof.ConnectionID,
+			"session_id": proof.SessionID, "destination_snapshot_sha256": destinationSnapshotSHA,
+			"requested_at": livenessRequested.Format(time.RFC3339Nano),
+		}
+		livenessRequestPath := proofPath + ".liveness-request"
+		livenessProofPath := proofPath + ".liveness-proof"
+		if fakeWriteJSON(livenessRequestPath, livenessRequest) != nil {
+			os.Exit(9)
+		}
+		livenessProofData, err := fakeWaitFile(livenessProofPath, 10*time.Second)
+		var livenessProof struct {
+			Schema                    string `json:"schema"`
+			Challenge                 string `json:"challenge"`
+			ConnectionID              string `json:"connection_id"`
+			SessionID                 string `json:"session_id"`
+			DestinationSnapshotSHA256 string `json:"destination_snapshot_sha256"`
+			RequestedAt               string `json:"requested_at"`
+			ResponseChunkAt           string `json:"response_chunk_at"`
+		}
+		if err != nil || json.Unmarshal(livenessProofData, &livenessProof) != nil ||
+			livenessProof.Schema != "subrouter.gcp.destination-liveness/v1" ||
+			livenessProof.Challenge != livenessChallenge || livenessProof.ConnectionID != proof.ConnectionID ||
+			livenessProof.SessionID != proof.SessionID ||
+			livenessProof.DestinationSnapshotSHA256 != destinationSnapshotSHA ||
+			livenessProof.RequestedAt != livenessRequested.Format(time.RFC3339Nano) {
+			os.Exit(9)
+		}
+		livenessReceived := time.Now().UTC()
+		if _, err := time.Parse(time.RFC3339Nano, livenessProof.ResponseChunkAt); err != nil {
+			os.Exit(9)
+		}
+		livenessProofDigest := sha256.Sum256(livenessProofData)
 		predecessorLinux := "99fcd10d912184c160370eb228b382795101f2b5b2467244f995aa2d10b0c323"
 		legacy := map[string]any{"service": "subrouter.service", "generation": "legacy-generation", "checksum": predecessorLinux}
 		front := map[string]any{"slot": "slot-a", "generation": "front-generation", "checksum": candidate, "control_checksum": candidate, "worker_checksum": goldenFakeBootstrapSHA256}
@@ -237,13 +284,21 @@ func fakeAction(args []string) {
 				"connection_id": proof.ConnectionID, "session_id": proof.SessionID,
 				"original_continuity_verified": true, "fresh_public_connection": true, "journal_correlated": true,
 				"observed_at": activated.Format(time.RFC3339Nano), "received_at": proofReceived.Format(time.RFC3339Nano),
+				"post_snapshot_liveness": map[string]any{
+					"sha256": fmt.Sprintf("%x", livenessProofDigest[:]), "challenge": livenessChallenge,
+					"connection_id": proof.ConnectionID, "session_id": proof.SessionID,
+					"destination_snapshot_sha256": destinationSnapshotSHA,
+					"requested_at":                livenessRequested.Format(time.RFC3339Nano),
+					"response_chunk_at":           livenessProof.ResponseChunkAt,
+					"received_at":                 livenessReceived.Format(time.RFC3339Nano),
+				},
 			},
 			"source": map[string]any{
 				"before": snapshot(source, sourceGeneration, expected), "after": snapshot(source, sourceGeneration, expected),
 				"accepting_new_public_before": true, "accepting_new_public_after": false,
 			},
 			"destination": map[string]any{
-				"before": snapshot(destination, destinationGeneration, 0), "after": snapshot(destination, destinationGeneration, 1),
+				"before": snapshot(destination, destinationGeneration, 0), "after": destinationAfter,
 				"connection_count_delta": 1,
 			},
 			"metrics": map[string]any{

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -1863,6 +1863,29 @@ func TestDeploymentContractValidatesGoldenTransitionProofs(t *testing.T) {
 	if output, err := run(proofArgs...); err == nil {
 		t.Fatalf("empty destination session succeeded: %s", output)
 	}
+
+	liveness := filepath.Join(t.TempDir(), "liveness.json")
+	connectionID := strings.Repeat("b", 64)
+	snapshotSHA := strings.Repeat("c", 64)
+	livenessBody := fmt.Sprintf(`{"schema":"subrouter.gcp.destination-liveness/v1","challenge":"challenge","operation":"final-cutover","destination":"front","destination_generation":"generation-b","connection_id":%q,"session_id":"session-id","destination_snapshot_sha256":%q,"requested_at":"2026-08-03T10:01:00Z","response_chunk_at":"2026-08-03T10:01:00.500Z"}`, connectionID, snapshotSHA)
+	if err := os.WriteFile(liveness, []byte(livenessBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	livenessArgs := []string{
+		"validate-destination-liveness", liveness, "challenge", "final-cutover", "front", "generation-b",
+		connectionID, "session-id", snapshotSHA, "2026-08-03T10:01:00Z", "2026-08-03T10:01:00.750Z",
+	}
+	if output, err := run(livenessArgs...); err != nil || len(output) != 0 {
+		t.Fatalf("destination liveness result = %q, %v", output, err)
+	}
+	lateLiveness := strings.Replace(livenessBody, "10:01:00.500Z", "10:01:10.000Z", 1)
+	if err := os.WriteFile(liveness, []byte(lateLiveness), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	livenessArgs[len(livenessArgs)-1] = "2026-08-03T10:01:10.000Z"
+	if output, err := run(livenessArgs...); err == nil {
+		t.Fatalf("ten-second destination liveness boundary succeeded: %s", output)
+	}
 }
 
 func TestDeploymentContractProbesSlotEndpoint(t *testing.T) {

--- a/deploy/gcp/deployment-contract.py
+++ b/deploy/gcp/deployment-contract.py
@@ -436,6 +436,42 @@ def command_validate_destination_proof(args: argparse.Namespace) -> None:
     )
 
 
+def command_validate_destination_liveness(args: argparse.Namespace) -> None:
+    if re.fullmatch(r"[0-9a-f]{64}", args.connection_id) is None:
+        fail("destination liveness connection_id is invalid")
+    if re.fullmatch(r"[A-Za-z0-9._:-]{1,256}", args.session_id) is None:
+        fail("destination liveness session_id is invalid")
+    if re.fullmatch(r"[0-9a-f]{64}", args.destination_snapshot_sha256) is None:
+        fail("destination liveness snapshot SHA-256 is invalid")
+    document = load_json(args.path, "destination liveness proof")
+    expect_exact(
+        document,
+        {
+            "schema": "subrouter.gcp.destination-liveness/v1",
+            "challenge": args.challenge,
+            "operation": args.operation,
+            "destination": args.destination,
+            "destination_generation": args.destination_generation,
+            "connection_id": args.connection_id,
+            "session_id": args.session_id,
+            "destination_snapshot_sha256": args.destination_snapshot_sha256,
+            "requested_at": args.requested_at,
+        },
+        "destination liveness proof",
+    )
+    requested = parse_timestamp(args.requested_at, "destination liveness requested time")
+    response_chunk = parse_timestamp(document.get("response_chunk_at"), "destination liveness response chunk time")
+    received = parse_timestamp(args.received_at, "destination liveness received time")
+    validate_ordered_window(
+        requested,
+        requested,
+        response_chunk,
+        received,
+        "destination liveness proof",
+        timedelta(seconds=10),
+    )
+
+
 def add_path(parser: argparse.ArgumentParser, name: str) -> None:
     parser.add_argument(name, type=Path)
 
@@ -528,6 +564,19 @@ def build_parser() -> argparse.ArgumentParser:
     proof.add_argument("requested_at")
     proof.add_argument("received_at")
     proof.set_defaults(handler=command_validate_destination_proof)
+
+    liveness = commands.add_parser("validate-destination-liveness")
+    add_path(liveness, "path")
+    liveness.add_argument("challenge")
+    liveness.add_argument("operation")
+    liveness.add_argument("destination")
+    liveness.add_argument("destination_generation")
+    liveness.add_argument("connection_id")
+    liveness.add_argument("session_id")
+    liveness.add_argument("destination_snapshot_sha256")
+    liveness.add_argument("requested_at")
+    liveness.add_argument("received_at")
+    liveness.set_defaults(handler=command_validate_destination_liveness)
 
     return parser
 

--- a/deploy/gcp/switch-front-migration.sh
+++ b/deploy/gcp/switch-front-migration.sh
@@ -431,9 +431,13 @@ done
 [[ "${destination_correlated}" == true ]] \
   || die "golden fresh public session did not reach the destination within ${proof_max_attempts} attempts"
 destination_after="$(supervisor_snapshot "${destination_kind}")"
-jq -e --arg generation "${destination_generation}" --argjson before "${destination_before}" \
-  '.generation == $generation and .public_connections >= ($before.public_connections + 1) and
-   .generation_connections >= ($before.generation_connections + 1) and .inactive_connections == 0' \
+# Earlier proof attempts drain asynchronously, so their departures can hide the
+# accepted proof in an aggregate before/after delta. The journal match above
+# correlates the exact session; this snapshot proves it is still live on the
+# expected generation.
+jq -e --arg generation "${destination_generation}" \
+  '.generation == $generation and .public_connections >= 1 and
+   .generation_connections >= 1 and .inactive_connections == 0' \
   < <(stream_shell_value "${destination_after}") >/dev/null \
   || die "golden fresh public connection was not correlated to the destination generation"
 destination_connection_delta="$(( $(jq -r '.generation_connections' < <(stream_shell_value "${destination_after}")) - $(jq -r '.generation_connections' < <(stream_shell_value "${destination_before}")) ))"
@@ -501,7 +505,7 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type "${evi
       evidence_emitted_at:$emitted_at},
     destination_proof:{sha256:$proof_sha,challenge:$challenge,connection_id:$connection_id,
       session_id:$session_id,
-      original_continuity_verified:true,fresh_public_connection:true,
+      original_continuity_verified:true,fresh_public_connection:true,journal_correlated:true,
       observed_at:$activated_at,received_at:$proof_received_at},
     destination:{before:$destination_before,after:$destination_after,
       connection_count_delta:$destination_delta},

--- a/deploy/gcp/switch-front-migration.sh
+++ b/deploy/gcp/switch-front-migration.sh
@@ -43,6 +43,7 @@ ARTIFACT_DIR="${SUBROUTER_DEPLOY_ARTIFACT_DIR:-${PWD}/artifacts/gcp-front-transi
 RUN_LABEL="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-lb-${OPERATION}-$$"
 RUN_LABEL="${RUN_LABEL//[^a-zA-Z0-9._-]/-}"
 MIGRATION_PROPAGATION_LIMIT_MS=300000
+DESTINATION_LIVENESS_LIMIT_MS=10000
 REMOTE_INSTALLER="/tmp/install-front-slots-${RUN_LABEL}.sh"
 REMOTE_DEPLOYMENT_CONTRACT="/tmp/deployment-contract-${RUN_LABEL}.py"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -381,7 +382,11 @@ destination_correlated=false
 while (( proof_attempt <= proof_max_attempts )); do
   proof_request_path="$(proof_attempt_path "${DESTINATION_PROOF_REQUEST}" "${proof_attempt}")"
   proof_path="$(proof_attempt_path "${DESTINATION_PROOF}" "${proof_attempt}")"
-  [[ ! -e "${proof_request_path}" && ! -L "${proof_request_path}" && ! -e "${proof_path}" && ! -L "${proof_path}" ]] \
+  liveness_request_path="${proof_path}.liveness-request"
+  liveness_proof_path="${proof_path}.liveness-proof"
+  [[ ! -e "${proof_request_path}" && ! -L "${proof_request_path}" && ! -e "${proof_path}" && ! -L "${proof_path}" &&
+     ! -e "${liveness_request_path}" && ! -L "${liveness_request_path}" &&
+     ! -e "${liveness_proof_path}" && ! -L "${liveness_proof_path}" ]] \
     || die "destination proof attempt path already exists"
   proof_challenge="$(python3 -c 'import secrets; print(secrets.token_hex(16))')"
   proof_request_tmp="$(mktemp "${proof_request_path}.tmp.XXXXXX")"
@@ -432,14 +437,44 @@ done
   || die "golden fresh public session did not reach the destination within ${proof_max_attempts} attempts"
 destination_after="$(supervisor_snapshot "${destination_kind}")"
 # Earlier proof attempts drain asynchronously, so their departures can hide the
-# accepted proof in an aggregate before/after delta. The journal match above
-# correlates the exact session; this snapshot proves it is still live on the
-# expected generation.
+# accepted proof in an aggregate before/after delta. Require a live connection
+# on the exact generation, then challenge the golden observer to produce a
+# response chunk on the accepted transport after this snapshot.
 jq -e --arg generation "${destination_generation}" \
   '.generation == $generation and .public_connections >= 1 and
    .generation_connections >= 1 and .inactive_connections == 0' \
   < <(stream_shell_value "${destination_after}") >/dev/null \
   || die "golden fresh public connection was not correlated to the destination generation"
+destination_snapshot_canonical="$(printf '%s' "${destination_after}" | jq -cS .)"
+destination_snapshot_sha256="$(printf '%s' "${destination_snapshot_canonical}" | sha256sum | awk '{print $1}')"
+liveness_challenge="$(python3 -c 'import secrets; print(secrets.token_hex(16))')"
+liveness_requested_at="$(utc_now)"
+liveness_requested_ms="$(epoch_millis)"
+liveness_request_tmp="$(mktemp "${liveness_request_path}.tmp.XXXXXX")"
+jq -n --arg schema 'subrouter.gcp.destination-liveness-request/v1' \
+  --arg challenge "${liveness_challenge}" --arg operation "${OPERATION}" \
+  --arg destination "${destination_kind}" --arg generation "${destination_generation}" \
+  --arg connection_id "${destination_connection_id}" --arg session_id "${destination_session_id}" \
+  --arg snapshot_sha "${destination_snapshot_sha256}" --arg requested_at "${liveness_requested_at}" \
+  '{schema:$schema,challenge:$challenge,operation:$operation,destination:$destination,
+    destination_generation:$generation,connection_id:$connection_id,session_id:$session_id,
+    destination_snapshot_sha256:$snapshot_sha,requested_at:$requested_at}' \
+  >"${liveness_request_tmp}"
+chmod 0600 "${liveness_request_tmp}"
+mv -f -- "${liveness_request_tmp}" "${liveness_request_path}"
+while [[ ! -f "${liveness_proof_path}" || -L "${liveness_proof_path}" ]]; do
+  (( $(epoch_millis) - liveness_requested_ms < DESTINATION_LIVENESS_LIMIT_MS )) \
+    || die "golden destination connection produced no response chunk after the destination snapshot"
+  sleep 0.05
+done
+liveness_received_at="$(utc_now)"
+python3 "${DEPLOYMENT_CONTRACT}" validate-destination-liveness \
+  "${liveness_proof_path}" "${liveness_challenge}" "${OPERATION}" \
+  "${destination_kind}" "${destination_generation}" "${destination_connection_id}" \
+  "${destination_session_id}" "${destination_snapshot_sha256}" "${liveness_requested_at}" \
+  "${liveness_received_at}"
+liveness_proof_sha256="$(sha256sum "${liveness_proof_path}" | awk '{print $1}')"
+liveness_response_chunk_at="$(jq -r '.response_chunk_at' "${liveness_proof_path}")"
 destination_connection_delta="$(( $(jq -r '.generation_connections' < <(stream_shell_value "${destination_after}")) - $(jq -r '.generation_connections' < <(stream_shell_value "${destination_before}")) ))"
 legacy_restarts_after="$(service_restarts legacy)"
 legacy_oom_after="$(service_oom_kills legacy)"
@@ -480,6 +515,10 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type "${evi
   --arg proof_received_at "${proof_received_at}" --arg emitted_at "${evidence_emitted_at}" \
   --arg proof_sha "${destination_proof_sha256}" --arg challenge "${proof_challenge}" \
   --arg connection_id "${destination_connection_id}" --arg session_id "${destination_session_id}" \
+  --arg liveness_sha "${liveness_proof_sha256}" --arg liveness_challenge "${liveness_challenge}" \
+  --arg snapshot_sha "${destination_snapshot_sha256}" --arg liveness_requested_at "${liveness_requested_at}" \
+  --arg liveness_response_chunk_at "${liveness_response_chunk_at}" \
+  --arg liveness_received_at "${liveness_received_at}" \
   --argjson before "${source_before}" \
   --argjson after "${source_after}" --argjson expected "${EXPECTED_CONNECTIONS}" \
   --argjson destination_before "${destination_before}" --argjson destination_after "${destination_after}" \
@@ -506,7 +545,11 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type "${evi
     destination_proof:{sha256:$proof_sha,challenge:$challenge,connection_id:$connection_id,
       session_id:$session_id,
       original_continuity_verified:true,fresh_public_connection:true,journal_correlated:true,
-      observed_at:$activated_at,received_at:$proof_received_at},
+      observed_at:$activated_at,received_at:$proof_received_at,
+      post_snapshot_liveness:{sha256:$liveness_sha,challenge:$liveness_challenge,
+        connection_id:$connection_id,session_id:$session_id,
+        destination_snapshot_sha256:$snapshot_sha,requested_at:$liveness_requested_at,
+        response_chunk_at:$liveness_response_chunk_at,received_at:$liveness_received_at}},
     destination:{before:$destination_before,after:$destination_after,
       connection_count_delta:$destination_delta},
     metrics:{source_service:(if $source=="legacy" then "legacy" else "slot" end),

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import hashlib
 import json
 import re
 import sys
@@ -917,7 +918,7 @@ def validate_front_migration_transition(document: dict[str, Any], expected: str)
     challenge = text(field(proof, "challenge", "destination_proof"), "destination_proof.challenge")
     if not re.fullmatch(r"[0-9a-f]{32}", challenge):
         fail("destination_proof.challenge must be a 128-bit lowercase hex challenge")
-    text(field(proof, "connection_id", "destination_proof"), "destination_proof.connection_id")
+    connection_id = text(field(proof, "connection_id", "destination_proof"), "destination_proof.connection_id")
     session_id = text(field(proof, "session_id", "destination_proof"), "destination_proof.session_id")
     if re.fullmatch(r"[A-Za-z0-9._:-]{1,256}", session_id) is None:
         fail("destination_proof.session_id is invalid")
@@ -952,6 +953,51 @@ def validate_front_migration_transition(document: dict[str, Any], expected: str)
         fail("destination proof receipt timestamps are out of order")
     if proof_received - requested >= dt.timedelta(minutes=5):
         fail("destination proof exceeded the five-minute route propagation boundary")
+
+    liveness = obj(
+        field(proof, "post_snapshot_liveness", "destination_proof"),
+        "destination_proof.post_snapshot_liveness",
+    )
+    sha(field(liveness, "sha256", "destination_proof.post_snapshot_liveness"),
+        "destination_proof.post_snapshot_liveness.sha256")
+    liveness_challenge = text(
+        field(liveness, "challenge", "destination_proof.post_snapshot_liveness"),
+        "destination_proof.post_snapshot_liveness.challenge",
+    )
+    if not re.fullmatch(r"[0-9a-f]{32}", liveness_challenge):
+        fail("destination_proof.post_snapshot_liveness.challenge must be a 128-bit lowercase hex challenge")
+    exact(
+        text(field(liveness, "connection_id", "destination_proof.post_snapshot_liveness"),
+             "destination_proof.post_snapshot_liveness.connection_id"),
+        connection_id,
+        "destination_proof.post_snapshot_liveness.connection_id",
+    )
+    exact(
+        text(field(liveness, "session_id", "destination_proof.post_snapshot_liveness"),
+             "destination_proof.post_snapshot_liveness.session_id"),
+        session_id,
+        "destination_proof.post_snapshot_liveness.session_id",
+    )
+    liveness_snapshot_sha = sha(
+        field(liveness, "destination_snapshot_sha256", "destination_proof.post_snapshot_liveness"),
+        "destination_proof.post_snapshot_liveness.destination_snapshot_sha256",
+    )
+    liveness_requested = timestamp(
+        field(liveness, "requested_at", "destination_proof.post_snapshot_liveness"),
+        "destination_proof.post_snapshot_liveness.requested_at",
+    )
+    liveness_chunk = timestamp(
+        field(liveness, "response_chunk_at", "destination_proof.post_snapshot_liveness"),
+        "destination_proof.post_snapshot_liveness.response_chunk_at",
+    )
+    liveness_received = timestamp(
+        field(liveness, "received_at", "destination_proof.post_snapshot_liveness"),
+        "destination_proof.post_snapshot_liveness.received_at",
+    )
+    if not proof_received <= liveness_requested <= liveness_chunk <= liveness_received <= emitted:
+        fail("destination post-snapshot liveness timestamps are out of order")
+    if liveness_received - liveness_requested >= dt.timedelta(seconds=10):
+        fail("destination post-snapshot liveness exceeded ten seconds")
 
     source = obj(field(document, "source", "root"), "source")
     before = validate_migration_snapshot(field(source, "before", "source"), "source.before", source_kind)
@@ -1004,6 +1050,16 @@ def validate_front_migration_transition(document: dict[str, Any], expected: str)
     )
     if destination_after["public_connections"] < 1 or destination_after["generation_connections"] < 1:
         fail("destination had no live connection after the journal-correlated golden proof")
+    canonical_destination = json.dumps(
+        destination_after,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    exact(
+        liveness_snapshot_sha,
+        hashlib.sha256(canonical_destination).hexdigest(),
+        "destination_proof.post_snapshot_liveness.destination_snapshot_sha256",
+    )
     metrics = obj(field(document, "metrics", "root"), "metrics")
     exact(
         field(metrics, "source_service", "metrics"),

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -934,6 +934,12 @@ def validate_front_migration_transition(document: dict[str, Any], expected: str)
         "destination_proof.original_continuity_verified",
     )
     exact(
+        boolean(field(proof, "journal_correlated", "destination_proof"),
+                "destination_proof.journal_correlated"),
+        True,
+        "destination_proof.journal_correlated",
+    )
+    exact(
         timestamp(field(proof, "observed_at", "destination_proof"), "destination_proof.observed_at"),
         activated,
         "destination_proof.observed_at",
@@ -989,15 +995,15 @@ def validate_front_migration_transition(document: dict[str, Any], expected: str)
     delta = integer(
         field(destination, "connection_count_delta", "destination"),
         "destination.connection_count_delta",
-        minimum=1,
+        minimum=-(1 << 63),
     )
     exact(
         delta,
         destination_after["generation_connections"] - destination_before["generation_connections"],
         "destination.connection_count_delta",
     )
-    if destination_after["public_connections"] < destination_before["public_connections"] + 1:
-        fail("destination public connection count did not increase for the golden proof")
+    if destination_after["public_connections"] < 1 or destination_after["generation_connections"] < 1:
+        fail("destination had no live connection after the journal-correlated golden proof")
     metrics = obj(field(document, "metrics", "root"), "metrics")
     exact(
         field(metrics, "source_service", "metrics"),


### PR DESCRIPTION
## Summary
- prove the accepted migration request by its exact session ID in the destination worker journal
- keep signed before/after connection deltas as telemetry without requiring a racy net increase
- require journal correlation in both Go and Python evidence validators
- add a red-before-green regression for concurrent probe drains

## Testing
- `go test ./cmd/subrouter-transport-observer -run "^TestGoldenMigrationAllowsConcurrentDestinationConnectionDrain$" -count=1`
- `go test ./cmd/subrouter -run "^TestGCPDeploymentEvidenceGateValidatesOutcomes$" -count=1`
- live staging golden reproduced a fresh front session hidden by concurrent aggregate drains, then restored the legacy route without interrupting either original stream

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788531145&installation_model_id=21920&pr_number=176&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F176&signature=28bbf9cfa0fb470c0626961d77173f163adce068200d016aa962889c6640319d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correlate the golden migration proof by session and require a post-snapshot liveness proof on the exact destination connection, waiting for that proof before emitting evidence. This makes cutovers reliable under load and verifies the session stayed live in both Go and Python.

- **Bug Fixes**
  - Require `journal_correlated` in destination proof across Go/Python validators.
  - Enforce `post_snapshot_liveness` in evidence: same connection/session, destination snapshot SHA matches, ordered timestamps, and liveness within 10s.
  - Wait for the liveness request and proof during the handshake; include the liveness proof digest in deploy evidence and fail if missing or late.
  - Relax destination checks: require at least one live public and generation connection; drop the positive before/after delta.
  - Update `deploy/gcp/switch-front-migration.sh` to issue a liveness challenge, wait for the `liveness-proof`, and include it; add `validate-destination-liveness` to `deploy/gcp/deployment-contract.py`; update the fake client and add regression tests (exact-connection chunk, missing/incorrect liveness, concurrent drains).

<sup>Written for commit 941214cd577894b7eb4fee0dc310542c037c1971. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added destination connection liveness checks during front-end migrations.
  * Migration validation now confirms the destination is reachable on the expected connection and responds within 10 seconds.
  * Deployment evidence now includes connection identity, snapshot linkage, timing, and liveness verification details.

* **Bug Fixes**
  * Improved migration handling when destination connections drain concurrently.
  * Prevented transitions when required post-snapshot liveness evidence is missing, stale, or linked to the wrong connection.
  * Added stricter validation for migration response timing and connection matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->