### PR TITLE
Accept legacy dual-stack listener handoff

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -51,7 +51,7 @@ const (
 	goldenPinnedBootstrapTag                  = "v0.1.63"
 	goldenPinnedBootstrapLinuxSHA256          = "39fcd2c3a86c7be12759ed0f0b366d9d13f90e538c2af2483dd50230c9ef2bf2"
 	goldenPinnedBootstrapRevision             = "763dcf6c304d9aea7f36659d4fba40ea27f42096"
-	goldenPinnedCandidateTag                  = "v0.1.69"
+	goldenPinnedCandidateTag                  = "v0.1.71"
 	goldenResponseRequestTokenEnv             = "SUBROUTER_GOLDEN_RESPONSE_REQUEST_TOKEN"
 	goldenFakeStreamReleaseTokenEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_TOKEN"
 	goldenFakeStreamReleaseStateEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_STATE"

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func TestGoldenOptionsRequireV0169Candidate(t *testing.T) {
+func TestGoldenOptionsRequireV0171Candidate(t *testing.T) {
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = false
 	t.Cleanup(func() { goldenTestHooks = previousHooks })
@@ -20,7 +20,7 @@ func TestGoldenOptionsRequireV0169Candidate(t *testing.T) {
 	args := []string{
 		"--predecessor-version", "v0.1.51",
 		"--predecessor-sha256", goldenPinnedPredecessorSHA256,
-		"--candidate-tag", "v0.1.69",
+		"--candidate-tag", "v0.1.71",
 		"--candidate-sha256", strings.Repeat("b", 64),
 		"--candidate-revision", strings.Repeat("c", 40),
 		"--deploy-evidence-validator", "validator",
@@ -34,10 +34,10 @@ func TestGoldenOptionsRequireV0169Candidate(t *testing.T) {
 		"--old-generation-check", "true",
 	}
 	if _, err := parseGoldenArgs(args); err != nil {
-		t.Fatalf("v0.1.69 candidate was rejected: %v", err)
+		t.Fatalf("v0.1.71 candidate was rejected: %v", err)
 	}
 	for index := range args {
-		if args[index] == "v0.1.69" {
+		if args[index] == "v0.1.71" {
 			args[index] = "v0.1.63"
 			break
 		}

--- a/cmd/subrouter/front_handoff_unix.go
+++ b/cmd/subrouter/front_handoff_unix.go
@@ -67,7 +67,7 @@ func inheritedFrontProcessFromEnvironment(config frontConfig) (*inheritedFrontPr
 		closeFrontListeners(publicListener, controlListener)
 		return nil, err
 	}
-	if _, ok := publicListener.(*net.TCPListener); !ok || !listenerAddressMatches(publicListener.Addr(), config.Addr) {
+	if _, ok := publicListener.(*net.TCPListener); !ok || !listenerCoversConfiguredAddress(publicListener, config.Addr) {
 		actual := publicListener.Addr().String()
 		closeFrontListeners(publicListener, controlListener, transferListener)
 		return nil, fmt.Errorf("inherited front public listener %q does not match %q", actual, config.Addr)

--- a/cmd/subrouter/listener_address.go
+++ b/cmd/subrouter/listener_address.go
@@ -54,3 +54,31 @@ func listenerAddressMatches(actual net.Addr, expected string) bool {
 	}
 	return strings.EqualFold(actualHost, expectedHost)
 }
+
+// listenerCoversConfiguredAddress accepts an exact address match or a
+// dual-stack IPv6 wildcard socket in place of an IPv4 wildcard configuration.
+// The latter is safe only when the live socket has IPV6_V6ONLY disabled.
+func listenerCoversConfiguredAddress(listener net.Listener, expected string) bool {
+	if listener == nil {
+		return false
+	}
+	if listenerAddressMatches(listener.Addr(), expected) {
+		return true
+	}
+	actualHost, actualPort, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		return false
+	}
+	expectedHost, expectedPort, err := net.SplitHostPort(expected)
+	if err != nil || actualPort != expectedPort {
+		return false
+	}
+	actualIP := net.ParseIP(strings.TrimSpace(actualHost))
+	expectedIP := net.ParseIP(strings.TrimSpace(expectedHost))
+	if actualIP == nil || expectedIP == nil ||
+		!actualIP.IsUnspecified() || actualIP.To4() != nil ||
+		!expectedIP.IsUnspecified() || expectedIP.To4() == nil {
+		return false
+	}
+	return listenerIPv6WildcardAcceptsIPv4(listener)
+}

--- a/cmd/subrouter/listener_address_linux.go
+++ b/cmd/subrouter/listener_address_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package main
+
+import (
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+func listenerIPv6WildcardAcceptsIPv4(listener net.Listener) bool {
+	tcp, ok := listener.(*net.TCPListener)
+	if !ok {
+		return false
+	}
+	raw, err := tcp.SyscallConn()
+	if err != nil {
+		return false
+	}
+	v6Only := 1
+	var optionErr error
+	if err := raw.Control(func(descriptor uintptr) {
+		v6Only, optionErr = unix.GetsockoptInt(int(descriptor), unix.IPPROTO_IPV6, unix.IPV6_V6ONLY)
+	}); err != nil || optionErr != nil {
+		return false
+	}
+	return v6Only == 0
+}

--- a/cmd/subrouter/listener_address_other.go
+++ b/cmd/subrouter/listener_address_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package main
+
+import "net"
+
+func listenerIPv6WildcardAcceptsIPv4(net.Listener) bool {
+	return false
+}

--- a/cmd/subrouter/listener_address_other.go
+++ b/cmd/subrouter/listener_address_other.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !(aix || android || darwin || dragonfly || freebsd || illumos || ios || linux || netbsd || openbsd || solaris)
 
 package main
 

--- a/cmd/subrouter/listener_address_unix.go
+++ b/cmd/subrouter/listener_address_unix.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build aix || android || darwin || dragonfly || freebsd || illumos || ios || linux || netbsd || openbsd || solaris
 
 package main
 

--- a/cmd/subrouter/listener_address_unix_test.go
+++ b/cmd/subrouter/listener_address_unix_test.go
@@ -1,0 +1,49 @@
+//go:build darwin || linux
+
+package main
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestListenerCoverageUsesLiveDualStackCapability(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		v6Only int
+		want   bool
+	}{
+		{name: "dual-stack", v6Only: 0, want: true},
+		{name: "IPv6-only", v6Only: 1, want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			config := net.ListenConfig{Control: func(_, _ string, raw syscall.RawConn) error {
+				var socketErr error
+				if err := raw.Control(func(descriptor uintptr) {
+					socketErr = unix.SetsockoptInt(
+						int(descriptor), unix.IPPROTO_IPV6, unix.IPV6_V6ONLY, test.v6Only,
+					)
+				}); err != nil {
+					return err
+				}
+				return socketErr
+			}}
+			listener, err := config.Listen(context.Background(), "tcp6", "[::]:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer listener.Close()
+			port := listener.Addr().(*net.TCPAddr).Port
+			expected := net.JoinHostPort("0.0.0.0", strconv.Itoa(port))
+			if got := listenerCoversConfiguredAddress(listener, expected); got != test.want {
+				t.Fatalf("listenerCoversConfiguredAddress(%q, %q) = %t, want %t",
+					listener.Addr(), expected, got, test.want)
+			}
+		})
+	}
+}

--- a/cmd/subrouter/listener_legacy_dual_stack_linux_test.go
+++ b/cmd/subrouter/listener_legacy_dual_stack_linux_test.go
@@ -1,0 +1,182 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestTakeoverTCPListenerAcceptsLegacyDualStackWildcardForIPv4Configuration(t *testing.T) {
+	original := listenIPv6Wildcard(t, false)
+	file, err := original.File()
+	if err != nil {
+		original.Close()
+		t.Fatal(err)
+	}
+
+	expected := ipv4WildcardForListener(t, original)
+	taken, err := takeoverTCPListener(os.Getpid(), int(file.Fd()), expected)
+	if err != nil {
+		file.Close()
+		original.Close()
+		t.Fatalf("take over legacy dual-stack listener for %s: %v", expected, err)
+	}
+	t.Cleanup(func() { _ = taken.Close() })
+	if err := original.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	assertListenerAcceptsIPv4(t, taken)
+}
+
+func TestTakeoverTCPListenerRejectsIPv6OnlyWildcardForIPv4Configuration(t *testing.T) {
+	original := listenIPv6Wildcard(t, true)
+	defer original.Close()
+	file, err := original.File()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	if taken, err := takeoverTCPListener(os.Getpid(), int(file.Fd()), ipv4WildcardForListener(t, original)); err == nil {
+		taken.Close()
+		t.Fatal("IPv6-only listener matched an IPv4 wildcard configuration")
+	}
+}
+
+func TestListenerTransferAcceptsLegacyDualStackWildcardForIPv4Configuration(t *testing.T) {
+	source := listenIPv6Wildcard(t, false)
+	defer source.Close()
+	directory := t.TempDir()
+	endpoint, err := listenForTransferredListeners(filepath.Join(directory, "listener.sock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer endpoint.Close()
+	server := endpoint.(*net.UnixListener)
+
+	type receiveResult struct {
+		listener net.Listener
+		err      error
+	}
+	received := make(chan receiveResult, 1)
+	go func() {
+		connection, acceptErr := server.AcceptUnix()
+		if acceptErr != nil {
+			received <- receiveResult{err: acceptErr}
+			return
+		}
+		defer connection.Close()
+		listener, receiveErr := receiveTransferredListener(connection)
+		response := listenerTransferResponse{}
+		if receiveErr != nil {
+			response.Error = receiveErr.Error()
+		} else {
+			response.Address = listener.Addr().String()
+		}
+		if encodeErr := json.NewEncoder(connection).Encode(response); receiveErr == nil && encodeErr != nil {
+			receiveErr = encodeErr
+		}
+		received <- receiveResult{listener: listener, err: receiveErr}
+	}()
+
+	expected := ipv4WildcardForListener(t, source)
+	if err := sendTransferredListener(server.Addr().String(), expected, source); err != nil {
+		t.Fatalf("transfer legacy dual-stack listener for %s: %v", expected, err)
+	}
+	result := <-received
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	defer result.listener.Close()
+	if err := source.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	assertListenerAcceptsIPv4(t, result.listener)
+}
+
+func listenIPv6Wildcard(t *testing.T, v6Only bool) *net.TCPListener {
+	t.Helper()
+	value := 0
+	if v6Only {
+		value = 1
+	}
+	config := net.ListenConfig{Control: func(_, _ string, raw syscall.RawConn) error {
+		var socketErr error
+		if err := raw.Control(func(descriptor uintptr) {
+			socketErr = unix.SetsockoptInt(int(descriptor), unix.IPPROTO_IPV6, unix.IPV6_V6ONLY, value)
+		}); err != nil {
+			return err
+		}
+		return socketErr
+	}}
+	listener, err := config.Listen(context.Background(), "tcp6", "[::]:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tcp, ok := listener.(*net.TCPListener)
+	if !ok {
+		listener.Close()
+		t.Fatalf("listener is %T, want TCP", listener)
+	}
+	return tcp
+}
+
+func ipv4WildcardForListener(t *testing.T, listener net.Listener) string {
+	t.Helper()
+	address, ok := listener.Addr().(*net.TCPAddr)
+	if !ok || address.IP.To4() != nil || !address.IP.IsUnspecified() {
+		t.Fatalf("listener address = %v, want IPv6 wildcard", listener.Addr())
+	}
+	return net.JoinHostPort("0.0.0.0", strconv.Itoa(address.Port))
+}
+
+func assertListenerAcceptsIPv4(t *testing.T, listener net.Listener) {
+	t.Helper()
+	address := listener.Addr().(*net.TCPAddr)
+	accepted := make(chan error, 1)
+	go func() {
+		connection, err := listener.Accept()
+		if err == nil {
+			defer connection.Close()
+			buffer := make([]byte, 1)
+			_, err = connection.Read(buffer)
+			if err == nil && buffer[0] != 'x' {
+				err = fmt.Errorf("received byte %q, want x", buffer[0])
+			}
+		}
+		accepted <- err
+	}()
+	client, err := net.DialTimeout("tcp4", net.JoinHostPort("127.0.0.1", strconv.Itoa(address.Port)), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Write([]byte{'x'}); err != nil {
+		client.Close()
+		t.Fatal(err)
+	}
+	_ = client.Close()
+	select {
+	case err := <-accepted:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener did not accept an IPv4 connection")
+	}
+}

--- a/cmd/subrouter/listener_takeover_linux.go
+++ b/cmd/subrouter/listener_takeover_linux.go
@@ -47,7 +47,7 @@ func takeoverTCPListener(pid, targetFD int, expectedAddress string) (net.Listene
 		_ = listener.Close()
 		return nil, fmt.Errorf("close duplicated listener file: %w", closeErr)
 	}
-	if _, ok := listener.(*net.TCPListener); !ok || !listenerAddressMatches(listener.Addr(), expectedAddress) {
+	if _, ok := listener.(*net.TCPListener); !ok || !listenerCoversConfiguredAddress(listener, expectedAddress) {
 		actual := listener.Addr().String()
 		_ = listener.Close()
 		return nil, fmt.Errorf("taken listener address %q does not match %q", actual, expectedAddress)

--- a/cmd/subrouter/listener_transfer_unix.go
+++ b/cmd/subrouter/listener_transfer_unix.go
@@ -147,7 +147,7 @@ func receiveTransferredListener(connection *net.UnixConn) (net.Listener, error) 
 	if err != nil {
 		return nil, fmt.Errorf("open transferred listener: %w", err)
 	}
-	if _, ok := listener.(*net.TCPListener); !ok || !listenerAddressMatches(listener.Addr(), request.Address) {
+	if _, ok := listener.(*net.TCPListener); !ok || !listenerCoversConfiguredAddress(listener, request.Address) {
 		actual := listener.Addr().String()
 		_ = listener.Close()
 		return nil, fmt.Errorf("transferred listener address %q does not match %q", actual, request.Address)

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify the immutable v0.1.51/v0.1.63/v0.1.69 release inputs, then run the complete
+# Verify the immutable v0.1.51/v0.1.63/v0.1.71 release inputs, then run the complete
 # legacy-to-front migration and slot-upgrade continuity gate from a local Mac.
 set -euo pipefail
 umask 077
@@ -16,8 +16,8 @@ bootstrap_tag="v0.1.63"
 bootstrap_version="0.1.63"
 bootstrap_revision="763dcf6c304d9aea7f36659d4fba40ea27f42096"
 bootstrap_linux_sha="39fcd2c3a86c7be12759ed0f0b366d9d13f90e538c2af2483dd50230c9ef2bf2"
-candidate_tag="v0.1.69"
-candidate_version="0.1.69"
+candidate_tag="v0.1.71"
+candidate_version="0.1.71"
 
 usage() {
   cat <<'EOF'
@@ -218,7 +218,7 @@ if ! gh release view "${candidate_tag}" --repo "${repository}" --json tagName,is
       '.tagName == $tag and (.isDraft | not) and (.isPrerelease | not) and .isImmutable == true and
        (.publishedAt | type == "string" and length > 0)' \
       >/dev/null; then
-  echo "v0.1.69 is not a published immutable release" >&2
+  echo "v0.1.71 is not a published immutable release" >&2
   exit 1
 fi
 candidate_revision="$(require_release_revision_on_main "${candidate_tag}")"


### PR DESCRIPTION
Fixes the zero-gap migration from legacy Go listeners that report `[::]:port` while accepting IPv4 and configuration says `0.0.0.0:port`.

Validation now inspects `IPV6_V6ONLY` before accepting that equivalence. IPv6-only sockets, concrete addresses, and wrong ports remain rejected. The golden candidate is pinned to v0.1.71.

Tests:
- Regression commit fails at direct takeover and listener transfer
- `go test ./...` on macOS
- `go test ./...` on Linux
- focused Linux race detector
- Windows and Linux cross-builds
- golden shell syntax check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788656187&installation_model_id=21920&pr_number=187&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F187&signature=59ce44025a43b27e937e7d0b5f204bcc951b95a24cefc730e3d4f16bbeec25ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept handoff from legacy Go listeners that report `[::]:port` while accepting IPv4 when config expects `0.0.0.0:port`. We only allow this when the live socket has `IPV6_V6ONLY=0`, enabling zero-downtime migrations without false matches.

- **Bug Fixes**
  - Added `listenerCoversConfiguredAddress` to treat dual-stack `[::]:port` as equivalent to `0.0.0.0:port` only if ports match and the socket is dual-stack.
  - Implemented Unix check via `GetsockoptInt(IPV6_V6ONLY)` using `golang.org/x/sys/unix`; non-Unix defaults to reject.
  - Applied to inherited front, listener takeover, and transfer; added Darwin/Linux tests; IPv6-only sockets, concrete addresses, and wrong ports remain rejected.

- **Dependencies**
  - Updated golden candidate to `v0.1.71` and adjusted tests and scripts accordingly.

<sup>Written for commit b9921affa84a7c477d4dc8de220372fb6dfe749b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved listener takeover and transfer handling for IPv4 wildcard configurations using compatible IPv6 dual-stack listeners.
  * Prevented incompatible or IPv6-only listeners from being incorrectly accepted.
  * Added validation for listener address, port, protocol, and address-family compatibility.

* **Chores**
  * Updated release continuity checks to target candidate version `v0.1.71`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->