### PR TITLE
Add Azure OpenAI Codex routing with Azure CLI auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,12 +286,10 @@ Run Codex against the Azure OpenAI GPT-5.6 family with Microsoft Entra credentia
 ```bash
 az login
 sr azure add work --endpoint https://RESOURCE.cognitiveservices.azure.com
-sr azure codex work --model sol
-sr az codex work --model terra
-sr az codex work --model luna
+sr az codex
 ```
 
-`sr azure` is canonical and `sr az` is its short alias. A profile defaults to deployments named `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`; repeat `--deployment model=name` during `add` when Azure uses custom deployment names. Subrouter stores only profile metadata. It acquires renewable access tokens through `az account get-access-token`, keeps them in daemon memory, and routes this launcher through the explicit local `/azure/work/v1` path. See [Azure OpenAI setup and security details](docs/codex.md#azure-openai).
+The first Azure profile becomes the default, so `sr az codex` needs no profile argument. Use `/model` inside Codex to switch among Sol, Terra, and Luna, `sr az default <profile>` to change the saved default profile, or `--azure-profile <profile>` for one run. `sr azure` is canonical and `sr az` is its short alias. A profile defaults to deployments named `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`; repeat `--deployment model=name` during `add` when Azure uses custom deployment names. Subrouter keeps Codex's canonical model names in the picker and translates them to Azure deployment names at the proxy boundary. It stores only profile metadata, acquires renewable access tokens through `az account get-access-token`, keeps them in daemon memory, and routes the launcher through the explicit local `/azure/work/v1` path. See [Azure OpenAI setup and security details](docs/codex.md#azure-openai).
 
 If `SUBROUTER_CODEX_BASE_URL` is not set, the wrapper uses local `127.0.0.1:31415/v1`. To make `sr codex`, Codex Desktop's app-server, and the default `sr` usage view use a remote Subrouter, register and select a named server:
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,16 @@ It does not edit Codex config or set auth environment variables. Do not set a du
 
 Override the subrouter URL with `SUBROUTER_CODEX_BASE_URL` if needed. See [docs/codex.md](docs/codex.md) for details and the custom-provider fallback.
 
+Run Codex against an Azure OpenAI deployment with Microsoft Entra credentials from Azure CLI:
+
+```bash
+az login
+sr azure add work --endpoint https://RESOURCE.openai.azure.com --deployment DEPLOYMENT_NAME
+sr azure codex work
+```
+
+Subrouter stores only profile metadata. It acquires renewable access tokens through `az account get-access-token`, keeps them in daemon memory, and routes this launcher through the explicit local `/azure/work/v1` path. See [Azure OpenAI setup and security details](docs/codex.md#azure-openai).
+
 If `SUBROUTER_CODEX_BASE_URL` is not set, the wrapper uses local `127.0.0.1:31415/v1`. To make `sr codex`, Codex Desktop's app-server, and the default `sr` usage view use a remote Subrouter, register and select a named server:
 
 ```bash
@@ -355,7 +365,7 @@ go run ./cmd/subrouter status
 sr status
 ```
 
-The supported Codex commands include `add`, `add-key`, `import`, `list`, `switch`, `g`, `gui`, `gui-switch`, `remove`, `status`, `usage`, `server`, `add-admin-key`, `admin-keys`, `remove-admin-key`, `attach-project`, `claude`, and `gemini`. The older `subrouter cx <command>` form remains as a compatibility alias.
+The supported Codex commands include `add`, `add-key`, `import`, `list`, `switch`, `g`, `gui`, `gui-switch`, `remove`, `status`, `usage`, `server`, `azure`, `add-admin-key`, `admin-keys`, `remove-admin-key`, `attach-project`, `claude`, and `gemini`. The older `subrouter cx <command>` form remains as a compatibility alias.
 
 `sr switch` also syncs compatible ChatGPT Codex credentials into:
 

--- a/README.md
+++ b/README.md
@@ -281,15 +281,17 @@ It does not edit Codex config or set auth environment variables. Do not set a du
 
 Override the subrouter URL with `SUBROUTER_CODEX_BASE_URL` if needed. See [docs/codex.md](docs/codex.md) for details and the custom-provider fallback.
 
-Run Codex against an Azure OpenAI deployment with Microsoft Entra credentials from Azure CLI:
+Run Codex against the Azure OpenAI GPT-5.6 family with Microsoft Entra credentials from Azure CLI:
 
 ```bash
 az login
-sr azure add work --endpoint https://RESOURCE.openai.azure.com --deployment DEPLOYMENT_NAME
-sr azure codex work
+sr azure add work --endpoint https://RESOURCE.cognitiveservices.azure.com
+sr azure codex work --model sol
+sr az codex work --model terra
+sr az codex work --model luna
 ```
 
-Subrouter stores only profile metadata. It acquires renewable access tokens through `az account get-access-token`, keeps them in daemon memory, and routes this launcher through the explicit local `/azure/work/v1` path. See [Azure OpenAI setup and security details](docs/codex.md#azure-openai).
+`sr azure` is canonical and `sr az` is its short alias. A profile defaults to deployments named `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`; repeat `--deployment model=name` during `add` when Azure uses custom deployment names. Subrouter stores only profile metadata. It acquires renewable access tokens through `az account get-access-token`, keeps them in daemon memory, and routes this launcher through the explicit local `/azure/work/v1` path. See [Azure OpenAI setup and security details](docs/codex.md#azure-openai).
 
 If `SUBROUTER_CODEX_BASE_URL` is not set, the wrapper uses local `127.0.0.1:31415/v1`. To make `sr codex`, Codex Desktop's app-server, and the default `sr` usage view use a remote Subrouter, register and select a named server:
 

--- a/account/types.go
+++ b/account/types.go
@@ -5,17 +5,19 @@ import "time"
 type Provider string
 
 const (
-	ProviderCodex  Provider = "codex"
-	ProviderClaude Provider = "claude"
-	ProviderKimi   Provider = "kimi"
-	ProviderZAI    Provider = "zai"
+	ProviderCodex       Provider = "codex"
+	ProviderClaude      Provider = "claude"
+	ProviderKimi        Provider = "kimi"
+	ProviderZAI         Provider = "zai"
+	ProviderAzureOpenAI Provider = "azure-openai"
 )
 
 type AuthMode string
 
 const (
-	AuthModeOAuth  AuthMode = "oauth"
-	AuthModeAPIKey AuthMode = "apikey"
+	AuthModeOAuth    AuthMode = "oauth"
+	AuthModeAPIKey   AuthMode = "apikey"
+	AuthModeAzureCLI AuthMode = "azure-cli"
 )
 
 type Account struct {

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -227,6 +227,7 @@ var directSRCommands = map[string]struct{}{
 	"account":          {},
 	"accounts":         {},
 	"attach-project":   {},
+	"az":               {},
 	"azure":            {},
 	"breadcrumbs":      {},
 	"claude":           {},

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -25,6 +25,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
+	"github.com/manaflow-ai/subrouter/internal/azureopenai"
 	"github.com/manaflow-ai/subrouter/internal/broker"
 	"github.com/manaflow-ai/subrouter/internal/proxy"
 	"github.com/manaflow-ai/subrouter/internal/stackauth"
@@ -226,6 +227,7 @@ var directSRCommands = map[string]struct{}{
 	"account":          {},
 	"accounts":         {},
 	"attach-project":   {},
+	"azure":            {},
 	"breadcrumbs":      {},
 	"claude":           {},
 	"claude-aws":       {},
@@ -477,6 +479,20 @@ func serve(args []string) error {
 		credentialBroker = broker.NewClient(cloudConfig)
 	}
 	outboundTransport := proxy.NewOutboundTransport()
+	azureStore := azureopenai.DefaultStore()
+	azureProfiles, err := azureStore.List()
+	if err != nil {
+		return fmt.Errorf("load Azure OpenAI profiles: %w", err)
+	}
+	var azureRegistry *azureopenai.Registry
+	var azureAccounts []accounts.Account
+	if len(azureProfiles) > 0 {
+		azureRegistry, err = azureopenai.NewRegistry(azureProfiles, azureopenai.ExecCommandRunner{})
+		if err != nil {
+			return fmt.Errorf("configure Azure OpenAI profiles: %w", err)
+		}
+		azureAccounts = azureRegistry.Accounts(azureStore.ProfilesPath())
+	}
 
 	store, err := session.NewStore(*sessionPath)
 	if err != nil {
@@ -592,7 +608,8 @@ func serve(args []string) error {
 		ClaudeUpstream:        claudeUpstream,
 		KimiUpstream:          kimiUpstream,
 		ZAIUpstream:           zaiUpstream,
-		Accounts:              nil,
+		AzureOpenAI:           azureRegistry,
+		Accounts:              azureAccounts,
 		AccountRef:            accountRef,
 		CredentialBroker:      credentialBroker,
 		Sessions:              store,
@@ -703,9 +720,9 @@ func serve(args []string) error {
 	}
 
 	if upstream != nil {
-		slog.Info("subrouter listening", "addr", *addr, "upstream", upstream.String(), "codex_accounts", len(codexAccounts), "claude_accounts", len(claudeAccounts), "cloud_team", cloudConfig.TeamID, "transcripts", *transcriptDir, "transcript_gcs_uri", *transcriptGCSURI)
+		slog.Info("subrouter listening", "addr", *addr, "upstream", upstream.String(), "codex_accounts", len(codexAccounts), "claude_accounts", len(claudeAccounts), "azure_openai_profiles", len(azureProfiles), "cloud_team", cloudConfig.TeamID, "transcripts", *transcriptDir, "transcript_gcs_uri", *transcriptGCSURI)
 	} else {
-		slog.Info("subrouter listening", "addr", *addr, "codex_upstream", codexUpstream.String(), "api_upstream", apiUpstream.String(), "claude_upstream", claudeUpstream.String(), "codex_accounts", len(codexAccounts), "claude_accounts", len(claudeAccounts), "cloud_team", cloudConfig.TeamID, "transcripts", *transcriptDir, "transcript_gcs_uri", *transcriptGCSURI)
+		slog.Info("subrouter listening", "addr", *addr, "codex_upstream", codexUpstream.String(), "api_upstream", apiUpstream.String(), "claude_upstream", claudeUpstream.String(), "codex_accounts", len(codexAccounts), "claude_accounts", len(claudeAccounts), "azure_openai_profiles", len(azureProfiles), "cloud_team", cloudConfig.TeamID, "transcripts", *transcriptDir, "transcript_gcs_uri", *transcriptGCSURI)
 	}
 	return listenAndServeWithSignals(httpServer, server.Lifecycle, *shutdownTimeout, slog.Default())
 }
@@ -1297,11 +1314,12 @@ Team vault management:
 
 Usage:
   %[1]s                    Show Codex and Claude usage, grouped by provider
-  %[1]s add                Add an account; asks whether it is Codex or Claude
+  %[1]s add                Add Codex, Claude, or Azure OpenAI credentials
   %[1]s add codex          Add a Codex account (opens OAuth login)
   %[1]s add claude         Add a Claude account (opens OAuth login)
   %[1]s add-key            Add an API key account
   %[1]s import             Import current ~/.codex/auth.json account
+  %[1]s azure              Manage Azure OpenAI profiles authenticated by Azure CLI
   %[1]s list               List all Codex accounts
   %[1]s switch [email]     Switch active Codex account and sync OpenCode/pi
   %[1]s g [email]          Switch active account, sync OpenCode/pi, and restart Codex.app

--- a/cmd/subrouter/main_test.go
+++ b/cmd/subrouter/main_test.go
@@ -313,6 +313,7 @@ func TestDirectSRCommandNames(t *testing.T) {
 		"add-key",
 		"admin-keys",
 		"attach-project",
+		"azure",
 		"breadcrumbs",
 		"claude",
 		"claude-aws",

--- a/cmd/subrouter/main_test.go
+++ b/cmd/subrouter/main_test.go
@@ -313,6 +313,7 @@ func TestDirectSRCommandNames(t *testing.T) {
 		"add-key",
 		"admin-keys",
 		"attach-project",
+		"az",
 		"azure",
 		"breadcrumbs",
 		"claude",

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -103,7 +103,7 @@ Running agents:
   sr codex [args]       Run codex through Subrouter
   sr claude [args]      Run claude through Subrouter
   sr gemini [args]      Run gemini through Subrouter
-  sr azure codex <profile> [--model sol|terra|luna] [args]
+  sr azure codex [--azure-profile <profile>] [--model sol|terra|luna] [args]
                         Run Codex against Azure OpenAI (short alias: sr az)
 
   sr server             Legacy form of sr remote

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -51,7 +51,7 @@ Usage:
   sr add                Ask whether to add Codex, Claude, or Azure OpenAI
   sr add codex          Add Codex to the active local or hosted pool
   sr add claude         Add Claude to the active local or hosted pool
-  sr add azure          Add a local Azure OpenAI deployment using Azure CLI auth
+  sr add azure          Add Azure OpenAI GPT-5.6 deployments using Azure CLI auth
   sr add-key            Add an API key account
   sr import             Import current ~/.codex/auth.json account
   sr list               List all Codex accounts
@@ -103,8 +103,8 @@ Running agents:
   sr codex [args]       Run codex through Subrouter
   sr claude [args]      Run claude through Subrouter
   sr gemini [args]      Run gemini through Subrouter
-  sr azure codex <profile> [args]
-                        Run Codex against one Azure OpenAI deployment
+  sr azure codex <profile> [--model sol|terra|luna] [args]
+                        Run Codex against Azure OpenAI (short alias: sr az)
 
   sr server             Legacy form of sr remote
   sr server add <name> --url <url> [--default]
@@ -210,7 +210,7 @@ func (r srRunner) run(ctx context.Context, args []string) error {
 			return runCleanup(r.store, args[1:], r.out)
 		case "doctor":
 			return runDoctor(ctx, r.store, r.out)
-		case "azure":
+		case "azure", "az":
 			return r.azure(ctx, args[1:])
 		case "add":
 			if len(args) > 1 && azureProviderAlias(args[1]) {
@@ -352,7 +352,7 @@ func (r srRunner) run(ctx context.Context, args []string) error {
 		return r.spend(ctx)
 	case "gemini":
 		return r.gemini(args[1:])
-	case "azure":
+	case "azure", "az":
 		return r.azure(ctx, args[1:])
 	default:
 		if strings.Contains(args[0], "@") {
@@ -509,7 +509,7 @@ func (r srRunner) addProvider(ctx context.Context, args []string) error {
 		return r.add(ctx)
 	case "claude", "anthropic":
 		return r.claude(ctx, append([]string{"add"}, args[1:]...))
-	case "azure", "azure-openai", "foundry":
+	case "az", "azure", "azure-openai", "foundry":
 		return r.azure(ctx, append([]string{"add"}, args[1:]...))
 	default:
 		return fmt.Errorf("unknown provider %q; use '%s add codex', '%s add claude', or '%s add azure'",

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
+	"github.com/manaflow-ai/subrouter/internal/azureopenai"
 	"github.com/manaflow-ai/subrouter/internal/broker"
 	"github.com/manaflow-ai/subrouter/selectacct"
 	"golang.org/x/term"
@@ -47,9 +48,10 @@ const srHelp = `sr - Manage Subrouter accounts
 
 Usage:
   sr                    Show Codex and Claude usage, grouped by provider
-  sr add                Ask whether to add Codex or Claude
+  sr add                Ask whether to add Codex, Claude, or Azure OpenAI
   sr add codex          Add Codex to the active local or hosted pool
   sr add claude         Add Claude to the active local or hosted pool
+  sr add azure          Add a local Azure OpenAI deployment using Azure CLI auth
   sr add-key            Add an API key account
   sr import             Import current ~/.codex/auth.json account
   sr list               List all Codex accounts
@@ -101,6 +103,8 @@ Running agents:
   sr codex [args]       Run codex through Subrouter
   sr claude [args]      Run claude through Subrouter
   sr gemini [args]      Run gemini through Subrouter
+  sr azure codex <profile> [args]
+                        Run Codex against one Azure OpenAI deployment
 
   sr server             Legacy form of sr remote
   sr server add <name> --url <url> [--default]
@@ -133,13 +137,15 @@ The subrouter cx <command> form is kept as a compatibility alias.
 `
 
 type srRunner struct {
-	program string
-	store   accounts.CodexStore
-	in      io.Reader
-	out     io.Writer
-	errOut  io.Writer
-	client  *http.Client
-	cmd     srCommandRunner
+	program       string
+	store         accounts.CodexStore
+	in            io.Reader
+	out           io.Writer
+	errOut        io.Writer
+	client        *http.Client
+	cmd           srCommandRunner
+	azureStore    azureopenai.Store
+	restartDaemon func() error
 }
 
 type srSwitchOptions struct {
@@ -204,6 +210,12 @@ func (r srRunner) run(ctx context.Context, args []string) error {
 			return runCleanup(r.store, args[1:], r.out)
 		case "doctor":
 			return runDoctor(ctx, r.store, r.out)
+		case "azure":
+			return r.azure(ctx, args[1:])
+		case "add":
+			if len(args) > 1 && azureProviderAlias(args[1]) {
+				return r.azure(ctx, append([]string{"add"}, args[2:]...))
+			}
 		}
 	}
 	if len(args) == 0 {
@@ -340,6 +352,8 @@ func (r srRunner) run(ctx context.Context, args []string) error {
 		return r.spend(ctx)
 	case "gemini":
 		return r.gemini(args[1:])
+	case "azure":
+		return r.azure(ctx, args[1:])
 	default:
 		if strings.Contains(args[0], "@") {
 			return r.statusOne(ctx, args[0])
@@ -495,9 +509,11 @@ func (r srRunner) addProvider(ctx context.Context, args []string) error {
 		return r.add(ctx)
 	case "claude", "anthropic":
 		return r.claude(ctx, append([]string{"add"}, args[1:]...))
+	case "azure", "azure-openai", "foundry":
+		return r.azure(ctx, append([]string{"add"}, args[1:]...))
 	default:
-		return fmt.Errorf("unknown provider %q; use '%s add codex' or '%s add claude'",
-			provider, r.program, r.program)
+		return fmt.Errorf("unknown provider %q; use '%s add codex', '%s add claude', or '%s add azure'",
+			provider, r.program, r.program, r.program)
 	}
 }
 
@@ -505,10 +521,10 @@ func (r srRunner) addProvider(ctx context.Context, args []string) error {
 // an error naming both commands rather than a hang on a read that never returns.
 func (r srRunner) promptProvider() (string, error) {
 	if !readerIsTerminal(r.in) {
-		return "", fmt.Errorf("no provider given; run '%s add codex' or '%s add claude'",
-			r.program, r.program)
+		return "", fmt.Errorf("no provider given; run '%s add codex', '%s add claude', or '%s add azure'",
+			r.program, r.program, r.program)
 	}
-	fmt.Fprintf(r.out, "Which account do you want to add?\n\n  1) Codex   (ChatGPT subscription or API key)\n  2) Claude  (Anthropic subscription or API key)\n\nChoice [1]: ")
+	fmt.Fprintf(r.out, "Which account do you want to add?\n\n  1) Codex        (ChatGPT subscription or API key)\n  2) Claude       (Anthropic subscription or API key)\n  3) Azure OpenAI (Azure CLI authentication)\n\nChoice [1]: ")
 	line, err := bufio.NewReader(r.in).ReadString('\n')
 	if err != nil && strings.TrimSpace(line) == "" {
 		return "", fmt.Errorf("no provider selected")
@@ -518,9 +534,11 @@ func (r srRunner) promptProvider() (string, error) {
 		return "codex", nil
 	case "2", "claude":
 		return "claude", nil
+	case "3", "azure", "azure-openai", "foundry":
+		return "azure", nil
 	default:
-		return "", fmt.Errorf("unrecognised choice %q; run '%s add codex' or '%s add claude'",
-			strings.TrimSpace(line), r.program, r.program)
+		return "", fmt.Errorf("unrecognised choice %q; run '%s add codex', '%s add claude', or '%s add azure'",
+			strings.TrimSpace(line), r.program, r.program, r.program)
 	}
 }
 

--- a/cmd/subrouter/sr_add_provider_test.go
+++ b/cmd/subrouter/sr_add_provider_test.go
@@ -38,7 +38,7 @@ func TestAddRejectsUnknownProvider(t *testing.T) {
 
 // Aliases exist because users type what their vendor calls itself.
 func TestProviderAliasesResolve(t *testing.T) {
-	for _, alias := range []string{"codex", "Codex", "openai", "chatgpt", "claude", "CLAUDE", "anthropic"} {
+	for _, alias := range []string{"codex", "Codex", "openai", "chatgpt", "claude", "CLAUDE", "anthropic", "azure", "azure-openai", "foundry"} {
 		var out, errOut bytes.Buffer
 		runner := srRunner{program: "sr", in: strings.NewReader(""), out: &out, errOut: &errOut}
 		err := runner.addProvider(context.Background(), []string{alias})

--- a/cmd/subrouter/sr_azure.go
+++ b/cmd/subrouter/sr_azure.go
@@ -19,18 +19,21 @@ import (
 const srAzureHelp = `sr azure - Run Codex through Azure OpenAI with Azure CLI authentication
 
 Usage:
-  sr azure add <profile> --endpoint <url> --deployment <name>
+  sr azure add <profile> --endpoint <url> [--deployment <model=name> ...]
   sr azure list
   sr azure remove <profile>
-  sr azure codex <profile> [codex args...]
+  sr azure codex <profile> [--model sol|terra|luna] [codex args...]
 
+The short alias 'sr az' supports the same commands. With no --deployment flags,
+the profile maps Sol, Terra, and Luna to their canonical GPT-5.6 deployment names.
+Repeat --deployment to override a mapping, for example --deployment sol=my-sol.
 The profile stores endpoint and deployment metadata, never an access token.
 Run 'az login' first. Subrouter renews Entra access tokens through the same Azure CLI session.
 `
 
 func azureProviderAlias(value string) bool {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "azure", "azure-openai", "foundry":
+	case "az", "azure", "azure-openai", "foundry":
 		return true
 	default:
 		return false
@@ -85,7 +88,8 @@ func (r srRunner) azureAdd(ctx context.Context, args []string) error {
 	flags.SetOutput(io.Discard)
 	nameFlag := flags.String("name", name, "profile name")
 	endpoint := flags.String("endpoint", strings.TrimSpace(os.Getenv("AZURE_OPENAI_ENDPOINT")), "Azure OpenAI endpoint")
-	deployment := flags.String("deployment", strings.TrimSpace(os.Getenv("AZURE_OPENAI_DEPLOYMENT")), "Azure model deployment name")
+	var deploymentFlags repeatedStringFlag
+	flags.Var(&deploymentFlags, "deployment", "Azure deployment mapping model=name; repeat for multiple models")
 	tokenResource := flags.String("token-resource", strings.TrimSpace(os.Getenv("AZURE_OPENAI_TOKEN_RESOURCE")), "Azure token resource audience")
 	azureCLI := flags.String("azure-cli", strings.TrimSpace(os.Getenv("AZURE_CLI")), "Azure CLI path")
 	if err := flags.Parse(args); err != nil {
@@ -94,11 +98,16 @@ func (r srRunner) azureAdd(ctx context.Context, args []string) error {
 	if flags.NArg() != 0 {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
 	}
+	if len(deploymentFlags) == 0 {
+		if value := strings.TrimSpace(os.Getenv("AZURE_OPENAI_DEPLOYMENT")); value != "" {
+			deploymentFlags = append(deploymentFlags, value)
+		}
+	}
 	reader := bufio.NewReader(r.in)
 	var err error
 	if strings.TrimSpace(*nameFlag) == "" {
 		if !readerIsTerminal(r.in) {
-			return errors.New("usage: sr azure add <profile> --endpoint <url> --deployment <name>")
+			return errors.New("usage: sr azure add <profile> --endpoint <url> [--deployment <model=name> ...]")
 		}
 		*nameFlag, err = promptLine(r.out, reader, "Profile name: ")
 		if err != nil {
@@ -114,14 +123,9 @@ func (r srRunner) azureAdd(ctx context.Context, args []string) error {
 			return err
 		}
 	}
-	if strings.TrimSpace(*deployment) == "" {
-		if !readerIsTerminal(r.in) {
-			return errors.New("Azure OpenAI deployment is required; pass --deployment")
-		}
-		*deployment, err = promptLine(r.out, reader, "Deployment name: ")
-		if err != nil {
-			return err
-		}
+	deployments, legacyDeployment, err := parseAzureDeploymentFlags(deploymentFlags)
+	if err != nil {
+		return err
 	}
 	cliPath, err := resolveAzureCLI(*azureCLI)
 	if err != nil {
@@ -130,7 +134,8 @@ func (r srRunner) azureAdd(ctx context.Context, args []string) error {
 	profile, err := azureopenai.NormalizeProfile(azureopenai.Profile{
 		Name:          *nameFlag,
 		Endpoint:      *endpoint,
-		Deployment:    *deployment,
+		Deployment:    legacyDeployment,
+		Deployments:   deployments,
 		TokenResource: *tokenResource,
 		AzureCLI:      cliPath,
 	})
@@ -153,8 +158,49 @@ func (r srRunner) azureAdd(ctx context.Context, args []string) error {
 	if existed {
 		verb = "Updated"
 	}
-	fmt.Fprintf(r.out, "%s Azure OpenAI profile %s (deployment %s). Access tokens are renewed through Azure CLI and are not stored.\n", verb, profile.Name, profile.Deployment)
+	fmt.Fprintf(r.out, "%s Azure OpenAI profile %s (%s). Access tokens are renewed through Azure CLI and are not stored.\n", verb, profile.Name, azureDeploymentSummary(profile))
 	return nil
+}
+
+func parseAzureDeploymentFlags(values []string) (map[string]string, string, error) {
+	if len(values) == 0 {
+		return azureopenai.DefaultGPT56Deployments(), "", nil
+	}
+	deployments := make(map[string]string, len(values))
+	legacy := ""
+	for _, value := range values {
+		model, deployment, mapped := strings.Cut(value, "=")
+		if !mapped {
+			if len(values) != 1 {
+				return nil, "", errors.New("a bare --deployment cannot be combined with model=deployment mappings")
+			}
+			legacy = strings.TrimSpace(value)
+			continue
+		}
+		canonical, ok := azureopenai.CanonicalGPT56Model(model)
+		if !ok || strings.TrimSpace(model) == "" {
+			return nil, "", fmt.Errorf("unsupported Azure OpenAI model %q; use sol, terra, or luna", model)
+		}
+		deployment = strings.TrimSpace(deployment)
+		if existing, exists := deployments[canonical]; exists && existing != deployment {
+			return nil, "", fmt.Errorf("conflicting deployment mappings for %s", canonical)
+		}
+		deployments[canonical] = deployment
+	}
+	return deployments, legacy, nil
+}
+
+func azureDeploymentSummary(profile azureopenai.Profile) string {
+	if len(profile.Deployments) == 0 {
+		return "deployment " + profile.Deployment
+	}
+	parts := make([]string, 0, len(profile.Deployments))
+	for _, model := range azureopenai.GPT56Models() {
+		if deployment, ok := profile.Deployments[model]; ok {
+			parts = append(parts, azureopenai.GPT56ModelAlias(model)+"="+deployment)
+		}
+	}
+	return "deployments " + strings.Join(parts, ", ")
 }
 
 func resolveAzureCLI(explicit string) (string, error) {
@@ -175,11 +221,11 @@ func (r srRunner) azureList() error {
 		return err
 	}
 	if len(profiles) == 0 {
-		fmt.Fprintln(r.out, "No Azure OpenAI profiles. Run: sr azure add <profile> --endpoint <url> --deployment <name>")
+		fmt.Fprintln(r.out, "No Azure OpenAI profiles. Run: sr azure add <profile> --endpoint <url>")
 		return nil
 	}
 	for _, profile := range profiles {
-		fmt.Fprintf(r.out, "%s\t%s\t%s\n", profile.Name, profile.Deployment, profile.Endpoint)
+		fmt.Fprintf(r.out, "%s\t%s\t%s\n", profile.Name, azureDeploymentSummary(profile), profile.Endpoint)
 	}
 	return nil
 }
@@ -201,7 +247,7 @@ func (r srRunner) azureRemove(name string) error {
 
 func (r srRunner) azureCodex(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: sr azure codex <profile> [codex args...]")
+		return errors.New("usage: sr azure codex <profile> [--model sol|terra|luna] [codex args...]")
 	}
 	profile, ok, err := r.azureProfileStore().Find(args[0])
 	if err != nil {
@@ -211,9 +257,15 @@ func (r srRunner) azureCodex(ctx context.Context, args []string) error {
 		return fmt.Errorf("Azure OpenAI profile %q not found; run 'sr azure list'", args[0])
 	}
 	codexArgsRaw := args[1:]
-	if requested := codexModelArg(codexArgsRaw); requested != "" && requested != profile.Deployment {
-		return fmt.Errorf("Azure profile %s is bound to deployment %q, not %q", profile.Name, profile.Deployment, requested)
+	requested := codexModelArg(codexArgsRaw)
+	deployment, ok := profile.DeploymentForModel(requested)
+	if !ok {
+		if len(profile.Deployments) == 0 {
+			return fmt.Errorf("Azure profile %s is bound to deployment %q, not %q", profile.Name, profile.Deployment, requested)
+		}
+		return fmt.Errorf("Azure profile %s has no mapping for model %q; use sol, terra, or luna", profile.Name, requested)
 	}
+	codexArgsRaw = rewriteCodexModelArg(codexArgsRaw, deployment)
 	// Fail before starting Codex when the Azure CLI session is absent or stale.
 	if _, err := azureopenai.FetchCLIAccessToken(ctx, r.commandRunner(), profile); err != nil {
 		return err
@@ -235,7 +287,7 @@ func (r srRunner) azureCodex(ctx context.Context, args []string) error {
 		return err
 	}
 	localProxyToken := cloudClientProxyToken(cloudConfig, local)
-	childArgs := azureCodexArgs(codexArgsRaw, baseURL, profile.Deployment, localProxyToken != "")
+	childArgs := azureCodexArgs(codexArgsRaw, baseURL, deployment, localProxyToken != "")
 	env := []string(nil)
 	if localProxyToken != "" {
 		env = []string{"SUBROUTER_CODEX_DUMMY_API_KEY=" + localProxyToken}
@@ -249,6 +301,24 @@ func (r srRunner) azureCodex(ctx context.Context, args []string) error {
 		r.out,
 		r.errOut,
 	)
+}
+
+func rewriteCodexModelArg(args []string, deployment string) []string {
+	out := append([]string(nil), args...)
+	for i := 0; i < len(out); i++ {
+		switch {
+		case out[i] == "-m" || out[i] == "--model":
+			if i+1 < len(out) {
+				out[i+1] = deployment
+				i++
+			}
+		case strings.HasPrefix(out[i], "--model="):
+			out[i] = "--model=" + deployment
+		case strings.HasPrefix(out[i], "-m="):
+			out[i] = "-m=" + deployment
+		}
+	}
+	return out
 }
 
 func azureCodexBaseURL(localBaseURL, profileName string) (string, error) {

--- a/cmd/subrouter/sr_azure.go
+++ b/cmd/subrouter/sr_azure.go
@@ -19,14 +19,17 @@ import (
 const srAzureHelp = `sr azure - Run Codex through Azure OpenAI with Azure CLI authentication
 
 Usage:
-  sr azure add <profile> --endpoint <url> [--deployment <model=name> ...]
+  sr azure add <profile> --endpoint <url> [--deployment <model=name> ...] [--default]
   sr azure list
+  sr azure default [profile]
   sr azure remove <profile>
-  sr azure codex <profile> [--model sol|terra|luna] [codex args...]
+  sr azure codex [--azure-profile <profile>] [--model sol|terra|luna] [codex args...]
 
 The short alias 'sr az' supports the same commands. With no --deployment flags,
 the profile maps Sol, Terra, and Luna to their canonical GPT-5.6 deployment names.
 Repeat --deployment to override a mapping, for example --deployment sol=my-sol.
+The first profile becomes the default. Use 'sr az default <profile>' to change it.
+Inside Codex, use /model to switch among the configured GPT-5.6 models.
 The profile stores endpoint and deployment metadata, never an access token.
 Run 'az login' first. Subrouter renews Entra access tokens through the same Azure CLI session.
 `
@@ -49,6 +52,8 @@ func (r srRunner) azure(ctx context.Context, args []string) error {
 		return r.azureAdd(ctx, args[1:])
 	case "list", "ls", "status":
 		return r.azureList()
+	case "default", "use":
+		return r.azureDefault(args[1:])
 	case "remove", "rm":
 		if len(args) != 2 {
 			return errors.New("usage: sr azure remove <profile>")
@@ -92,6 +97,7 @@ func (r srRunner) azureAdd(ctx context.Context, args []string) error {
 	flags.Var(&deploymentFlags, "deployment", "Azure deployment mapping model=name; repeat for multiple models")
 	tokenResource := flags.String("token-resource", strings.TrimSpace(os.Getenv("AZURE_OPENAI_TOKEN_RESOURCE")), "Azure token resource audience")
 	azureCLI := flags.String("azure-cli", strings.TrimSpace(os.Getenv("AZURE_CLI")), "Azure CLI path")
+	makeDefault := flags.Bool("default", false, "make this the default Azure OpenAI profile")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -150,6 +156,11 @@ func (r srRunner) azureAdd(ctx context.Context, args []string) error {
 	existed, err := r.azureProfileStore().Save(profile)
 	if err != nil {
 		return err
+	}
+	if *makeDefault {
+		if err := r.azureProfileStore().SetDefault(profile.Name); err != nil {
+			return err
+		}
 	}
 	if err := r.restartAzureDaemon(); err != nil {
 		return err
@@ -216,7 +227,8 @@ func resolveAzureCLI(explicit string) (string, error) {
 }
 
 func (r srRunner) azureList() error {
-	profiles, err := r.azureProfileStore().List()
+	store := r.azureProfileStore()
+	profiles, err := store.List()
 	if err != nil {
 		return err
 	}
@@ -224,10 +236,42 @@ func (r srRunner) azureList() error {
 		fmt.Fprintln(r.out, "No Azure OpenAI profiles. Run: sr azure add <profile> --endpoint <url>")
 		return nil
 	}
+	defaultProfile, _, err := store.Default()
+	if err != nil {
+		return err
+	}
 	for _, profile := range profiles {
-		fmt.Fprintf(r.out, "%s\t%s\t%s\n", profile.Name, azureDeploymentSummary(profile), profile.Endpoint)
+		marker := " "
+		if profile.Name == defaultProfile.Name {
+			marker = "*"
+		}
+		fmt.Fprintf(r.out, "%s %s\t%s\t%s\n", marker, profile.Name, azureDeploymentSummary(profile), profile.Endpoint)
 	}
 	return nil
+}
+
+func (r srRunner) azureDefault(args []string) error {
+	store := r.azureProfileStore()
+	switch len(args) {
+	case 0:
+		profile, ok, err := store.Default()
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return errors.New("no Azure OpenAI profiles; run 'sr az add <profile> --endpoint <url>'")
+		}
+		fmt.Fprintf(r.out, "%s\n", profile.Name)
+		return nil
+	case 1:
+		if err := store.SetDefault(args[0]); err != nil {
+			return err
+		}
+		fmt.Fprintf(r.out, "Default Azure OpenAI profile set to %s.\n", strings.ToLower(strings.TrimSpace(args[0])))
+		return nil
+	default:
+		return errors.New("usage: sr azure default [profile]")
+	}
 }
 
 func (r srRunner) azureRemove(name string) error {
@@ -246,26 +290,19 @@ func (r srRunner) azureRemove(name string) error {
 }
 
 func (r srRunner) azureCodex(ctx context.Context, args []string) error {
-	if len(args) == 0 {
-		return errors.New("usage: sr azure codex <profile> [--model sol|terra|luna] [codex args...]")
-	}
-	profile, ok, err := r.azureProfileStore().Find(args[0])
+	profile, codexArgsRaw, err := r.azureCodexProfile(args)
 	if err != nil {
 		return err
 	}
-	if !ok {
-		return fmt.Errorf("Azure OpenAI profile %q not found; run 'sr azure list'", args[0])
-	}
-	codexArgsRaw := args[1:]
 	requested := codexModelArg(codexArgsRaw)
-	deployment, ok := profile.DeploymentForModel(requested)
+	codexModel, _, ok := profile.ResolveModel(requested)
 	if !ok {
 		if len(profile.Deployments) == 0 {
 			return fmt.Errorf("Azure profile %s is bound to deployment %q, not %q", profile.Name, profile.Deployment, requested)
 		}
 		return fmt.Errorf("Azure profile %s has no mapping for model %q; use sol, terra, or luna", profile.Name, requested)
 	}
-	codexArgsRaw = rewriteCodexModelArg(codexArgsRaw, deployment)
+	codexArgsRaw = rewriteCodexModelArg(codexArgsRaw, codexModel)
 	// Fail before starting Codex when the Azure CLI session is absent or stale.
 	if _, err := azureopenai.FetchCLIAccessToken(ctx, r.commandRunner(), profile); err != nil {
 		return err
@@ -287,7 +324,7 @@ func (r srRunner) azureCodex(ctx context.Context, args []string) error {
 		return err
 	}
 	localProxyToken := cloudClientProxyToken(cloudConfig, local)
-	childArgs := azureCodexArgs(codexArgsRaw, baseURL, deployment, localProxyToken != "")
+	childArgs := azureCodexArgs(codexArgsRaw, baseURL, codexModel, localProxyToken != "")
 	env := []string(nil)
 	if localProxyToken != "" {
 		env = []string{"SUBROUTER_CODEX_DUMMY_API_KEY=" + localProxyToken}
@@ -301,6 +338,56 @@ func (r srRunner) azureCodex(ctx context.Context, args []string) error {
 		r.out,
 		r.errOut,
 	)
+}
+
+func (r srRunner) azureCodexProfile(args []string) (azureopenai.Profile, []string, error) {
+	store := r.azureProfileStore()
+	profileName := ""
+	codexArgs := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		switch {
+		case args[i] == "--azure-profile":
+			if i+1 >= len(args) {
+				return azureopenai.Profile{}, nil, errors.New("--azure-profile requires a profile name")
+			}
+			profileName = args[i+1]
+			i++
+		case strings.HasPrefix(args[i], "--azure-profile="):
+			profileName = strings.TrimPrefix(args[i], "--azure-profile=")
+		default:
+			codexArgs = append(codexArgs, args[i])
+		}
+	}
+	if strings.TrimSpace(profileName) != "" {
+		profile, ok, err := store.Find(profileName)
+		if err != nil {
+			return azureopenai.Profile{}, nil, err
+		}
+		if !ok {
+			return azureopenai.Profile{}, nil, fmt.Errorf("Azure OpenAI profile %q not found; run 'sr az list'", profileName)
+		}
+		return profile, codexArgs, nil
+	}
+
+	// Preserve the original positional profile syntax when the first argument
+	// names an existing profile. Otherwise every argument belongs to Codex.
+	if len(codexArgs) > 0 && !strings.HasPrefix(codexArgs[0], "-") {
+		profile, ok, err := store.Find(codexArgs[0])
+		if err != nil {
+			return azureopenai.Profile{}, nil, err
+		}
+		if ok {
+			return profile, codexArgs[1:], nil
+		}
+	}
+	profile, ok, err := store.Default()
+	if err != nil {
+		return azureopenai.Profile{}, nil, err
+	}
+	if !ok {
+		return azureopenai.Profile{}, nil, errors.New("no Azure OpenAI profiles; run 'sr az add <profile> --endpoint <url>'")
+	}
+	return profile, codexArgs, nil
 }
 
 func rewriteCodexModelArg(args []string, deployment string) []string {

--- a/cmd/subrouter/sr_azure.go
+++ b/cmd/subrouter/sr_azure.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/manaflow-ai/subrouter/internal/azureopenai"
+)
+
+const srAzureHelp = `sr azure - Run Codex through Azure OpenAI with Azure CLI authentication
+
+Usage:
+  sr azure add <profile> --endpoint <url> --deployment <name>
+  sr azure list
+  sr azure remove <profile>
+  sr azure codex <profile> [codex args...]
+
+The profile stores endpoint and deployment metadata, never an access token.
+Run 'az login' first. Subrouter renews Entra access tokens through the same Azure CLI session.
+`
+
+func azureProviderAlias(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "azure", "azure-openai", "foundry":
+		return true
+	default:
+		return false
+	}
+}
+
+func (r srRunner) azure(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return r.azureList()
+	}
+	switch strings.ToLower(strings.TrimSpace(args[0])) {
+	case "add", "login":
+		return r.azureAdd(ctx, args[1:])
+	case "list", "ls", "status":
+		return r.azureList()
+	case "remove", "rm":
+		if len(args) != 2 {
+			return errors.New("usage: sr azure remove <profile>")
+		}
+		return r.azureRemove(args[1])
+	case "codex", "run":
+		return r.azureCodex(ctx, args[1:])
+	case "help", "-h", "--help":
+		fmt.Fprint(r.out, srAzureHelp)
+		return nil
+	default:
+		return fmt.Errorf("unknown command %q\n%s", "sr azure "+args[0], srAzureHelp)
+	}
+}
+
+func (r srRunner) azureProfileStore() azureopenai.Store {
+	if strings.TrimSpace(r.azureStore.Path) != "" {
+		return r.azureStore
+	}
+	return azureopenai.DefaultStore()
+}
+
+func (r srRunner) restartAzureDaemon() error {
+	if r.restartDaemon != nil {
+		return r.restartDaemon()
+	}
+	return restartInstalledDaemon()
+}
+
+func (r srRunner) azureAdd(ctx context.Context, args []string) error {
+	name := ""
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		name = args[0]
+		args = args[1:]
+	}
+	flags := flag.NewFlagSet("azure add", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	nameFlag := flags.String("name", name, "profile name")
+	endpoint := flags.String("endpoint", strings.TrimSpace(os.Getenv("AZURE_OPENAI_ENDPOINT")), "Azure OpenAI endpoint")
+	deployment := flags.String("deployment", strings.TrimSpace(os.Getenv("AZURE_OPENAI_DEPLOYMENT")), "Azure model deployment name")
+	tokenResource := flags.String("token-resource", strings.TrimSpace(os.Getenv("AZURE_OPENAI_TOKEN_RESOURCE")), "Azure token resource audience")
+	azureCLI := flags.String("azure-cli", strings.TrimSpace(os.Getenv("AZURE_CLI")), "Azure CLI path")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	reader := bufio.NewReader(r.in)
+	var err error
+	if strings.TrimSpace(*nameFlag) == "" {
+		if !readerIsTerminal(r.in) {
+			return errors.New("usage: sr azure add <profile> --endpoint <url> --deployment <name>")
+		}
+		*nameFlag, err = promptLine(r.out, reader, "Profile name: ")
+		if err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(*endpoint) == "" {
+		if !readerIsTerminal(r.in) {
+			return errors.New("Azure OpenAI endpoint is required; pass --endpoint")
+		}
+		*endpoint, err = promptLine(r.out, reader, "Azure OpenAI endpoint: ")
+		if err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(*deployment) == "" {
+		if !readerIsTerminal(r.in) {
+			return errors.New("Azure OpenAI deployment is required; pass --deployment")
+		}
+		*deployment, err = promptLine(r.out, reader, "Deployment name: ")
+		if err != nil {
+			return err
+		}
+	}
+	cliPath, err := resolveAzureCLI(*azureCLI)
+	if err != nil {
+		return err
+	}
+	profile, err := azureopenai.NormalizeProfile(azureopenai.Profile{
+		Name:          *nameFlag,
+		Endpoint:      *endpoint,
+		Deployment:    *deployment,
+		TokenResource: *tokenResource,
+		AzureCLI:      cliPath,
+	})
+	if err != nil {
+		return err
+	}
+	// Validate the selected Azure CLI session before committing the profile.
+	// The returned bearer token stays in memory and is deliberately discarded.
+	if _, err := azureopenai.FetchCLIAccessToken(ctx, r.commandRunner(), profile); err != nil {
+		return err
+	}
+	existed, err := r.azureProfileStore().Save(profile)
+	if err != nil {
+		return err
+	}
+	if err := r.restartAzureDaemon(); err != nil {
+		return err
+	}
+	verb := "Added"
+	if existed {
+		verb = "Updated"
+	}
+	fmt.Fprintf(r.out, "%s Azure OpenAI profile %s (deployment %s). Access tokens are renewed through Azure CLI and are not stored.\n", verb, profile.Name, profile.Deployment)
+	return nil
+}
+
+func resolveAzureCLI(explicit string) (string, error) {
+	name := strings.TrimSpace(explicit)
+	if name == "" {
+		name = "az"
+	}
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return "", errors.New("Azure CLI not found; install 'az', run 'az login', then retry")
+	}
+	return path, nil
+}
+
+func (r srRunner) azureList() error {
+	profiles, err := r.azureProfileStore().List()
+	if err != nil {
+		return err
+	}
+	if len(profiles) == 0 {
+		fmt.Fprintln(r.out, "No Azure OpenAI profiles. Run: sr azure add <profile> --endpoint <url> --deployment <name>")
+		return nil
+	}
+	for _, profile := range profiles {
+		fmt.Fprintf(r.out, "%s\t%s\t%s\n", profile.Name, profile.Deployment, profile.Endpoint)
+	}
+	return nil
+}
+
+func (r srRunner) azureRemove(name string) error {
+	removed, err := r.azureProfileStore().Remove(name)
+	if err != nil {
+		return err
+	}
+	if !removed {
+		return fmt.Errorf("Azure OpenAI profile %q not found", name)
+	}
+	if err := r.restartAzureDaemon(); err != nil {
+		return err
+	}
+	fmt.Fprintf(r.out, "Removed Azure OpenAI profile %s.\n", strings.ToLower(strings.TrimSpace(name)))
+	return nil
+}
+
+func (r srRunner) azureCodex(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: sr azure codex <profile> [codex args...]")
+	}
+	profile, ok, err := r.azureProfileStore().Find(args[0])
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("Azure OpenAI profile %q not found; run 'sr azure list'", args[0])
+	}
+	codexArgsRaw := args[1:]
+	if requested := codexModelArg(codexArgsRaw); requested != "" && requested != profile.Deployment {
+		return fmt.Errorf("Azure profile %s is bound to deployment %q, not %q", profile.Name, profile.Deployment, requested)
+	}
+	// Fail before starting Codex when the Azure CLI session is absent or stale.
+	if _, err := azureopenai.FetchCLIAccessToken(ctx, r.commandRunner(), profile); err != nil {
+		return err
+	}
+	local := localBaseURL()
+	client := fallbackHTTPClient()
+	if r.client != nil {
+		client = r.client
+	}
+	if !ensureLocalHealthy(ctx, client, local, defaultDaemonStarter(), r.errOut) {
+		return fmt.Errorf("local proxy is unavailable; run '%s setup'", programBase())
+	}
+	baseURL, err := azureCodexBaseURL(local, profile.Name)
+	if err != nil {
+		return err
+	}
+	cloudConfig, err := cloudModeConfig()
+	if err != nil {
+		return err
+	}
+	localProxyToken := cloudClientProxyToken(cloudConfig, local)
+	childArgs := azureCodexArgs(codexArgsRaw, baseURL, profile.Deployment, localProxyToken != "")
+	env := []string(nil)
+	if localProxyToken != "" {
+		env = []string{"SUBROUTER_CODEX_DUMMY_API_KEY=" + localProxyToken}
+	}
+	return r.commandRunner().RunWithEnv(
+		ctx,
+		envOrDefault("SUBROUTER_CODEX_BIN", "codex"),
+		childArgs,
+		env,
+		r.in,
+		r.out,
+		r.errOut,
+	)
+}
+
+func azureCodexBaseURL(localBaseURL, profileName string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(localBaseURL))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("invalid local Subrouter URL %q", localBaseURL)
+	}
+	parsed.Path = azureOpenAIClientPath(profileName) + "/v1"
+	parsed.RawPath = ""
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func azureOpenAIClientPath(profileName string) string {
+	return "/azure/" + strings.ToLower(strings.TrimSpace(profileName))
+}
+
+func azureCodexArgs(args []string, baseURL, deployment string, forceAuthenticatedProvider bool) []string {
+	authConfig := `model_providers.subrouter_azure.experimental_bearer_token="subrouter"`
+	if forceAuthenticatedProvider {
+		authConfig = `model_providers.subrouter_azure.env_key="SUBROUTER_CODEX_DUMMY_API_KEY"`
+	}
+	configArgs := []string{
+		"-c", "model=" + strconv.Quote(deployment),
+		"-c", `model_provider="subrouter_azure"`,
+		"-c", `model_providers.subrouter_azure.name="Azure OpenAI via Subrouter"`,
+		"-c", "model_providers.subrouter_azure.base_url=" + strconv.Quote(baseURL),
+		"-c", authConfig,
+		"-c", `model_providers.subrouter_azure.wire_api="responses"`,
+		"-c", `model_providers.subrouter_azure.supports_websockets=false`,
+		"-c", `model_providers.subrouter_azure.http_headers={"X-Subrouter-Agent"="codex"}`,
+	}
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") || !isKnownCodexCommand(args[0]) {
+		return append(configArgs, args...)
+	}
+	if !isSubrouterRoutedCodexCommand(args[0]) {
+		return append([]string(nil), args...)
+	}
+	out := []string{args[0]}
+	out = append(out, configArgs...)
+	out = append(out, args[1:]...)
+	return out
+}

--- a/cmd/subrouter/sr_azure_test.go
+++ b/cmd/subrouter/sr_azure_test.go
@@ -222,6 +222,90 @@ func TestSRAzureCodexBindsCustomProviderToDeployment(t *testing.T) {
 	}
 }
 
+func TestSRAzureCodexUsesSavedDefaultWithoutProfileArgument(t *testing.T) {
+	local := healthServer(t, 200)
+	t.Setenv("SUBROUTER_LOCAL_BASE_URL", local.URL+"/v1")
+	t.Setenv("SUBROUTER_CLOUD_CONFIG", filepath.Join(t.TempDir(), "cloud.json"))
+	t.Setenv("SUBROUTER_CODEX_BIN", "codex-test")
+
+	store := azureopenai.Store{Path: filepath.Join(t.TempDir(), "azure-openai.json")}
+	for _, profile := range []azureopenai.Profile{
+		{
+			Name:        "primary",
+			Endpoint:    "https://primary.openai.azure.com",
+			Deployments: azureopenai.DefaultGPT56Deployments(),
+			AzureCLI:    "/opt/homebrew/bin/az",
+		},
+		{
+			Name:        "secondary",
+			Endpoint:    "https://secondary.openai.azure.com",
+			Deployments: azureopenai.DefaultGPT56Deployments(),
+			AzureCLI:    "/opt/homebrew/bin/az",
+		},
+	} {
+		if _, err := store.Save(profile); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.SetDefault("secondary"); err != nil {
+		t.Fatal(err)
+	}
+
+	commands := &azureTestCommandRunner{output: []byte(`{"accessToken":"azure-cli-secret","expires_on":4070908800}`)}
+	runner := srRunner{
+		program:    "sr",
+		in:         strings.NewReader(""),
+		out:        io.Discard,
+		errOut:     io.Discard,
+		client:     local.Client(),
+		cmd:        commands,
+		azureStore: store,
+	}
+
+	if err := runner.run(context.Background(), []string{"az", "codex"}); err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(commands.runArgs, "\n")
+	for _, want := range []string{
+		`model="gpt-5.6-sol"`,
+		`model_providers.subrouter_azure.base_url="` + local.URL + `/azure/secondary/v1"`,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("Codex args missing %q:\n%s", want, joined)
+		}
+	}
+	for _, arg := range commands.runArgs {
+		if arg == "--model" || arg == "-m" || strings.HasPrefix(arg, "--model=") || strings.HasPrefix(arg, "-m=") {
+			t.Fatalf("launcher pinned Codex's model flag instead of leaving /model available: %#v", commands.runArgs)
+		}
+	}
+}
+
+func TestSRAzureCodexProfileOverrideDoesNotReachCodex(t *testing.T) {
+	store := azureopenai.Store{Path: filepath.Join(t.TempDir(), "azure-openai.json")}
+	for _, name := range []string{"primary", "secondary"} {
+		if _, err := store.Save(azureopenai.Profile{
+			Name:        name,
+			Endpoint:    "https://" + name + ".openai.azure.com",
+			Deployments: azureopenai.DefaultGPT56Deployments(),
+			AzureCLI:    "/opt/homebrew/bin/az",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runner := srRunner{azureStore: store}
+	profile, args, err := runner.azureCodexProfile([]string{"exec", "--azure-profile=secondary", "hello"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if profile.Name != "secondary" {
+		t.Fatalf("profile = %q, want secondary", profile.Name)
+	}
+	if !reflect.DeepEqual(args, []string{"exec", "hello"}) {
+		t.Fatalf("Codex args = %#v, want exec hello", args)
+	}
+}
+
 func TestSRAzureCodexRejectsDeploymentOverride(t *testing.T) {
 	store := azureopenai.Store{Path: filepath.Join(t.TempDir(), "azure-openai.json")}
 	if _, err := store.Save(azureopenai.Profile{
@@ -294,11 +378,18 @@ func TestSRAzureCodexResolvesGPT56FamilyAndRewritesModelFlag(t *testing.T) {
 				t.Fatal(err)
 			}
 			joined := strings.Join(commands.runArgs, "\n")
-			if !strings.Contains(joined, `model="`+test.deployment+`"`) {
-				t.Fatalf("Codex args do not select %q:\n%s", test.deployment, joined)
+			canonicalModel, ok := azureopenai.CanonicalGPT56Model("")
+			if len(test.modelArgs) > 0 {
+				canonicalModel, ok = azureopenai.CanonicalGPT56Model(codexModelArg(test.modelArgs))
+			}
+			if !ok {
+				t.Fatalf("test model selector is not canonical: %#v", test.modelArgs)
+			}
+			if !strings.Contains(joined, `model="`+canonicalModel+`"`) {
+				t.Fatalf("Codex args do not retain canonical picker model %q:\n%s", canonicalModel, joined)
 			}
 			for _, arg := range commands.runArgs {
-				if arg == "gpt-5.6" || arg == "terra" || arg == "gpt-5.6-luna" || arg == "--model=terra" {
+				if arg == test.deployment || arg == "gpt-5.6" || arg == "terra" || arg == "--model=terra" {
 					t.Fatalf("unresolved model selector reached Codex: %#v", commands.runArgs)
 				}
 			}

--- a/cmd/subrouter/sr_azure_test.go
+++ b/cmd/subrouter/sr_azure_test.go
@@ -100,6 +100,76 @@ func TestSRAzureAddValidatesCLIThenPersistsMetadata(t *testing.T) {
 	}
 }
 
+func TestSRAzAddDefaultsToAllGPT56Deployments(t *testing.T) {
+	dir := t.TempDir()
+	cliPath := filepath.Join(dir, "az")
+	if err := os.WriteFile(cliPath, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	store := azureopenai.Store{Path: filepath.Join(dir, "azure-openai.json")}
+	commands := &azureTestCommandRunner{output: []byte(`{"accessToken":"azure-cli-secret","expires_on":4070908800}`)}
+	runner := srRunner{
+		program:    "sr",
+		in:         strings.NewReader(""),
+		out:        io.Discard,
+		errOut:     io.Discard,
+		cmd:        commands,
+		azureStore: store,
+		restartDaemon: func() error {
+			return nil
+		},
+	}
+
+	if err := runner.run(context.Background(), []string{
+		"az", "add", "work",
+		"--endpoint", "https://example.openai.azure.com",
+		"--azure-cli", cliPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	profile, ok, err := store.Find("work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("Azure profile was not saved")
+	}
+	if profile.Deployment != azureopenai.GPT56Sol {
+		t.Fatalf("compatibility deployment = %q, want %q", profile.Deployment, azureopenai.GPT56Sol)
+	}
+	for _, model := range azureopenai.GPT56Models() {
+		if profile.Deployments[model] != model {
+			t.Errorf("deployment %s = %q, want canonical model name", model, profile.Deployments[model])
+		}
+	}
+}
+
+func TestParseAzureDeploymentFlagsSupportsAliasesAndRejectsConflicts(t *testing.T) {
+	deployments, legacy, err := parseAzureDeploymentFlags([]string{
+		"sol=production-sol",
+		"gpt-5.6-terra=production-terra",
+		"luna=production-luna",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy != "" {
+		t.Fatalf("legacy deployment = %q", legacy)
+	}
+	for model, want := range map[string]string{
+		azureopenai.GPT56Sol:   "production-sol",
+		azureopenai.GPT56Terra: "production-terra",
+		azureopenai.GPT56Luna:  "production-luna",
+	} {
+		if deployments[model] != want {
+			t.Errorf("deployment %s = %q, want %q", model, deployments[model], want)
+		}
+	}
+	if _, _, err := parseAzureDeploymentFlags([]string{"sol=one", "gpt-5.6-sol=two"}); err == nil {
+		t.Fatal("conflicting model aliases were accepted")
+	}
+}
+
 func TestSRAzureCodexBindsCustomProviderToDeployment(t *testing.T) {
 	local := healthServer(t, 200)
 	t.Setenv("SUBROUTER_LOCAL_BASE_URL", local.URL+"/v1")
@@ -172,6 +242,90 @@ func TestSRAzureCodexRejectsDeploymentOverride(t *testing.T) {
 	}
 	err := runner.run(context.Background(), []string{"azure", "codex", "work", "-m", "other-deployment"})
 	if err == nil || !strings.Contains(err.Error(), `bound to deployment "codex-deployment"`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestSRAzureCodexResolvesGPT56FamilyAndRewritesModelFlag(t *testing.T) {
+	local := healthServer(t, 200)
+	t.Setenv("SUBROUTER_LOCAL_BASE_URL", local.URL+"/v1")
+	t.Setenv("SUBROUTER_CLOUD_CONFIG", filepath.Join(t.TempDir(), "cloud.json"))
+	t.Setenv("SUBROUTER_CODEX_BIN", "codex-test")
+
+	store := azureopenai.Store{Path: filepath.Join(t.TempDir(), "azure-openai.json")}
+	if _, err := store.Save(azureopenai.Profile{
+		Name:     "work",
+		Endpoint: "https://example.openai.azure.com",
+		Deployments: map[string]string{
+			azureopenai.GPT56Sol:   "deployment-sol",
+			azureopenai.GPT56Terra: "deployment-terra",
+			azureopenai.GPT56Luna:  "deployment-luna",
+		},
+		AzureCLI: "/opt/homebrew/bin/az",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name       string
+		modelArgs  []string
+		deployment string
+	}{
+		{name: "default sol", deployment: "deployment-sol"},
+		{name: "OpenAI alias", modelArgs: []string{"--model", "gpt-5.6"}, deployment: "deployment-sol"},
+		{name: "terra short alias", modelArgs: []string{"--model=terra"}, deployment: "deployment-terra"},
+		{name: "luna full name", modelArgs: []string{"-m", "gpt-5.6-luna"}, deployment: "deployment-luna"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			commands := &azureTestCommandRunner{output: []byte(`{"accessToken":"azure-cli-secret","expires_on":4070908800}`)}
+			runner := srRunner{
+				program:    "sr",
+				in:         strings.NewReader(""),
+				out:        io.Discard,
+				errOut:     io.Discard,
+				client:     local.Client(),
+				cmd:        commands,
+				azureStore: store,
+			}
+			args := []string{"az", "codex", "work", "exec"}
+			args = append(args, test.modelArgs...)
+			args = append(args, "hello")
+			if err := runner.run(context.Background(), args); err != nil {
+				t.Fatal(err)
+			}
+			joined := strings.Join(commands.runArgs, "\n")
+			if !strings.Contains(joined, `model="`+test.deployment+`"`) {
+				t.Fatalf("Codex args do not select %q:\n%s", test.deployment, joined)
+			}
+			for _, arg := range commands.runArgs {
+				if arg == "gpt-5.6" || arg == "terra" || arg == "gpt-5.6-luna" || arg == "--model=terra" {
+					t.Fatalf("unresolved model selector reached Codex: %#v", commands.runArgs)
+				}
+			}
+		})
+	}
+}
+
+func TestSRAzureCodexRejectsUnknownGPT56Mapping(t *testing.T) {
+	store := azureopenai.Store{Path: filepath.Join(t.TempDir(), "azure-openai.json")}
+	if _, err := store.Save(azureopenai.Profile{
+		Name:        "work",
+		Endpoint:    "https://example.openai.azure.com",
+		Deployments: azureopenai.DefaultGPT56Deployments(),
+		AzureCLI:    "/opt/homebrew/bin/az",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	runner := srRunner{
+		program:    "sr",
+		in:         strings.NewReader(""),
+		out:        io.Discard,
+		errOut:     io.Discard,
+		cmd:        &azureTestCommandRunner{},
+		azureStore: store,
+	}
+	err := runner.run(context.Background(), []string{"azure", "codex", "work", "--model", "gpt-5.5"})
+	if err == nil || !strings.Contains(err.Error(), "use sol, terra, or luna") {
 		t.Fatalf("error = %v", err)
 	}
 }

--- a/cmd/subrouter/sr_azure_test.go
+++ b/cmd/subrouter/sr_azure_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/azureopenai"
+)
+
+type azureTestCommandRunner struct {
+	output      []byte
+	outputCalls [][]string
+	runName     string
+	runArgs     []string
+	runEnv      []string
+}
+
+func (r *azureTestCommandRunner) Run(ctx context.Context, name string, args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
+	return r.RunWithEnv(ctx, name, args, nil, stdin, stdout, stderr)
+}
+
+func (r *azureTestCommandRunner) RunWithEnv(_ context.Context, name string, args []string, env []string, _ io.Reader, _ io.Writer, _ io.Writer) error {
+	r.runName = name
+	r.runArgs = append([]string(nil), args...)
+	r.runEnv = append([]string(nil), env...)
+	return nil
+}
+
+func (r *azureTestCommandRunner) Output(_ context.Context, name string, args []string) ([]byte, error) {
+	r.outputCalls = append(r.outputCalls, append([]string{name}, args...))
+	return append([]byte(nil), r.output...), nil
+}
+
+func TestSRAzureAddValidatesCLIThenPersistsMetadata(t *testing.T) {
+	dir := t.TempDir()
+	cliPath := filepath.Join(dir, "az")
+	if err := os.WriteFile(cliPath, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	store := azureopenai.Store{Path: filepath.Join(dir, "azure-openai.json")}
+	commands := &azureTestCommandRunner{output: []byte(`{"accessToken":"azure-cli-secret","expires_on":4070908800}`)}
+	var restarts int
+	var out bytes.Buffer
+	runner := srRunner{
+		program:    "sr",
+		in:         strings.NewReader(""),
+		out:        &out,
+		errOut:     &out,
+		cmd:        commands,
+		azureStore: store,
+		restartDaemon: func() error {
+			restarts++
+			return nil
+		},
+	}
+
+	err := runner.run(context.Background(), []string{
+		"add", "azure", "work",
+		"--endpoint", "https://example.openai.azure.com",
+		"--deployment", "codex-deployment",
+		"--azure-cli", cliPath,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCommand := []string{
+		cliPath,
+		"account", "get-access-token",
+		"--resource", azureopenai.FoundryTokenResource,
+		"--output", "json",
+	}
+	if len(commands.outputCalls) != 1 || !reflect.DeepEqual(commands.outputCalls[0], wantCommand) {
+		t.Fatalf("Azure CLI calls = %#v, want %#v", commands.outputCalls, wantCommand)
+	}
+	if restarts != 1 {
+		t.Fatalf("daemon restarts = %d, want 1", restarts)
+	}
+	profile, ok, err := store.Find("work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || profile.Deployment != "codex-deployment" || profile.AzureCLI != cliPath {
+		t.Fatalf("profile = %#v, found = %t", profile, ok)
+	}
+	body, err := os.ReadFile(store.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "azure-cli-secret") {
+		t.Fatalf("profile store contains access token: %s", body)
+	}
+	if !strings.Contains(out.String(), "Access tokens are renewed through Azure CLI and are not stored") {
+		t.Fatalf("output = %q", out.String())
+	}
+}
+
+func TestSRAzureCodexBindsCustomProviderToDeployment(t *testing.T) {
+	local := healthServer(t, 200)
+	t.Setenv("SUBROUTER_LOCAL_BASE_URL", local.URL+"/v1")
+	t.Setenv("SUBROUTER_CLOUD_CONFIG", filepath.Join(t.TempDir(), "cloud.json"))
+	t.Setenv("SUBROUTER_CODEX_BIN", "codex-test")
+
+	store := azureopenai.Store{Path: filepath.Join(t.TempDir(), "azure-openai.json")}
+	if _, err := store.Save(azureopenai.Profile{
+		Name:       "work",
+		Endpoint:   "https://example.openai.azure.com",
+		Deployment: "codex-deployment",
+		AzureCLI:   "/opt/homebrew/bin/az",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	commands := &azureTestCommandRunner{output: []byte(`{"accessToken":"azure-cli-secret","expires_on":4070908800}`)}
+	runner := srRunner{
+		program:    "sr",
+		in:         strings.NewReader(""),
+		out:        io.Discard,
+		errOut:     io.Discard,
+		client:     local.Client(),
+		cmd:        commands,
+		azureStore: store,
+	}
+
+	if err := runner.run(context.Background(), []string{"azure", "codex", "work", "exec", "hello"}); err != nil {
+		t.Fatal(err)
+	}
+	if commands.runName != "codex-test" {
+		t.Fatalf("command = %q, want codex-test", commands.runName)
+	}
+	joined := strings.Join(commands.runArgs, "\n")
+	for _, want := range []string{
+		"exec",
+		`model="codex-deployment"`,
+		`model_provider="subrouter_azure"`,
+		`model_providers.subrouter_azure.base_url="` + local.URL + `/azure/work/v1"`,
+		`model_providers.subrouter_azure.experimental_bearer_token="subrouter"`,
+		`model_providers.subrouter_azure.wire_api="responses"`,
+		`model_providers.subrouter_azure.supports_websockets=false`,
+		"hello",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("Codex args missing %q:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "azure-cli-secret") || strings.Contains(strings.Join(commands.runEnv, "\n"), "azure-cli-secret") {
+		t.Fatal("Azure access token was passed to the Codex child")
+	}
+}
+
+func TestSRAzureCodexRejectsDeploymentOverride(t *testing.T) {
+	store := azureopenai.Store{Path: filepath.Join(t.TempDir(), "azure-openai.json")}
+	if _, err := store.Save(azureopenai.Profile{
+		Name:       "work",
+		Endpoint:   "https://example.openai.azure.com",
+		Deployment: "codex-deployment",
+		AzureCLI:   "/opt/homebrew/bin/az",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	runner := srRunner{
+		program:    "sr",
+		in:         strings.NewReader(""),
+		out:        io.Discard,
+		errOut:     io.Discard,
+		cmd:        &azureTestCommandRunner{},
+		azureStore: store,
+	}
+	err := runner.run(context.Background(), []string{"azure", "codex", "work", "-m", "other-deployment"})
+	if err == nil || !strings.Contains(err.Error(), `bound to deployment "codex-deployment"`) {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -24,6 +24,30 @@ This includes Responses WebSockets at `/v1/responses` and realtime WebSockets at
 
 Do not set a dummy `OPENAI_API_KEY` for normal subscription routing. Codex should stay logged in normally, ideally with ChatGPT auth. Subrouter replaces the outbound Authorization and `ChatGPT-Account-ID` headers with the selected `sr` account.
 
+## Azure OpenAI
+
+Subrouter can run Codex against an Azure OpenAI deployment while Azure CLI owns the Microsoft Entra login:
+
+```bash
+brew install azure-cli
+az login
+sr azure add work \
+  --endpoint https://RESOURCE.openai.azure.com \
+  --deployment DEPLOYMENT_NAME
+sr azure codex work
+sr azure codex work exec "your prompt"
+```
+
+Use the Azure deployment name, which can differ from the underlying model name. The launcher binds Codex to that deployment and rejects a conflicting `-m` or `--model` argument. `sr azure list` shows configured profiles, and `sr azure remove work` removes one.
+
+`sr azure add` validates the current Azure CLI session with `az account get-access-token`, stores the resolved CLI path plus non-secret profile metadata in `~/.subrouter/codex/azure-openai.json`, and restarts the local daemon. The daemon acquires tokens on demand, keeps them only in memory, and renews them before expiry. Run `az login` again when Azure CLI reports that the session or tenant access is invalid.
+
+Profiles default to the current Foundry token resource, `https://ai.azure.com`. Pass `--token-resource https://cognitiveservices.azure.com` for an Azure OpenAI resource that requires the Cognitive Services audience. `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT`, `AZURE_OPENAI_TOKEN_RESOURCE`, and `AZURE_CLI` provide defaults for `sr azure add`.
+
+The Codex child talks only to the local route `/azure/<profile>/v1`. Subrouter replaces its placeholder credential with the Azure CLI token, strips OpenAI API-key and organization headers, and forwards Responses requests to `<endpoint>/openai/v1`. Azure traffic does not enter the ChatGPT subscription pool, OAuth refresh, usage polling, or account failover paths. The custom provider uses HTTP streaming because Azure's Responses WebSocket mode is not enabled here.
+
+The signed-in identity needs access to the deployment. See Microsoft's [Codex with Azure OpenAI](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/codex), [keyless authentication](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/configure-entra-id), and [Responses API reference](https://learn.microsoft.com/en-us/rest/api/microsoft-foundry/azureopenai/responses).
+
 ## Server Switching
 
 Register and select a remote server:
@@ -109,6 +133,10 @@ OPENAI_API_KEY=dummy codex exec \
 - `SUBROUTER_CODEX_BIN`: Codex binary used by the wrapper; defaults to `codex`.
 - `SUBROUTER_CODEX_USER_EMAIL`: optional self-reported user email. When set, the wrapper sends `X-Subrouter-Agent: codex` and `X-Subrouter-User-Email` through a custom Subrouter provider.
 - `SUBROUTER_CODEX_ACCOUNT_ID`: optional Subrouter account id or API-key label. When set, the wrapper sends `X-Subrouter-Account-ID` and Subrouter forces that account for the session.
+- `AZURE_OPENAI_ENDPOINT`: default endpoint for `sr azure add`.
+- `AZURE_OPENAI_DEPLOYMENT`: default Azure deployment name for `sr azure add`.
+- `AZURE_OPENAI_TOKEN_RESOURCE`: optional Azure token resource override for `sr azure add`.
+- `AZURE_CLI`: optional Azure CLI executable or absolute path for `sr azure add`.
 - `OPENAI_API_KEY`: only for real API-key mode or custom env-key providers. Avoid setting it when you want ChatGPT subscription model behavior.
 - `CODEX_HOME`: optional. Use it to test an isolated Codex config.
 - `OPENAI_ORGANIZATION` and `OPENAI_PROJECT`: Codex forwards these as OpenAI headers for the built-in OpenAI provider.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -26,23 +26,35 @@ Do not set a dummy `OPENAI_API_KEY` for normal subscription routing. Codex shoul
 
 ## Azure OpenAI
 
-Subrouter can run Codex against an Azure OpenAI deployment while Azure CLI owns the Microsoft Entra login:
+Subrouter can run Codex against all three Azure OpenAI GPT-5.6 models while Azure CLI owns the Microsoft Entra login:
 
 ```bash
 brew install azure-cli
 az login
 sr azure add work \
-  --endpoint https://RESOURCE.openai.azure.com \
-  --deployment DEPLOYMENT_NAME
-sr azure codex work
-sr azure codex work exec "your prompt"
+  --endpoint https://RESOURCE.cognitiveservices.azure.com
+sr azure codex work --model sol
+sr az codex work --model terra
+sr az codex work --model luna exec "your prompt"
 ```
 
-Use the Azure deployment name, which can differ from the underlying model name. The launcher binds Codex to that deployment and rejects a conflicting `-m` or `--model` argument. `sr azure list` shows configured profiles, and `sr azure remove work` removes one.
+`sr azure` is the canonical command and `sr az` is its short alias. `sol` is the default when `--model` is omitted. The selectors `sol`, `terra`, and `luna` map to `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`; `gpt-5.6` is an alias for Sol. Full model names also work.
+
+By default, each Azure deployment has the same name as its model. Override custom Azure deployment names by repeating the flag during setup:
+
+```bash
+sr azure add work \
+  --endpoint https://RESOURCE.cognitiveservices.azure.com \
+  --deployment sol=production-sol \
+  --deployment terra=production-terra \
+  --deployment luna=production-luna
+```
+
+The launcher resolves the selector to the configured Azure deployment before starting Codex. A legacy bare `--deployment DEPLOYMENT_NAME` remains supported as a single-deployment profile. `sr azure list` shows configured profiles, and `sr azure remove work` removes one.
 
 `sr azure add` validates the current Azure CLI session with `az account get-access-token`, stores the resolved CLI path plus non-secret profile metadata in `~/.subrouter/codex/azure-openai.json`, and restarts the local daemon. The daemon acquires tokens on demand, keeps them only in memory, and renews them before expiry. Run `az login` again when Azure CLI reports that the session or tenant access is invalid.
 
-Profiles default to the current Foundry token resource, `https://ai.azure.com`. Pass `--token-resource https://cognitiveservices.azure.com` for an Azure OpenAI resource that requires the Cognitive Services audience. `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT`, `AZURE_OPENAI_TOKEN_RESOURCE`, and `AZURE_CLI` provide defaults for `sr azure add`.
+Profiles default to the current Foundry token resource, `https://ai.azure.com`. Pass `--token-resource https://cognitiveservices.azure.com` for an Azure OpenAI resource that requires the Cognitive Services audience. `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT`, `AZURE_OPENAI_TOKEN_RESOURCE`, and `AZURE_CLI` provide defaults for `sr azure add`. `AZURE_OPENAI_DEPLOYMENT` accepts either a legacy deployment name or one `model=name` mapping; use flags for multiple mappings.
 
 The Codex child talks only to the local route `/azure/<profile>/v1`. Subrouter replaces its placeholder credential with the Azure CLI token, strips OpenAI API-key and organization headers, and forwards Responses requests to `<endpoint>/openai/v1`. Azure traffic does not enter the ChatGPT subscription pool, OAuth refresh, usage polling, or account failover paths. The custom provider uses HTTP streaming because Azure's Responses WebSocket mode is not enabled here.
 
@@ -134,7 +146,7 @@ OPENAI_API_KEY=dummy codex exec \
 - `SUBROUTER_CODEX_USER_EMAIL`: optional self-reported user email. When set, the wrapper sends `X-Subrouter-Agent: codex` and `X-Subrouter-User-Email` through a custom Subrouter provider.
 - `SUBROUTER_CODEX_ACCOUNT_ID`: optional Subrouter account id or API-key label. When set, the wrapper sends `X-Subrouter-Account-ID` and Subrouter forces that account for the session.
 - `AZURE_OPENAI_ENDPOINT`: default endpoint for `sr azure add`.
-- `AZURE_OPENAI_DEPLOYMENT`: default Azure deployment name for `sr azure add`.
+- `AZURE_OPENAI_DEPLOYMENT`: default legacy deployment name or one `model=name` mapping for `sr azure add`.
 - `AZURE_OPENAI_TOKEN_RESOURCE`: optional Azure token resource override for `sr azure add`.
 - `AZURE_CLI`: optional Azure CLI executable or absolute path for `sr azure add`.
 - `OPENAI_API_KEY`: only for real API-key mode or custom env-key providers. Avoid setting it when you want ChatGPT subscription model behavior.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -33,12 +33,12 @@ brew install azure-cli
 az login
 sr azure add work \
   --endpoint https://RESOURCE.cognitiveservices.azure.com
-sr azure codex work --model sol
-sr az codex work --model terra
-sr az codex work --model luna exec "your prompt"
+sr az codex
 ```
 
-`sr azure` is the canonical command and `sr az` is its short alias. `sol` is the default when `--model` is omitted. The selectors `sol`, `terra`, and `luna` map to `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`; `gpt-5.6` is an alias for Sol. Full model names also work.
+`sr azure` is the canonical command and `sr az` is its short alias. The first saved Azure profile becomes the default, so `sr az codex` launches directly. Use `/model` inside Codex to switch among Sol, Terra, and Luna. Use `sr az default <profile>` to change the default, `sr az default` to print it, or `sr az codex --azure-profile <profile>` for one run. The original `sr az codex <profile>` form remains supported.
+
+Sol is the default model when `--model` is omitted. The selectors `sol`, `terra`, and `luna` map to `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`; `gpt-5.6` is an alias for Sol. Full model names also work, including non-interactive runs such as `sr az codex --model luna exec "your prompt"`.
 
 By default, each Azure deployment has the same name as its model. Override custom Azure deployment names by repeating the flag during setup:
 
@@ -50,7 +50,7 @@ sr azure add work \
   --deployment luna=production-luna
 ```
 
-The launcher resolves the selector to the configured Azure deployment before starting Codex. A legacy bare `--deployment DEPLOYMENT_NAME` remains supported as a single-deployment profile. `sr azure list` shows configured profiles, and `sr azure remove work` removes one.
+Codex keeps canonical GPT-5.6 model names and native picker metadata. Subrouter translates each request to the configured Azure deployment at the proxy boundary, including after an in-session `/model` change. A legacy bare `--deployment DEPLOYMENT_NAME` remains supported as a single-deployment profile. `sr azure list` marks the default profile with `*`, and `sr azure remove work` removes one.
 
 `sr azure add` validates the current Azure CLI session with `az account get-access-token`, stores the resolved CLI path plus non-secret profile metadata in `~/.subrouter/codex/azure-openai.json`, and restarts the local daemon. The daemon acquires tokens on demand, keeps them only in memory, and renews them before expiry. Run `az login` again when Azure CLI reports that the session or tenant access is invalid.
 

--- a/internal/accounts/types.go
+++ b/internal/accounts/types.go
@@ -19,11 +19,13 @@ type (
 )
 
 const (
-	ProviderCodex  = account.ProviderCodex
-	ProviderClaude = account.ProviderClaude
-	ProviderKimi   = account.ProviderKimi
-	ProviderZAI    = account.ProviderZAI
+	ProviderCodex       = account.ProviderCodex
+	ProviderClaude      = account.ProviderClaude
+	ProviderKimi        = account.ProviderKimi
+	ProviderZAI         = account.ProviderZAI
+	ProviderAzureOpenAI = account.ProviderAzureOpenAI
 
-	AuthModeOAuth  = account.AuthModeOAuth
-	AuthModeAPIKey = account.AuthModeAPIKey
+	AuthModeOAuth    = account.AuthModeOAuth
+	AuthModeAPIKey   = account.AuthModeAPIKey
+	AuthModeAzureCLI = account.AuthModeAzureCLI
 )

--- a/internal/azureopenai/profile.go
+++ b/internal/azureopenai/profile.go
@@ -42,8 +42,9 @@ type Store struct {
 }
 
 type profilesFile struct {
-	Version  int       `json:"version"`
-	Profiles []Profile `json:"profiles"`
+	Version        int       `json:"version"`
+	DefaultProfile string    `json:"defaultProfile,omitempty"`
+	Profiles       []Profile `json:"profiles"`
 }
 
 func DefaultStore() Store {
@@ -75,6 +76,7 @@ func NormalizeProfile(profile Profile) (Profile, error) {
 		}
 	}
 	deployments := make(map[string]string, len(profile.Deployments))
+	deploymentModels := make(map[string]string, len(profile.Deployments))
 	for rawModel, rawDeployment := range profile.Deployments {
 		if strings.TrimSpace(rawModel) == "" {
 			return Profile{}, errors.New("Azure OpenAI model mapping name is required")
@@ -90,7 +92,11 @@ func NormalizeProfile(profile Profile) (Profile, error) {
 		if existing, exists := deployments[model]; exists && existing != deployment {
 			return Profile{}, fmt.Errorf("conflicting Azure OpenAI deployment mappings for %s", model)
 		}
+		if existingModel, exists := deploymentModels[deployment]; exists && existingModel != model {
+			return Profile{}, fmt.Errorf("Azure OpenAI deployment %q cannot map both %s and %s", deployment, existingModel, model)
+		}
 		deployments[model] = deployment
+		deploymentModels[deployment] = model
 	}
 	if len(deployments) == 0 {
 		if profile.Deployment == "" {
@@ -180,22 +186,33 @@ func GPT56ModelAlias(model string) string {
 }
 
 func (p Profile) DeploymentForModel(value string) (string, bool) {
+	_, deployment, ok := p.ResolveModel(value)
+	return deployment, ok
+}
+
+// ResolveModel returns the canonical Codex model slug and the Azure deployment
+// that serves it. Keeping those names separate lets Codex retain its native
+// model picker metadata while the proxy translates to custom deployment names.
+func (p Profile) ResolveModel(value string) (string, string, bool) {
 	if len(p.Deployments) == 0 {
 		requested := strings.TrimSpace(value)
-		return p.Deployment, requested == "" || requested == p.Deployment
+		if requested == "" || requested == p.Deployment {
+			return p.Deployment, p.Deployment, true
+		}
+		return "", "", false
 	}
 	model, ok := CanonicalGPT56Model(value)
 	if ok {
 		deployment, exists := p.Deployments[model]
-		return deployment, exists
+		return model, deployment, exists
 	}
 	requested := strings.TrimSpace(value)
-	for _, deployment := range p.Deployments {
+	for model, deployment := range p.Deployments {
 		if requested == deployment {
-			return deployment, true
+			return model, deployment, true
 		}
 	}
-	return "", false
+	return "", "", false
 }
 
 func normalizeEndpoint(raw string) (*url.URL, error) {
@@ -261,32 +278,50 @@ func azureEndpointHost(host string) bool {
 }
 
 func (s Store) List() ([]Profile, error) {
-	body, err := os.ReadFile(s.ProfilesPath())
-	if errors.Is(err, os.ErrNotExist) {
-		return nil, nil
-	}
+	file, err := s.load()
 	if err != nil {
 		return nil, err
 	}
+	return file.Profiles, nil
+}
+
+func (s Store) load() (profilesFile, error) {
+	body, err := os.ReadFile(s.ProfilesPath())
+	if errors.Is(err, os.ErrNotExist) {
+		return profilesFile{Version: 3}, nil
+	}
+	if err != nil {
+		return profilesFile{}, err
+	}
 	var file profilesFile
 	if err := json.Unmarshal(body, &file); err != nil {
-		return nil, fmt.Errorf("parse Azure OpenAI profiles: %w", err)
+		return profilesFile{}, fmt.Errorf("parse Azure OpenAI profiles: %w", err)
 	}
 	profiles := make([]Profile, 0, len(file.Profiles))
 	seen := map[string]bool{}
 	for _, raw := range file.Profiles {
 		profile, err := NormalizeProfile(raw)
 		if err != nil {
-			return nil, fmt.Errorf("Azure OpenAI profile %q: %w", raw.Name, err)
+			return profilesFile{}, fmt.Errorf("Azure OpenAI profile %q: %w", raw.Name, err)
 		}
 		if seen[profile.Name] {
-			return nil, fmt.Errorf("duplicate Azure OpenAI profile %q", profile.Name)
+			return profilesFile{}, fmt.Errorf("duplicate Azure OpenAI profile %q", profile.Name)
 		}
 		seen[profile.Name] = true
 		profiles = append(profiles, profile)
 	}
 	sort.Slice(profiles, func(i, j int) bool { return profiles[i].Name < profiles[j].Name })
-	return profiles, nil
+	file.Profiles = profiles
+	file.DefaultProfile = strings.ToLower(strings.TrimSpace(file.DefaultProfile))
+	if file.DefaultProfile == "" && len(profiles) > 0 {
+		// Version 2 stores predate an explicit default. Their first sorted
+		// profile becomes the deterministic default without requiring migration.
+		file.DefaultProfile = profiles[0].Name
+	}
+	if file.DefaultProfile != "" && !seen[file.DefaultProfile] {
+		return profilesFile{}, fmt.Errorf("default Azure OpenAI profile %q not found", file.DefaultProfile)
+	}
+	return file, nil
 }
 
 func (s Store) Find(name string) (Profile, bool, error) {
@@ -303,46 +338,85 @@ func (s Store) Find(name string) (Profile, bool, error) {
 	return Profile{}, false, nil
 }
 
+func (s Store) Default() (Profile, bool, error) {
+	file, err := s.load()
+	if err != nil {
+		return Profile{}, false, err
+	}
+	if file.DefaultProfile == "" {
+		return Profile{}, false, nil
+	}
+	for _, profile := range file.Profiles {
+		if profile.Name == file.DefaultProfile {
+			return profile, true, nil
+		}
+	}
+	return Profile{}, false, fmt.Errorf("default Azure OpenAI profile %q not found", file.DefaultProfile)
+}
+
+func (s Store) SetDefault(name string) error {
+	name = strings.ToLower(strings.TrimSpace(name))
+	file, err := s.load()
+	if err != nil {
+		return err
+	}
+	found := false
+	for _, profile := range file.Profiles {
+		if profile.Name == name {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("Azure OpenAI profile %q not found", name)
+	}
+	file.DefaultProfile = name
+	return s.write(file)
+}
+
 func (s Store) Save(profile Profile) (bool, error) {
 	profile, err := NormalizeProfile(profile)
 	if err != nil {
 		return false, err
 	}
-	profiles, err := s.List()
+	file, err := s.load()
 	if err != nil {
 		return false, err
 	}
 	existed := false
-	for i := range profiles {
-		if profiles[i].Name != profile.Name {
+	for i := range file.Profiles {
+		if file.Profiles[i].Name != profile.Name {
 			continue
 		}
 		existed = true
 		if profile.AddedAt == "" {
-			profile.AddedAt = profiles[i].AddedAt
+			profile.AddedAt = file.Profiles[i].AddedAt
 		}
-		profiles[i] = profile
+		file.Profiles[i] = profile
 		break
 	}
 	if profile.AddedAt == "" {
 		profile.AddedAt = time.Now().UTC().Format(time.RFC3339)
 	}
 	if !existed {
-		profiles = append(profiles, profile)
+		file.Profiles = append(file.Profiles, profile)
 	}
-	sort.Slice(profiles, func(i, j int) bool { return profiles[i].Name < profiles[j].Name })
-	return existed, s.write(profiles)
+	if file.DefaultProfile == "" {
+		file.DefaultProfile = profile.Name
+	}
+	sort.Slice(file.Profiles, func(i, j int) bool { return file.Profiles[i].Name < file.Profiles[j].Name })
+	return existed, s.write(file)
 }
 
 func (s Store) Remove(name string) (bool, error) {
 	name = strings.ToLower(strings.TrimSpace(name))
-	profiles, err := s.List()
+	file, err := s.load()
 	if err != nil {
 		return false, err
 	}
-	kept := profiles[:0]
+	kept := file.Profiles[:0]
 	removed := false
-	for _, profile := range profiles {
+	for _, profile := range file.Profiles {
 		if profile.Name == name {
 			removed = true
 			continue
@@ -352,11 +426,19 @@ func (s Store) Remove(name string) (bool, error) {
 	if !removed {
 		return false, nil
 	}
-	return true, s.write(kept)
+	file.Profiles = kept
+	if file.DefaultProfile == name {
+		file.DefaultProfile = ""
+		if len(kept) > 0 {
+			file.DefaultProfile = kept[0].Name
+		}
+	}
+	return true, s.write(file)
 }
 
-func (s Store) write(profiles []Profile) error {
-	body, err := json.MarshalIndent(profilesFile{Version: 2, Profiles: profiles}, "", "  ")
+func (s Store) write(file profilesFile) error {
+	file.Version = 3
+	body, err := json.MarshalIndent(file, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/internal/azureopenai/profile.go
+++ b/internal/azureopenai/profile.go
@@ -1,0 +1,290 @@
+package azureopenai
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/storepath"
+)
+
+const (
+	CognitiveServicesTokenResource = "https://cognitiveservices.azure.com"
+	FoundryTokenResource           = "https://ai.azure.com"
+)
+
+var profileNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+
+type Profile struct {
+	Name          string `json:"name"`
+	Endpoint      string `json:"endpoint"`
+	Deployment    string `json:"deployment"`
+	TokenResource string `json:"tokenResource"`
+	AzureCLI      string `json:"azureCli"`
+	AddedAt       string `json:"addedAt"`
+}
+
+type Store struct {
+	Path string
+}
+
+type profilesFile struct {
+	Version  int       `json:"version"`
+	Profiles []Profile `json:"profiles"`
+}
+
+func DefaultStore() Store {
+	return Store{Path: filepath.Join(storepath.CodexDir(), "azure-openai.json")}
+}
+
+func (s Store) ProfilesPath() string {
+	if strings.TrimSpace(s.Path) != "" {
+		return s.Path
+	}
+	return DefaultStore().Path
+}
+
+func NormalizeProfile(profile Profile) (Profile, error) {
+	profile.Name = strings.ToLower(strings.TrimSpace(profile.Name))
+	if !profileNamePattern.MatchString(profile.Name) {
+		return Profile{}, errors.New("Azure OpenAI profile name must use 1-64 lowercase letters, digits, dots, dashes, or underscores")
+	}
+
+	endpoint, err := normalizeEndpoint(profile.Endpoint)
+	if err != nil {
+		return Profile{}, err
+	}
+	profile.Endpoint = endpoint.String()
+	profile.Deployment = strings.TrimSpace(profile.Deployment)
+	if profile.Deployment == "" || len(profile.Deployment) > 256 || strings.ContainsAny(profile.Deployment, "\r\n\x00") {
+		return Profile{}, errors.New("Azure OpenAI deployment name is invalid")
+	}
+
+	profile.TokenResource = strings.TrimRight(strings.TrimSpace(profile.TokenResource), "/")
+	if profile.TokenResource == "" {
+		profile.TokenResource = FoundryTokenResource
+	}
+	if err := validateTokenResource(profile.TokenResource); err != nil {
+		return Profile{}, err
+	}
+	profile.AzureCLI = strings.TrimSpace(profile.AzureCLI)
+	if profile.AzureCLI == "" {
+		return Profile{}, errors.New("Azure CLI path is required")
+	}
+	if strings.ContainsAny(profile.AzureCLI, "\r\n\x00") {
+		return Profile{}, errors.New("Azure CLI path is invalid")
+	}
+	if profile.AddedAt != "" {
+		if _, err := time.Parse(time.RFC3339, profile.AddedAt); err != nil {
+			return Profile{}, errors.New("Azure OpenAI profile addedAt is invalid")
+		}
+	}
+	return profile, nil
+}
+
+func normalizeEndpoint(raw string) (*url.URL, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, errors.New("Azure OpenAI endpoint must be an absolute URL without credentials, query, or fragment")
+	}
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && loopbackHost(parsed.Hostname())) {
+		return nil, errors.New("Azure OpenAI endpoint must use HTTPS, except for loopback development")
+	}
+	if !loopbackHost(parsed.Hostname()) && !azureEndpointHost(parsed.Hostname()) {
+		return nil, errors.New("Azure OpenAI endpoint must use an Azure OpenAI, Foundry, or Cognitive Services hostname")
+	}
+	path := strings.TrimRight(parsed.EscapedPath(), "/")
+	switch path {
+	case "", "/":
+		parsed.Path = "/openai/v1"
+		parsed.RawPath = ""
+	case "/openai/v1":
+		parsed.Path = "/openai/v1"
+		parsed.RawPath = ""
+	default:
+		return nil, errors.New("Azure OpenAI endpoint path must be empty or /openai/v1")
+	}
+	return parsed, nil
+}
+
+func validateTokenResource(raw string) error {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil ||
+		(parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return errors.New("Azure token resource must be an HTTPS origin")
+	}
+	return nil
+}
+
+func loopbackHost(host string) bool {
+	if strings.EqualFold(strings.TrimSpace(host), "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func azureEndpointHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	for _, suffix := range []string{
+		".openai.azure.com",
+		".openai.azure.us",
+		".openai.azure.cn",
+		".services.ai.azure.com",
+		".services.ai.azure.us",
+		".services.ai.azure.cn",
+		".cognitiveservices.azure.com",
+		".cognitiveservices.azure.us",
+		".cognitiveservices.azure.cn",
+	} {
+		if strings.HasSuffix(host, suffix) && len(host) > len(suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s Store) List() ([]Profile, error) {
+	body, err := os.ReadFile(s.ProfilesPath())
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var file profilesFile
+	if err := json.Unmarshal(body, &file); err != nil {
+		return nil, fmt.Errorf("parse Azure OpenAI profiles: %w", err)
+	}
+	profiles := make([]Profile, 0, len(file.Profiles))
+	seen := map[string]bool{}
+	for _, raw := range file.Profiles {
+		profile, err := NormalizeProfile(raw)
+		if err != nil {
+			return nil, fmt.Errorf("Azure OpenAI profile %q: %w", raw.Name, err)
+		}
+		if seen[profile.Name] {
+			return nil, fmt.Errorf("duplicate Azure OpenAI profile %q", profile.Name)
+		}
+		seen[profile.Name] = true
+		profiles = append(profiles, profile)
+	}
+	sort.Slice(profiles, func(i, j int) bool { return profiles[i].Name < profiles[j].Name })
+	return profiles, nil
+}
+
+func (s Store) Find(name string) (Profile, bool, error) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	profiles, err := s.List()
+	if err != nil {
+		return Profile{}, false, err
+	}
+	for _, profile := range profiles {
+		if profile.Name == name {
+			return profile, true, nil
+		}
+	}
+	return Profile{}, false, nil
+}
+
+func (s Store) Save(profile Profile) (bool, error) {
+	profile, err := NormalizeProfile(profile)
+	if err != nil {
+		return false, err
+	}
+	profiles, err := s.List()
+	if err != nil {
+		return false, err
+	}
+	existed := false
+	for i := range profiles {
+		if profiles[i].Name != profile.Name {
+			continue
+		}
+		existed = true
+		if profile.AddedAt == "" {
+			profile.AddedAt = profiles[i].AddedAt
+		}
+		profiles[i] = profile
+		break
+	}
+	if profile.AddedAt == "" {
+		profile.AddedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	if !existed {
+		profiles = append(profiles, profile)
+	}
+	sort.Slice(profiles, func(i, j int) bool { return profiles[i].Name < profiles[j].Name })
+	return existed, s.write(profiles)
+}
+
+func (s Store) Remove(name string) (bool, error) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	profiles, err := s.List()
+	if err != nil {
+		return false, err
+	}
+	kept := profiles[:0]
+	removed := false
+	for _, profile := range profiles {
+		if profile.Name == name {
+			removed = true
+			continue
+		}
+		kept = append(kept, profile)
+	}
+	if !removed {
+		return false, nil
+	}
+	return true, s.write(kept)
+}
+
+func (s Store) write(profiles []Profile) error {
+	body, err := json.MarshalIndent(profilesFile{Version: 1, Profiles: profiles}, "", "  ")
+	if err != nil {
+		return err
+	}
+	body = append(body, '\n')
+	path := s.ProfilesPath()
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(body); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	if dirFile, err := os.Open(dir); err == nil {
+		_ = dirFile.Sync()
+		_ = dirFile.Close()
+	}
+	return nil
+}

--- a/internal/azureopenai/profile.go
+++ b/internal/azureopenai/profile.go
@@ -19,17 +19,22 @@ import (
 const (
 	CognitiveServicesTokenResource = "https://cognitiveservices.azure.com"
 	FoundryTokenResource           = "https://ai.azure.com"
+	GPT56Sol                       = "gpt-5.6-sol"
+	GPT56Terra                     = "gpt-5.6-terra"
+	GPT56Luna                      = "gpt-5.6-luna"
+	DefaultGPT56Model              = GPT56Sol
 )
 
 var profileNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
 
 type Profile struct {
-	Name          string `json:"name"`
-	Endpoint      string `json:"endpoint"`
-	Deployment    string `json:"deployment"`
-	TokenResource string `json:"tokenResource"`
-	AzureCLI      string `json:"azureCli"`
-	AddedAt       string `json:"addedAt"`
+	Name          string            `json:"name"`
+	Endpoint      string            `json:"endpoint"`
+	Deployment    string            `json:"deployment,omitempty"`
+	Deployments   map[string]string `json:"deployments,omitempty"`
+	TokenResource string            `json:"tokenResource"`
+	AzureCLI      string            `json:"azureCli"`
+	AddedAt       string            `json:"addedAt"`
 }
 
 type Store struct {
@@ -64,8 +69,47 @@ func NormalizeProfile(profile Profile) (Profile, error) {
 	}
 	profile.Endpoint = endpoint.String()
 	profile.Deployment = strings.TrimSpace(profile.Deployment)
-	if profile.Deployment == "" || len(profile.Deployment) > 256 || strings.ContainsAny(profile.Deployment, "\r\n\x00") {
-		return Profile{}, errors.New("Azure OpenAI deployment name is invalid")
+	if profile.Deployment != "" {
+		if err := validateDeploymentName(profile.Deployment); err != nil {
+			return Profile{}, err
+		}
+	}
+	deployments := make(map[string]string, len(profile.Deployments))
+	for rawModel, rawDeployment := range profile.Deployments {
+		if strings.TrimSpace(rawModel) == "" {
+			return Profile{}, errors.New("Azure OpenAI model mapping name is required")
+		}
+		model, ok := CanonicalGPT56Model(rawModel)
+		if !ok {
+			return Profile{}, fmt.Errorf("unsupported Azure OpenAI model mapping %q", rawModel)
+		}
+		deployment := strings.TrimSpace(rawDeployment)
+		if err := validateDeploymentName(deployment); err != nil {
+			return Profile{}, fmt.Errorf("Azure OpenAI %s mapping: %w", model, err)
+		}
+		if existing, exists := deployments[model]; exists && existing != deployment {
+			return Profile{}, fmt.Errorf("conflicting Azure OpenAI deployment mappings for %s", model)
+		}
+		deployments[model] = deployment
+	}
+	if len(deployments) == 0 {
+		if profile.Deployment == "" {
+			return Profile{}, errors.New("at least one Azure OpenAI deployment is required")
+		}
+		profile.Deployments = nil
+	} else {
+		defaultDeployment, ok := deployments[DefaultGPT56Model]
+		if !ok {
+			return Profile{}, fmt.Errorf("Azure OpenAI profile requires a %s deployment mapping", DefaultGPT56Model)
+		}
+		if profile.Deployment != "" && profile.Deployment != defaultDeployment {
+			return Profile{}, errors.New("Azure OpenAI compatibility deployment must match the Sol deployment mapping")
+		}
+		// Keep the default deployment in the legacy field so rolling back to a
+		// single-deployment Subrouter still launches Sol instead of rejecting the
+		// profile file. New binaries use Deployments for model selection.
+		profile.Deployment = defaultDeployment
+		profile.Deployments = deployments
 	}
 
 	profile.TokenResource = strings.TrimRight(strings.TrimSpace(profile.TokenResource), "/")
@@ -88,6 +132,70 @@ func NormalizeProfile(profile Profile) (Profile, error) {
 		}
 	}
 	return profile, nil
+}
+
+func validateDeploymentName(value string) error {
+	if value == "" || len(value) > 256 || strings.ContainsAny(value, "\r\n\x00") {
+		return errors.New("Azure OpenAI deployment name is invalid")
+	}
+	return nil
+}
+
+func GPT56Models() []string {
+	return []string{GPT56Sol, GPT56Terra, GPT56Luna}
+}
+
+func DefaultGPT56Deployments() map[string]string {
+	return map[string]string{
+		GPT56Sol:   GPT56Sol,
+		GPT56Terra: GPT56Terra,
+		GPT56Luna:  GPT56Luna,
+	}
+}
+
+func CanonicalGPT56Model(value string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "gpt-5.6", "sol", GPT56Sol:
+		return GPT56Sol, true
+	case "terra", GPT56Terra:
+		return GPT56Terra, true
+	case "luna", GPT56Luna:
+		return GPT56Luna, true
+	default:
+		return "", false
+	}
+}
+
+func GPT56ModelAlias(model string) string {
+	switch model {
+	case GPT56Sol:
+		return "sol"
+	case GPT56Terra:
+		return "terra"
+	case GPT56Luna:
+		return "luna"
+	default:
+		return model
+	}
+}
+
+func (p Profile) DeploymentForModel(value string) (string, bool) {
+	if len(p.Deployments) == 0 {
+		requested := strings.TrimSpace(value)
+		return p.Deployment, requested == "" || requested == p.Deployment
+	}
+	model, ok := CanonicalGPT56Model(value)
+	if ok {
+		deployment, exists := p.Deployments[model]
+		return deployment, exists
+	}
+	requested := strings.TrimSpace(value)
+	for _, deployment := range p.Deployments {
+		if requested == deployment {
+			return deployment, true
+		}
+	}
+	return "", false
 }
 
 func normalizeEndpoint(raw string) (*url.URL, error) {
@@ -248,7 +356,7 @@ func (s Store) Remove(name string) (bool, error) {
 }
 
 func (s Store) write(profiles []Profile) error {
-	body, err := json.MarshalIndent(profilesFile{Version: 1, Profiles: profiles}, "", "  ")
+	body, err := json.MarshalIndent(profilesFile{Version: 2, Profiles: profiles}, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/internal/azureopenai/profile_test.go
+++ b/internal/azureopenai/profile_test.go
@@ -67,6 +67,63 @@ func TestNormalizeProfileKeepsExplicitCognitiveServicesAudience(t *testing.T) {
 	}
 }
 
+func TestNormalizeProfileCanonicalizesGPT56DeploymentMappings(t *testing.T) {
+	profile, err := NormalizeProfile(Profile{
+		Name:     "work",
+		Endpoint: "https://example.openai.azure.com",
+		Deployments: map[string]string{
+			"sol":           "team-sol",
+			"gpt-5.6-terra": "team-terra",
+			"LUNA":          "team-luna",
+		},
+		AzureCLI: "/opt/homebrew/bin/az",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		GPT56Sol:   "team-sol",
+		GPT56Terra: "team-terra",
+		GPT56Luna:  "team-luna",
+	}
+	for model, deployment := range want {
+		if profile.Deployments[model] != deployment {
+			t.Fatalf("deployment %s = %q, want %q", model, profile.Deployments[model], deployment)
+		}
+	}
+	for selector, deployment := range map[string]string{
+		"":             "team-sol",
+		"gpt-5.6":      "team-sol",
+		"sol":          "team-sol",
+		"terra":        "team-terra",
+		"gpt-5.6-luna": "team-luna",
+		"team-luna":    "team-luna",
+	} {
+		got, ok := profile.DeploymentForModel(selector)
+		if !ok || got != deployment {
+			t.Errorf("DeploymentForModel(%q) = %q, %t; want %q, true", selector, got, ok, deployment)
+		}
+	}
+	if _, ok := profile.DeploymentForModel("gpt-5.5"); ok {
+		t.Fatal("unsupported model selector was accepted")
+	}
+}
+
+func TestNormalizeProfileRejectsInconsistentCompatibilityDeployment(t *testing.T) {
+	_, err := NormalizeProfile(Profile{
+		Name:       "work",
+		Endpoint:   "https://example.openai.azure.com",
+		Deployment: "legacy",
+		Deployments: map[string]string{
+			GPT56Sol: "team-sol",
+		},
+		AzureCLI: "/opt/homebrew/bin/az",
+	})
+	if err == nil || !strings.Contains(err.Error(), "must match") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestStorePersistsOnlyProfileMetadata(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "azure-openai.json")
 	store := Store{Path: path}

--- a/internal/azureopenai/profile_test.go
+++ b/internal/azureopenai/profile_test.go
@@ -104,8 +104,27 @@ func TestNormalizeProfileCanonicalizesGPT56DeploymentMappings(t *testing.T) {
 			t.Errorf("DeploymentForModel(%q) = %q, %t; want %q, true", selector, got, ok, deployment)
 		}
 	}
+	model, deployment, ok := profile.ResolveModel("team-luna")
+	if !ok || model != GPT56Luna || deployment != "team-luna" {
+		t.Fatalf("ResolveModel(team-luna) = %q, %q, %t", model, deployment, ok)
+	}
 	if _, ok := profile.DeploymentForModel("gpt-5.5"); ok {
 		t.Fatal("unsupported model selector was accepted")
+	}
+}
+
+func TestNormalizeProfileRejectsOneDeploymentForMultipleModels(t *testing.T) {
+	_, err := NormalizeProfile(Profile{
+		Name:     "work",
+		Endpoint: "https://example.openai.azure.com",
+		Deployments: map[string]string{
+			GPT56Sol:   "shared",
+			GPT56Terra: "shared",
+		},
+		AzureCLI: "/opt/homebrew/bin/az",
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot map both") {
+		t.Fatalf("error = %v", err)
 	}
 }
 
@@ -186,6 +205,69 @@ func TestStorePersistsOnlyProfileMetadata(t *testing.T) {
 	}
 	if len(profiles) != 0 {
 		t.Fatalf("profiles after remove = %#v", profiles)
+	}
+}
+
+func TestStoreDefaultsToFirstProfileAndAllowsChangingDefault(t *testing.T) {
+	store := Store{Path: filepath.Join(t.TempDir(), "azure-openai.json")}
+	for _, name := range []string{"work", "backup"} {
+		if _, err := store.Save(Profile{
+			Name:        name,
+			Endpoint:    "https://" + name + ".openai.azure.com",
+			Deployments: DefaultGPT56Deployments(),
+			AzureCLI:    "/opt/homebrew/bin/az",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	profile, ok, err := store.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || profile.Name != "work" {
+		t.Fatalf("default profile = %#v, found = %t; want work", profile, ok)
+	}
+	if err := store.SetDefault("BACKUP"); err != nil {
+		t.Fatal(err)
+	}
+	profile, ok, err = store.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || profile.Name != "backup" {
+		t.Fatalf("changed default profile = %#v, found = %t; want backup", profile, ok)
+	}
+	if removed, err := store.Remove("backup"); err != nil || !removed {
+		t.Fatalf("remove default = %t, %v", removed, err)
+	}
+	profile, ok, err = store.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || profile.Name != "work" {
+		t.Fatalf("fallback default profile = %#v, found = %t; want work", profile, ok)
+	}
+}
+
+func TestStoreReadsVersionTwoProfilesWithDeterministicDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "azure-openai.json")
+	body := `{
+  "version": 2,
+  "profiles": [
+    {"name":"zeta","endpoint":"https://zeta.openai.azure.com/openai/v1","deployment":"zeta","tokenResource":"https://ai.azure.com","azureCli":"az"},
+    {"name":"alpha","endpoint":"https://alpha.openai.azure.com/openai/v1","deployment":"alpha","tokenResource":"https://ai.azure.com","azureCli":"az"}
+  ]
+}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	profile, ok, err := (Store{Path: path}).Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || profile.Name != "alpha" {
+		t.Fatalf("version 2 default profile = %#v, found = %t; want alpha", profile, ok)
 	}
 }
 

--- a/internal/azureopenai/profile_test.go
+++ b/internal/azureopenai/profile_test.go
@@ -1,0 +1,152 @@
+package azureopenai
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeProfileBuildsAzureResponsesBaseURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		endpoint     string
+		wantEndpoint string
+		wantResource string
+	}{
+		{
+			name:         "Azure OpenAI resource",
+			endpoint:     "https://example.openai.azure.com/",
+			wantEndpoint: "https://example.openai.azure.com/openai/v1",
+			wantResource: FoundryTokenResource,
+		},
+		{
+			name:         "Foundry resource",
+			endpoint:     "https://example.services.ai.azure.com/openai/v1/",
+			wantEndpoint: "https://example.services.ai.azure.com/openai/v1",
+			wantResource: FoundryTokenResource,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			profile, err := NormalizeProfile(Profile{
+				Name:       "WORK",
+				Endpoint:   test.endpoint,
+				Deployment: "gpt-5.3-codex",
+				AzureCLI:   "/opt/homebrew/bin/az",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if profile.Name != "work" {
+				t.Fatalf("name = %q, want work", profile.Name)
+			}
+			if profile.Endpoint != test.wantEndpoint {
+				t.Fatalf("endpoint = %q, want %q", profile.Endpoint, test.wantEndpoint)
+			}
+			if profile.TokenResource != test.wantResource {
+				t.Fatalf("token resource = %q, want %q", profile.TokenResource, test.wantResource)
+			}
+		})
+	}
+}
+
+func TestNormalizeProfileKeepsExplicitCognitiveServicesAudience(t *testing.T) {
+	profile, err := NormalizeProfile(Profile{
+		Name:          "work",
+		Endpoint:      "https://example.openai.azure.com",
+		Deployment:    "codex-deployment",
+		TokenResource: CognitiveServicesTokenResource,
+		AzureCLI:      "/opt/homebrew/bin/az",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if profile.TokenResource != CognitiveServicesTokenResource {
+		t.Fatalf("token resource = %q", profile.TokenResource)
+	}
+}
+
+func TestStorePersistsOnlyProfileMetadata(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "azure-openai.json")
+	store := Store{Path: path}
+	profile := Profile{
+		Name:       "work",
+		Endpoint:   "https://example.openai.azure.com",
+		Deployment: "codex-deployment",
+		AzureCLI:   "/opt/homebrew/bin/az",
+	}
+
+	existed, err := store.Save(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if existed {
+		t.Fatal("new profile reported as an update")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("profile mode = %o, want 600", got)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"accessToken", "refreshToken", "apiKey", "Bearer "} {
+		if strings.Contains(string(body), forbidden) {
+			t.Fatalf("profile store contains credential field %q: %s", forbidden, body)
+		}
+	}
+
+	stored, ok, err := store.Find("WORK")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || stored.Endpoint != "https://example.openai.azure.com/openai/v1" {
+		t.Fatalf("stored profile = %#v, found = %t", stored, ok)
+	}
+	stored.Deployment = "replacement"
+	existed, err = store.Save(stored)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !existed {
+		t.Fatal("existing profile reported as new")
+	}
+	removed, err := store.Remove("work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !removed {
+		t.Fatal("existing profile was not removed")
+	}
+	profiles, err := store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(profiles) != 0 {
+		t.Fatalf("profiles after remove = %#v", profiles)
+	}
+}
+
+func TestNormalizeProfileRejectsUnsafeLocations(t *testing.T) {
+	for _, endpoint := range []string{
+		"http://example.openai.azure.com",
+		"https://attacker.example.com",
+		"https://user@example.openai.azure.com",
+		"https://example.openai.azure.com/openai/deployments/one",
+	} {
+		_, err := NormalizeProfile(Profile{
+			Name:       "work",
+			Endpoint:   endpoint,
+			Deployment: "codex-deployment",
+			AzureCLI:   "az",
+		})
+		if err == nil {
+			t.Fatalf("endpoint %q was accepted", endpoint)
+		}
+	}
+}

--- a/internal/azureopenai/registry.go
+++ b/internal/azureopenai/registry.go
@@ -1,0 +1,116 @@
+package azureopenai
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/manaflow-ai/subrouter/account"
+)
+
+const accountIDPrefix = "azure:"
+
+type Registry struct {
+	profiles map[string]Profile
+	tokens   map[string]TokenSource
+}
+
+func NewRegistry(profiles []Profile, runner CommandRunner) (*Registry, error) {
+	return NewRegistryWithTokenFactory(profiles, func(profile Profile) TokenSource {
+		return &CachedCLITokenSource{Profile: profile, Runner: runner}
+	})
+}
+
+func NewRegistryWithTokenFactory(profiles []Profile, factory func(Profile) TokenSource) (*Registry, error) {
+	if factory == nil {
+		return nil, fmt.Errorf("Azure OpenAI token factory is required")
+	}
+	registry := &Registry{
+		profiles: make(map[string]Profile, len(profiles)),
+		tokens:   make(map[string]TokenSource, len(profiles)),
+	}
+	for _, raw := range profiles {
+		profile, err := NormalizeProfile(raw)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := registry.profiles[profile.Name]; exists {
+			return nil, fmt.Errorf("duplicate Azure OpenAI profile %q", profile.Name)
+		}
+		source := factory(profile)
+		if source == nil {
+			return nil, fmt.Errorf("Azure OpenAI profile %q has no token source", profile.Name)
+		}
+		registry.profiles[profile.Name] = profile
+		registry.tokens[profile.Name] = source
+	}
+	return registry, nil
+}
+
+func AccountID(name string) string {
+	return accountIDPrefix + strings.ToLower(strings.TrimSpace(name))
+}
+
+func ProfileNameFromAccountID(id string) (string, bool) {
+	if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(id)), accountIDPrefix) {
+		return "", false
+	}
+	name := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(id)), accountIDPrefix)
+	return name, profileNamePattern.MatchString(name)
+}
+
+func (r *Registry) Profile(name string) (Profile, bool) {
+	if r == nil {
+		return Profile{}, false
+	}
+	profile, ok := r.profiles[strings.ToLower(strings.TrimSpace(name))]
+	return profile, ok
+}
+
+func (r *Registry) ProfileForAccount(id string) (Profile, bool) {
+	name, ok := ProfileNameFromAccountID(id)
+	if !ok {
+		return Profile{}, false
+	}
+	return r.Profile(name)
+}
+
+func (r *Registry) Token(ctx context.Context, accountID string) (string, error) {
+	name, ok := ProfileNameFromAccountID(accountID)
+	if !ok || r == nil {
+		return "", errorsForUnknownProfile(accountID)
+	}
+	source, ok := r.tokens[name]
+	if !ok {
+		return "", errorsForUnknownProfile(accountID)
+	}
+	return source.Token(ctx)
+}
+
+func errorsForUnknownProfile(value string) error {
+	return fmt.Errorf("Azure OpenAI profile for account %q is not configured", value)
+}
+
+func (r *Registry) Accounts(source string) []account.Account {
+	if r == nil {
+		return nil
+	}
+	names := make([]string, 0, len(r.profiles))
+	for name := range r.profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]account.Account, 0, len(names))
+	for _, name := range names {
+		profile := r.profiles[name]
+		out = append(out, account.Account{
+			ID:       AccountID(name),
+			Provider: account.ProviderAzureOpenAI,
+			AuthMode: account.AuthModeAzureCLI,
+			Label:    profile.Name,
+			Source:   source,
+		})
+	}
+	return out
+}

--- a/internal/azureopenai/token.go
+++ b/internal/azureopenai/token.go
@@ -1,0 +1,164 @@
+package azureopenai
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type CommandRunner interface {
+	Output(context.Context, string, []string) ([]byte, error)
+}
+
+type ExecCommandRunner struct{}
+
+func (ExecCommandRunner) Output(ctx context.Context, name string, args []string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).Output()
+}
+
+type AccessToken struct {
+	Value     string
+	ExpiresAt time.Time
+}
+
+func FetchCLIAccessToken(ctx context.Context, runner CommandRunner, profile Profile) (AccessToken, error) {
+	if runner == nil {
+		runner = ExecCommandRunner{}
+	}
+	output, err := runner.Output(ctx, profile.AzureCLI, []string{
+		"account", "get-access-token",
+		"--resource", profile.TokenResource,
+		"--output", "json",
+	})
+	if err != nil {
+		return AccessToken{}, fmt.Errorf("Azure CLI authentication failed; run 'az login' and confirm Azure OpenAI access: %w", err)
+	}
+	token, err := parseAccessToken(output)
+	if err != nil {
+		return AccessToken{}, fmt.Errorf("parse Azure CLI access token response: %w", err)
+	}
+	return token, nil
+}
+
+func parseAccessToken(body []byte) (AccessToken, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return AccessToken{}, err
+	}
+	var value string
+	if err := json.Unmarshal(fields["accessToken"], &value); err != nil || strings.TrimSpace(value) == "" {
+		return AccessToken{}, errors.New("Azure CLI returned no access token")
+	}
+	expiresAt := parseExpiry(fields["expires_on"])
+	if expiresAt.IsZero() {
+		expiresAt = parseExpiry(fields["expiresOn"])
+	}
+	if expiresAt.IsZero() {
+		expiresAt = jwtExpiry(value)
+	}
+	if expiresAt.IsZero() {
+		// Azure CLI normally returns an expiry. A short cache still avoids one
+		// process spawn per request on older or customized CLI output.
+		expiresAt = time.Now().Add(10 * time.Minute)
+	}
+	return AccessToken{Value: strings.TrimSpace(value), ExpiresAt: expiresAt}, nil
+}
+
+func parseExpiry(raw json.RawMessage) time.Time {
+	if len(raw) == 0 || string(raw) == "null" {
+		return time.Time{}
+	}
+	var number json.Number
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.UseNumber()
+	if err := decoder.Decode(&number); err == nil {
+		if seconds, err := strconv.ParseInt(number.String(), 10, 64); err == nil && seconds > 0 {
+			return time.Unix(seconds, 0).UTC()
+		}
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return time.Time{}
+	}
+	value = strings.TrimSpace(value)
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil && seconds > 0 {
+		return time.Unix(seconds, 0).UTC()
+	}
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999",
+		"2006-01-02 15:04:05",
+	} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func jwtExpiry(token string) time.Time {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return time.Time{}
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return time.Time{}
+	}
+	var claims struct {
+		Expires json.Number `json:"exp"`
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(payload)))
+	decoder.UseNumber()
+	if err := decoder.Decode(&claims); err != nil {
+		return time.Time{}
+	}
+	seconds, err := strconv.ParseInt(claims.Expires.String(), 10, 64)
+	if err != nil || seconds <= 0 {
+		return time.Time{}
+	}
+	return time.Unix(seconds, 0).UTC()
+}
+
+type TokenSource interface {
+	Token(context.Context) (string, error)
+}
+
+type CachedCLITokenSource struct {
+	Profile       Profile
+	Runner        CommandRunner
+	Now           func() time.Time
+	RefreshBefore time.Duration
+
+	mu    sync.Mutex
+	token AccessToken
+}
+
+func (s *CachedCLITokenSource) Token(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	if s.Now != nil {
+		now = s.Now()
+	}
+	refreshBefore := s.RefreshBefore
+	if refreshBefore <= 0 {
+		refreshBefore = 5 * time.Minute
+	}
+	if s.token.Value != "" && now.Add(refreshBefore).Before(s.token.ExpiresAt) {
+		return s.token.Value, nil
+	}
+	token, err := FetchCLIAccessToken(ctx, s.Runner, s.Profile)
+	if err != nil {
+		return "", err
+	}
+	s.token = token
+	return token.Value, nil
+}

--- a/internal/azureopenai/token_test.go
+++ b/internal/azureopenai/token_test.go
@@ -1,0 +1,95 @@
+package azureopenai
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+type recordingCommandRunner struct {
+	mu      sync.Mutex
+	outputs [][]byte
+	calls   [][]string
+}
+
+func (r *recordingCommandRunner) Output(_ context.Context, name string, args []string) ([]byte, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, append([]string{name}, args...))
+	if len(r.outputs) == 0 {
+		return nil, fmt.Errorf("unexpected command")
+	}
+	output := r.outputs[0]
+	r.outputs = r.outputs[1:]
+	return output, nil
+}
+
+func TestCachedCLITokenSourceUsesAzureCLIAndRefreshesNearExpiry(t *testing.T) {
+	now := time.Date(2026, 8, 6, 9, 0, 0, 0, time.UTC)
+	runner := &recordingCommandRunner{outputs: [][]byte{
+		[]byte(`{"accessToken":"first-secret","expires_on":1786010400}`),
+		[]byte(`{"accessToken":"second-secret","expires_on":1786014000}`),
+	}}
+	source := &CachedCLITokenSource{
+		Profile: Profile{
+			AzureCLI:      "/opt/homebrew/bin/az",
+			TokenResource: FoundryTokenResource,
+		},
+		Runner: runner,
+		Now:    func() time.Time { return now },
+	}
+
+	first, err := source.Token(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := source.Token(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != "first-secret" || second != "first-secret" {
+		t.Fatalf("cached tokens = %q, %q", first, second)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("Azure CLI calls = %d, want 1", len(runner.calls))
+	}
+	wantCommand := []string{
+		"/opt/homebrew/bin/az",
+		"account", "get-access-token",
+		"--resource", FoundryTokenResource,
+		"--output", "json",
+	}
+	if !reflect.DeepEqual(runner.calls[0], wantCommand) {
+		t.Fatalf("command = %#v, want %#v", runner.calls[0], wantCommand)
+	}
+
+	now = time.Unix(1786010400, 0).Add(-4 * time.Minute)
+	refreshed, err := source.Token(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refreshed != "second-secret" {
+		t.Fatalf("refreshed token = %q", refreshed)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("Azure CLI calls after expiry window = %d, want 2", len(runner.calls))
+	}
+}
+
+func TestParseAccessTokenAcceptsCurrentAzureCLIExpiryFormats(t *testing.T) {
+	for _, body := range []string{
+		`{"accessToken":"secret","expires_on":"1786010400"}`,
+		`{"accessToken":"secret","expiresOn":"2026-08-06 10:00:00.000000"}`,
+	} {
+		token, err := parseAccessToken([]byte(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if token.Value != "secret" || token.ExpiresAt.IsZero() {
+			t.Fatalf("parsed token = %#v", token)
+		}
+	}
+}

--- a/internal/proxy/azure_openai.go
+++ b/internal/proxy/azure_openai.go
@@ -1,6 +1,12 @@
 package proxy
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
 	"strings"
 
 	"github.com/manaflow-ai/subrouter/internal/azureopenai"
@@ -30,4 +36,69 @@ func stripAzureOpenAIPath(requestPath string) (name, rest string, ok bool) {
 func azureOpenAIBasePath(requestPath string) bool {
 	_, rest, ok := stripAzureOpenAIPath(requestPath)
 	return ok && (rest == "" || rest == "/" || rest == "/v1" || rest == "/v1/")
+}
+
+func rewriteAzureOpenAIRequestModel(r *http.Request, requestedModel, deployment string, maxBodyBytes int64) error {
+	if r == nil || requestedModel == deployment {
+		return nil
+	}
+	if maxBodyBytes <= 0 {
+		return errors.New("Azure OpenAI request body limit is not configured")
+	}
+
+	query := r.URL.Query()
+	if values, exists := query["model"]; exists {
+		for _, value := range values {
+			if strings.TrimSpace(value) != requestedModel {
+				return errors.New("Azure OpenAI request contains conflicting model selectors")
+			}
+		}
+		query.Set("model", deployment)
+		r.URL.RawQuery = query.Encode()
+	}
+
+	if r.Body == nil {
+		return nil
+	}
+	if contentType := strings.ToLower(r.Header.Get("Content-Type")); !strings.Contains(contentType, "json") {
+		return errors.New("Azure OpenAI model translation requires a JSON request body")
+	}
+	if encoding := strings.ToLower(strings.TrimSpace(r.Header.Get("Content-Encoding"))); encoding != "" && encoding != "identity" {
+		return fmt.Errorf("Azure OpenAI model translation does not support %s request encoding", encoding)
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes+1))
+	if err != nil {
+		return errors.New("read Azure OpenAI request body")
+	}
+	if int64(len(body)) > maxBodyBytes {
+		return errors.New("Azure OpenAI request body is too large")
+	}
+	if err := r.Body.Close(); err != nil {
+		return errors.New("close Azure OpenAI request body")
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return errors.New("Azure OpenAI request body is not valid JSON")
+	}
+	rawModel, exists := payload["model"]
+	if !exists {
+		return errors.New("Azure OpenAI request body model is required")
+	}
+	var bodyModel string
+	if err := json.Unmarshal(rawModel, &bodyModel); err != nil || strings.TrimSpace(bodyModel) != requestedModel {
+		return errors.New("Azure OpenAI request contains conflicting model selectors")
+	}
+	payload["model"], _ = json.Marshal(deployment)
+	rewritten, err := json.Marshal(payload)
+	if err != nil {
+		return errors.New("encode Azure OpenAI request body")
+	}
+	r.Body = io.NopCloser(bytes.NewReader(rewritten))
+	r.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(rewritten)), nil
+	}
+	r.ContentLength = int64(len(rewritten))
+	r.Header.Set("Content-Length", fmt.Sprintf("%d", len(rewritten)))
+	return nil
 }

--- a/internal/proxy/azure_openai.go
+++ b/internal/proxy/azure_openai.go
@@ -1,0 +1,33 @@
+package proxy
+
+import (
+	"strings"
+
+	"github.com/manaflow-ai/subrouter/internal/azureopenai"
+)
+
+func azureOpenAIProfileNameFromPath(requestPath string) (string, bool) {
+	name, _, ok := stripAzureOpenAIPath(requestPath)
+	return name, ok
+}
+
+func stripAzureOpenAIPath(requestPath string) (name, rest string, ok bool) {
+	trimmed := strings.TrimPrefix(requestPath, "/")
+	parts := strings.Split(trimmed, "/")
+	if len(parts) < 2 || parts[0] != "azure" {
+		return "", "", false
+	}
+	name, valid := azureopenai.ProfileNameFromAccountID(azureopenai.AccountID(parts[1]))
+	if !valid || !strings.EqualFold(parts[1], name) {
+		return "", "", false
+	}
+	if len(parts) == 2 {
+		return name, "", true
+	}
+	return name, "/" + strings.Join(parts[2:], "/"), true
+}
+
+func azureOpenAIBasePath(requestPath string) bool {
+	_, rest, ok := stripAzureOpenAIPath(requestPath)
+	return ok && (rest == "" || rest == "/" || rest == "/v1" || rest == "/v1/")
+}

--- a/internal/proxy/azure_openai_test.go
+++ b/internal/proxy/azure_openai_test.go
@@ -70,12 +70,7 @@ func TestAzureOpenAIResponsesRouteUsesCLITokenAndProfileEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	handler := Server{
-		AzureOpenAI:  registry,
-		Accounts:     registry.Accounts("test"),
-		Sessions:     store,
-		MaxBodyBytes: 1 << 20,
-	}.Handler()
+	handler := Server{AzureOpenAI: registry, Accounts: registry.Accounts("test"), Sessions: store}.Handler()
 
 	request := httptest.NewRequest(http.MethodPost, "/azure/work/v1/responses", strings.NewReader(requestBody))
 	request.Header.Set("Authorization", "Bearer client-placeholder")
@@ -123,7 +118,12 @@ func TestAzureOpenAIProfileProbeAndUnknownProfile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	handler := Server{AzureOpenAI: registry, Accounts: registry.Accounts("test"), Sessions: store}.Handler()
+	handler := Server{
+		AzureOpenAI:  registry,
+		Accounts:     registry.Accounts("test"),
+		Sessions:     store,
+		MaxBodyBytes: 1 << 20,
+	}.Handler()
 
 	for _, test := range []struct {
 		path string
@@ -138,5 +138,45 @@ func TestAzureOpenAIProfileProbeAndUnknownProfile(t *testing.T) {
 		if response.Code != test.want {
 			t.Errorf("HEAD %s status = %d, want %d", test.path, response.Code, test.want)
 		}
+	}
+}
+
+func TestAzureOpenAIResponsesRouteRejectsUnconfiguredDeployment(t *testing.T) {
+	registry, err := azureopenai.NewRegistryWithTokenFactory([]azureopenai.Profile{{
+		Name:     "work",
+		Endpoint: "https://example.openai.azure.com",
+		Deployments: map[string]string{
+			azureopenai.GPT56Sol: "production-sol",
+		},
+		AzureCLI: "/opt/homebrew/bin/az",
+	}}, func(azureopenai.Profile) azureopenai.TokenSource {
+		return azureTokenSourceFunc(func(context.Context) (string, error) { return "token", nil })
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := Server{
+		AzureOpenAI:  registry,
+		Accounts:     registry.Accounts("test"),
+		Sessions:     store,
+		MaxBodyBytes: 1 << 20,
+	}.Handler()
+
+	request := httptest.NewRequest(http.MethodPost, "/azure/work/v1/responses", strings.NewReader(`{"model":"gpt-5.6-sol","input":"hello"}`))
+	request.Header.Set("Authorization", "Bearer client-placeholder")
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Subrouter-Agent", "codex")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", response.Code, response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "not a configured deployment") {
+		t.Fatalf("body = %q", response.Body.String())
 	}
 }

--- a/internal/proxy/azure_openai_test.go
+++ b/internal/proxy/azure_openai_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -166,7 +167,7 @@ func TestAzureOpenAIResponsesRouteRejectsUnconfiguredDeployment(t *testing.T) {
 		MaxBodyBytes: 1 << 20,
 	}.Handler()
 
-	request := httptest.NewRequest(http.MethodPost, "/azure/work/v1/responses", strings.NewReader(`{"model":"gpt-5.6-sol","input":"hello"}`))
+	request := httptest.NewRequest(http.MethodPost, "/azure/work/v1/responses", strings.NewReader(`{"model":"gpt-5.5","input":"hello"}`))
 	request.Header.Set("Authorization", "Bearer client-placeholder")
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("X-Subrouter-Agent", "codex")
@@ -178,5 +179,66 @@ func TestAzureOpenAIResponsesRouteRejectsUnconfiguredDeployment(t *testing.T) {
 	}
 	if !strings.Contains(response.Body.String(), "not a configured deployment") {
 		t.Fatalf("body = %q", response.Body.String())
+	}
+}
+
+func TestAzureOpenAIResponsesRouteMapsPickerModelToCustomDeployment(t *testing.T) {
+	var upstreamBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		upstreamBody = string(body)
+		if request.ContentLength != int64(len(body)) {
+			t.Errorf("content length = %d, want %d", request.ContentLength, len(body))
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.completed\"}\n\n")
+	}))
+	defer upstream.Close()
+
+	registry, err := azureopenai.NewRegistryWithTokenFactory([]azureopenai.Profile{{
+		Name:     "work",
+		Endpoint: upstream.URL,
+		Deployments: map[string]string{
+			azureopenai.GPT56Sol:   "production-sol",
+			azureopenai.GPT56Terra: "production-terra",
+			azureopenai.GPT56Luna:  "production-luna",
+		},
+		AzureCLI: "/opt/homebrew/bin/az",
+	}}, func(azureopenai.Profile) azureopenai.TokenSource {
+		return azureTokenSourceFunc(func(context.Context) (string, error) { return "token", nil })
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := Server{
+		AzureOpenAI:  registry,
+		Accounts:     registry.Accounts("test"),
+		Sessions:     store,
+		MaxBodyBytes: 1 << 20,
+	}.Handler()
+
+	request := httptest.NewRequest(http.MethodPost, "/azure/work/v1/responses", strings.NewReader(`{"model":"gpt-5.6-terra","input":"hello"}`))
+	request.Header.Set("Authorization", "Bearer client-placeholder")
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Subrouter-Agent", "codex")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", response.Code, response.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(upstreamBody), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["model"] != "production-terra" || payload["input"] != "hello" {
+		t.Fatalf("upstream body = %s", upstreamBody)
 	}
 }

--- a/internal/proxy/azure_openai_test.go
+++ b/internal/proxy/azure_openai_test.go
@@ -1,0 +1,142 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/azureopenai"
+	"github.com/manaflow-ai/subrouter/session"
+)
+
+type azureTokenSourceFunc func(context.Context) (string, error)
+
+func (f azureTokenSourceFunc) Token(ctx context.Context) (string, error) {
+	return f(ctx)
+}
+
+func TestAzureOpenAIResponsesRouteUsesCLITokenAndProfileEndpoint(t *testing.T) {
+	const requestBody = `{"model":"codex-deployment","input":"hello"}`
+	var upstreamHits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		upstreamHits.Add(1)
+		if request.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", request.Method)
+		}
+		if request.URL.Path != "/openai/v1/responses" {
+			t.Errorf("path = %q, want /openai/v1/responses", request.URL.Path)
+		}
+		if got := request.Header.Get("Authorization"); got != "Bearer azure-cli-secret" {
+			t.Errorf("Authorization = %q, want Azure CLI bearer token", got)
+		}
+		for _, header := range []string{"Api-Key", "X-Api-Key", "OpenAI-Organization", "OpenAI-Project", "X-Subrouter-Account-ID"} {
+			if got := request.Header.Get(header); got != "" {
+				t.Errorf("%s leaked upstream: %q", header, got)
+			}
+		}
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		if string(body) != requestBody {
+			t.Errorf("body = %s, want %s", body, requestBody)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.completed\"}\n\n")
+	}))
+	defer upstream.Close()
+
+	var tokenCalls atomic.Int32
+	registry, err := azureopenai.NewRegistryWithTokenFactory([]azureopenai.Profile{{
+		Name:       "work",
+		Endpoint:   upstream.URL,
+		Deployment: "codex-deployment",
+		AzureCLI:   "/opt/homebrew/bin/az",
+	}}, func(azureopenai.Profile) azureopenai.TokenSource {
+		return azureTokenSourceFunc(func(context.Context) (string, error) {
+			tokenCalls.Add(1)
+			return "azure-cli-secret", nil
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := Server{
+		AzureOpenAI:  registry,
+		Accounts:     registry.Accounts("test"),
+		Sessions:     store,
+		MaxBodyBytes: 1 << 20,
+	}.Handler()
+
+	request := httptest.NewRequest(http.MethodPost, "/azure/work/v1/responses", strings.NewReader(requestBody))
+	request.Header.Set("Authorization", "Bearer client-placeholder")
+	request.Header.Set("Api-Key", "client-api-key")
+	request.Header.Set("X-Api-Key", "client-x-api-key")
+	request.Header.Set("OpenAI-Organization", "org-client")
+	request.Header.Set("OpenAI-Project", "project-client")
+	request.Header.Set("X-Subrouter-Account-ID", "azure:other")
+	request.Header.Set("X-Subrouter-Agent", "codex")
+	request.Header.Set("X-Subrouter-Session", "azure-test-session")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", response.Code, response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "response.completed") {
+		t.Fatalf("response body = %q", response.Body.String())
+	}
+	if got := upstreamHits.Load(); got != 1 {
+		t.Fatalf("upstream hits = %d, want 1", got)
+	}
+	if got := tokenCalls.Load(); got != 1 {
+		t.Fatalf("token calls = %d, want 1", got)
+	}
+	assignment, ok := store.Get("codex", "azure-test-session")
+	if !ok || assignment.AccountID != azureopenai.AccountID("work") {
+		t.Fatalf("session assignment = %#v, found = %t", assignment, ok)
+	}
+}
+
+func TestAzureOpenAIProfileProbeAndUnknownProfile(t *testing.T) {
+	registry, err := azureopenai.NewRegistryWithTokenFactory([]azureopenai.Profile{{
+		Name:       "work",
+		Endpoint:   "https://example.openai.azure.com",
+		Deployment: "codex-deployment",
+		AzureCLI:   "/opt/homebrew/bin/az",
+	}}, func(azureopenai.Profile) azureopenai.TokenSource {
+		return azureTokenSourceFunc(func(context.Context) (string, error) { return "token", nil })
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := Server{AzureOpenAI: registry, Accounts: registry.Accounts("test"), Sessions: store}.Handler()
+
+	for _, test := range []struct {
+		path string
+		want int
+	}{
+		{path: "/azure/work/v1", want: http.StatusNoContent},
+		{path: "/azure/missing/v1", want: http.StatusNotFound},
+	} {
+		request := httptest.NewRequest(http.MethodHead, test.path, nil)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+		if response.Code != test.want {
+			t.Errorf("HEAD %s status = %d, want %d", test.path, response.Code, test.want)
+		}
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
+	"github.com/manaflow-ai/subrouter/internal/azureopenai"
 	"github.com/manaflow-ai/subrouter/internal/broker"
 	"github.com/manaflow-ai/subrouter/internal/transcript"
 	"github.com/manaflow-ai/subrouter/selectacct"
@@ -53,6 +54,7 @@ type Server struct {
 	ClaudeUpstream *url.URL
 	KimiUpstream   *url.URL
 	ZAIUpstream    *url.URL
+	AzureOpenAI    *azureopenai.Registry
 	Accounts       []accounts.Account
 	AccountRef     *AccountRef
 	Sessions       *session.Store
@@ -2225,6 +2227,23 @@ func (s Server) proxyHandler() http.Handler {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+		azureProfileName, azurePath := azureOpenAIProfileNameFromPath(r.URL.Path)
+		if azurePath && r.Method == http.MethodHead && azureOpenAIBasePath(r.URL.Path) {
+			if s.RequireSessionLease || !s.localProxyAuthorized(r) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			if s.AzureOpenAI == nil {
+				http.NotFound(w, r)
+				return
+			}
+			if _, ok := s.AzureOpenAI.Profile(azureProfileName); !ok {
+				http.NotFound(w, r)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		if r.Method != http.MethodGet && r.Method != http.MethodPost {
 			w.Header().Set("Allow", "GET, POST")
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -2236,6 +2255,19 @@ func (s Server) proxyHandler() http.Handler {
 		}
 		agentType := session.ExtractAgentType(r)
 		requestProvider := providerForRequest(agentType, r.URL.Path)
+		if requestProvider == accounts.ProviderAzureOpenAI {
+			if !azurePath || s.AzureOpenAI == nil {
+				http.NotFound(w, r)
+				return
+			}
+			if _, ok := s.AzureOpenAI.Profile(azureProfileName); !ok {
+				http.NotFound(w, r)
+				return
+			}
+			// The path is the authority for Azure profile selection. Binding the
+			// account internally prevents a client header from crossing profiles.
+			r.Header.Set("X-Subrouter-Account-ID", azureopenai.AccountID(azureProfileName))
+		}
 		modelCatalogRequest := requestProvider == accounts.ProviderCodex && codexModelCatalogRequest(r)
 		sessionID := session.ExtractID(r, s.MaxBodyBytes)
 		if modelCatalogRequest {
@@ -2325,7 +2357,7 @@ func (s Server) proxyHandler() http.Handler {
 		var account accounts.Account
 		var credentialLease *broker.Lease
 		var err error
-		if s.CredentialBroker != nil {
+		if s.CredentialBroker != nil && requestProvider != accounts.ProviderAzureOpenAI {
 			requiredAuthMode := accounts.AuthMode("")
 			if requestProvider == accounts.ProviderCodex &&
 				(chatGPTBackendPath(r.URL.Path) || modelCatalogRequest) {
@@ -2383,6 +2415,17 @@ func (s Server) proxyHandler() http.Handler {
 		if boundLease != nil && !boundLease.allowsAccount(account) {
 			http.Error(w, "session lease account binding is unavailable", http.StatusServiceUnavailable)
 			return
+		}
+		if requestProvider == accounts.ProviderAzureOpenAI {
+			token, tokenErr := s.AzureOpenAI.Token(r.Context(), account.ID)
+			if tokenErr != nil {
+				if s.Logger != nil {
+					s.Logger.Error("Azure OpenAI credential acquisition failed", "account", account.ID, "error", tokenErr)
+				}
+				http.Error(w, tokenErr.Error(), http.StatusServiceUnavailable)
+				return
+			}
+			account.Token = token
 		}
 
 		auth := account.AuthorizationHeader()
@@ -3935,6 +3978,11 @@ func setAccountAuthHeaders(headers http.Header, account accounts.Account) {
 		}
 	case accounts.ProviderZAI:
 		headers.Del("X-Api-Key")
+	case accounts.ProviderAzureOpenAI:
+		headers.Del("X-Api-Key")
+		headers.Del("Api-Key")
+		headers.Del("OpenAI-Organization")
+		headers.Del("OpenAI-Project")
 	case accounts.ProviderCodex, "":
 		if account.AccountID != "" {
 			headers.Set("ChatGPT-Account-ID", account.AccountID)
@@ -3990,6 +4038,17 @@ func (s Server) upstreamForRequest(path string, account accounts.Account) *url.U
 	if account.Provider == accounts.ProviderZAI {
 		return s.ZAIUpstream
 	}
+	if account.Provider == accounts.ProviderAzureOpenAI && s.AzureOpenAI != nil {
+		profile, ok := s.AzureOpenAI.ProfileForAccount(account.ID)
+		if !ok {
+			return nil
+		}
+		upstream, err := url.Parse(profile.Endpoint)
+		if err != nil {
+			return nil
+		}
+		return upstream
+	}
 	if account.AuthMode == accounts.AuthModeAPIKey {
 		return s.APIUpstream
 	}
@@ -4027,6 +4086,19 @@ func (s Server) pathForUpstream(path string, account accounts.Account) string {
 	}
 	if account.Provider == accounts.ProviderZAI {
 		return stripProviderPathPrefix(path, "zai")
+	}
+	if account.Provider == accounts.ProviderAzureOpenAI {
+		_, rest, ok := stripAzureOpenAIPath(path)
+		if !ok {
+			return path
+		}
+		if rest == "" || rest == "/" || rest == "/v1" {
+			return "/"
+		}
+		if strings.HasPrefix(rest, "/v1/") {
+			return strings.TrimPrefix(rest, "/v1")
+		}
+		return rest
 	}
 	if account.AuthMode == accounts.AuthModeOAuth {
 		if stripped, ok := stripChatGPTBackendPath(path); ok {
@@ -4389,6 +4461,8 @@ func providerForPath(path string) (accounts.Provider, bool) {
 		return accounts.ProviderKimi, true
 	case "zai":
 		return accounts.ProviderZAI, true
+	case "azure":
+		return accounts.ProviderAzureOpenAI, true
 	default:
 		return "", false
 	}
@@ -4432,7 +4506,7 @@ func filterAccountsForProvider(all []accounts.Account, provider accounts.Provide
 	if len(filtered) > 0 {
 		return filtered
 	}
-	if provider == accounts.ProviderKimi || provider == accounts.ProviderZAI {
+	if provider == accounts.ProviderKimi || provider == accounts.ProviderZAI || provider == accounts.ProviderAzureOpenAI {
 		return nil
 	}
 	return legacy

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2266,9 +2266,13 @@ func (s Server) proxyHandler() http.Handler {
 				return
 			}
 			if requestedModel := session.ExtractModel(r, s.MaxBodyBytes); requestedModel != "" {
-				deployment, allowed := profile.DeploymentForModel(requestedModel)
-				if !allowed || deployment != requestedModel {
+				_, deployment, allowed := profile.ResolveModel(requestedModel)
+				if !allowed {
 					http.Error(w, "Azure OpenAI model is not a configured deployment for this profile", http.StatusBadRequest)
+					return
+				}
+				if err := rewriteAzureOpenAIRequestModel(r, requestedModel, deployment, s.MaxBodyBytes); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
 					return
 				}
 			}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2260,9 +2260,17 @@ func (s Server) proxyHandler() http.Handler {
 				http.NotFound(w, r)
 				return
 			}
-			if _, ok := s.AzureOpenAI.Profile(azureProfileName); !ok {
+			profile, ok := s.AzureOpenAI.Profile(azureProfileName)
+			if !ok {
 				http.NotFound(w, r)
 				return
+			}
+			if requestedModel := session.ExtractModel(r, s.MaxBodyBytes); requestedModel != "" {
+				deployment, allowed := profile.DeploymentForModel(requestedModel)
+				if !allowed || deployment != requestedModel {
+					http.Error(w, "Azure OpenAI model is not a configured deployment for this profile", http.StatusBadRequest)
+					return
+				}
 			}
 			// The path is the authority for Azure profile selection. Binding the
 			// account internally prevents a client header from crossing profiles.


### PR DESCRIPTION
## Summary

- add Azure OpenAI profiles authenticated by renewable Microsoft Entra tokens from Azure CLI
- make the first profile the default, support `sr az default <profile>`, and let bare `sr az codex` launch immediately
- keep legacy positional profiles and add `--azure-profile` for one-run overrides
- map one profile to GPT-5.6 Sol, Terra, and Luna, with Sol as the launch default
- preserve canonical GPT-5.6 slugs and native Codex `/model` picker metadata, then translate each request to its Azure deployment name
- route through an explicit `/azure/<profile>/v1` path, enforce configured deployments, strip client credentials, and keep Azure outside ChatGPT failover
- persist only non-secret metadata and keep bearer tokens in daemon memory

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --check`
- installed the exact branch binary at the existing `sr` path
- `sr az codex` launched Codex 0.146.1 with no profile argument and selected Sol
- `/model` visibly listed GPT-5.6 Sol, Terra, and Luna
- a proxy test verifies picker slug translation to a custom Azure deployment
- Azure CLI 2.89.0 returned a valid Foundry bearer token
- the signed-in Foundry catalog and Azure CLI both expose `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`
- live inference is pending Azure quota; the subscription currently reports 0 TPM for all three models in every offered scope

Dictionary: TPM means tokens per minute, the Azure quota that controls model deployment capacity. A token audience identifies the Azure service allowed to accept a Microsoft Entra access token.