### PR TITLE
Fix golden session start ordering

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -51,7 +51,7 @@ const (
 	goldenPinnedBootstrapTag                  = "v0.1.63"
 	goldenPinnedBootstrapLinuxSHA256          = "39fcd2c3a86c7be12759ed0f0b366d9d13f90e538c2af2483dd50230c9ef2bf2"
 	goldenPinnedBootstrapRevision             = "763dcf6c304d9aea7f36659d4fba40ea27f42096"
-	goldenPinnedCandidateTag                  = "v0.1.71"
+	goldenPinnedCandidateTag                  = "v0.1.72"
 	goldenResponseRequestTokenEnv             = "SUBROUTER_GOLDEN_RESPONSE_REQUEST_TOKEN"
 	goldenFakeStreamReleaseTokenEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_TOKEN"
 	goldenFakeStreamReleaseStateEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_STATE"

--- a/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
+++ b/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
@@ -214,7 +214,7 @@ esac
 	t.Setenv("SUBROUTER_GOLDEN_FAKE_PROCESS_STATE", processState)
 	t.Setenv("SUBROUTER_GOLDEN_FAKE_PROCESS_PARENT_OWNED", "1")
 	t.Setenv("SUBROUTER_GOLDEN_FAKE_MIGRATION_RETRY_ONCE", "1")
-	t.Setenv("SUBROUTER_GOLDEN_FAKE_REQUIRE_SESSIONS_DURING_PREPARE", "1")
+	t.Setenv("SUBROUTER_GOLDEN_FAKE_REQUIRE_PREPARE_BEFORE_SESSIONS", "1")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	artifacts := filepath.Join(root, "artifacts")
 	err = runGolden([]string{

--- a/cmd/subrouter-transport-observer/golden_migration_cycle.go
+++ b/cmd/subrouter-transport-observer/golden_migration_cycle.go
@@ -17,6 +17,17 @@ type goldenMigrationResult struct {
 func (r *goldenRunner) runMigrationCycle(ctx context.Context, inputs goldenCycleInputs) (goldenMigrationResult, error) {
 	var result goldenMigrationResult
 	var err error
+	result.preparation, err = r.runMigrationEvidenceAction(ctx, goldenMigrationActionOptions{
+		label: "migration-preparation", argv: r.options.migrationPrepare,
+		expect: "front-migration-preparation", evidenceName: "migration-preparation.json",
+	})
+	if err != nil {
+		return result, err
+	}
+	if err := r.validateGoldenCandidateIdentity(result.preparation.migrationCanonical); err != nil {
+		return result, err
+	}
+
 	result.initial, err = r.startCycleInitialSessions(ctx, inputs, false)
 	if err != nil {
 		return result, err
@@ -37,17 +48,6 @@ func (r *goldenRunner) runMigrationCycle(ctx context.Context, inputs goldenCycle
 			cancelGoldenContinuityMonitors(initialMonitors)
 		}
 	}()
-
-	result.preparation, err = r.runMigrationEvidenceAction(ctx, goldenMigrationActionOptions{
-		label: "migration-preparation", argv: r.options.migrationPrepare,
-		expect: "front-migration-preparation", evidenceName: "migration-preparation.json",
-	})
-	if err != nil {
-		return result, err
-	}
-	if err := r.validateGoldenCandidateIdentity(result.preparation.migrationCanonical); err != nil {
-		return result, err
-	}
 
 	var frontProof *goldenSession
 	result.finalCutover, frontProof, err = r.runMigrationTransitionWithProof(

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func TestGoldenOptionsRequireV0171Candidate(t *testing.T) {
+func TestGoldenOptionsRequireV0172Candidate(t *testing.T) {
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = false
 	t.Cleanup(func() { goldenTestHooks = previousHooks })
@@ -20,7 +20,7 @@ func TestGoldenOptionsRequireV0171Candidate(t *testing.T) {
 	args := []string{
 		"--predecessor-version", "v0.1.51",
 		"--predecessor-sha256", goldenPinnedPredecessorSHA256,
-		"--candidate-tag", "v0.1.71",
+		"--candidate-tag", "v0.1.72",
 		"--candidate-sha256", strings.Repeat("b", 64),
 		"--candidate-revision", strings.Repeat("c", 40),
 		"--deploy-evidence-validator", "validator",
@@ -34,10 +34,10 @@ func TestGoldenOptionsRequireV0171Candidate(t *testing.T) {
 		"--old-generation-check", "true",
 	}
 	if _, err := parseGoldenArgs(args); err != nil {
-		t.Fatalf("v0.1.71 candidate was rejected: %v", err)
+		t.Fatalf("v0.1.72 candidate was rejected: %v", err)
 	}
 	for index := range args {
-		if args[index] == "v0.1.71" {
+		if args[index] == "v0.1.72" {
 			args[index] = "v0.1.63"
 			break
 		}

--- a/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
+++ b/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
@@ -56,17 +56,17 @@ func fakeAction(args []string) {
 		os.Exit(9)
 	}
 	operation := args[0]
-	if operation == "migration-prepare" && os.Getenv("SUBROUTER_GOLDEN_FAKE_REQUIRE_SESSIONS_DURING_PREPARE") == "1" {
+	if operation == "migration-prepare" && os.Getenv("SUBROUTER_GOLDEN_FAKE_REQUIRE_PREPARE_BEFORE_SESSIONS") == "1" {
 		entries, err := os.ReadDir(os.Getenv("SUBROUTER_GOLDEN_FAKE_PROCESS_STATE"))
-		// The harness process and this action are already registered. Require at
-		// least one separately held Codex session before migration preparation.
+		// The harness, local daemon, and this action are already registered.
+		// Reject any separately held Codex session during migration preparation.
 		registered := 0
 		for _, entry := range entries {
 			if _, parseErr := strconv.Atoi(entry.Name()); parseErr == nil {
 				registered++
 			}
 		}
-		if err != nil || registered <= 2 {
+		if err != nil || registered > 3 {
 			os.Exit(9)
 		}
 	}

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify the immutable v0.1.51/v0.1.63/v0.1.71 release inputs, then run the complete
+# Verify the immutable v0.1.51/v0.1.63/v0.1.72 release inputs, then run the complete
 # legacy-to-front migration and slot-upgrade continuity gate from a local Mac.
 set -euo pipefail
 umask 077
@@ -16,8 +16,8 @@ bootstrap_tag="v0.1.63"
 bootstrap_version="0.1.63"
 bootstrap_revision="763dcf6c304d9aea7f36659d4fba40ea27f42096"
 bootstrap_linux_sha="39fcd2c3a86c7be12759ed0f0b366d9d13f90e538c2af2483dd50230c9ef2bf2"
-candidate_tag="v0.1.71"
-candidate_version="0.1.71"
+candidate_tag="v0.1.72"
+candidate_version="0.1.72"
 
 usage() {
   cat <<'EOF'
@@ -218,7 +218,7 @@ if ! gh release view "${candidate_tag}" --repo "${repository}" --json tagName,is
       '.tagName == $tag and (.isDraft | not) and (.isPrerelease | not) and .isImmutable == true and
        (.publishedAt | type == "string" and length > 0)' \
       >/dev/null; then
-  echo "v0.1.71 is not a published immutable release" >&2
+  echo "v0.1.72 is not a published immutable release" >&2
   exit 1
 fi
 candidate_revision="$(require_release_revision_on_main "${candidate_tag}")"


### PR DESCRIPTION
The production-continuity harness started held Codex sessions before migration preparation, which includes a multi-minute backend canary. Its deliberately paced stream could then exceed Codex's application timeout before cutover and manufacture retry/error events.

This moves migration preparation ahead of session startup. Held HTTP and WebSocket sessions still start before listener takeover and remain open through the cutover.

Regression coverage proves the old ordering fails and the corrected ordering passes. The candidate pin advances to v0.1.72.

Verified:
- `go test ./...`
- `go test -race ./cmd/subrouter-transport-observer`
- `docker run --rm --init --privileged ... go test ./...`
- `bash -n deploy/gcp/golden-local-mac-production-continuity.sh`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788659314&installation_model_id=21920&pr_number=188&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F188&signature=b6acdad361d746fd9171568b75e4ab1460a640a23988dc5f45c7fdebdad80b1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run migration preparation before starting held Codex sessions to avoid timeouts during the canary and eliminate spurious retry/error events.

- **Bug Fixes**
  - Reordered migration: run migration-preparation first, then start held HTTP/WebSocket sessions; sessions still start before listener takeover and stay open through cutover.
  - Updated fake client and tests to require preparation before sessions; added regression coverage that fails with the old order and passes now.
  - Advanced golden candidate pin to `v0.1.72` and updated the local continuity script accordingly.

<sup>Written for commit cfe5d241eb31d07bb11a0db4cca4ad4882deaedc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

