### PR TITLE
Prevent verifier from reviving retired legacy service

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -2461,14 +2461,20 @@ func TestFrontSlotInstallerDetachesVerifierFromRetiredLegacyService(t *testing.T
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("configure front verifier: %v\n%s", err, output)
 	}
-	dropin, err := os.ReadFile(filepath.Join(verifyDropinDir, "front.conf"))
+	unit, err := os.ReadFile(verifyUnit)
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"[Unit]\n", "Wants=\n", "After=\n", "After=subrouter-front.service\n"} {
-		if !strings.Contains(string(dropin), want) {
-			t.Fatalf("verifier drop-in retained a legacy lifecycle dependency, missing %q:\n%s", want, dropin)
+	for _, want := range []string{
+		"After=subrouter-front.service\n",
+		"Environment=SUBROUTER_VERIFY_HEALTH_URL=http://127.0.0.1:31415/_subrouter/health\n",
+	} {
+		if !strings.Contains(string(unit), want) {
+			t.Fatalf("front verifier unit missing %q:\n%s", want, unit)
 		}
+	}
+	if strings.Contains(string(unit), "Wants=subrouter.service") {
+		t.Fatalf("front verifier unit retained the retired legacy lifecycle dependency:\n%s", unit)
 	}
 }
 

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -2431,6 +2431,47 @@ exit 0
 	}
 }
 
+func TestFrontSlotInstallerDetachesVerifierFromRetiredLegacyService(t *testing.T) {
+	requireDeployScriptTools(t, "bash", "curl", "jq", "python3", "sha256sum")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	root := t.TempDir()
+	fakeBin := filepath.Join(root, "bin")
+	verifyUnit := filepath.Join(root, "subrouter-verify.service")
+	verifyDropinDir := verifyUnit + ".d"
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "id"), "#!/bin/sh\nprintf '0\\n'\n")
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "curl"), "#!/bin/sh\nexit 0\n")
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "python3"), "#!/bin/sh\nexit 0\n")
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "systemctl"), "#!/bin/sh\nexit 0\n")
+	if err := os.WriteFile(verifyUnit, []byte("[Unit]\nWants=subrouter.service\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.Command(mustLookPath(t, "bash"),
+		filepath.Join(repoRoot, "deploy", "gcp", "install-front-slots.sh"),
+		"configure-verify-front", "127.0.0.1:31415")
+	command.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"SUBROUTER_VERIFY_UNIT="+verifyUnit,
+		"SUBROUTER_VERIFY_DROPIN_DIR="+verifyDropinDir,
+		"SUBROUTER_DEPLOYMENT_CONTRACT="+filepath.Join(repoRoot, "deploy", "gcp", "deployment-contract.py"),
+	)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("configure front verifier: %v\n%s", err, output)
+	}
+	dropin, err := os.ReadFile(filepath.Join(verifyDropinDir, "front.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"[Unit]\n", "Wants=\n", "After=\n", "After=subrouter-front.service\n"} {
+		if !strings.Contains(string(dropin), want) {
+			t.Fatalf("verifier drop-in retained a legacy lifecycle dependency, missing %q:\n%s", want, dropin)
+		}
+	}
+}
+
 func TestFrontSlotInstallerSafelyBeginsDormantStaleMigrationReconciliation(t *testing.T) {
 	requireDeployScriptTools(t, "bash", "curl", "jq", "python3", "sha256sum")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/deploy/gcp/install-front-slots.sh
+++ b/deploy/gcp/install-front-slots.sh
@@ -143,6 +143,11 @@ write_verify_front_address() {
   install -d -m 0755 "${VERIFY_DROPIN_DIR}"
   temporary="$(mktemp "${VERIFY_DROPIN_DIR}/front.conf.tmp.XXXXXX")"
   {
+    printf '[Unit]\n'
+    printf 'After=\n'
+    printf 'After=subrouter-front.service\n'
+    printf 'Wants=\n'
+    printf '\n'
     printf '[Service]\n'
     printf 'Environment=SUBROUTER_VERIFY_HEALTH_URL=http://%s/_subrouter/health\n' "${address}"
     printf 'Environment=SUBROUTER_VERIFY_USAGE_URL=http://%s/_subrouter/usage-status\n' "${address}"
@@ -747,6 +752,11 @@ case "${1:-}" in
     [[ "$#" == 1 ]] || die "usage: $0 restore-front-bootstrap"
     restore_front_bootstrap
     ;;
+  configure-verify-front)
+    [[ "$#" == 2 ]] || die "usage: $0 configure-verify-front <127.0.0.1:31415|127.0.0.1:31416>"
+    write_verify_front_address "$2"
+    systemctl daemon-reload
+    ;;
   retire-slot)
     [[ "$#" == 2 ]] || die "usage: $0 retire-slot <slot-a|slot-b>"
     retire_slot "$2"
@@ -772,6 +782,6 @@ case "${1:-}" in
     listener_status "$2" "$3"
     ;;
   *)
