### PR TITLE
Scope golden liveness errors to the exact response request

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -1993,8 +1993,8 @@ func waitGoldenObserverRequestConnectionsClosed(ctx context.Context, stats *obse
 		return failGolden("observer_stats_missing")
 	}
 	for {
-		requests, _, observerErrors := stats.snapshot()
-		if observerErrors != 0 {
+		requests, _, _ := stats.snapshot()
+		if observerScopedErrorCount(stats, nil) != 0 {
 			return failGolden("observer_evidence_error")
 		}
 		requestConnections := make(map[string]struct{})
@@ -3023,6 +3023,26 @@ func responseRequests(stats *observerStats) []transportEvent {
 	return result
 }
 
+func observerScopedErrorCount(stats *observerStats, matchesProxyError func(transportEvent) bool) int {
+	if stats == nil {
+		return 1
+	}
+	count := 0
+	for _, event := range stats.errorSnapshot() {
+		if event.Kind == "recording_error" ||
+			(event.Kind == "proxy_error" && matchesProxyError != nil && matchesProxyError(event)) {
+			count++
+		}
+	}
+	return count
+}
+
+func observerResponseErrorCount(stats *observerStats) int {
+	return observerScopedErrorCount(stats, func(event transportEvent) bool {
+		return event.Path == "/v1/responses" || event.Path == "/responses"
+	})
+}
+
 func goldenSessionResponseChunks(session *goldenSession) []transportEvent {
 	if session == nil || session.observer == nil || session.observer.stats == nil {
 		return nil
@@ -3237,8 +3257,8 @@ func validateObserverTurns(sessions []*goldenSession, expectedRequests int) erro
 		if _, err := validatedGoldenResponseRequests(session, expectedRequests); err != nil {
 			return err
 		}
-		_, chunks, proxyErrors := session.observer.stats.snapshot()
-		if proxyErrors != 0 {
+		_, chunks, _ := session.observer.stats.snapshot()
+		if observerResponseErrorCount(session.observer.stats) != 0 {
 			return failGolden("observer_proxy_error")
 		}
 		responseBytes := int64(0)
@@ -4281,12 +4301,13 @@ func summarizeGoldenSession(session, resume *goldenSession, _ int, before, after
 		requests []transportEvent
 		chunks   []transportEvent
 	}
-	requests, chunks, proxyErrors := session.observer.stats.snapshot()
+	requests, chunks, _ := session.observer.stats.snapshot()
+	proxyErrors := observerResponseErrorCount(session.observer.stats)
 	snapshots := []observerSnapshot{{scope: "initial", requests: requests, chunks: chunks}}
 	if resume != nil && resume.observer != nil && resume.observer != session.observer {
-		resumeRequests, resumeChunks, resumeProxyErrors := resume.observer.stats.snapshot()
+		resumeRequests, resumeChunks, _ := resume.observer.stats.snapshot()
 		snapshots = append(snapshots, observerSnapshot{scope: "resume", requests: resumeRequests, chunks: resumeChunks})
-		proxyErrors += resumeProxyErrors
+		proxyErrors += observerResponseErrorCount(resume.observer.stats)
 	}
 	responseRequests := 0
 	connections := make(map[string]bool)

--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -1994,15 +1994,22 @@ func waitGoldenObserverRequestConnectionsClosed(ctx context.Context, stats *obse
 	}
 	for {
 		requests, _, _ := stats.snapshot()
-		if observerScopedErrorCount(stats, nil) != 0 {
-			return failGolden("observer_evidence_error")
-		}
 		requestConnections := make(map[string]struct{})
+		responseRequests := make(map[string]struct{})
 		for _, request := range requests {
 			if request.ConnectionID == "" {
 				return failGolden("observer_request_connection_missing")
 			}
 			requestConnections[request.ConnectionID] = struct{}{}
+			if request.Path == "/v1/responses" || request.Path == "/responses" {
+				responseRequests[request.RequestID+"\x00"+request.ConnectionID] = struct{}{}
+			}
+		}
+		if observerScopedErrorCount(stats, func(event transportEvent) bool {
+			_, relevant := responseRequests[event.RequestID+"\x00"+event.ConnectionID]
+			return relevant
+		}) != 0 {
+			return failGolden("observer_evidence_error")
 		}
 		opened := make(map[string]int)
 		for _, connection := range stats.openedSnapshot() {

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -194,6 +194,38 @@ func TestGoldenMigrationPostSnapshotLivenessUsesExactTransportConnection(t *test
 	}
 }
 
+func TestGoldenMigrationPostSnapshotLivenessIgnoresUnrelatedRequestErrors(t *testing.T) {
+	connectionID := strings.Repeat("a", 64)
+	requestID := "request-response"
+	boundary := time.Now().UTC()
+	want := boundary.Add(time.Millisecond)
+	stats := newObserverStats()
+	session := &goldenSession{
+		observer: &runningGoldenObserver{stats: stats},
+		done:     make(chan struct{}),
+	}
+	stats.observe(transportEvent{
+		Kind: "request_started", Transport: "http", Method: "POST", Path: "/v1/responses",
+		RequestID: requestID, ConnectionID: connectionID, Timestamp: boundary.Add(-time.Millisecond).Format(time.RFC3339Nano),
+	})
+	stats.observe(transportEvent{
+		Kind: "proxy_error", Transport: "http", Method: "GET", Path: "/other",
+		RequestID: "request-metadata", ConnectionID: strings.Repeat("b", 64),
+	})
+	stats.observe(transportEvent{
+		Kind: "response_chunk", Timestamp: want.Format(time.RFC3339Nano),
+		Path: "/v1/responses", RequestID: requestID, ConnectionID: connectionID, Bytes: 8,
+	})
+
+	got, err := waitGoldenConnectionResponseChunkAfter(context.Background(), session, connectionID, boundary)
+	if err != nil {
+		t.Fatalf("unrelated request error invalidated exact connection liveness: %v", err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("response chunk timestamp = %s, want %s", got, want)
+	}
+}
+
 func TestGoldenMigrationTransitionRejectsRetargetedRoutingSelectors(t *testing.T) {
 	evidence := validGoldenMigrationTransitionEvidence(
 		"final-cutover", "front-migration-rollback", strings.Repeat("1", 64), strings.Repeat("2", 64),

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -266,6 +266,38 @@ func TestGoldenResponseValidationScopesObserverErrors(t *testing.T) {
 	}
 }
 
+func TestGoldenObserverClosureScopesErrorsToResponseRequests(t *testing.T) {
+	newStats := func(errorEvent transportEvent) *observerStats {
+		stats := newObserverStats()
+		for _, event := range []transportEvent{
+			{Kind: "connection_opened", ConnectionID: "response-connection"},
+			{Kind: "connection_opened", ConnectionID: "metadata-connection"},
+			{Kind: "request_started", Path: "/v1/responses", RequestID: "response-request", ConnectionID: "response-connection"},
+			{Kind: "request_started", Path: "/other", RequestID: "metadata-request", ConnectionID: "metadata-connection"},
+			errorEvent,
+			{Kind: "connection_closed", ConnectionID: "response-connection"},
+			{Kind: "connection_closed", ConnectionID: "metadata-connection"},
+		} {
+			stats.observe(event)
+		}
+		return stats
+	}
+
+	unrelated := newStats(transportEvent{
+		Kind: "proxy_error", Path: "/other", RequestID: "metadata-request", ConnectionID: "metadata-connection",
+	})
+	if err := waitGoldenObserverRequestConnectionsClosed(context.Background(), unrelated); err != nil {
+		t.Fatalf("unrelated request error invalidated observer closure: %v", err)
+	}
+
+	responseFailure := newStats(transportEvent{
+		Kind: "proxy_error", Path: "/v1/responses", RequestID: "response-request", ConnectionID: "response-connection",
+	})
+	if err := waitGoldenObserverRequestConnectionsClosed(context.Background(), responseFailure); err == nil {
+		t.Fatal("response request proxy error was ignored during observer closure")
+	}
+}
+
 func TestGoldenMigrationTransitionRejectsRetargetedRoutingSelectors(t *testing.T) {
 	evidence := validGoldenMigrationTransitionEvidence(
 		"final-cutover", "front-migration-rollback", strings.Repeat("1", 64), strings.Repeat("2", 64),

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -226,6 +226,46 @@ func TestGoldenMigrationPostSnapshotLivenessIgnoresUnrelatedRequestErrors(t *tes
 	}
 }
 
+func TestGoldenResponseValidationScopesObserverErrors(t *testing.T) {
+	newSession := func(errorEvent transportEvent) *goldenSession {
+		stats := newObserverStats()
+		connectionID := strings.Repeat("a", 64)
+		requestID := "request-response"
+		stats.observe(transportEvent{
+			Kind: "request_started", Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+			Transport: "http", Method: "POST", Path: "/v1/responses",
+			RequestID: requestID, ConnectionID: connectionID,
+		})
+		stats.observe(transportEvent{
+			Kind: "response_chunk", Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+			Path: "/v1/responses", RequestID: requestID, ConnectionID: connectionID, Bytes: 8,
+		})
+		stats.observe(errorEvent)
+		return &goldenSession{
+			transport: "http", observer: &runningGoldenObserver{stats: stats}, done: make(chan struct{}),
+		}
+	}
+
+	unrelated := newSession(transportEvent{
+		Kind: "proxy_error", Path: "/other", RequestID: "request-metadata", ConnectionID: strings.Repeat("b", 64),
+	})
+	if err := validateObserverTurns([]*goldenSession{unrelated}, 1); err != nil {
+		t.Fatalf("unrelated request error invalidated the response turn: %v", err)
+	}
+
+	responseFailure := newSession(transportEvent{
+		Kind: "proxy_error", Path: "/v1/responses", RequestID: "request-response", ConnectionID: strings.Repeat("a", 64),
+	})
+	if err := validateObserverTurns([]*goldenSession{responseFailure}, 1); err == nil {
+		t.Fatal("response request proxy error was ignored")
+	}
+
+	recordingFailure := newSession(transportEvent{Kind: "recording_error"})
+	if err := validateObserverTurns([]*goldenSession{recordingFailure}, 1); err == nil {
+		t.Fatal("global evidence recording error was ignored")
+	}
+}
+
 func TestGoldenMigrationTransitionRejectsRetargetedRoutingSelectors(t *testing.T) {
 	evidence := validGoldenMigrationTransitionEvidence(
 		"final-cutover", "front-migration-rollback", strings.Repeat("1", 64), strings.Repeat("2", 64),

--- a/cmd/subrouter-transport-observer/golden_migration_transition.go
+++ b/cmd/subrouter-transport-observer/golden_migration_transition.go
@@ -325,16 +325,19 @@ func waitGoldenConnectionResponseChunkAfter(
 	waitContext, cancel := context.WithTimeout(ctx, goldenDestinationLivenessLimit)
 	defer cancel()
 	for {
-		requests, chunks, observerErrors := session.observer.stats.snapshot()
-		if observerErrors != 0 {
-			return time.Time{}, failGolden("migration_destination_connection_not_held")
-		}
+		requests, chunks, _ := session.observer.stats.snapshot()
 		requestIDs := make(map[string]bool)
 		for _, request := range requests {
 			if request.ConnectionID == connectionID &&
 				(request.Path == "/v1/responses" || request.Path == "/responses") {
 				requestIDs[request.RequestID] = true
 			}
+		}
+		if observerScopedErrorCount(session.observer.stats, func(event transportEvent) bool {
+			return event.ConnectionID == connectionID && requestIDs[event.RequestID] &&
+				(event.Path == "/v1/responses" || event.Path == "/responses")
+		}) != 0 {
+			return time.Time{}, failGolden("migration_destination_connection_not_held")
 		}
 		for _, chunk := range chunks {
 			if chunk.Kind != "response_chunk" || chunk.ConnectionID != connectionID || chunk.Bytes <= 0 ||

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -285,7 +285,7 @@ type observerStats struct {
 	chunks   []transportEvent
 	upstream []transportEvent
 	closed   []transportEvent
-	errors   int
+	errors   []transportEvent
 	notify   chan struct{}
 }
 
@@ -306,10 +306,8 @@ func (s *observerStats) observe(event transportEvent) {
 		s.upstream = append(s.upstream, event)
 	case "connection_closed":
 		s.closed = append(s.closed, event)
-	case "proxy_error":
-		s.errors++
-	case "recording_error":
-		s.errors++
+	case "proxy_error", "recording_error":
+		s.errors = append(s.errors, event)
 	}
 	s.mu.Unlock()
 	select {
@@ -327,7 +325,13 @@ func (s *observerStats) openedSnapshot() []transportEvent {
 func (s *observerStats) snapshot() (requests, chunks []transportEvent, proxyErrors int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return append([]transportEvent(nil), s.requests...), append([]transportEvent(nil), s.chunks...), s.errors
+	return append([]transportEvent(nil), s.requests...), append([]transportEvent(nil), s.chunks...), len(s.errors)
+}
+
+func (s *observerStats) errorSnapshot() []transportEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]transportEvent(nil), s.errors...)
 }
 
 func (s *observerStats) closedSnapshot() []transportEvent {


### PR DESCRIPTION
The staging golden gate observed a healthy accepted Responses connection emitting paced chunks every 500 ms, but an unrelated Codex metadata GET returned 502 on another connection. The aggregate observer error count incorrectly invalidated exact-connection liveness and caused a safe rollback.\n\nThis records observer error identities and scopes liveness, turn validation, and summaries to Responses requests while retaining fail-closed behavior for the exact request and all evidence-recording failures.\n\nVerification:\n- regression test fails on the test-only commit and passes with the fix\n- focused observer package tests pass\n- both timing-sensitive failures from the first concurrent full run pass in isolation\n- serialized full suite is running

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788536719&installation_model_id=21920&pr_number=178&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F178&signature=d2fcec28768e1143358decc164e603f191e711659f49390a9cf939f28a159ba2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes golden observer liveness, validation, and closure to the exact /v1/responses request/connection so unrelated proxy errors don’t trigger false failures. Keeps fail-closed behavior for the affected request and for evidence recording errors.

- **Bug Fixes**
  - Store observer errors as events in `observerStats` and add `errorSnapshot()`.
  - Add `observerScopedErrorCount()` and `observerResponseErrorCount()` to filter by path/connection/request.
  - Scope checks in `waitGoldenObserverRequestConnectionsClosed` (still fails on response errors), `waitGoldenConnectionResponseChunkAfter`, `validateObserverTurns`, and `summarizeGoldenSession`.
  - Add regression tests for liveness, validation, and observer closure: ignore unrelated request errors; still fail on response request errors and `recording_error`.

<sup>Written for commit 6f973e642ddd5c1c31d702e787e8f89ea5af8f98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved observer validation by distinguishing response-related errors from unrelated request errors.
  * Response connection checks now remain valid when errors occur on unrelated requests.
  * Recording errors and errors affecting the response request continue to correctly invalidate validation.
  * Error reporting and session summaries now accurately include relevant errors, including resumed sessions.

* **Tests**
  * Added regression coverage for response connection liveness and scoped observer error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->