### PR TITLE
Retire superseded golden response attempts

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -52,6 +52,7 @@ const (
 	goldenPinnedBootstrapLinuxSHA256          = "39fcd2c3a86c7be12759ed0f0b366d9d13f90e538c2af2483dd50230c9ef2bf2"
 	goldenPinnedBootstrapRevision             = "763dcf6c304d9aea7f36659d4fba40ea27f42096"
 	goldenPinnedCandidateTag                  = "v0.1.66"
+	goldenResponseRequestTokenEnv             = "SUBROUTER_GOLDEN_RESPONSE_REQUEST_TOKEN"
 	goldenFakeStreamReleaseTokenEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_TOKEN"
 	goldenFakeStreamReleaseStateEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_STATE"
 )
@@ -2690,7 +2691,7 @@ func (r *goldenRunner) startSession(
 		configPath = teamConfigPath
 		baseURL = observation.baseURL + "/v1"
 	}
-	streamReleaseToken, err := newGoldenTestStreamReleaseToken()
+	streamReleaseToken, err := newGoldenSessionRequestToken()
 	if err != nil {
 		return nil, err
 	}
@@ -2717,6 +2718,7 @@ func (r *goldenRunner) launchSession(ctx context.Context, clientPath string, ses
 	args := []string{
 		"codex", "exec", "--json", "--ignore-user-config", "--ignore-rules",
 		"--skip-git-repo-check", "-C", r.privateRoot, "-s", "read-only", "-m", r.options.model,
+		"-c", `model_providers.subrouter.env_http_headers={"` + goldenRequestTokenHeader + `"="` + goldenResponseRequestTokenEnv + `"}`,
 	}
 	if session.transport == "http" {
 		args = append(args, "-c", `model_providers.subrouter.supports_websockets=false`)
@@ -2729,12 +2731,13 @@ func (r *goldenRunner) launchSession(ctx context.Context, clientPath string, ses
 	command := exec.CommandContext(ctx, clientPath, args...)
 	configureProcessGroup(command)
 	overrides := map[string]string{
-		"CODEX_HOME":                 session.codexHome,
-		"SUBROUTER_CLOUD_CONFIG":     session.configPath,
-		"SUBROUTER_CODEX_BASE_URL":   session.baseURL,
-		"SUBROUTER_CODEX_BIN":        r.options.codexBinary,
-		"SUBROUTER_DISABLE_FALLBACK": "1",
-		"SUBROUTER_STATE_DIR":        filepath.Join(session.home, ".subrouter"),
+		"CODEX_HOME":                  session.codexHome,
+		"SUBROUTER_CLOUD_CONFIG":      session.configPath,
+		"SUBROUTER_CODEX_BASE_URL":    session.baseURL,
+		"SUBROUTER_CODEX_BIN":         r.options.codexBinary,
+		"SUBROUTER_DISABLE_FALLBACK":  "1",
+		"SUBROUTER_STATE_DIR":         filepath.Join(session.home, ".subrouter"),
+		goldenResponseRequestTokenEnv: session.streamReleaseToken,
 	}
 	if session.route == "local-egress" {
 		overrides["SUBROUTER_LOCAL_BASE_URL"] = session.baseURL
@@ -2830,10 +2833,7 @@ func (r *goldenRunner) launchSession(ctx context.Context, clientPath string, ses
 	return nil
 }
 
-func newGoldenTestStreamReleaseToken() (string, error) {
-	if !goldenTestHooks.enabled {
-		return "", nil
-	}
+func newGoldenSessionRequestToken() (string, error) {
 	token, err := randomGoldenToken("")
 	if err != nil {
 		return "", failGolden("stream_release_token_generation_failed")
@@ -3727,7 +3727,7 @@ func (r *goldenRunner) startResumeSessions(ctx context.Context, clientPath strin
 		if original.observer == nil || original.observer.upstream == nil {
 			return nil, failGolden("resume_observer_missing")
 		}
-		streamReleaseToken, err := newGoldenTestStreamReleaseToken()
+		streamReleaseToken, err := newGoldenSessionRequestToken()
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -2718,7 +2718,7 @@ func (r *goldenRunner) launchSession(ctx context.Context, clientPath string, ses
 	args := []string{
 		"codex", "exec", "--json", "--ignore-user-config", "--ignore-rules",
 		"--skip-git-repo-check", "-C", r.privateRoot, "-s", "read-only", "-m", r.options.model,
-		"-c", `model_providers.subrouter.env_http_headers={"` + goldenRequestTokenHeader + `"="` + goldenResponseRequestTokenEnv + `"}`,
+		"-c", `model_providers.subrouter.env_http_headers={"` + goldenResponseAttemptTokenHeader + `"="` + goldenResponseRequestTokenEnv + `"}`,
 	}
 	if session.transport == "http" {
 		args = append(args, "-c", `model_providers.subrouter.supports_websockets=false`)

--- a/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
@@ -134,6 +134,7 @@ func TestGoldenObserverSupersedesAbandonedResponseAttempt(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		identifier := request.URL.Query().Get("id")
 		writer.Header().Set("Content-Type", "text/event-stream")
+		writer.(http.Flusher).Flush()
 		_, _ = writer.Write([]byte(identifier))
 		upstreamWritten <- identifier
 	}))

--- a/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
@@ -28,7 +28,7 @@ func (delay *accumulatingObserverDelay) wait(
 
 func TestGoldenObserverDefaultPacingOutlastsDeploymentGate(t *testing.T) {
 	gate := newGoldenResponseGate()
-	pacer := gate.newResponsePacer()
+	pacer := gate.newResponsePacer("")
 	delay := &accumulatingObserverDelay{}
 	pacer.delay = delay
 
@@ -128,8 +128,8 @@ func TestGoldenObserverHoldsRealResponseUntilGateRelease(t *testing.T) {
 func TestGoldenObserverLeavesPostReleaseResponsesIndependent(t *testing.T) {
 	gate := newGoldenResponseGate()
 	gate.releasePacing()
-	first := gate.newResponsePacer()
-	second := gate.newResponsePacer()
+	first := gate.newResponsePacer("")
+	second := gate.newResponsePacer("")
 
 	var firstDelivered bytes.Buffer
 	if _, err := first.write(context.Background(), []byte("first"), firstDelivered.Write); err != nil {
@@ -155,6 +155,9 @@ func TestGoldenObserverSupersedesAbandonedResponseAttempt(t *testing.T) {
 
 	upstreamWritten := make(chan string, 2)
 	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Header.Get(goldenRequestTokenHeader) != "" {
+			t.Error("golden response request token escaped the observer")
+		}
 		identifier := request.URL.Query().Get("id")
 		writer.Header().Set("Content-Type", "text/event-stream")
 		writer.(http.Flusher).Flush()
@@ -191,7 +194,17 @@ func TestGoldenObserverSupersedesAbandonedResponseAttempt(t *testing.T) {
 	}
 	startRequest := func(identifier string) {
 		go func(identifier string) {
-			response, err := http.Post(observation.baseURL+"/v1/responses?id="+identifier, "application/json", bytes.NewReader([]byte("{}")))
+			request, err := http.NewRequest(
+				http.MethodPost,
+				observation.baseURL+"/v1/responses?id="+identifier,
+				bytes.NewReader([]byte("{}")),
+			)
+			if err != nil {
+				results[identifier] <- responseResult{identifier: identifier, err: err}
+				return
+			}
+			request.Header.Set(goldenRequestTokenHeader, "0123456789abcdef0123456789abcdef")
+			response, err := http.DefaultClient.Do(request)
 			if err != nil {
 				results[identifier] <- responseResult{identifier: identifier, err: err}
 				return

--- a/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
@@ -125,6 +125,29 @@ func TestGoldenObserverHoldsRealResponseUntilGateRelease(t *testing.T) {
 	}
 }
 
+func TestGoldenObserverLeavesPostReleaseResponsesIndependent(t *testing.T) {
+	gate := newGoldenResponseGate()
+	gate.releasePacing()
+	first := gate.newResponsePacer()
+	second := gate.newResponsePacer()
+
+	var firstDelivered bytes.Buffer
+	if _, err := first.write(context.Background(), []byte("first"), firstDelivered.Write); err != nil {
+		t.Fatal(err)
+	}
+	var secondDelivered bytes.Buffer
+	if _, err := second.write(context.Background(), []byte("second"), secondDelivered.Write); err != nil {
+		t.Fatal(err)
+	}
+
+	if firstDelivered.String() != "first" {
+		t.Fatalf("first post-release response = %q, want first", firstDelivered.String())
+	}
+	if secondDelivered.String() != "second" {
+		t.Fatalf("second post-release response = %q, want second", secondDelivered.String())
+	}
+}
+
 func TestGoldenObserverSupersedesAbandonedResponseAttempt(t *testing.T) {
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = false

--- a/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
@@ -253,3 +253,107 @@ func TestGoldenObserverSupersedesAbandonedResponseAttempt(t *testing.T) {
 		t.Fatal("current response did not drain")
 	}
 }
+
+func TestGoldenObserverKeepsDistinctConcurrentResponsesIndependent(t *testing.T) {
+	previousHooks := goldenTestHooks
+	goldenTestHooks.enabled = false
+	t.Cleanup(func() { goldenTestHooks = previousHooks })
+
+	upstreamWritten := make(chan string, 2)
+	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		identifier := request.URL.Query().Get("id")
+		writer.Header().Set("Content-Type", "text/event-stream")
+		writer.(http.Flusher).Flush()
+		_, _ = writer.Write([]byte(identifier))
+		upstreamWritten <- identifier
+	}))
+	t.Cleanup(upstream.Close)
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &goldenRunner{artifactDir: t.TempDir()}
+	observation, err := runner.startObserver("distinct-concurrent-real-stream-pacing", upstreamURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := observation.stop(ctx); err != nil {
+			t.Errorf("stop observer: %v", err)
+		}
+	})
+
+	type responseResult struct {
+		identifier string
+		body       string
+		err        error
+	}
+	results := make(chan responseResult, 2)
+	startRequest := func(identifier, token string) {
+		go func() {
+			request, requestErr := http.NewRequest(
+				http.MethodPost,
+				observation.baseURL+"/v1/responses?id="+identifier,
+				bytes.NewReader([]byte("{}")),
+			)
+			if requestErr != nil {
+				results <- responseResult{identifier: identifier, err: requestErr}
+				return
+			}
+			request.Header.Set(goldenRequestTokenHeader, token)
+			response, requestErr := http.DefaultClient.Do(request)
+			if requestErr != nil {
+				results <- responseResult{identifier: identifier, err: requestErr}
+				return
+			}
+			body, readErr := io.ReadAll(response.Body)
+			closeErr := response.Body.Close()
+			if readErr == nil {
+				readErr = closeErr
+			}
+			results <- responseResult{identifier: identifier, body: string(body), err: readErr}
+		}()
+	}
+	waitForUpstream := func(identifier string) {
+		t.Helper()
+		select {
+		case got := <-upstreamWritten:
+			if got != identifier {
+				t.Fatalf("upstream response = %q, want %q", got, identifier)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("%s upstream response was not written", identifier)
+		}
+	}
+
+	startRequest("first-response", "0123456789abcdef0123456789abcdef")
+	waitForUpstream("first-response")
+	startRequest("second-response", "fedcba9876543210fedcba9876543210")
+	waitForUpstream("second-response")
+
+	select {
+	case result := <-results:
+		t.Fatalf("distinct response completed before gate release: id=%s body=%q err=%v", result.identifier, result.body, result.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if err := releaseGoldenTestSessions([]*goldenSession{{observer: observation}}); err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		select {
+		case result := <-results:
+			if result.err != nil {
+				t.Fatalf("%s failed: %v", result.identifier, result.err)
+			}
+			if result.body != result.identifier {
+				t.Fatalf("%s body = %q, want %q", result.identifier, result.body, result.identifier)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("distinct concurrent response did not drain")
+		}
+	}
+}

--- a/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
@@ -125,7 +125,7 @@ func TestGoldenObserverHoldsRealResponseUntilGateRelease(t *testing.T) {
 	}
 }
 
-func TestGoldenObserverIsolatesConcurrentResponseHoldbacks(t *testing.T) {
+func TestGoldenObserverSupersedesAbandonedResponseAttempt(t *testing.T) {
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = false
 	t.Cleanup(func() { goldenTestHooks = previousHooks })
@@ -161,12 +161,15 @@ func TestGoldenObserverIsolatesConcurrentResponseHoldbacks(t *testing.T) {
 		body       string
 		err        error
 	}
-	results := make(chan responseResult, 2)
-	for _, identifier := range []string{"first-response", "second-response"} {
+	results := map[string]chan responseResult{
+		"first-response":  make(chan responseResult, 1),
+		"second-response": make(chan responseResult, 1),
+	}
+	startRequest := func(identifier string) {
 		go func(identifier string) {
 			response, err := http.Post(observation.baseURL+"/v1/responses?id="+identifier, "application/json", bytes.NewReader([]byte("{}")))
 			if err != nil {
-				results <- responseResult{identifier: identifier, err: err}
+				results[identifier] <- responseResult{identifier: identifier, err: err}
 				return
 			}
 			body, readErr := io.ReadAll(response.Body)
@@ -174,32 +177,55 @@ func TestGoldenObserverIsolatesConcurrentResponseHoldbacks(t *testing.T) {
 			if readErr == nil {
 				readErr = closeErr
 			}
-			results <- responseResult{identifier: identifier, body: string(body), err: readErr}
+			results[identifier] <- responseResult{identifier: identifier, body: string(body), err: readErr}
 		}(identifier)
 	}
-	for range 2 {
+	waitForUpstream := func(identifier string) {
+		t.Helper()
 		select {
-		case <-upstreamWritten:
+		case got := <-upstreamWritten:
+			if got != identifier {
+				t.Fatalf("upstream response = %q, want %q", got, identifier)
+			}
 		case <-time.After(5 * time.Second):
-			t.Fatal("concurrent upstream response was not written")
+			t.Fatalf("%s upstream response was not written", identifier)
 		}
 	}
-	time.Sleep(100 * time.Millisecond)
+
+	startRequest("first-response")
+	waitForUpstream("first-response")
+	startRequest("second-response")
+	waitForUpstream("second-response")
+
+	select {
+	case result := <-results["first-response"]:
+		if result.err != nil {
+			t.Fatalf("superseded response failed: %v", result.err)
+		}
+		if result.body != "" {
+			t.Fatalf("superseded response body = %q, want empty", result.body)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("superseded response remained held")
+	}
+	select {
+	case result := <-results["second-response"]:
+		t.Fatalf("current response completed before gate release: body=%q err=%v", result.body, result.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
 	if err := releaseGoldenTestSessions([]*goldenSession{{observer: observation}}); err != nil {
 		t.Fatal(err)
 	}
-
-	for range 2 {
-		select {
-		case result := <-results:
-			if result.err != nil {
-				t.Fatalf("%s failed: %v", result.identifier, result.err)
-			}
-			if result.body != result.identifier {
-				t.Fatalf("%s body = %q", result.identifier, result.body)
-			}
-		case <-time.After(5 * time.Second):
-			t.Fatal("concurrent response did not drain")
+	select {
+	case result := <-results["second-response"]:
+		if result.err != nil {
+			t.Fatalf("current response failed: %v", result.err)
 		}
+		if result.body != result.identifier {
+			t.Fatalf("current response body = %q, want %q", result.body, result.identifier)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("current response did not drain")
 	}
 }

--- a/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -148,6 +149,58 @@ func TestGoldenObserverLeavesPostReleaseResponsesIndependent(t *testing.T) {
 	}
 }
 
+func TestGoldenObserverSerializesSupersessionWithGateRelease(t *testing.T) {
+	gate := newGoldenResponseGate()
+	token := "0123456789abcdef0123456789abcdef"
+	previous := gate.newResponsePacer(token)
+
+	onceEntered := make(chan struct{})
+	onceRelease := make(chan struct{})
+	go previous.releaseRequestOnce.Do(func() {
+		close(onceEntered)
+		<-onceRelease
+	})
+	<-onceEntered
+
+	newPacerDone := make(chan struct{})
+	go func() {
+		gate.newResponsePacer(token)
+		close(newPacerDone)
+	}()
+	deadline := time.After(5 * time.Second)
+	for !previous.wasSuperseded() {
+		select {
+		case <-deadline:
+			t.Fatal("new response did not begin superseding the previous attempt")
+		default:
+			runtime.Gosched()
+		}
+	}
+
+	releaseDone := make(chan struct{})
+	go func() {
+		gate.releasePacing()
+		close(releaseDone)
+	}()
+	select {
+	case <-releaseDone:
+		t.Fatal("gate release overtook an in-progress supersession")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(onceRelease)
+	select {
+	case <-newPacerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("supersession did not finish")
+	}
+	select {
+	case <-releaseDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("gate release did not finish after supersession")
+	}
+}
+
 func TestGoldenObserverSupersedesAbandonedResponseAttempt(t *testing.T) {
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = false
@@ -155,7 +208,7 @@ func TestGoldenObserverSupersedesAbandonedResponseAttempt(t *testing.T) {
 
 	upstreamWritten := make(chan string, 2)
 	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if request.Header.Get(goldenRequestTokenHeader) != "" {
+		if request.Header.Get(goldenResponseAttemptTokenHeader) != "" {
 			t.Error("golden response request token escaped the observer")
 		}
 		identifier := request.URL.Query().Get("id")
@@ -203,7 +256,7 @@ func TestGoldenObserverSupersedesAbandonedResponseAttempt(t *testing.T) {
 				results[identifier] <- responseResult{identifier: identifier, err: err}
 				return
 			}
-			request.Header.Set(goldenRequestTokenHeader, "0123456789abcdef0123456789abcdef")
+			request.Header.Set(goldenResponseAttemptTokenHeader, "0123456789abcdef0123456789abcdef")
 			response, err := http.DefaultClient.Do(request)
 			if err != nil {
 				results[identifier] <- responseResult{identifier: identifier, err: err}
@@ -316,7 +369,7 @@ func TestGoldenObserverKeepsDistinctConcurrentResponsesIndependent(t *testing.T)
 				results <- responseResult{identifier: identifier, err: requestErr}
 				return
 			}
-			request.Header.Set(goldenRequestTokenHeader, token)
+			request.Header.Set(goldenResponseAttemptTokenHeader, token)
 			response, requestErr := http.DefaultClient.Do(request)
 			if requestErr != nil {
 				results <- responseResult{identifier: identifier, err: requestErr}

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -63,10 +63,11 @@ func (timerObserverDelay) wait(
 }
 
 type goldenResponseGate struct {
-	released chan struct{}
-	release  sync.Once
-	mu       sync.Mutex
-	current  *goldenResponsePacer
+	released       chan struct{}
+	release        sync.Once
+	mu             sync.Mutex
+	pacingReleased bool
+	current        *goldenResponsePacer
 }
 
 func newGoldenResponseGate() *goldenResponseGate {
@@ -77,7 +78,13 @@ func (g *goldenResponseGate) releasePacing() {
 	if g == nil {
 		return
 	}
-	g.release.Do(func() { close(g.released) })
+	g.release.Do(func() {
+		g.mu.Lock()
+		g.pacingReleased = true
+		g.current = nil
+		close(g.released)
+		g.mu.Unlock()
+	})
 }
 
 func (g *goldenResponseGate) newResponsePacer() *goldenResponsePacer {
@@ -93,8 +100,11 @@ func (g *goldenResponseGate) newResponsePacer() *goldenResponsePacer {
 		requestReleased: make(chan struct{}),
 	}
 	g.mu.Lock()
-	previous := g.current
-	g.current = pacer
+	var previous *goldenResponsePacer
+	if !g.pacingReleased {
+		previous = g.current
+		g.current = pacer
+	}
 	g.mu.Unlock()
 	previous.supersede()
 	return pacer

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -67,11 +67,14 @@ type goldenResponseGate struct {
 	release        sync.Once
 	mu             sync.Mutex
 	pacingReleased bool
-	current        *goldenResponsePacer
+	current        map[string]*goldenResponsePacer
 }
 
 func newGoldenResponseGate() *goldenResponseGate {
-	return &goldenResponseGate{released: make(chan struct{})}
+	return &goldenResponseGate{
+		released: make(chan struct{}),
+		current:  make(map[string]*goldenResponsePacer),
+	}
 }
 
 func (g *goldenResponseGate) releasePacing() {
@@ -81,13 +84,15 @@ func (g *goldenResponseGate) releasePacing() {
 	g.release.Do(func() {
 		g.mu.Lock()
 		g.pacingReleased = true
-		g.current = nil
+		clear(g.current)
 		close(g.released)
 		g.mu.Unlock()
 	})
 }
 
-func (g *goldenResponseGate) newResponsePacer() *goldenResponsePacer {
+// newResponsePacer treats matching non-empty tokens as attempts for one golden
+// Codex turn. Untagged and differently tagged requests remain independent.
+func (g *goldenResponseGate) newResponsePacer(requestToken string) *goldenResponsePacer {
 	if g == nil {
 		return nil
 	}
@@ -101,13 +106,24 @@ func (g *goldenResponseGate) newResponsePacer() *goldenResponsePacer {
 	}
 	g.mu.Lock()
 	var previous *goldenResponsePacer
-	if !g.pacingReleased {
-		previous = g.current
-		g.current = pacer
+	if !g.pacingReleased && requestToken != "" {
+		previous = g.current[requestToken]
+		g.current[requestToken] = pacer
 	}
 	g.mu.Unlock()
 	previous.supersede()
 	return pacer
+}
+
+func (g *goldenResponseGate) finishResponsePacer(requestToken string, pacer *goldenResponsePacer) {
+	if g == nil || requestToken == "" || pacer == nil {
+		return
+	}
+	g.mu.Lock()
+	if g.current[requestToken] == pacer {
+		delete(g.current, requestToken)
+	}
+	g.mu.Unlock()
 }
 
 // goldenResponsePacer applies backpressure from the local continuity observer
@@ -794,7 +810,7 @@ func newObserverHandlerWithObserverAndGate(upstream *url.URL, observation *obser
 		observation.emit(event)
 		return &countingUpstreamConn{Conn: connection, observer: observation, meta: meta, id: id}, nil
 	}
-	proxy.Transport = transport
+	proxy.Transport = &goldenRequestHeaderStripTransport{base: transport}
 	if goldenTestHooks.enabled {
 		proxy.Transport = &goldenRequestWriteTransport{
 			base:   transport,
@@ -823,6 +839,7 @@ func newObserverHandlerWithObserverAndGate(upstream *url.URL, observation *obser
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+		requestToken := goldenResponseRequestToken(request.Header)
 		finishRequest := observation.requests.begin()
 		defer finishRequest()
 		meta := requestEvidence{
@@ -839,7 +856,7 @@ func newObserverHandlerWithObserverAndGate(upstream *url.URL, observation *obser
 		request = request.WithContext(context.WithValue(request.Context(), requestEvidenceContextKey{}, meta))
 		var responsePacer *goldenResponsePacer
 		if meta.path == "/v1/responses" || meta.path == "/responses" {
-			responsePacer = gate.newResponsePacer()
+			responsePacer = gate.newResponsePacer(requestToken)
 		}
 		responseWriter := &countingResponseWriter{
 			ResponseWriter: w, observer: observation, meta: meta,
@@ -847,6 +864,7 @@ func newObserverHandlerWithObserverAndGate(upstream *url.URL, observation *obser
 		}
 		proxy.ServeHTTP(responseWriter, request)
 		if responsePacer != nil {
+			defer gate.finishResponsePacer(requestToken, responsePacer)
 			if !responsePacer.hasPayload() {
 				responsePacer.releaseRequest()
 			}
@@ -860,6 +878,23 @@ func newObserverHandlerWithObserverAndGate(upstream *url.URL, observation *obser
 		responseWriter.finish()
 		observation.emit(meta.event("request_completed"))
 	})
+}
+
+type goldenRequestHeaderStripTransport struct {
+	base http.RoundTripper
+}
+
+func (transport *goldenRequestHeaderStripTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	request.Header.Del(goldenRequestTokenHeader)
+	return transport.base.RoundTrip(request)
+}
+
+func goldenResponseRequestToken(header http.Header) string {
+	values := header.Values(goldenRequestTokenHeader)
+	if len(values) != 1 || !validGoldenRequestToken(values[0]) {
+		return ""
+	}
+	return values[0]
 }
 
 type goldenRequestWriteTransport struct {

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -28,12 +28,13 @@ import (
 )
 
 const (
-	goldenRequestTokenHeader = "X-Subrouter-Golden-Request-Token"
-	goldenRequestStateEnv    = "SUBROUTER_GOLDEN_FAKE_REQUEST_STATE"
-	goldenPacedChunkBytes    = 8
-	goldenPacedChunkInterval = 500 * time.Millisecond
-	goldenPacedReadBuffer    = 64 << 10
-	goldenPacedHoldbackBytes = 256
+	goldenRequestTokenHeader         = "X-Subrouter-Golden-Request-Token"
+	goldenResponseAttemptTokenHeader = "X-Subrouter-Golden-Response-Attempt"
+	goldenRequestStateEnv            = "SUBROUTER_GOLDEN_FAKE_REQUEST_STATE"
+	goldenPacedChunkBytes            = 8
+	goldenPacedChunkInterval         = 500 * time.Millisecond
+	goldenPacedReadBuffer            = 64 << 10
+	goldenPacedHoldbackBytes         = 256
 )
 
 type observerDelay interface {
@@ -105,13 +106,12 @@ func (g *goldenResponseGate) newResponsePacer(requestToken string) *goldenRespon
 		requestReleased: make(chan struct{}),
 	}
 	g.mu.Lock()
-	var previous *goldenResponsePacer
 	if !g.pacingReleased && requestToken != "" {
-		previous = g.current[requestToken]
+		previous := g.current[requestToken]
 		g.current[requestToken] = pacer
+		previous.supersede()
 	}
 	g.mu.Unlock()
-	previous.supersede()
 	return pacer
 }
 
@@ -810,10 +810,10 @@ func newObserverHandlerWithObserverAndGate(upstream *url.URL, observation *obser
 		observation.emit(event)
 		return &countingUpstreamConn{Conn: connection, observer: observation, meta: meta, id: id}, nil
 	}
-	proxy.Transport = &goldenRequestHeaderStripTransport{base: transport}
+	proxy.Transport = &goldenResponseAttemptHeaderStripTransport{base: transport}
 	if goldenTestHooks.enabled {
 		proxy.Transport = &goldenRequestWriteTransport{
-			base:   transport,
+			base:   proxy.Transport,
 			signal: goldenTestHooks.outboundRequestWritten,
 		}
 	}
@@ -839,7 +839,7 @@ func newObserverHandlerWithObserverAndGate(upstream *url.URL, observation *obser
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
-		requestToken := goldenResponseRequestToken(request.Header)
+		requestToken := goldenResponseAttemptToken(request.Header)
 		finishRequest := observation.requests.begin()
 		defer finishRequest()
 		meta := requestEvidence{
@@ -880,17 +880,17 @@ func newObserverHandlerWithObserverAndGate(upstream *url.URL, observation *obser
 	})
 }
 
-type goldenRequestHeaderStripTransport struct {
+type goldenResponseAttemptHeaderStripTransport struct {
 	base http.RoundTripper
 }
 
-func (transport *goldenRequestHeaderStripTransport) RoundTrip(request *http.Request) (*http.Response, error) {
-	request.Header.Del(goldenRequestTokenHeader)
+func (transport *goldenResponseAttemptHeaderStripTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	request.Header.Del(goldenResponseAttemptTokenHeader)
 	return transport.base.RoundTrip(request)
 }
 
-func goldenResponseRequestToken(header http.Header) string {
-	values := header.Values(goldenRequestTokenHeader)
+func goldenResponseAttemptToken(header http.Header) string {
+	values := header.Values(goldenResponseAttemptTokenHeader)
 	if len(values) != 1 || !validGoldenRequestToken(values[0]) {
 		return ""
 	}

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -65,6 +65,8 @@ func (timerObserverDelay) wait(
 type goldenResponseGate struct {
 	released chan struct{}
 	release  sync.Once
+	mu       sync.Mutex
+	current  *goldenResponsePacer
 }
 
 func newGoldenResponseGate() *goldenResponseGate {
@@ -82,7 +84,7 @@ func (g *goldenResponseGate) newResponsePacer() *goldenResponsePacer {
 	if g == nil {
 		return nil
 	}
-	return &goldenResponsePacer{
+	pacer := &goldenResponsePacer{
 		chunkBytes:      goldenPacedChunkBytes,
 		holdbackBytes:   goldenPacedHoldbackBytes,
 		interval:        goldenPacedChunkInterval,
@@ -90,6 +92,12 @@ func (g *goldenResponseGate) newResponsePacer() *goldenResponsePacer {
 		gateReleased:    g.released,
 		requestReleased: make(chan struct{}),
 	}
+	g.mu.Lock()
+	previous := g.current
+	g.current = pacer
+	g.mu.Unlock()
+	previous.supersede()
+	return pacer
 }
 
 // goldenResponsePacer applies backpressure from the local continuity observer
@@ -103,10 +111,23 @@ type goldenResponsePacer struct {
 	gateReleased       <-chan struct{}
 	requestReleased    chan struct{}
 	releaseRequestOnce sync.Once
+	superseded         atomic.Bool
 	mu                 sync.Mutex
 	started            bool
 	pending            []byte
 	sink               func([]byte) (int, error)
+}
+
+func (p *goldenResponsePacer) supersede() {
+	if p == nil {
+		return
+	}
+	p.superseded.Store(true)
+	p.releaseRequest()
+}
+
+func (p *goldenResponsePacer) wasSuperseded() bool {
+	return p != nil && p.superseded.Load()
 }
 
 func (p *goldenResponsePacer) releaseRequest() {
@@ -137,6 +158,10 @@ func (p *goldenResponsePacer) write(ctx context.Context, payload []byte, write f
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.sink = write
+	if p.wasSuperseded() {
+		p.pending = nil
+		return len(payload), nil
+	}
 	if p.isReleased() {
 		if err := p.flushPendingLocked(); err != nil {
 			return 0, err
@@ -166,6 +191,9 @@ func (p *goldenResponsePacer) write(ctx context.Context, payload []byte, write f
 func (p *goldenResponsePacer) writePacedLocked(ctx context.Context, payload []byte) (int, error) {
 	total := 0
 	for total < len(payload) {
+		if p.wasSuperseded() {
+			return len(payload), nil
+		}
 		if p.isReleased() {
 			n, err := p.sink(payload[total:])
 			total += n
@@ -204,6 +232,10 @@ func (p *goldenResponsePacer) writePacedLocked(ctx context.Context, payload []by
 }
 
 func (p *goldenResponsePacer) flushPendingLocked() error {
+	if p.wasSuperseded() {
+		p.pending = nil
+		return nil
+	}
 	if len(p.pending) == 0 {
 		return nil
 	}
@@ -810,6 +842,9 @@ func newObserverHandlerWithObserverAndGate(upstream *url.URL, observation *obser
 			}
 			if err := responsePacer.waitAndFlush(); err != nil {
 				observation.emit(meta.event("proxy_error"))
+			}
+			if responsePacer.wasSuperseded() {
+				observation.emit(meta.event("response_superseded"))
 			}
 		}
 		responseWriter.finish()

--- a/cmd/subrouter-transport-observer/main_test.go
+++ b/cmd/subrouter-transport-observer/main_test.go
@@ -51,6 +51,39 @@ func TestObserverFailsClosedWhenGoldenRequestSignalWriteFails(t *testing.T) {
 	}
 }
 
+func TestObserverStripsResponseAttemptTokenWithRequestSignalHook(t *testing.T) {
+	const responseAttemptHeader = "X-Subrouter-Golden-Response-Attempt"
+	previousHooks := goldenTestHooks
+	goldenTestHooks.enabled = true
+	goldenTestHooks.outboundRequestWritten = func(string) error { return nil }
+	t.Cleanup(func() { goldenTestHooks = previousHooks })
+
+	attemptTokenReachedUpstream := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		attemptTokenReachedUpstream = request.Header.Get(responseAttemptHeader) != ""
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := newObserverHandler(upstreamURL, &bytes.Buffer{})
+	request := httptest.NewRequest(http.MethodPost, "http://observer/v1/responses", strings.NewReader("request body"))
+	request.Header.Set(goldenRequestTokenHeader, "0123456789abcdef0123456789abcdef")
+	request.Header.Set(responseAttemptHeader, "fedcba9876543210fedcba9876543210")
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+	if attemptTokenReachedUpstream {
+		t.Fatal("golden response attempt token escaped the observer")
+	}
+}
+
 func TestObserverRejectsInvalidGoldenRequestTokenBeforeUpstream(t *testing.T) {
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = true

--- a/cmd/subrouter-transport-observer/main_test.go
+++ b/cmd/subrouter-transport-observer/main_test.go
@@ -52,7 +52,6 @@ func TestObserverFailsClosedWhenGoldenRequestSignalWriteFails(t *testing.T) {
 }
 
 func TestObserverStripsResponseAttemptTokenWithRequestSignalHook(t *testing.T) {
-	const responseAttemptHeader = "X-Subrouter-Golden-Response-Attempt"
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = true
 	goldenTestHooks.outboundRequestWritten = func(string) error { return nil }
@@ -60,7 +59,7 @@ func TestObserverStripsResponseAttemptTokenWithRequestSignalHook(t *testing.T) {
 
 	attemptTokenReachedUpstream := false
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
-		attemptTokenReachedUpstream = request.Header.Get(responseAttemptHeader) != ""
+		attemptTokenReachedUpstream = request.Header.Get(goldenResponseAttemptTokenHeader) != ""
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer upstream.Close()
@@ -72,7 +71,7 @@ func TestObserverStripsResponseAttemptTokenWithRequestSignalHook(t *testing.T) {
 	handler := newObserverHandler(upstreamURL, &bytes.Buffer{})
 	request := httptest.NewRequest(http.MethodPost, "http://observer/v1/responses", strings.NewReader("request body"))
 	request.Header.Set(goldenRequestTokenHeader, "0123456789abcdef0123456789abcdef")
-	request.Header.Set(responseAttemptHeader, "fedcba9876543210fedcba9876543210")
+	request.Header.Set(goldenResponseAttemptTokenHeader, "fedcba9876543210fedcba9876543210")
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, request)
 


### PR DESCRIPTION
The deployment observer held every Codex retry until the final gate release. After a long migration, abandoned HTTP and WebSocket responses flushed together and made the synthetic Codex session fail even though the active connection crossed each route transition cleanly.

This keeps one current paced response per isolated observer. A newer attempt retires the older holdback without writing stale bytes, while the current response remains held until the deployment gate releases it. Evidence records each superseded request.

Regression sequence:
- `fc91c10` adds the failing retry lifecycle test.
- `63973eb` implements current-response ownership.

Verification: `go test ./...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788545543&installation_model_id=21920&pr_number=180&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F180&signature=49f6e77727357aa06ebed489078adf53d8bcceed9da9be6ffa6cc598083ba845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep only the latest golden response per request token and retire older attempts so stale bytes aren’t flushed. Distinct tokens (and all responses after gate release) stay independent, and supersession is serialized with gate release.

- **Bug Fixes**
  - Gate tracks the current paced response keyed by a validated request token; newer attempts supersede only the previous one for that token.
  - Supersession is serialized with gate release to prevent races; superseded responses drop pending bytes and short-circuit write/flush; emit `response_superseded`.
  - Attach a per-session request token to `/responses` via `SUBROUTER_GOLDEN_RESPONSE_REQUEST_TOKEN`; always strip `X-Subrouter-Golden-Response-Attempt` before proxying upstream, including with the request signal hook.
  - After gate release, pacing is disabled and responses drain independently (no cross-superseding).
  - Tests cover abandoned retries, post-release independence, distinct concurrent responses, attempt-token stripping, and serialized supersession.

<sup>Written for commit 2cc5df156ddab9320cfaa01dbb18e8e85e3991c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response pacing so newer responses supersede abandoned earlier responses.
  * Prevented outdated responses from continuing to write data after replacement.
  * Ensured independent concurrent responses remain correctly held and released.
  * Preserved the active response until the session is released.
  * Improved pacing-token handling across new and resumed sessions.
  * Added event tracking when a response is superseded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->