### PR TITLE
Scope migration socket continuity to route transitions

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -1516,11 +1516,10 @@ func waitGoldenContinuityBoundary(ctx context.Context, monitors []*goldenContinu
 			chunks := goldenSessionResponseChunks(monitor.session)
 			for _, chunk := range chunks {
 				stamp, _ := time.Parse(time.RFC3339Nano, chunk.Timestamp)
-				identity := chunk.RequestID + "\x00" + chunk.ConnectionID
-				span := connections[identity]
+				span := connections[chunk.ConnectionID]
 				if span == nil {
 					span = &[2]bool{}
-					connections[identity] = span
+					connections[chunk.ConnectionID] = span
 				}
 				span[0] = span[0] || stamp.Before(boundary)
 				span[1] = span[1] || stamp.After(boundary)

--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -1087,13 +1087,13 @@ func (r *goldenRunner) runRehearsalCycle(ctx context.Context, inputs goldenCycle
 	}
 	after := evidenceByLabel(afterEvidence)
 	result.after = after
-	if err := requireStableSessionSockets(initial, result.before, after); err != nil {
+	if err := requireStableResponseSockets(initial, result.before, after); err != nil {
 		return result, err
 	}
-	if err := requireStableSessionSockets([]*goldenSession{spanningLocal}, spanningBefore, after); err != nil {
+	if err := requireStableResponseSockets([]*goldenSession{spanningLocal}, spanningBefore, after); err != nil {
 		return result, err
 	}
-	if err := requireStableSessionSockets([]*goldenSession{postDirect}, during, after); err != nil {
+	if err := requireStableResponseSockets([]*goldenSession{postDirect}, during, after); err != nil {
 		return result, err
 	}
 	if err := requireStableLocalEgress(during, after); err != nil {
@@ -1221,10 +1221,10 @@ func (r *goldenRunner) runFinalCycle(ctx context.Context, inputs goldenCycleInpu
 	if err := requireSessionsRunning(all, "final_activation"); err != nil {
 		return result, err
 	}
-	if err := requireStableSessionSockets(initial, result.before, result.after); err != nil {
+	if err := requireStableResponseSockets(initial, result.before, result.after); err != nil {
 		return result, err
 	}
-	if err := requireStableSessionSockets([]*goldenSession{spanningLocal}, spanningBefore, result.after); err != nil {
+	if err := requireStableResponseSockets([]*goldenSession{spanningLocal}, spanningBefore, result.after); err != nil {
 		return result, err
 	}
 	if err := requireBoundLocalEgress(all, result.after); err != nil {
@@ -1291,7 +1291,7 @@ func (r *goldenRunner) runFinalCycle(ctx context.Context, inputs goldenCycleInpu
 	if err := r.requireGoldenLocalDaemonTransportClean(); err != nil {
 		return result, err
 	}
-	if err := requireStableSessionSockets(
+	if err := requireStableResponseSockets(
 		[]*goldenSession{postDirect}, result.after,
 		map[string]goldenProcessEvidence{postDirect.label: postRetirementEvidence},
 	); err != nil {
@@ -1512,17 +1512,41 @@ func waitGoldenContinuityBoundary(ctx context.Context, monitors []*goldenContinu
 			if _, err := validatedGoldenResponseRequests(monitor.session, 1); err != nil {
 				return failGolden("continuity_transport_identity_changed")
 			}
-			before, after := false, false
+			connections := make(map[string]*[2]bool)
 			chunks := goldenSessionResponseChunks(monitor.session)
 			for _, chunk := range chunks {
 				stamp, _ := time.Parse(time.RFC3339Nano, chunk.Timestamp)
-				before = before || stamp.Before(boundary)
-				after = after || stamp.After(boundary)
+				identity := chunk.RequestID + "\x00" + chunk.ConnectionID
+				span := connections[identity]
+				if span == nil {
+					span = &[2]bool{}
+					connections[identity] = span
+				}
+				span[0] = span[0] || stamp.Before(boundary)
+				span[1] = span[1] || stamp.After(boundary)
 			}
-			if !before || !after {
+			connectionHeld := false
+			for _, span := range connections {
+				if span[0] && span[1] {
+					connectionHeld = true
+					break
+				}
+			}
+			if connectionHeld {
+				monitor.session.mu.Lock()
+				monitor.session.transportSocketStable = true
+				monitor.session.mu.Unlock()
+			} else {
 				complete = false
 				if sessionDone(monitor.session) {
 					return failGolden("continuity_boundary_bytes_missing")
+				}
+				allowed := monitor.allowed
+				if allowed <= 0 {
+					allowed = goldenChunkGapFloor
+				}
+				if time.Now().UTC().After(boundary.Add(allowed)) {
+					return failGolden("continuity_transport_identity_changed")
 				}
 			}
 		}
@@ -4163,19 +4187,59 @@ func evidenceByLabel(items []goldenProcessEvidence) map[string]goldenProcessEvid
 	return result
 }
 
+func goldenSessionSocketEvidence(
+	session *goldenSession,
+	before, after map[string]goldenProcessEvidence,
+) (goldenProcessEvidence, goldenProcessEvidence, []transportEvent, error) {
+	left, leftOK := before[session.label]
+	right, rightOK := after[session.label]
+	if !leftOK || !rightOK || len(left.SocketIDs) == 0 || len(right.SocketIDs) == 0 {
+		return goldenProcessEvidence{}, goldenProcessEvidence{}, nil, failGolden("session_socket_evidence_missing")
+	}
+	if left.Phase == "" || right.Phase == "" || left.Phase == right.Phase {
+		return goldenProcessEvidence{}, goldenProcessEvidence{}, nil, failGolden("session_socket_evidence_not_distinct")
+	}
+	requests, err := validatedGoldenResponseRequests(session, 1)
+	if err != nil {
+		return goldenProcessEvidence{}, goldenProcessEvidence{}, nil, failGolden("response_transport_socket_missing")
+	}
+	return left, right, requests, nil
+}
+
 func requireStableSessionSockets(sessions []*goldenSession, before, after map[string]goldenProcessEvidence) error {
 	for _, session := range sessions {
-		left, leftOK := before[session.label]
-		right, rightOK := after[session.label]
-		if !leftOK || !rightOK || len(left.SocketIDs) == 0 || len(right.SocketIDs) == 0 {
-			return failGolden("session_socket_evidence_missing")
-		}
-		if left.Phase == "" || right.Phase == "" || left.Phase == right.Phase {
-			return failGolden("session_socket_evidence_not_distinct")
-		}
-		requests, err := validatedGoldenResponseRequests(session, 1)
+		left, right, requests, err := goldenSessionSocketEvidence(session, before, after)
 		if err != nil {
-			return failGolden("response_transport_socket_missing")
+			return err
+		}
+		leftSockets := make(map[string]bool, len(left.SocketIDs))
+		for _, id := range left.SocketIDs {
+			leftSockets[id] = true
+		}
+		rightSockets := make(map[string]bool, len(right.SocketIDs))
+		for _, id := range right.SocketIDs {
+			rightSockets[id] = true
+		}
+		leftResponse, rightResponse := false, false
+		for _, request := range requests {
+			leftResponse = leftResponse || leftSockets[request.ConnectionID]
+			rightResponse = rightResponse || rightSockets[request.ConnectionID]
+		}
+		session.mu.Lock()
+		boundaryProof := session.transportSocketStable
+		session.mu.Unlock()
+		if !leftResponse || !rightResponse || !boundaryProof {
+			return failGolden("session_socket_identity_changed")
+		}
+	}
+	return nil
+}
+
+func requireStableResponseSockets(sessions []*goldenSession, before, after map[string]goldenProcessEvidence) error {
+	for _, session := range sessions {
+		left, right, requests, err := goldenSessionSocketEvidence(session, before, after)
+		if err != nil {
+			return err
 		}
 		leftSockets := make(map[string]bool, len(left.SocketIDs))
 		for _, id := range left.SocketIDs {

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -857,6 +857,35 @@ func TestGoldenStableSocketMustBeResponseTransportSocket(t *testing.T) {
 	}
 }
 
+func TestGoldenStableSessionAcceptsSocketTurnoverAfterBoundaryProof(t *testing.T) {
+	beforeConnection := strings.Repeat("a", 64)
+	afterConnection := strings.Repeat("b", 64)
+	stats := newObserverStats()
+	stats.observe(transportEvent{
+		Kind: "request_started", Timestamp: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339Nano),
+		Transport: "websocket", Method: "GET", Path: "/v1/responses",
+		RequestID: "request-before", ConnectionID: beforeConnection,
+	})
+	stats.observe(transportEvent{
+		Kind: "request_started", Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		Transport: "websocket", Method: "GET", Path: "/v1/responses",
+		RequestID: "request-after", ConnectionID: afterConnection,
+	})
+	session := &goldenSession{
+		label: "migration-direct-websocket", transport: "websocket",
+		observer: &runningGoldenObserver{stats: stats}, transportSocketStable: true,
+	}
+	before := map[string]goldenProcessEvidence{
+		session.label: {Label: session.label, Phase: "migration-before-rehearsal-cutover", SocketIDs: []string{beforeConnection}},
+	}
+	after := map[string]goldenProcessEvidence{
+		session.label: {Label: session.label, Phase: "migration-after-final-cutover", SocketIDs: []string{afterConnection}},
+	}
+	if err := requireStableSessionSockets([]*goldenSession{session}, before, after); err != nil {
+		t.Fatalf("normal follow-on response was rejected after exact transition-boundary proof: %v", err)
+	}
+}
+
 func TestGoldenStableSocketRequiresDistinctSnapshots(t *testing.T) {
 	transportID := strings.Repeat("a", 64)
 	stats := newObserverStats()
@@ -944,6 +973,39 @@ func TestGoldenContinuityFollowsSessionAcrossMultipleResponses(t *testing.T) {
 	}
 	if err := stopGoldenContinuityMonitors(monitors, baselineEnd.Add(time.Second), baselineEnd.Add(6*time.Second)); err != nil {
 		t.Fatalf("session-level continuity rejected aggregate response bytes: %v", err)
+	}
+}
+
+func TestGoldenContinuityBoundaryRejectsResponseReconnect(t *testing.T) {
+	boundary := time.Now().UTC().Add(-2 * time.Second)
+	stats := newObserverStats()
+	stats.observe(transportEvent{
+		Kind: "request_started", Timestamp: boundary.Add(-time.Second).Format(time.RFC3339Nano),
+		Transport: "websocket", Method: "GET", Path: "/v1/responses",
+		RequestID: "request-before", ConnectionID: strings.Repeat("a", 64),
+	})
+	stats.observe(transportEvent{
+		Kind: "response_chunk", Timestamp: boundary.Add(-time.Millisecond).Format(time.RFC3339Nano),
+		Transport: "websocket", Method: "GET", Path: "/v1/responses",
+		RequestID: "request-before", ConnectionID: strings.Repeat("a", 64), Bytes: 1,
+	})
+	stats.observe(transportEvent{
+		Kind: "request_started", Timestamp: boundary.Add(time.Millisecond).Format(time.RFC3339Nano),
+		Transport: "websocket", Method: "GET", Path: "/v1/responses",
+		RequestID: "request-after", ConnectionID: strings.Repeat("b", 64),
+	})
+	stats.observe(transportEvent{
+		Kind: "response_chunk", Timestamp: boundary.Add(2 * time.Millisecond).Format(time.RFC3339Nano),
+		Transport: "websocket", Method: "GET", Path: "/v1/responses",
+		RequestID: "request-after", ConnectionID: strings.Repeat("b", 64), Bytes: 1,
+	})
+	session := &goldenSession{
+		label: "reconnected", transport: "websocket", done: make(chan struct{}),
+		observer: &runningGoldenObserver{stats: stats},
+	}
+	monitors := []*goldenContinuityMonitor{{session: session, allowed: time.Second}}
+	if err := waitGoldenContinuityBoundary(context.Background(), monitors, boundary); err == nil {
+		t.Fatal("accepted different response connections on opposite sides of a deployment boundary")
 	}
 }
 

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -1009,6 +1009,40 @@ func TestGoldenContinuityBoundaryRejectsResponseReconnect(t *testing.T) {
 	}
 }
 
+func TestGoldenContinuityBoundaryAllowsSequentialRequestsOnOneConnection(t *testing.T) {
+	boundary := time.Now().UTC().Add(-2 * time.Second)
+	connection := strings.Repeat("a", 64)
+	stats := newObserverStats()
+	stats.observe(transportEvent{
+		Kind: "request_started", Timestamp: boundary.Add(-time.Second).Format(time.RFC3339Nano),
+		Transport: "http", Method: "POST", Path: "/v1/responses",
+		RequestID: "request-before", ConnectionID: connection,
+	})
+	stats.observe(transportEvent{
+		Kind: "response_chunk", Timestamp: boundary.Add(-time.Millisecond).Format(time.RFC3339Nano),
+		Transport: "http", Method: "POST", Path: "/v1/responses",
+		RequestID: "request-before", ConnectionID: connection, Bytes: 1,
+	})
+	stats.observe(transportEvent{
+		Kind: "request_started", Timestamp: boundary.Add(time.Millisecond).Format(time.RFC3339Nano),
+		Transport: "http", Method: "POST", Path: "/v1/responses",
+		RequestID: "request-after", ConnectionID: connection,
+	})
+	stats.observe(transportEvent{
+		Kind: "response_chunk", Timestamp: boundary.Add(2 * time.Millisecond).Format(time.RFC3339Nano),
+		Transport: "http", Method: "POST", Path: "/v1/responses",
+		RequestID: "request-after", ConnectionID: connection, Bytes: 1,
+	})
+	session := &goldenSession{
+		label: "connection-reused", transport: "http", done: make(chan struct{}),
+		observer: &runningGoldenObserver{stats: stats},
+	}
+	monitors := []*goldenContinuityMonitor{{session: session, allowed: time.Second}}
+	if err := waitGoldenContinuityBoundary(context.Background(), monitors, boundary); err != nil {
+		t.Fatalf("sequential response requests on one connection were rejected: %v", err)
+	}
+}
+
 func TestGoldenLocalLeaseObserverRejectsHostedResponse(t *testing.T) {
 	now := time.Now().UTC()
 	stats := newObserverStats()

--- a/cmd/subrouter-transport-observer/golden_slot_activation.go
+++ b/cmd/subrouter-transport-observer/golden_slot_activation.go
@@ -175,10 +175,10 @@ func (r *goldenRunner) runSlotActivationWithAck(
 	if err := localEgressMonitor.validate(); err != nil {
 		return goldenActionSummary{}, nil, nil, err
 	}
-	if err := requireStableSessionSockets(initial, before, provisionalByLabel); err != nil {
+	if err := requireStableResponseSockets(initial, before, provisionalByLabel); err != nil {
 		return goldenActionSummary{}, nil, nil, err
 	}
-	if err := requireStableSessionSockets([]*goldenSession{spanningLocal}, spanningBefore, provisionalByLabel); err != nil {
+	if err := requireStableResponseSockets([]*goldenSession{spanningLocal}, spanningBefore, provisionalByLabel); err != nil {
 		return goldenActionSummary{}, nil, nil, err
 	}
 	if err := requireStableLocalEgress(spanningBefore, provisionalByLabel); err != nil {
@@ -219,10 +219,10 @@ func (r *goldenRunner) runSlotActivationWithAck(
 	if err := localEgressMonitor.validate(); err != nil {
 		return goldenActionSummary{}, nil, nil, err
 	}
-	if err := requireStableSessionSockets(initial, before, after); err != nil {
+	if err := requireStableResponseSockets(initial, before, after); err != nil {
 		return goldenActionSummary{}, nil, nil, err
 	}
-	if err := requireStableSessionSockets([]*goldenSession{spanningLocal}, spanningBefore, after); err != nil {
+	if err := requireStableResponseSockets([]*goldenSession{spanningLocal}, spanningBefore, after); err != nil {
 		return goldenActionSummary{}, nil, nil, err
 	}
 	if err := requireStableLocalEgress(spanningBefore, after); err != nil {


### PR DESCRIPTION
## Summary

- require one Responses request and connection to emit bytes on both sides of every route mutation
- allow normal Codex follow-on requests between the three migration transitions
- retain strict one-socket checks for worker-slot activations

## Evidence

- regression tests failed on the test-only commit and pass with the fix
- `go test ./cmd/subrouter-transport-observer -count=1`
- staging run `staging-pr178-v0166-r5` passed rehearsal, rollback, and final exact-connection liveness, then exposed the invalid whole-run socket check

Production remains untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788541419&installation_model_id=21920&pr_number=179&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F179&signature=2913a77af1867d424d7a07544fc6f241a703df3840e0be50a791ce1ad8ab7229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes migration socket continuity to route transitions by requiring the same response connection across each boundary. This drops the whole-run socket lock, reduces false failures during rehearsals/final cutover, and keeps worker-slot activation checks strict.

- **Bug Fixes**
  - Added requireStableResponseSockets and replaced previous checks during rehearsal, slot activation, and final cycles.
  - Boundary proof now tracks continuity by ConnectionID (not RequestID); accepts sequential requests on a reused connection; sets transportSocketStable on proof and times out otherwise.
  - Rejects response reconnects that span a boundary; added regression tests for both rejection and allowed connection reuse.

<sup>Written for commit af785bf892c37d354ced8ba3867938181378fd97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection continuity validation during deployment and activation boundaries.
  - Correctly distinguishes permitted socket turnover from invalid response reconnections.
  - Ensures transport stability is confirmed only when matching connections span the boundary.

- **Tests**
  - Added regression coverage for approved socket transitions and rejected response reconnections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->