### PR TITLE
Pin golden continuity gate to v0.1.74

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -51,7 +51,7 @@ const (
 	goldenPinnedBootstrapTag                  = "v0.1.63"
 	goldenPinnedBootstrapLinuxSHA256          = "39fcd2c3a86c7be12759ed0f0b366d9d13f90e538c2af2483dd50230c9ef2bf2"
 	goldenPinnedBootstrapRevision             = "763dcf6c304d9aea7f36659d4fba40ea27f42096"
-	goldenPinnedCandidateTag                  = "v0.1.73"
+	goldenPinnedCandidateTag                  = "v0.1.74"
 	goldenResponseRequestTokenEnv             = "SUBROUTER_GOLDEN_RESPONSE_REQUEST_TOKEN"
 	goldenFakeStreamReleaseTokenEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_TOKEN"
 	goldenFakeStreamReleaseStateEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_STATE"

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -20,7 +20,7 @@ func TestGoldenOptionsRequireProductionPredecessorV0160(t *testing.T) {
 	args := []string{
 		"--predecessor-version", "v0.1.60",
 		"--predecessor-sha256", "769e504b731ef8b43db67e7651dcfe9ae169516570c7d2d2d211a6f997be1a7c",
-		"--candidate-tag", "v0.1.73",
+		"--candidate-tag", "v0.1.74",
 		"--candidate-sha256", strings.Repeat("b", 64),
 		"--candidate-revision", strings.Repeat("c", 40),
 		"--deploy-evidence-validator", "validator",

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -38,7 +38,7 @@ func TestGoldenOptionsRequireProductionPredecessorV0160(t *testing.T) {
 	}
 }
 
-func TestGoldenOptionsRequireV0172Candidate(t *testing.T) {
+func TestGoldenOptionsRequireV0174Candidate(t *testing.T) {
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = false
 	t.Cleanup(func() { goldenTestHooks = previousHooks })
@@ -46,7 +46,7 @@ func TestGoldenOptionsRequireV0172Candidate(t *testing.T) {
 	args := []string{
 		"--predecessor-version", "v0.1.60",
 		"--predecessor-sha256", goldenPinnedPredecessorSHA256,
-		"--candidate-tag", "v0.1.73",
+		"--candidate-tag", "v0.1.74",
 		"--candidate-sha256", strings.Repeat("b", 64),
 		"--candidate-revision", strings.Repeat("c", 40),
 		"--deploy-evidence-validator", "validator",
@@ -60,10 +60,10 @@ func TestGoldenOptionsRequireV0172Candidate(t *testing.T) {
 		"--old-generation-check", "true",
 	}
 	if _, err := parseGoldenArgs(args); err != nil {
-		t.Fatalf("v0.1.73 candidate was rejected: %v", err)
+		t.Fatalf("v0.1.74 candidate was rejected: %v", err)
 	}
 	for index := range args {
-		if args[index] == "v0.1.73" {
+		if args[index] == "v0.1.74" {
 			args[index] = "v0.1.63"
 			break
 		}

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify the immutable v0.1.60/v0.1.63/v0.1.73 release inputs, then run the complete
+# Verify the immutable v0.1.60/v0.1.63/v0.1.74 release inputs, then run the complete
 # legacy-to-front migration and slot-upgrade continuity gate from a local Mac.
 set -euo pipefail
 umask 077
@@ -16,8 +16,8 @@ bootstrap_tag="v0.1.63"
 bootstrap_version="0.1.63"
 bootstrap_revision="763dcf6c304d9aea7f36659d4fba40ea27f42096"
 bootstrap_linux_sha="39fcd2c3a86c7be12759ed0f0b366d9d13f90e538c2af2483dd50230c9ef2bf2"
-candidate_tag="v0.1.73"
-candidate_version="0.1.73"
+candidate_tag="v0.1.74"
+candidate_version="0.1.74"
 
 usage() {
   cat <<'EOF'
@@ -218,7 +218,7 @@ if ! gh release view "${candidate_tag}" --repo "${repository}" --json tagName,is
       '.tagName == $tag and (.isDraft | not) and (.isPrerelease | not) and .isImmutable == true and
        (.publishedAt | type == "string" and length > 0)' \
       >/dev/null; then
-  echo "v0.1.73 is not a published immutable release" >&2
+  echo "v0.1.74 is not a published immutable release" >&2
   exit 1
 fi
 candidate_revision="$(require_release_revision_on_main "${candidate_tag}")"


### PR DESCRIPTION
Advance the production continuity gate from v0.1.73 to the immutable v0.1.74 candidate containing the verifier lifecycle fix. The wrapper will download and strictly verify the release binary, installer, deployment contract, provenance, checksums, and attestations before any mutation.

Regression sequence:
1. 5c8072f requires v0.1.74 and fails against the old pin.
2. 4a9fc53 advances the observer and local-Mac wrapper.

Verification:
- go test ./...
- bash syntax check for the golden wrapper
- focused candidate and release-helper coherence tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788668392&installation_model_id=21920&pr_number=193&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F193&signature=5bd382de6514fd7b9b9e27c78c56cdda5315de81cd0faf904efb9fbf504640e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the production continuity gate from v0.1.73 to v0.1.74 to include the verifier lifecycle fix.
Updates the transport observer constants, tests, and the local Mac continuity script to require v0.1.74 while preserving strict release artifact verification.

<sup>Written for commit 4a9fc5304386b85f0621a3cc063464066deb84fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

