### PR TITLE
Force classic SCP for GCP deployment copies

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -18,6 +18,34 @@ import (
 	"time"
 )
 
+func TestGCPClassicSCPWrapperForcesLegacyProtocol(t *testing.T) {
+	requireDeployScriptTools(t, "bash")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	wrapper := filepath.Join(repoRoot, "deploy", "gcp", "gcloud-scp.sh")
+	fakeGcloud := filepath.Join(t.TempDir(), "gcloud")
+	capture := filepath.Join(t.TempDir(), "arguments")
+	writeExecutableTestFile(t, fakeGcloud, `#!/bin/sh
+printf '%s\n' "$@" >"$GCLOUD_ARGUMENT_CAPTURE"
+`)
+	command := exec.Command(
+		mustLookPath(t, "bash"), wrapper, fakeGcloud,
+		"source artifact", "instance:/tmp/candidate", "--project", "test-project", "--quiet",
+	)
+	command.Env = append(os.Environ(), "GCLOUD_ARGUMENT_CAPTURE="+capture)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("classic SCP wrapper failed: %v\n%s", err, output)
+	}
+	arguments, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "compute\nscp\n--scp-flag=-O\nsource artifact\ninstance:/tmp/candidate\n--project\ntest-project\n--quiet\n"
+	if string(arguments) != want {
+		t.Fatalf("gcloud arguments:\n%s\nwant:\n%s", arguments, want)
+	}
+}
+
 func TestGCPURLMapCanaryRemainsReferencedAcrossActiveRouteSwitches(t *testing.T) {
 	requireDeployScriptTools(t, "python3")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -21,27 +21,52 @@ import (
 func TestGCPClassicSCPWrapperForcesLegacyProtocol(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))
 	wrapper := filepath.Join(repoRoot, "deploy", "gcp", "gcloud-scp.sh")
-	fakeGcloud := filepath.Join(t.TempDir(), "gcloud")
+	fakeBin := t.TempDir()
+	fakeGcloud := filepath.Join(fakeBin, "gcloud")
 	capture := filepath.Join(t.TempDir(), "arguments")
 	writeExecutableTestFile(t, fakeGcloud, `#!/bin/sh
 printf '%s\n' "$@" >"$GCLOUD_ARGUMENT_CAPTURE"
 `)
-	command := exec.Command(
-		wrapper, fakeGcloud,
-		"source artifact", "instance:/tmp/candidate", "--project", "test-project", "--quiet",
-	)
-	command.Env = append(os.Environ(), "GCLOUD_ARGUMENT_CAPTURE="+capture)
-	output, err := command.CombinedOutput()
-	if err != nil {
-		t.Fatalf("classic SCP wrapper failed: %v\n%s", err, output)
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "scp"), `#!/bin/sh
+if [ "$FAKE_SCP_SUPPORTS_CLASSIC_FLAG" = 1 ]; then
+  printf '%s\n' 'usage: scp [-O] source target' >&2
+else
+  printf '%s\n' 'scp: unknown option -- O' >&2
+fi
+exit 1
+`)
+	run := func(supportsClassicFlag bool) string {
+		t.Helper()
+		command := exec.Command(
+			wrapper, fakeGcloud,
+			"source artifact", "instance:/tmp/candidate", "--project", "test-project", "--quiet",
+		)
+		support := "0"
+		if supportsClassicFlag {
+			support = "1"
+		}
+		command.Env = append(os.Environ(),
+			"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+			"GCLOUD_ARGUMENT_CAPTURE="+capture,
+			"FAKE_SCP_SUPPORTS_CLASSIC_FLAG="+support,
+		)
+		output, err := command.CombinedOutput()
+		if err != nil {
+			t.Fatalf("classic SCP wrapper failed: %v\n%s", err, output)
+		}
+		arguments, err := os.ReadFile(capture)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(arguments)
 	}
-	arguments, err := os.ReadFile(capture)
-	if err != nil {
-		t.Fatal(err)
+	withFlag := "compute\nscp\n--scp-flag=-O\nsource artifact\ninstance:/tmp/candidate\n--project\ntest-project\n--quiet\n"
+	if got := run(true); got != withFlag {
+		t.Fatalf("gcloud arguments with modern SCP:\n%s\nwant:\n%s", got, withFlag)
 	}
-	want := "compute\nscp\n--scp-flag=-O\nsource artifact\ninstance:/tmp/candidate\n--project\ntest-project\n--quiet\n"
-	if string(arguments) != want {
-		t.Fatalf("gcloud arguments:\n%s\nwant:\n%s", arguments, want)
+	withoutFlag := "compute\nscp\nsource artifact\ninstance:/tmp/candidate\n--project\ntest-project\n--quiet\n"
+	if got := run(false); got != withoutFlag {
+		t.Fatalf("gcloud arguments with legacy SCP:\n%s\nwant:\n%s", got, withoutFlag)
 	}
 }
 

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestGCPClassicSCPWrapperForcesLegacyProtocol(t *testing.T) {
-	requireDeployScriptTools(t, "bash")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))
 	wrapper := filepath.Join(repoRoot, "deploy", "gcp", "gcloud-scp.sh")
 	fakeGcloud := filepath.Join(t.TempDir(), "gcloud")
