### PR TITLE
Authenticate self-hosted servers with the tailnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,20 @@ When `SUBROUTER_ADMIN_TOKEN` or `--admin-token` is set, non-loopback requests to
 
 A server with neither credential configured rejects every account import, including `sr add`. That state is reported as `"account_import": "disabled"` by `/_subrouter/health` and logged as a warning at startup, and `sr doctor` runs the same preflight `sr add` runs against the selected server.
 
+### Tailnet authentication for self-hosted servers
+
+A server whose port is already restricted to a tailnet by ACL does not need a second credential system on top of it. Start it with `--tailscale-auth` (or `SUBROUTER_TAILSCALE_AUTH=1`) and non-loopback callers are authenticated by their tailnet identity instead:
+
+```bash
+subrouter serve --addr 0.0.0.0:31415 --tailscale-auth
+sr server add mac-mini --url http://mac-mini.tailnet.ts.net:31415   # no tokens
+sr add                                                              # just works
+```
+
+Identity comes from this machine's own tailscaled through `tailscale whois`, so it is an assertion about a WireGuard-authenticated peer rather than a claim carried in the request, and account imports are logged with the tailnet user or tags that made them. Narrow it further with `--tailscale-auth-users lawrence@example.com` or `--tailscale-auth-tags tag:dev-workstation`; with neither, every tailnet peer is accepted, which is the point of the mode.
+
+Enabling it closes the unsecured legacy default: a caller the tailnet does not recognize gets only the token path, never open access. Configured tokens keep working alongside it. It is refused together with `--multi-tenant`, because a shared cloud deployment authenticates tenants rather than network peers, and `/_subrouter/health` reports the active mode as `"auth": "tailnet" | "token" | "tenant" | "open"`.
+
 `sr server install <name>` provisions those credentials for you and keeps both sides in step. It reaches a GCP instance through gcloud, and any other machine through SSH:
 
 ```bash

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/manaflow-ai/subrouter/internal/proxy"
 	"github.com/manaflow-ai/subrouter/internal/stackauth"
 	"github.com/manaflow-ai/subrouter/internal/storepath"
+	"github.com/manaflow-ai/subrouter/internal/tailnet"
 	"github.com/manaflow-ai/subrouter/internal/tenant"
 	"github.com/manaflow-ai/subrouter/internal/transcript"
 	"github.com/manaflow-ai/subrouter/selectacct"
@@ -295,6 +296,10 @@ func serve(args []string) error {
 	shutdownTimeout := flags.Duration("shutdown-timeout", 10*time.Minute, "maximum time to drain in-flight proxy requests after SIGTERM/SIGINT")
 	adminToken := flags.String("admin-token", "", "admin token required for non-loopback _subrouter endpoints; defaults to SUBROUTER_ADMIN_TOKEN")
 	accountImportToken := flags.String("account-import-token", "", "token limited to protected account import; defaults to SUBROUTER_ACCOUNT_IMPORT_TOKEN")
+	tailscaleAuth := flags.Bool("tailscale-auth", false, "authenticate non-loopback callers with their tailnet identity instead of a token; defaults to SUBROUTER_TAILSCALE_AUTH")
+	tailscaleAuthUsers := flags.String("tailscale-auth-users", "", "comma-separated tailnet logins allowed by --tailscale-auth; empty allows every tailnet peer")
+	tailscaleAuthTags := flags.String("tailscale-auth-tags", "", "comma-separated tailnet tags allowed by --tailscale-auth; empty allows every tailnet peer")
+	tailscaleCLI := flags.String("tailscale-cli", "", "path to the tailscale CLI used for peer identity")
 	requireSessionLeases := flags.Bool("require-session-leases", false, "reject proxy requests without a valid session lease; defaults to SUBROUTER_REQUIRE_SESSION_LEASES")
 	maxBodyBytes := flags.Int64("max-body-bytes", 1<<20, "max JSON request body bytes to inspect for session IDs")
 	fetchUsage := flags.Bool("fetch-usage", true, "fetch Codex usage on startup for account selection")
@@ -552,6 +557,33 @@ func serve(args []string) error {
 		slog.Info("bedrock gateway enabled", "regions", strings.Join(regions, ","), "auth", token != "", "autobump", *bedrockAutoBump, "profiles", strings.Join(bedrockSourceNames(sources), ","))
 	}
 
+	// Tailnet authentication is for self-hosted servers whose port is already
+	// restricted to a tailnet by ACL. It is deliberately incompatible with
+	// multi-tenant mode: a shared cloud deployment authenticates tenants, not
+	// network peers, and must never fall back to trusting a network boundary.
+	var tailnetAuthorizer proxy.TailnetAuthorizer
+	if *tailscaleAuth || envTrue("SUBROUTER_TAILSCALE_AUTH") {
+		if *multiTenant {
+			return errors.New("--tailscale-auth cannot be combined with --multi-tenant")
+		}
+		resolver, err := tailnet.NewResolver(*tailscaleCLI)
+		if err != nil {
+			return fmt.Errorf("tailscale auth: %w", err)
+		}
+		authorizer := &tailnet.Authorizer{
+			Resolver: resolver,
+			Users:    splitAndTrim(*tailscaleAuthUsers),
+			Tags:     splitAndTrim(*tailscaleAuthTags),
+		}
+		tailnetAuthorizer = authorizer
+		slog.Info(
+			"tailnet authentication enabled",
+			"cli", resolver.CLIPath,
+			"users", strings.Join(authorizer.Users, ","),
+			"tags", strings.Join(authorizer.Tags, ","),
+		)
+	}
+
 	server := proxy.Server{
 		StreamDrops:           &proxy.StreamDropStats{},
 		Upstream:              upstream,
@@ -571,6 +603,7 @@ func serve(args []string) error {
 		Lifecycle:             proxy.NewLifecycle(),
 		AdminToken:            *adminToken,
 		AccountImportToken:    *accountImportToken,
+		TailnetAuth:           tailnetAuthorizer,
 		RequireSessionLease:   *requireSessionLeases || envTrue("SUBROUTER_REQUIRE_SESSION_LEASES"),
 		ForwardSessionHeaders: envTrue("SUBROUTER_FORWARD_SESSION_HEADERS"),
 		LocalProxyToken:       localProxyToken,
@@ -1343,4 +1376,19 @@ Session stickiness:
   For %[1]s codex, set SUBROUTER_CODEX_USER_EMAIL and/or SUBROUTER_CODEX_ACCOUNT_ID instead.
   The proxy also checks common session headers, query params, and small JSON bodies.
 `, program)