-    die "usage: $0 {install-release|install-topology|ensure-migration-topology|prepare-fresh-topology|activate-fresh-topology|prepare-slot|set-front-default|activate-front-takeover|restore-front-bootstrap|retire-slot|stop-drained-slot|sample-service-rss|enable-slot|disable-slot|listener-status} ..."
+    die "usage: $0 {install-release|install-topology|ensure-migration-topology|prepare-fresh-topology|activate-fresh-topology|prepare-slot|set-front-default|activate-front-takeover|restore-front-bootstrap|configure-verify-front|retire-slot|stop-drained-slot|sample-service-rss|enable-slot|disable-slot|listener-status} ..."
     ;;
 esac

--- a/deploy/gcp/install-front-slots.sh
+++ b/deploy/gcp/install-front-slots.sh
@@ -140,21 +140,24 @@ write_verify_front_address() {
   [[ "${address}" == "127.0.0.1:31415" || "${address}" == "127.0.0.1:31416" ]] \
     || die "verify front address must use the managed public port"
   [[ -f "${VERIFY_UNIT}" ]] || return 0
-  install -d -m 0755 "${VERIFY_DROPIN_DIR}"
-  temporary="$(mktemp "${VERIFY_DROPIN_DIR}/front.conf.tmp.XXXXXX")"
+  temporary="$(mktemp "${VERIFY_UNIT}.tmp.XXXXXX")"
   {
     printf '[Unit]\n'
-    printf 'After=\n'
+    printf 'Description=Subrouter Claude rate-limit reroute self-verification\n'
     printf 'After=subrouter-front.service\n'
-    printf 'Wants=\n'
     printf '\n'
     printf '[Service]\n'
+    printf 'Type=oneshot\n'
     printf 'Environment=SUBROUTER_VERIFY_HEALTH_URL=http://%s/_subrouter/health\n' "${address}"
     printf 'Environment=SUBROUTER_VERIFY_USAGE_URL=http://%s/_subrouter/usage-status\n' "${address}"
     printf 'Environment=SUBROUTER_VERIFY_PROXY_URL=http://%s/v1/messages\n' "${address}"
+    printf 'ExecStart=/usr/local/bin/subrouter-verify.sh\n'
+    printf 'User=root\n'
+    printf 'Nice=10\n'
   } >"${temporary}"
   chmod 0644 "${temporary}"
-  mv -f -- "${temporary}" "${VERIFY_DROPIN_DIR}/front.conf"
+  mv -f -- "${temporary}" "${VERIFY_UNIT}"
+  rm -f -- "${VERIFY_DROPIN_DIR}/front.conf"
 }
 
 install_release() {

--- a/deploy/gcp/subrouter-verify.service
+++ b/deploy/gcp/subrouter-verify.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Subrouter Claude rate-limit reroute self-verification
-After=subrouter.service
-Wants=subrouter.service
+After=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The five-minute verifier unit had Wants=subrouter.service. After listener takeover, its timer relaunched the disabled legacy supervisor against the front-owned port and produced a restart loop.

Make verification lifecycle read-only. New legacy installs no longer depend on the serving unit. Front topology installation atomically replaces the verifier unit with a front-only observer, removes the stale override, and exposes the same shared configuration action for reconciliation.

A drop-in dependency reset was rejected after real systemd proved it ineffective. The final implementation replaces the unit this installer owns.

Verification:
- regression test failed before each lifecycle correction and passes now
- go test ./...
- real staging systemd proof: verifier Wants is empty, After selects subrouter-front.service, verifier run completed, legacy NRestarts stayed 0, front readiness stayed healthy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788667755&installation_model_id=21920&pr_number=192&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F192&signature=f4a07db0714cbab0bafb915db4947a5731d0f6cd66237924302b664e354724b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the verify timer from reviving the retired legacy service by making the verifier unit standalone and front-only. The installer now replaces the unit and removes stale drop-ins so verification stays read-only.

- **Bug Fixes**
  - Removed legacy dependencies from `subrouter-verify.service` (default: `After=network-online.target`).
  - Installer now writes a front-only unit (`After=subrouter-front.service`) with the correct envs and `ExecStart`, replaces the unit atomically, and deletes the old drop-in.
  - Added `configure-verify-front` command to apply the rewrite and `daemon-reload`.
  - Test ensures the verifier no longer references `subrouter.service`.

- **Migration**
  - Run: `deploy/gcp/install-front-slots.sh configure-verify-front 127.0.0.1:31415` (or `127.0.0.1:31416`) on hosts to update the unit and detach from the legacy service.

<sup>Written for commit fe342c3782156016b7a35f4339528b86c2eb0ce7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `configure-verify-front` command to configure the verification service’s front-end health address and reload system services.
  * Updated command usage information to include the new configuration option.

* **Bug Fixes**
  * Improved verification service startup ordering by waiting for network availability.
  * Removed dependency on the retired legacy service and ensured correct ordering after the front-end service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->