@@ -28,7 +27,7 @@ func TestGCPClassicSCPWrapperForcesLegacyProtocol(t *testing.T) {
 printf '%s\n' "$@" >"$GCLOUD_ARGUMENT_CAPTURE"
 `)
 	command := exec.Command(
-		mustLookPath(t, "bash"), wrapper, fakeGcloud,
+		wrapper, fakeGcloud,
 		"source artifact", "instance:/tmp/candidate", "--project", "test-project", "--quiet",
 	)
 	command.Env = append(os.Environ(), "GCLOUD_ARGUMENT_CAPTURE="+capture)

--- a/deploy/gcp/create-subrouter-vm.sh
+++ b/deploy/gcp/create-subrouter-vm.sh
@@ -243,7 +243,7 @@ cleanup_files+=("${artifact_dir}/topology.json")
 topology_file="${artifact_dir}/topology.json"
 topology_ready=false
 for _ in $(seq 1 180); do
-  if gcloud compute scp "${script_dir}/verify-fresh-vm.sh" "${instance_name}:${remote_probe}" \
+  if "${script_dir}/gcloud-scp.sh" gcloud "${script_dir}/verify-fresh-vm.sh" "${instance_name}:${remote_probe}" \
       --project "${project_id}" --zone "${zone}" --tunnel-through-iap --quiet >/dev/null 2>&1 &&
       gcloud compute ssh "${instance_name}" --project "${project_id}" --zone "${zone}" \
         --tunnel-through-iap --quiet \

--- a/deploy/gcp/deploy-live-upgrade.sh
+++ b/deploy/gcp/deploy-live-upgrade.sh
@@ -146,7 +146,7 @@ gcloud_ssh() {
 }
 
 gcloud_scp() {
-  "${GCLOUD_BINARY}" compute scp "$1" "${INSTANCE}:$2" \
+  "${SCRIPT_DIR}/gcloud-scp.sh" "${GCLOUD_BINARY}" "$1" "${INSTANCE}:$2" \
     --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet
 }
 

--- a/deploy/gcp/finalize-legacy-retirement.sh
+++ b/deploy/gcp/finalize-legacy-retirement.sh
@@ -130,7 +130,7 @@ gcloud_ssh() {
     --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet --command "$1"
 }
 gcloud_scp() {
-  "${GCLOUD_BINARY}" compute scp "$1" "${INSTANCE}:$2" \
+  "${SCRIPT_DIR}/gcloud-scp.sh" "${GCLOUD_BINARY}" "$1" "${INSTANCE}:$2" \
     --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet
 }
 assert_canary_access_boundary() {

--- a/deploy/gcp/finalize-slot-retirement.sh
+++ b/deploy/gcp/finalize-slot-retirement.sh
@@ -102,7 +102,7 @@ gcloud_ssh() {
     --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet --command "$1"
 }
 gcloud_scp() {
-  "${GCLOUD_BINARY}" compute scp "$1" "${INSTANCE}:$2" \
+  "${SCRIPT_DIR}/gcloud-scp.sh" "${GCLOUD_BINARY}" "$1" "${INSTANCE}:$2" \
     --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet
 }
 slot_service() { printf 'subrouter-slot@%s.service\n' "$1"; }

--- a/deploy/gcp/gcloud-scp.sh
+++ b/deploy/gcp/gcloud-scp.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# < 3 )); then
+  echo "usage: $0 <gcloud-binary> <source> <destination> [gcloud-arguments...]" >&2
+  exit 2
+fi
+
+gcloud_binary="$1"
+shift
+exec "${gcloud_binary}" compute scp --scp-flag=-O "$@"

--- a/deploy/gcp/gcloud-scp.sh
+++ b/deploy/gcp/gcloud-scp.sh
@@ -8,4 +8,17 @@ fi
 
 gcloud_binary="$1"
 shift
-exec "${gcloud_binary}" compute scp --scp-flag=-O "$@"
+
+command -v scp >/dev/null 2>&1 || {
+  echo "scp is required" >&2
+  exit 127
+}
+scp_probe="$(LC_ALL=C scp -O 2>&1 || true)"
+case "${scp_probe}" in
+  *"unknown option"*|*"illegal option"*|*"invalid option"*)
+    exec "${gcloud_binary}" compute scp "$@"
+    ;;
+  *)
+    exec "${gcloud_binary}" compute scp --scp-flag=-O "$@"
+    ;;
+esac

--- a/deploy/gcp/migrate-to-front-slots.sh
+++ b/deploy/gcp/migrate-to-front-slots.sh
@@ -186,7 +186,7 @@ gcloud_ssh() {
 }
 
 gcloud_scp() {
-  "${GCLOUD_BINARY}" compute scp "$1" "${INSTANCE}:$2" \
+  "${SCRIPT_DIR}/gcloud-scp.sh" "${GCLOUD_BINARY}" "$1" "${INSTANCE}:$2" \
     --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet
 }
 

--- a/deploy/gcp/normalize-staging-predecessor.sh
+++ b/deploy/gcp/normalize-staging-predecessor.sh
@@ -81,7 +81,7 @@ gcloud_ssh() {
     --tunnel-through-iap --quiet --command "$1"
 }
 gcloud_scp() {
-  "${GCLOUD_BINARY}" compute scp "$1" "${INSTANCE}:$2" --project "${PROJECT_ID}" --zone "${ZONE}" \
+  "${SCRIPT_DIR}/gcloud-scp.sh" "${GCLOUD_BINARY}" "$1" "${INSTANCE}:$2" --project "${PROJECT_ID}" --zone "${ZONE}" \
     --tunnel-through-iap --quiet
 }
 utc_now() { python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z"))'; }

--- a/deploy/gcp/publish-subrouter.sh
+++ b/deploy/gcp/publish-subrouter.sh
@@ -233,7 +233,7 @@ done
 if [[ "${topology}" == "fresh-prepared" ]]; then
   remote_probe="/tmp/subrouter-verify-fresh-vm-${run_label}.sh"
   topology_tmp="$(mktemp "${TMPDIR:-/tmp}/subrouter-fresh-topology.json.XXXXXX")"
-  gcloud compute scp "${script_dir}/verify-fresh-vm.sh" "${instance_name}:${remote_probe}" \
+  "${script_dir}/gcloud-scp.sh" gcloud "${script_dir}/verify-fresh-vm.sh" "${instance_name}:${remote_probe}" \
     --project "${project_id}" --zone "${zone}" --tunnel-through-iap --quiet >/dev/null
   gcloud_ssh "sudo env SUBROUTER_EXPECTED_SHA256='${expected_sha256}' SUBROUTER_RELEASE_TAG='${subrouter_version}' bash '${remote_probe}'" \
     >"${topology_tmp}"

--- a/deploy/gcp/rollback-slot.sh
+++ b/deploy/gcp/rollback-slot.sh
@@ -93,7 +93,7 @@ gcloud_ssh() {
 }
 
 gcloud_scp() {
-  "${GCLOUD_BINARY}" compute scp "$1" "${INSTANCE}:$2" \
+  "${SCRIPT_DIR}/gcloud-scp.sh" "${GCLOUD_BINARY}" "$1" "${INSTANCE}:$2" \
     --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet
 }
 

--- a/deploy/gcp/switch-front-migration.sh
+++ b/deploy/gcp/switch-front-migration.sh
@@ -145,7 +145,7 @@ gcloud_ssh() {
     --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet --command "$1"
 }
 gcloud_scp() {
-  "${GCLOUD_BINARY}" compute scp "$1" "${INSTANCE}:$2" \
+  "${SCRIPT_DIR}/gcloud-scp.sh" "${GCLOUD_BINARY}" "$1" "${INSTANCE}:$2" \
     --project "${PROJECT_ID}" --zone "${ZONE}" --tunnel-through-iap --quiet
 }
 assert_canary_access_boundary() {


### PR DESCRIPTION
## What
- route every GCP deployment copy through one classic-SCP wrapper
- cover the wrapper with a behavior test

## Why
The default SFTP transport stalled for roughly four minutes during the v0.1.72 staging golden run. The same copy with `--scp-flag=-O` completed in about three seconds. The stall pushed the held Codex HTTP request past its five-minute application timeout before listener handoff.

## Verification
- regression commit fails because the wrapper is absent
- focused test passes after the fix
- `go test ./...`
- shell syntax checks for every touched deployment script
- live staging SCP probe completed in about three seconds

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788663160&installation_model_id=21920&pr_number=189&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F189&signature=85718a7946415d965e39174d83c880e9c95bcfd923a1d242cb8985689b614a2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force classic SCP for all GCP deployment copies via a `gcloud-scp.sh` wrapper, with a fallback for older `scp` clients. This prevents SFTP stalls that caused multi-minute delays and timeouts.

- **Bug Fixes**
  - Added `deploy/gcp/gcloud-scp.sh` that probes `scp -O` support and passes `--scp-flag=-O` only when supported.
  - Updated all GCP deploy scripts to use the wrapper for file copies.
  - Expanded tests to run the wrapper with fake `gcloud`/`scp`, asserting legacy mode when available and argument preservation.

<sup>Written for commit 337730617b7861d55e4bc7cd1961a3f404776bf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Google Cloud VM file transfers by consistently using a compatibility mode for legacy SCP connections.
  * Preserved existing project, zone, secure tunneling, quiet-mode, and source/destination options across deployment and migration workflows.
  * Added clearer command validation and usage feedback when required transfer arguments are missing.

* **Tests**
  * Added coverage confirming legacy SCP protocol settings and transfer arguments are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->