+}
+
+// splitAndTrim parses a comma-separated flag value into non-empty entries.
+func splitAndTrim(value string) []string {
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }

--- a/cmd/subrouter/sr_doctor_account_import_test.go
+++ b/cmd/subrouter/sr_doctor_account_import_test.go
@@ -37,10 +37,19 @@ func TestDoctorFailsWhenServerEntryHasNoImportCredential(t *testing.T) {
 	t.Setenv("SUBROUTER_LOCAL_BASE_URL", local.URL+"/v1")
 	t.Setenv("SUBROUTER_CODEX_SERVER", "")
 
+	// The server is the authority on whether it can accept an import, so this
+	// stub answers the preflight the way a token-protected server does. A bare
+	// address would make the test depend on whatever listens on the developer's
+	// own machine.
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "protected account import credential required", http.StatusUnauthorized)
+	}))
+	t.Cleanup(remote.Close)
+
 	store := emptyStore(t)
 	writeDoctorServerFile(t, store, srServerConfig{
 		Name: "mac-mini",
-		URL:  "http://127.0.0.1:31415",
+		URL:  remote.URL,
 	})
 
 	var out bytes.Buffer

--- a/cmd/subrouter/sr_server_account_import.go
+++ b/cmd/subrouter/sr_server_account_import.go
@@ -31,9 +31,9 @@ type serverClaudeAccountImport struct {
 }
 
 func (r srRunner) ensureServerAccountImportAvailable(ctx context.Context, server srServerConfig) error {
-	if strings.TrimSpace(server.AccountImportToken) == "" && strings.TrimSpace(server.AdminToken) == "" && strings.TrimSpace(server.TenantKey) == "" {
-		return fmt.Errorf("server %s has no protected HTTP account-import credential; run '%s install %s' first", server.Name, r.serverCommand(), server.Name)
-	}
+	// Ask the server rather than assuming a stored credential is required. A
+	// self-hosted server can authenticate callers by tailnet identity, in which
+	// case this entry has nothing to carry and the preflight simply succeeds.
 	res, err := r.doServerAccountImportRequest(ctx, server, http.MethodGet, nil)
 	if err != nil {
 		return fmt.Errorf("check HTTP account import on server %s: %w", server.Name, err)
@@ -53,6 +53,9 @@ func (r srRunner) ensureServerAccountImportAvailable(ctx context.Context, server
 		}
 		return nil
 	case res.StatusCode == http.StatusUnauthorized || res.StatusCode == http.StatusForbidden:
+		if !serverHasAccountImportCredential(server) {
+			return fmt.Errorf("server %s has no protected HTTP account-import credential; run '%s install %s' first", server.Name, r.serverCommand(), server.Name)
+		}
 		return fmt.Errorf("server %s rejected its protected HTTP account-import credential; run '%s install %s' to rotate it", server.Name, r.serverCommand(), server.Name)
 	case res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusMethodNotAllowed:
 		return fmt.Errorf("server %s is too old for HTTP account import; run '%s install %s' first", server.Name, r.serverCommand(), server.Name)
@@ -109,6 +112,15 @@ func (r srRunner) postServerAccountImport(ctx context.Context, server srServerCo
 		return fmt.Errorf("server %s returned an invalid account-import response", server.Name)
 	}
 	return nil
+}
+
+// serverHasAccountImportCredential reports whether this entry carries anything
+// the server could have rejected, which decides whether a 401 means "add a
+// credential" or "the one you have is wrong".
+func serverHasAccountImportCredential(server srServerConfig) bool {
+	return strings.TrimSpace(server.AccountImportToken) != "" ||
+		strings.TrimSpace(server.AdminToken) != "" ||
+		strings.TrimSpace(server.TenantKey) != ""
 }
 
 func (r srRunner) doServerAccountImportRequest(ctx context.Context, server srServerConfig, method string, body []byte) (*http.Response, error) {

--- a/cmd/subrouter/sr_server_import_preflight_test.go
+++ b/cmd/subrouter/sr_server_import_preflight_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// A server that authenticates by tailnet identity has no credential for the
+// client to carry, so the preflight must ask it rather than refusing locally.
+func TestAccountImportPreflightSucceedsWithoutAStoredCredential(t *testing.T) {
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			t.Error("client sent an Authorization header it does not have")
+		}
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer remote.Close()
+
+	var out bytes.Buffer
+	runner := srRunner{program: "sr", out: &out, errOut: &out, client: remote.Client()}
+	err := runner.ensureServerAccountImportAvailable(
+		context.Background(),
+		srServerConfig{Name: "mac-mini", URL: remote.URL},
+	)
+	if err != nil {
+		t.Fatalf("preflight failed against a credential-free server: %v", err)
+	}
+}
+
+func TestAccountImportPreflightExplainsAMissingCredential(t *testing.T) {
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "protected account import credential required", http.StatusUnauthorized)
+	}))
+	defer remote.Close()
+
+	var out bytes.Buffer
+	runner := srRunner{program: "sr", out: &out, errOut: &out, client: remote.Client()}
+	err := runner.ensureServerAccountImportAvailable(
+		context.Background(),
+		srServerConfig{Name: "mac-mini", URL: remote.URL},
+	)
+	if err == nil || !strings.Contains(err.Error(), "has no protected HTTP account-import credential") {
+		t.Fatalf("error = %v, want the missing-credential guidance", err)
+	}
+}
+
+func TestAccountImportPreflightExplainsARejectedCredential(t *testing.T) {
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "protected account import credential required", http.StatusUnauthorized)
+	}))
+	defer remote.Close()
+
+	var out bytes.Buffer
+	runner := srRunner{program: "sr", out: &out, errOut: &out, client: remote.Client()}
+	err := runner.ensureServerAccountImportAvailable(
+		context.Background(),
+		srServerConfig{Name: "mac-mini", URL: remote.URL, AccountImportToken: "stale"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "rejected its protected HTTP account-import credential") {
+		t.Fatalf("error = %v, want the rotation guidance", err)
+	}
+}

