### PR TITLE
Pin production continuity gate to v0.1.73

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -51,7 +51,7 @@ const (
 	goldenPinnedBootstrapTag                  = "v0.1.63"
 	goldenPinnedBootstrapLinuxSHA256          = "39fcd2c3a86c7be12759ed0f0b366d9d13f90e538c2af2483dd50230c9ef2bf2"
 	goldenPinnedBootstrapRevision             = "763dcf6c304d9aea7f36659d4fba40ea27f42096"
-	goldenPinnedCandidateTag                  = "v0.1.72"
+	goldenPinnedCandidateTag                  = "v0.1.73"
 	goldenResponseRequestTokenEnv             = "SUBROUTER_GOLDEN_RESPONSE_REQUEST_TOKEN"
 	goldenFakeStreamReleaseTokenEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_TOKEN"
 	goldenFakeStreamReleaseStateEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_STATE"

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -20,7 +20,7 @@ func TestGoldenOptionsRequireV0172Candidate(t *testing.T) {
 	args := []string{
 		"--predecessor-version", "v0.1.51",
 		"--predecessor-sha256", goldenPinnedPredecessorSHA256,
-		"--candidate-tag", "v0.1.72",
+		"--candidate-tag", "v0.1.73",
 		"--candidate-sha256", strings.Repeat("b", 64),
 		"--candidate-revision", strings.Repeat("c", 40),
 		"--deploy-evidence-validator", "validator",
@@ -34,10 +34,10 @@ func TestGoldenOptionsRequireV0172Candidate(t *testing.T) {
 		"--old-generation-check", "true",
 	}
 	if _, err := parseGoldenArgs(args); err != nil {
-		t.Fatalf("v0.1.72 candidate was rejected: %v", err)
+		t.Fatalf("v0.1.73 candidate was rejected: %v", err)
 	}
 	for index := range args {
-		if args[index] == "v0.1.72" {
+		if args[index] == "v0.1.73" {
 			args[index] = "v0.1.63"
 			break
 		}

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify the immutable v0.1.51/v0.1.63/v0.1.72 release inputs, then run the complete
+# Verify the immutable v0.1.51/v0.1.63/v0.1.73 release inputs, then run the complete
 # legacy-to-front migration and slot-upgrade continuity gate from a local Mac.
 set -euo pipefail
 umask 077
@@ -16,8 +16,8 @@ bootstrap_tag="v0.1.63"
 bootstrap_version="0.1.63"
 bootstrap_revision="763dcf6c304d9aea7f36659d4fba40ea27f42096"
 bootstrap_linux_sha="39fcd2c3a86c7be12759ed0f0b366d9d13f90e538c2af2483dd50230c9ef2bf2"
-candidate_tag="v0.1.72"
-candidate_version="0.1.72"
+candidate_tag="v0.1.73"
+candidate_version="0.1.73"
 
 usage() {
   cat <<'EOF'
@@ -218,7 +218,7 @@ if ! gh release view "${candidate_tag}" --repo "${repository}" --json tagName,is
       '.tagName == $tag and (.isDraft | not) and (.isPrerelease | not) and .isImmutable == true and
        (.publishedAt | type == "string" and length > 0)' \
       >/dev/null; then
-  echo "v0.1.72 is not a published immutable release" >&2
+  echo "v0.1.73 is not a published immutable release" >&2
   exit 1
 fi
 candidate_revision="$(require_release_revision_on_main "${candidate_tag}")"


### PR DESCRIPTION
## What
- pin the golden deployment wrapper and observer to immutable v0.1.73
- update the option regression test

## Why
The production continuity gate must exercise the release containing the classic-SCP deployment fix.

## Verification
- focused observer option tests
- shell syntax check
- `go test ./...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788664770&installation_model_id=21920&pr_number=190&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F190&signature=fc2b5d5da1050a5d6c1702e97770734fa0e441f4059506c28bbc527fefb82855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the production continuity gate (golden deployment wrapper and observer) to immutable v0.1.73 to exercise the classic-SCP deployment fix. Updated the observer options test and the GCP local continuity script to require v0.1.73.

<sup>Written for commit f9c9e3f9af95795ac94c715c70ca2cc2eb39f77c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