--- a/cmd/subrouter/sr_server_test.go
+++ b/cmd/subrouter/sr_server_test.go
@@ -1306,6 +1306,16 @@ func TestSRServerSyncURLOnlyServerFailsBeforeOAuthWithoutProtectedImportCredenti
 		errOut: &out,
 		cmd:    fake,
 		client: &http.Client{Transport: srRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			// A token-protected server answers the preflight with 401; the
+			// client must stop there rather than starting an OAuth login it
+			// would have to discard.
+			if strings.HasSuffix(req.URL.Path, serverAccountImportPath) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("protected account import credential required")),
+				}, nil
+			}
 			body, _ := json.Marshal([]remoteServerAccountStatus{})
 			return &http.Response{
 				StatusCode: http.StatusOK,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -84,6 +84,13 @@ type Server struct {
 	// It is intentionally distinct from AdminToken, which can read operational
 	// state and transcripts.
 	AccountImportToken string
+	// TailnetAuth authenticates callers with the tailnet itself instead of a
+	// token, for self-hosted servers whose port is already restricted to a
+	// tailnet by ACL. Identity comes from this machine's tailscaled, so it is
+	// an assertion about a WireGuard-authenticated peer rather than a claim
+	// carried in the request. Nil disables the mode, which is the default and
+	// the only supported configuration for shared cloud deployments.
+	TailnetAuth TailnetAuthorizer
 	// LocalProxyToken protects provider proxy routes in cloud mode. Health and
 	// readiness stay unauthenticated so supervisors can probe the daemon.
 	LocalProxyToken string
@@ -1033,7 +1040,11 @@ func normalizedCredentialBroker(value CredentialBroker) CredentialBroker {
 }
 
 func (s Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, map[string]any{"ok": true, "account_import": s.AccountImportState()})
+	writeJSON(w, map[string]any{
+		"ok":             true,
+		"account_import": s.AccountImportState(),
+		"auth":           s.AuthMode(),
+	})
 }
 
 // AccountImportState reports whether this server can accept `sr add` uploads.
@@ -1043,6 +1054,7 @@ func (s Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 // healthy right up until someone tries to add an account.
 func (s Server) AccountImportState() string {
 	if s.tenantAccountImportAuthorized ||
+		s.TailnetAuth != nil ||
 		strings.TrimSpace(s.AccountImportToken) != "" ||
 		strings.TrimSpace(s.AdminToken) != "" {
 		return AccountImportEnabled
@@ -2141,6 +2153,15 @@ func (s Server) requireAccountImportAuth(next func(http.ResponseWriter, *http.Re
 			next(w, r)
 			return
 		}
+		if identity, ok := s.authorizeTailnet(r); ok {
+			// Name who onboarded an account. A tailnet identity is the one
+			// thing a shared token could never tell us.
+			if s.Logger != nil {
+				s.Logger.Info("account import authorized by tailnet identity", "peer", identity.String())
+			}
+			next(w, r)
+			return
+		}
 		http.Error(w, "protected account import credential required", http.StatusUnauthorized)
 	}
 }
@@ -2171,6 +2192,16 @@ func matchesConfiguredBearerToken(r *http.Request, configuredToken, dedicatedHea
 func (s Server) authorizeAdmin(r *http.Request) bool {
 	if isLoopbackRemote(r.RemoteAddr) {
 		return true
+	}
+	if _, ok := s.authorizeTailnet(r); ok {
+		return true
+	}
+	if s.TailnetAuth != nil {
+		// Tailnet identity is this server's configured mechanism, so a caller it
+		// does not recognize gets only the token path. Falling through to the
+		// unsecured legacy default would make enabling authentication widen
+		// access to anything that can route to the port.
+		return s.matchesConfiguredAdminToken(r)
 	}
 	if strings.TrimSpace(s.AdminToken) == "" {
 		// Preserve explicitly unsecured legacy/local configurations, but never let

--- a/internal/proxy/tailnet_auth.go
+++ b/internal/proxy/tailnet_auth.go
@@ -1,0 +1,42 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/manaflow-ai/subrouter/internal/tailnet"
+)
+
+// TailnetAuthorizer resolves the tailnet principal behind a request. It is an
+// interface so the proxy never depends on how identity is obtained, and so
+// tests can assert the authorization rule without a running tailscaled.
+type TailnetAuthorizer interface {
+	Authorize(ctx context.Context, remoteAddr string) (tailnet.Identity, bool)
+}
+
+// authorizeTailnet reports the tailnet identity behind a request when the mode
+// is enabled and the peer is allowed. A peer that is not on the tailnet, or is
+// outside the configured allowlist, falls through to the token rules rather
+// than being rejected here: enabling tailnet auth adds a way in, it does not
+// remove the existing ones.
+func (s Server) authorizeTailnet(r *http.Request) (tailnet.Identity, bool) {
+	if s.TailnetAuth == nil || r == nil {
+		return tailnet.Identity{}, false
+	}
+	return s.TailnetAuth.Authorize(r.Context(), r.RemoteAddr)
+}
+
+// AuthMode describes how this server authenticates non-loopback callers, for
+// health output and startup logging.
+func (s Server) AuthMode() string {
+	switch {
+	case s.tenantAccountImportAuthorized:
+		return "tenant"
+	case s.TailnetAuth != nil:
+		return "tailnet"
+	case s.AdminToken != "" || s.AccountImportToken != "":
+		return "token"
+	default:
+		return "open"
+	}
+}

--- a/internal/proxy/tailnet_auth_test.go
+++ b/internal/proxy/tailnet_auth_test.go
@@ -1,0 +1,121 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
+	"github.com/manaflow-ai/subrouter/internal/tailnet"
+)
+
+type stubTailnetAuth struct {
+	identity tailnet.Identity
+	allow    bool
+	seen     string
+}
+
+func (s *stubTailnetAuth) Authorize(_ context.Context, remoteAddr string) (tailnet.Identity, bool) {
+	s.seen = remoteAddr
+	return s.identity, s.allow
+}
+
+func tailnetTestServer(t *testing.T, auth TailnetAuthorizer) Server {
+	t.Helper()
+	ref := NewAccountRef(accounts.CodexStore{Dir: t.TempDir()}, nil, nil)
+	ref.claudeStore = agentclaude.Store{Dir: t.TempDir()}
+	return Server{AccountRef: ref, TailnetAuth: auth}
+}
+
+func tailnetRequest(method, path string) *http.Request {
+	req := httptest.NewRequest(method, path, nil)
+	req.RemoteAddr = "100.82.214.112:52344"
+	return req
+}
+
+// The whole point of the mode: no token anywhere, and a tailnet peer still gets
+// in, on both the admin and the account-import surfaces.
+func TestTailnetIdentityAuthorizesWithoutAnyToken(t *testing.T) {
+	auth := &stubTailnetAuth{identity: tailnet.Identity{LoginName: "lawrence@manaflow.ai"}, allow: true}
+	handler := tailnetTestServer(t, auth).Handler()
+
+	for _, path := range []string{"/_subrouter/accounts", "/_subrouter/account-import"} {
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, tailnetRequest(http.MethodGet, path))
+		if resp.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want 200: %s", path, resp.Code, resp.Body.String())
+		}
+	}
+	if auth.seen != "100.82.214.112:52344" {
+		t.Fatalf("authorizer saw %q, want the peer address", auth.seen)
+	}
+}
+
+func TestNonTailnetPeerStillDeniedWithoutToken(t *testing.T) {
+	handler := tailnetTestServer(t, &stubTailnetAuth{allow: false}).Handler()
+
+	for _, path := range []string{"/_subrouter/accounts", "/_subrouter/account-import"} {
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, tailnetRequest(http.MethodGet, path))
+		if resp.Code != http.StatusUnauthorized {
+			t.Fatalf("%s status = %d, want 401", path, resp.Code)
+		}
+	}
+}
+
+// Tailnet auth adds a way in; it must not disable the token path a mixed
+// deployment may still rely on.
+func TestConfiguredTokenStillWorksAlongsideTailnetAuth(t *testing.T) {
+	server := tailnetTestServer(t, &stubTailnetAuth{allow: false})
+	server.AdminToken = "admin-secret"
+	handler := server.Handler()
+
+	req := tailnetRequest(http.MethodGet, "/_subrouter/accounts")
+	req.Header.Set("Authorization", "Bearer admin-secret")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for a valid admin token", resp.Code)
+	}
+}
+
+// A server with no tailnet auth configured must behave exactly as before, which
+// is what keeps this change out of the cloud deployment's path.
+func TestDisabledTailnetAuthLeavesTokenRulesUnchanged(t *testing.T) {
+	server := tailnetTestServer(t, nil)
+	server.AccountImportToken = "import-secret"
+	handler := server.Handler()
+
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, tailnetRequest(http.MethodGet, "/_subrouter/accounts"))
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 when only an import token is configured", resp.Code)
+	}
+	if server.AuthMode() != "token" {
+		t.Fatalf("auth mode = %q, want token", server.AuthMode())
+	}
+}
+
+func TestHealthReportsTailnetAuthMode(t *testing.T) {
+	server := tailnetTestServer(t, &stubTailnetAuth{allow: true})
+	resp := httptest.NewRecorder()
+	server.Handler().ServeHTTP(resp, tailnetRequest(http.MethodGet, "/_subrouter/health"))
+
+	var body struct {
+		Auth          string `json:"auth"`
+		AccountImport string `json:"account_import"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode health: %v (%s)", err, resp.Body.String())
+	}
+	if body.Auth != "tailnet" {
+		t.Fatalf("auth = %q, want tailnet", body.Auth)
+	}
+	// Import works in this mode, so health must not report it as disabled.
+	if body.AccountImport != AccountImportEnabled {
+		t.Fatalf("account_import = %q, want %q", body.AccountImport, AccountImportEnabled)
+	}
+}

--- a/internal/tailnet/whois.go
+++ b/internal/tailnet/whois.go
@@ -1,0 +1,257 @@
+// Package tailnet identifies the Tailscale peer behind a request, so a
+// self-hosted server can use the tailnet itself as its authentication
+// mechanism instead of carrying a second credential system on top of it.
+//
+// Identity comes from the local tailscaled through the `tailscale whois`
+// command. That is an assertion by this machine's own daemon about a
+// WireGuard-authenticated peer, not a claim carried in the request, so it
+// cannot be forged by anything that merely reaches the port.
+package tailnet
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Identity is the tailnet principal behind a connection. LoginName is the
+// tailnet user ("someone@example.com"), or "tagged-devices" for a tagged node,
+// in which case Tags carries the tags that authorize it.
+type Identity struct {
+	LoginName string
+	NodeName  string
+	Tags      []string
+}
+
+// String renders an identity for logs: a tagged node is identified by its tags,
+// which is what an ACL is written against.
+func (i Identity) String() string {
+	name := i.NodeName
+	if name == "" {
+		name = "unknown-node"
+	}
+	if len(i.Tags) > 0 {
+		return fmt.Sprintf("%s (%s)", name, strings.Join(i.Tags, ","))
+	}
+	return fmt.Sprintf("%s (%s)", name, i.LoginName)
+}
+
+type commandRunner interface {
+	Output(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type execRunner struct{}
+
+func (execRunner) Output(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).Output()
+}
+
+// Resolver answers "who is the peer at this address" with a short-lived cache.
+// Admin and account-import requests are rare, but a status page can fan out
+// several at once and there is no reason to spawn a process for each.
+type Resolver struct {
+	CLIPath string
+	Timeout time.Duration
+	TTL     time.Duration
+
+	runner commandRunner
+	now    func() time.Time
+
+	mu      sync.Mutex
+	entries map[string]cacheEntry
+}
+
+type cacheEntry struct {
+	identity Identity
+	ok       bool
+	expires  time.Time
+}
+
+// DefaultCLICandidates covers Homebrew, the standard package location, and the
+// macOS app bundle, in that order.
+var DefaultCLICandidates = []string{
+	"tailscale",
+	"/opt/homebrew/bin/tailscale",
+	"/usr/local/bin/tailscale",
+	"/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+}
+
+// NewResolver locates the tailscale CLI. It fails when no CLI is present rather
+// than degrading to "allow everyone": a server told to authenticate with the
+// tailnet must not silently stop authenticating.
+func NewResolver(cliPath string) (*Resolver, error) {
+	resolved, err := resolveCLI(cliPath)
+	if err != nil {
+		return nil, err
+	}
+	return &Resolver{
+		CLIPath: resolved,
+		Timeout: 2 * time.Second,
+		TTL:     30 * time.Second,
+		runner:  execRunner{},
+		now:     time.Now,
+		entries: map[string]cacheEntry{},
+	}, nil
+}
+
+func resolveCLI(cliPath string) (string, error) {
+	if strings.TrimSpace(cliPath) != "" {
+		path, err := exec.LookPath(cliPath)
+		if err != nil {
+			return "", fmt.Errorf("tailscale CLI %q is not executable: %w", cliPath, err)
+		}
+		return path, nil
+	}
+	for _, candidate := range DefaultCLICandidates {
+		if path, err := exec.LookPath(candidate); err == nil {
+			return path, nil
+		}
+	}
+	return "", errors.New("tailscale CLI not found; install Tailscale or pass --tailscale-cli")
+}
+
+type whoisResponse struct {
+	Node struct {
+		Name string   `json:"Name"`
+		Tags []string `json:"Tags"`
+	} `json:"Node"`
+	UserProfile struct {
+		LoginName string `json:"LoginName"`
+	} `json:"UserProfile"`
+}
+
+// Lookup resolves a remote address to its tailnet identity. A peer that is not
+// on the tailnet returns ok=false rather than an error, because "not a tailnet
+// peer" is a normal answer, not a malfunction.
+func (r *Resolver) Lookup(ctx context.Context, remoteAddr string) (Identity, bool) {
+	host := hostOnly(remoteAddr)
+	if host == "" {
+		return Identity{}, false
+	}
+	if identity, ok, found := r.cached(host); found {
+		return identity, ok
+	}
+	identity, ok := r.lookupUncached(ctx, host)
+	r.store(host, identity, ok)
+	return identity, ok
+}
+
+func (r *Resolver) lookupUncached(ctx context.Context, host string) (Identity, bool) {
+	timeout := r.Timeout
+	if timeout <= 0 {
+		timeout = 2 * time.Second
+	}
+	lookupCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	// whois takes ip[:port]; the port is only used to disambiguate proto.
+	body, err := r.runner.Output(lookupCtx, r.CLIPath, "whois", "--json", host)
+	if err != nil {
+		return Identity{}, false
+	}
+	var response whoisResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return Identity{}, false
+	}
+	login := strings.TrimSpace(response.UserProfile.LoginName)
+	if login == "" && len(response.Node.Tags) == 0 {
+		return Identity{}, false
+	}
+	return Identity{
+		LoginName: login,
+		NodeName:  strings.TrimSuffix(strings.TrimSpace(response.Node.Name), "."),
+		Tags:      response.Node.Tags,
+	}, true
+}
+
+func (r *Resolver) cached(host string) (Identity, bool, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry, found := r.entries[host]
+	if !found || r.clock().After(entry.expires) {
+		return Identity{}, false, false
+	}
+	return entry.identity, entry.ok, true
+}
+
+func (r *Resolver) store(host string, identity Identity, ok bool) {
+	ttl := r.TTL
+	if ttl <= 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.entries == nil {
+		r.entries = map[string]cacheEntry{}
+	}
+	r.entries[host] = cacheEntry{identity: identity, ok: ok, expires: r.clock().Add(ttl)}
+}
+
+func (r *Resolver) clock() time.Time {
+	if r.now != nil {
+		return r.now()
+	}
+	return time.Now()
+}
+
+func hostOnly(remoteAddr string) string {
+	address := strings.TrimSpace(remoteAddr)
+	if address == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(address); err == nil {
+		return host
+	}
+	return address
+}
+
+// Authorizer decides whether a resolved tailnet identity may act on this
+// server. With no allowlist every tailnet peer is accepted, which is the point
+// of the mode: the tailnet ACL already decides who can reach the port.
+type Authorizer struct {
+	Resolver *Resolver
+	Users    []string
+	Tags     []string
+}
+
+// Authorize reports the identity behind a request and whether it is allowed.
+func (a *Authorizer) Authorize(ctx context.Context, remoteAddr string) (Identity, bool) {
+	if a == nil || a.Resolver == nil {
+		return Identity{}, false
+	}
+	identity, ok := a.Resolver.Lookup(ctx, remoteAddr)
+	if !ok {
+		return Identity{}, false
+	}
+	if len(a.Users) == 0 && len(a.Tags) == 0 {
+		return identity, true
+	}
+	for _, user := range a.Users {
+		if strings.EqualFold(strings.TrimSpace(user), identity.LoginName) {
+			return identity, true
+		}
+	}
+	for _, allowed := range a.Tags {
+		for _, tag := range identity.Tags {
+			if strings.EqualFold(normalizeTag(allowed), normalizeTag(tag)) {
+				return identity, true
+			}
+		}
+	}
+	return identity, false
+}
+
+// normalizeTag accepts both "tag:ci" and "ci" so a flag value that omits the
+// prefix does not silently match nothing.
+func normalizeTag(tag string) string {
+	trimmed := strings.TrimSpace(tag)
+	if trimmed == "" {
+		return ""
+	}
+	return "tag:" + strings.TrimPrefix(trimmed, "tag:")
+}

--- a/internal/tailnet/whois_test.go
+++ b/internal/tailnet/whois_test.go
@@ -1,0 +1,168 @@
+package tailnet
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeRunner struct {
+	mu     sync.Mutex
+	calls  int
+	output string
+	err    error
+	args   []string
+}
+
+func (f *fakeRunner) Output(_ context.Context, _ string, args ...string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.args = args
+	if f.err != nil {
+		return nil, f.err
+	}
+	return []byte(f.output), nil
+}
+
+const userWhois = `{
+  "Node": {"Name": "lawrences-macbook-pro-2.tail137216.ts.net.", "Tags": null},
+  "UserProfile": {"LoginName": "lawrence@manaflow.ai", "DisplayName": "Lawrence Chen"}
+}`
+
+const taggedWhois = `{
+  "Node": {"Name": "cmux-lawrences-mac-mini.tail137216.ts.net.", "Tags": ["tag:dev-workstation"]},
+  "UserProfile": {"LoginName": "tagged-devices", "DisplayName": "Tagged Devices"}
+}`
+
+func newTestResolver(runner commandRunner) *Resolver {
+	return &Resolver{
+		CLIPath: "tailscale",
+		Timeout: time.Second,
+		TTL:     30 * time.Second,
+		runner:  runner,
+		now:     time.Now,
+		entries: map[string]cacheEntry{},
+	}
+}
+
+func TestLookupReturnsUserIdentity(t *testing.T) {
+	runner := &fakeRunner{output: userWhois}
+	identity, ok := newTestResolver(runner).Lookup(context.Background(), "100.82.214.112:52344")
+	if !ok {
+		t.Fatal("expected the peer to resolve")
+	}
+	if identity.LoginName != "lawrence@manaflow.ai" {
+		t.Fatalf("login = %q", identity.LoginName)
+	}
+	// The trailing dot in a MagicDNS name is noise in logs.
+	if identity.NodeName != "lawrences-macbook-pro-2.tail137216.ts.net" {
+		t.Fatalf("node = %q", identity.NodeName)
+	}
+	// whois takes the bare address; the port must be stripped before the call.
+	if got := strings.Join(runner.args, " "); got != "whois --json 100.82.214.112" {
+		t.Fatalf("args = %q", got)
+	}
+}
+
+func TestLookupReturnsTagsForTaggedNode(t *testing.T) {
+	identity, ok := newTestResolver(&fakeRunner{output: taggedWhois}).Lookup(context.Background(), "100.89.225.106:4001")
+	if !ok {
+		t.Fatal("expected the tagged peer to resolve")
+	}
+	if len(identity.Tags) != 1 || identity.Tags[0] != "tag:dev-workstation" {
+		t.Fatalf("tags = %v", identity.Tags)
+	}
+	if !strings.Contains(identity.String(), "tag:dev-workstation") {
+		t.Fatalf("string form should identify a tagged node by tag: %q", identity.String())
+	}
+}
+
+// A peer that is not on the tailnet is a normal answer, not an error, and must
+// never resolve to an identity.
+func TestLookupRejectsNonTailnetPeer(t *testing.T) {
+	for name, runner := range map[string]*fakeRunner{
+		"command fails": {err: errors.New("no peer")},
+		"empty profile": {output: `{"Node":{"Name":"x"},"UserProfile":{"LoginName":""}}`},
+		"garbage":       {output: "not json"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, ok := newTestResolver(runner).Lookup(context.Background(), "203.0.113.7:9000"); ok {
+				t.Fatal("expected the peer to be rejected")
+			}
+		})
+	}
+}
+
+func TestLookupCachesWithinTTL(t *testing.T) {
+	runner := &fakeRunner{output: userWhois}
+	resolver := newTestResolver(runner)
+	now := time.Now()
+	resolver.now = func() time.Time { return now }
+
+	for i := 0; i < 3; i++ {
+		if _, ok := resolver.Lookup(context.Background(), "100.82.214.112:1"); !ok {
+			t.Fatal("expected the peer to resolve")
+		}
+	}
+	if runner.calls != 1 {
+		t.Fatalf("calls = %d, want 1 within the TTL", runner.calls)
+	}
+	now = now.Add(31 * time.Second)
+	if _, ok := resolver.Lookup(context.Background(), "100.82.214.112:1"); !ok {
+		t.Fatal("expected the peer to resolve after expiry")
+	}
+	if runner.calls != 2 {
+		t.Fatalf("calls = %d, want a refresh after the TTL", runner.calls)
+	}
+}
+
+func TestAuthorizerAllowsEveryTailnetPeerWithoutAnAllowlist(t *testing.T) {
+	authorizer := &Authorizer{Resolver: newTestResolver(&fakeRunner{output: userWhois})}
+	if _, ok := authorizer.Authorize(context.Background(), "100.82.214.112:1"); !ok {
+		t.Fatal("an empty allowlist must accept any tailnet peer")
+	}
+}
+
+func TestAuthorizerEnforcesUserAndTagAllowlists(t *testing.T) {
+	for name, tc := range map[string]struct {
+		whois string
+		users []string
+		tags  []string
+		want  bool
+	}{
+		"matching user":                 {whois: userWhois, users: []string{"lawrence@manaflow.ai"}, want: true},
+		"other user":                    {whois: userWhois, users: []string{"austin@manaflow.ai"}, want: false},
+		"matching tag":                  {whois: taggedWhois, tags: []string{"tag:dev-workstation"}, want: true},
+		"tag without prefix":            {whois: taggedWhois, tags: []string{"dev-workstation"}, want: true},
+		"other tag":                     {whois: taggedWhois, tags: []string{"tag:ci"}, want: false},
+		"user list rejects tagged node": {whois: taggedWhois, users: []string{"lawrence@manaflow.ai"}, want: false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			authorizer := &Authorizer{
+				Resolver: newTestResolver(&fakeRunner{output: tc.whois}),
+				Users:    tc.users,
+				Tags:     tc.tags,
+			}
+			_, ok := authorizer.Authorize(context.Background(), "100.64.0.5:1")
+			if ok != tc.want {
+				t.Fatalf("authorized = %v, want %v", ok, tc.want)
+			}
+		})
+	}
+}
+
+// A nil authorizer must never authorize, so a disabled mode cannot become an
+// accidental bypass.
+func TestNilAuthorizerDeniesEverything(t *testing.T) {
+	var authorizer *Authorizer
+	if _, ok := authorizer.Authorize(context.Background(), "100.82.214.112:1"); ok {
+		t.Fatal("a nil authorizer must deny")
+	}
+	if _, ok := (&Authorizer{}).Authorize(context.Background(), "100.82.214.112:1"); ok {
+		t.Fatal("an authorizer without a resolver must deny")
+	}
+}


### PR DESCRIPTION
## Why

Tokens exist for a public GCP deployment reachable from anywhere. They were carried onto a self-hosted Mac mini whose port is already restricted to a tailnet by ACL, where they add an onboarding step per machine and protect against nothing the tailnet does not already exclude. That is what made a routine credential gap turn into "nobody can run `sr add`".

## What

`--tailscale-auth` (or `SUBROUTER_TAILSCALE_AUTH=1`) authenticates non-loopback callers by tailnet identity. Identity comes from this machine's own tailscaled through `tailscale whois`, so it is an assertion about a WireGuard-authenticated peer rather than a claim carried in the request. Results are cached for 30s, since a status page fans out several admin reads at once.

`--tailscale-auth-users` and `--tailscale-auth-tags` narrow it; with neither, every tailnet peer is accepted, which is the point of the mode. Tags match with or without the `tag:` prefix.

Three properties keep this out of the cloud's path:

- Default off. A server without the flag behaves exactly as before, asserted by a test.
- Refused together with `--multi-tenant`. A shared deployment authenticates tenants, not network peers, and must never fall back to trusting a network boundary.
- Enabling it *closes* the unsecured legacy default. Today a server with no tokens allows every remote admin read; under tailnet auth an unrecognized peer gets only the token path.

Configured tokens keep working alongside it. `/_subrouter/health` reports `"auth": "tailnet" | "token" | "tenant" | "open"`, and account imports log the tailnet user or tags behind them, which a shared token could never tell us.

Client side, `sr` stops presuming a stored credential is required and asks the server, so an entry for a tailnet server carries nothing and `sr add` works with no setup. A 401 still distinguishes "you have no credential" from "yours was rejected".

## Verified on a real host

Running on cmux-lawrence with no tokens at all, requests from a non-loopback tailnet address:

```
health:   {"account_import":"enabled","auth":"tailnet","ok":true}
accounts: 200
import:   {"ok":true,"providers":["codex","claude","kimi","zai"]}
log:      account import authorized by tailnet identity peer="cmux-lawrences-mac-mini.tail137216.ts.net (tag:dev-workstation)"
```

Restarted with `--tailscale-auth-users someone-else@example.com`, the same peer gets 401 on both endpoints while loopback still returns 200.

## Tests

`go test ./...` passes. New coverage: whois parsing for user and tagged nodes, non-tailnet peers rejected rather than erroring, TTL caching, allowlist matching, nil-authorizer denial, both proxy surfaces authorized without a token, unrecognized peers denied, token path unaffected, disabled mode unchanged, and the client preflight against a credential-free server.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788567080&installation_model_id=21920&pr_number=182&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F182&signature=11aadb14e480a305157d0717c756249da669909b3f7d4f1eba3f9be2ab0def36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authenticate self-hosted servers by Tailscale identity with `--tailscale-auth`, so tailnet-restricted hosts can drop tokens while keeping cloud multi-tenant behavior unchanged. Tokens still work; enabling tailnet auth closes the legacy open admin access for non-tailnet peers.

- **New Features**
  - `--tailscale-auth` (or `SUBROUTER_TAILSCALE_AUTH=1`) identifies non-loopback callers via local `tailscale whois`, with a 30s cache.
  - Optional allowlists: `--tailscale-auth-users` and `--tailscale-auth-tags` (accepts `tag:ci` or `ci`); incompatible with `--multi-tenant`. Unrecognized peers fall back to the token path; tokens continue to authorize.
  - `/_subrouter/health` now reports `"auth": "tailnet" | "token" | "tenant" | "open"`; account imports log the tailnet user/tags.
  - Client change: `sr` preflights the server, so tailnet servers need no stored creds; clearer errors for missing vs rejected credentials.
  - `--tailscale-cli` lets you set the CLI path used for identity resolution.

- **Bug Fixes**
  - `sr doctor` import preflight no longer depends on the local machine; it asks the server and provides consistent guidance.

<sup>Written for commit e7a3617ad5bd3108fad28b279bcaeb9ac932b3fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Tailscale-based authentication for self-hosted servers.
  * Supports unrestricted tailnet access or restrictions by users and tags.
  * Health information now displays the active authentication mode.
  * Token authentication remains available alongside tailnet authentication.

* **Bug Fixes**
  * Improved account-import preflight handling for missing, invalid, and rejected credentials.
  * Unauthorized server responses now provide clearer guidance without disrupting local authentication state.

* **Documentation**
  * Documented tailnet authentication setup, access restrictions, and configuration limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->