### PR TITLE
Fix legacy retirement after listener handoff

### DIFF
--- a/cmd/subrouter-transport-observer/golden_local_daemon.go
+++ b/cmd/subrouter-transport-observer/golden_local_daemon.go
@@ -9,6 +9,13 @@ import (
 
 func goldenTransportIssueCategories(text string) []string {
 	text = strings.ToLower(text)
+	lines := strings.Split(text, "\n")
+	for index, line := range lines {
+		if strings.Contains(line, "subrouter shutdown signal received") && strings.Contains(line, "signal=terminated") {
+			lines[index] = ""
+		}
+	}
+	text = strings.Join(lines, "\n")
 	categories := map[string][]string{
 		"reconnect": {"reconnect", "disconnected", "connection reset"},
 		"retry":     {"retry", "retrying"},
@@ -26,8 +33,20 @@ func goldenTransportIssueCategories(text string) []string {
 			}
 		}
 	}
+	if strings.Contains(text, "deadline exceeded") && !containsString(result, "timeout") {
+		result = append(result, "timeout")
+	}
 	sort.Strings(result)
 	return result
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *goldenRunner) consumeGoldenLocalDaemonStderr(reader io.Reader) {

--- a/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
+++ b/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
@@ -498,6 +498,41 @@ func TestGoldenLocalDaemonStderrIsClassifiedWithoutPersistingText(t *testing.T) 
 	}
 }
 
+func TestGoldenLocalDaemonStderrIgnoresShutdownTimeoutConfiguration(t *testing.T) {
+	var evidence bytes.Buffer
+	runner := &goldenRunner{evidence: &jsonlRecorder{writer: &evidence}}
+	runner.consumeGoldenLocalDaemonStderr(strings.NewReader(
+		"2026-08-07T04:49:35Z INFO subrouter shutdown signal received signal=terminated timeout=10m0s\n",
+	))
+	if err := runner.requireGoldenLocalDaemonTransportClean(); err != nil {
+		t.Fatalf("normal shutdown metadata was treated as a transport failure: %v", err)
+	}
+	if evidence.Len() != 0 {
+		t.Fatalf("normal shutdown metadata emitted issue evidence: %s", evidence.String())
+	}
+
+	evidence.Reset()
+	runner = &goldenRunner{evidence: &jsonlRecorder{writer: &evidence}}
+	runner.consumeGoldenLocalDaemonStderr(strings.NewReader("upstream request timeout while reading response\n"))
+	if got := fixedGoldenFailure(runner.requireGoldenLocalDaemonTransportClean()); got != "local_daemon_transport_issue_timeout" {
+		t.Fatalf("real timeout failure = %q, want local_daemon_transport_issue_timeout", got)
+	}
+
+	evidence.Reset()
+	runner = &goldenRunner{evidence: &jsonlRecorder{writer: &evidence}}
+	runner.consumeGoldenLocalDaemonStderr(strings.NewReader("repeated timeouts while connecting upstream\n"))
+	if got := fixedGoldenFailure(runner.requireGoldenLocalDaemonTransportClean()); got != "local_daemon_transport_issue_timeout" {
+		t.Fatalf("plural timeout failure = %q, want local_daemon_transport_issue_timeout", got)
+	}
+
+	evidence.Reset()
+	runner = &goldenRunner{evidence: &jsonlRecorder{writer: &evidence}}
+	runner.consumeGoldenLocalDaemonStderr(strings.NewReader("upstream_request timeout=true\n"))
+	if got := fixedGoldenFailure(runner.requireGoldenLocalDaemonTransportClean()); got != "local_daemon_transport_issue_timeout" {
+		t.Fatalf("structured timeout failure = %q, want local_daemon_transport_issue_timeout", got)
+	}
+}
+
 func TestGoldenCounterContinuityRejectsActionRebaselining(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -2478,6 +2478,415 @@ func TestFrontSlotInstallerDetachesVerifierFromRetiredLegacyService(t *testing.T
 	}
 }
 
+func TestLegacyRetirementStatePolicyWaitsForNormalSystemdTransitions(t *testing.T) {
+	requireDeployScriptTools(t, "bash")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	policy := filepath.Join(repoRoot, "deploy", "gcp", "systemd-state.sh")
+	command := exec.Command(mustLookPath(t, "bash"), "-c", `
+set -euo pipefail
+source "$1"
+for state in active activating deactivating inactive maintenance reloading refreshing; do
+  subrouter_systemd_active_state_is_waitable "$state"
+  subrouter_systemd_socket_state_is_waitable "$state"
+done
+subrouter_systemd_socket_state_is_waitable not-found
+for service_state in inactive deactivating; do
+  for socket_state in active activating deactivating inactive maintenance not-found reloading refreshing; do
+    subrouter_legacy_sampler_stop_is_reconcilable "$service_state" "$socket_state"
+  done
+done
+for state in failed unknown ''; do
+  if subrouter_systemd_active_state_is_waitable "$state"; then
+    printf 'service state unexpectedly accepted: %s\n' "$state" >&2
+    exit 1
+  fi
+  if subrouter_systemd_socket_state_is_waitable "$state"; then
+    printf 'socket state unexpectedly accepted: %s\n' "$state" >&2
+    exit 1
+  fi
+done
+for service_state in active activating failed; do
+  if subrouter_legacy_sampler_stop_is_reconcilable "$service_state" inactive; then
+    printf 'sampler stop unexpectedly accepted service state: %s\n' "$service_state" >&2
+    exit 1
+  fi
+done
+if subrouter_legacy_sampler_stop_is_reconcilable inactive failed; then
+  printf 'sampler stop unexpectedly accepted failed socket state\n' >&2
+  exit 1
+fi
+`, "state-policy-test", policy)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("exercise legacy retirement state policy: %v\n%s", err, output)
+	}
+}
+
+func TestFrontSlotInstallerQuiescesLegacySocketWithoutStoppingService(t *testing.T) {
+	requireDeployScriptTools(t, "bash", "curl", "jq", "python3", "sha256sum")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	root := t.TempDir()
+	fakeBin := filepath.Join(root, "bin")
+	stateDir := filepath.Join(root, "state")
+	systemctlLog := filepath.Join(root, "systemctl.log")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, marker := range []string{"service.active", "socket.active", "socket.enabled"} {
+		if err := os.WriteFile(filepath.Join(stateDir, marker), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "id"), "#!/bin/sh\nprintf '0\\n'\n")
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "systemctl"), `#!/bin/sh
+printf '%s\n' "$*" >>"$SYSTEMCTL_LOG"
+case "$1" in
+  show)
+    case "$*" in
+      *"subrouter.socket"*"-p LoadState"*)
+        if [ -e "$SYSTEMCTL_STATE/socket.masked" ]; then printf 'masked\n'; else printf 'loaded\n'; fi
+        ;;
+      *"subrouter.socket"*"-p ActiveState"*)
+        if [ -e "$SYSTEMCTL_STATE/socket.active" ]; then printf 'active\n'; else printf 'inactive\n'; fi
+        ;;
+      *"subrouter.service"*"-p ActiveState"*)
+        if [ -e "$SYSTEMCTL_STATE/service.active" ]; then printf 'active\n'; else printf 'inactive\n'; fi
+        ;;
+      *) printf 'loaded\n' ;;
+    esac
+    ;;
+  disable)
+    rm -f -- "$SYSTEMCTL_STATE/socket.enabled"
+    ;;
+  is-enabled)
+    test -e "$SYSTEMCTL_STATE/socket.enabled"
+    ;;
+  mask)
+    : >"$SYSTEMCTL_STATE/socket.masked"
+    ;;
+  unmask)
+    rm -f -- "$SYSTEMCTL_STATE/socket.masked"
+    ;;
+  --job-mode=ignore-dependencies)
+    test "${2:-}" = stop && test "${3:-}" = subrouter.socket
+    rm -f -- "$SYSTEMCTL_STATE/socket.active"
+    ;;
+  *) exit 0 ;;
+esac
+`)
+	run := func() ([]byte, error) {
+		command := exec.Command(mustLookPath(t, "bash"),
+			filepath.Join(repoRoot, "deploy", "gcp", "install-front-slots.sh"),
+			"quiesce-legacy-socket")
+		command.Env = append(os.Environ(),
+			"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+			"SYSTEMCTL_LOG="+systemctlLog,
+			"SYSTEMCTL_STATE="+stateDir,
+			"SUBROUTER_DEPLOYMENT_CONTRACT="+filepath.Join(repoRoot, "deploy", "gcp", "deployment-contract.py"),
+		)
+		return command.CombinedOutput()
+	}
+	if output, err := run(); err != nil {
+		t.Fatalf("quiesce active legacy socket: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "service.active")); err != nil {
+		t.Fatalf("legacy service was stopped while quiescing its socket: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "socket.active")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("legacy socket remained active: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "socket.enabled")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("legacy socket remained enabled: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "socket.masked")); err != nil {
+		t.Fatalf("legacy socket runtime mask did not remain: %v", err)
+	}
+	logBody, err := os.ReadFile(systemctlLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logText := string(logBody)
+	maskAt := strings.Index(logText, "mask --runtime subrouter.socket")
+	stopAt := strings.Index(logText, "--job-mode=ignore-dependencies stop subrouter.socket")
+	if maskAt < 0 || stopAt <= maskAt || strings.Contains(logText, "stop subrouter.service") {
+		t.Fatalf("legacy socket was not quiesced independently of the service:\n%s", logText)
+	}
+	if output, err := run(); err != nil {
+		t.Fatalf("repeat legacy socket quiescence: %v\n%s", err, output)
+	}
+}
+
+func TestFrontSlotInstallerRemovesOnlyInactiveLegacyControlSocket(t *testing.T) {
+	requireDeployScriptTools(t, "bash", "curl", "jq", "python3", "sha256sum")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	root, err := os.MkdirTemp("/tmp", "subrouter-stale-control-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	fakeBin := filepath.Join(root, "bin")
+	controlSocket := filepath.Join(root, "supervisor.sock")
+	systemctlLog := filepath.Join(root, "systemctl.log")
+	systemctlState := filepath.Join(root, "systemctl-state")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(systemctlState, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "id"), "#!/bin/sh\nprintf '0\\n'\n")
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "systemctl"), `#!/bin/sh
+printf '%s\n' "$*" >>"$SYSTEMCTL_LOG"
+case "$1" in
+  show)
+    case "$*" in
+      *"-p LoadState"*)
+        case "${2:-}" in
+          subrouter.socket)
+            if [ "${LEGACY_SOCKET_LOAD_STATE:-loaded}" = not-found ]; then
+              printf 'not-found\n'
+            elif [ -e "$SYSTEMCTL_STATE/runtime-mask" ]; then
+              printf 'masked\n'
+            else
+              printf 'loaded\n'
+            fi
+            ;;
+          *)
+            if [ -e "$SYSTEMCTL_STATE/runtime-mask" ]; then
+              printf 'masked\n'
+            else
+              printf 'loaded\n'
+            fi
+            ;;
+        esac
+        ;;
+      *)
+        case "${2:-}" in
+          subrouter.service)
+            if [ -e "$SYSTEMCTL_STATE/runtime-mask" ] && [ -n "${LEGACY_STATE_AFTER_MASK:-}" ]; then
+              printf '%s\n' "$LEGACY_STATE_AFTER_MASK"
+            else
+              printf '%s\n' "${LEGACY_STATE:-inactive}"
+            fi
+            ;;
+          subrouter.socket)
+            if [ -e "$SYSTEMCTL_STATE/runtime-mask" ] && [ -n "${LEGACY_SOCKET_STATE_AFTER_MASK:-}" ]; then
+              printf '%s\n' "$LEGACY_SOCKET_STATE_AFTER_MASK"
+            else
+              printf '%s\n' "${LEGACY_SOCKET_STATE:-inactive}"
+            fi
+            ;;
+          *) printf 'inactive\n' ;;
+        esac
+        ;;
+    esac
+    ;;
+  is-enabled)
+    test -e "$SYSTEMCTL_STATE/${3:-}.enabled"
+    ;;
+  disable)
+    shift
+    for unit in "$@"; do
+      rm -f -- "$SYSTEMCTL_STATE/$unit.enabled"
+    done
+    ;;
+  mask)
+    : >"$SYSTEMCTL_STATE/runtime-mask"
+    if [ "${ENABLE_AFTER_MASK:-0}" = 1 ]; then
+      : >"$SYSTEMCTL_STATE/subrouter.service.enabled"
+      if [ "${LEGACY_SOCKET_LOAD_STATE:-loaded}" = loaded ]; then
+        : >"$SYSTEMCTL_STATE/subrouter.socket.enabled"
+      fi
+    fi
+    [ "${MASK_RUNTIME_FAIL:-0}" != 1 ]
+    ;;
+  unmask)
+    rm -f -- "$SYSTEMCTL_STATE/runtime-mask"
+    ;;
+  *) exit 0 ;;
+esac
+`)
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "ss"), `#!/bin/sh
+if [ "${LEGACY_SOCKET_OWNER:-0}" = 1 ]; then
+  printf 'u_str LISTEN 0 4096 %s 12345 * 0 users:(("subrouter",pid=42,fd=6))\n' "$SUBROUTER_LEGACY_CONTROL_SOCKET"
+fi
+`)
+	makeStaleSocket := func() {
+		t.Helper()
+		listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: controlSocket, Net: "unix"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		listener.SetUnlinkOnClose(false)
+		if err := listener.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if info, err := os.Lstat(controlSocket); err != nil || info.Mode()&os.ModeSocket == 0 {
+			t.Fatalf("stale control socket was not created: info=%v err=%v", info, err)
+		}
+	}
+	invoke := func(serviceState, socketState, socketLoadState, owner, serviceStateAfterMask, socketStateAfterMask, maskRuntimeFail, enableAfterMask string) ([]byte, error) {
+		t.Helper()
+		command := exec.Command(mustLookPath(t, "bash"),
+			filepath.Join(repoRoot, "deploy", "gcp", "install-front-slots.sh"),
+			"cleanup-stopped-legacy-control")
+		command.Env = append(os.Environ(),
+			"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+			"SYSTEMCTL_LOG="+systemctlLog,
+			"SYSTEMCTL_STATE="+systemctlState,
+			"LEGACY_STATE="+serviceState,
+			"LEGACY_SOCKET_STATE="+socketState,
+			"LEGACY_STATE_AFTER_MASK="+serviceStateAfterMask,
+			"LEGACY_SOCKET_STATE_AFTER_MASK="+socketStateAfterMask,
+			"MASK_RUNTIME_FAIL="+maskRuntimeFail,
+			"ENABLE_AFTER_MASK="+enableAfterMask,
+			"LEGACY_SOCKET_LOAD_STATE="+socketLoadState,
+			"LEGACY_SOCKET_OWNER="+owner,
+			"SUBROUTER_LEGACY_CONTROL_SOCKET="+controlSocket,
+			"SUBROUTER_DEPLOYMENT_CONTRACT="+filepath.Join(repoRoot, "deploy", "gcp", "deployment-contract.py"),
+		)
+		return command.CombinedOutput()
+	}
+	run := func(serviceState, socketState, socketLoadState, owner, serviceStateAfterMask, socketStateAfterMask, maskRuntimeFail, enableAfterMask string) ([]byte, error) {
+		t.Helper()
+		if err := os.WriteFile(systemctlLog, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Remove(filepath.Join(systemctlState, "runtime-mask")); err != nil && !errors.Is(err, os.ErrNotExist) {
+			t.Fatal(err)
+		}
+		for _, unit := range []string{"subrouter.service", "subrouter.socket"} {
+			marker := filepath.Join(systemctlState, unit+".enabled")
+			if err := os.Remove(marker); err != nil && !errors.Is(err, os.ErrNotExist) {
+				t.Fatal(err)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(systemctlState, "subrouter.service.enabled"), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if socketLoadState == "loaded" {
+			if err := os.WriteFile(filepath.Join(systemctlState, "subrouter.socket.enabled"), nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return invoke(serviceState, socketState, socketLoadState, owner, serviceStateAfterMask, socketStateAfterMask, maskRuntimeFail, enableAfterMask)
+	}
+
+	makeStaleSocket()
+	if output, err := run("inactive", "inactive", "loaded", "0", "", "", "0", "0"); err != nil {
+		t.Fatalf("clean inactive legacy control socket: %v\n%s", err, output)
+	}
+	if _, err := os.Lstat(controlSocket); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("inactive legacy control socket remained: %v", err)
+	}
+	logBody, err := os.ReadFile(systemctlLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logText := string(logBody)
+	disableAt := strings.Index(logText, "disable subrouter.service")
+	maskAt := strings.Index(logText, "mask --runtime subrouter.service subrouter.socket")
+	stateAt := strings.Index(logText, "show subrouter.service -p ActiveState --value")
+	unmaskAt := strings.Index(logText, "unmask --runtime subrouter.service subrouter.socket")
+	if disableAt < 0 || maskAt <= disableAt || stateAt <= maskAt || unmaskAt >= 0 || strings.Contains(logText, "stop subrouter.service") {
+		t.Fatalf("legacy control cleanup did not retain its runtime activation mask without stopping the service:\n%s", logText)
+	}
+	if _, err := os.Stat(filepath.Join(systemctlState, "runtime-mask")); err != nil {
+		t.Fatalf("runtime mask did not remain after successful cleanup: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(systemctlState, "subrouter.socket.enabled"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if output, err := invoke("inactive", "inactive", "loaded", "0", "", "", "0", "0"); err != nil {
+		t.Fatalf("repeat cleanup with retained runtime masks: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(filepath.Join(systemctlState, "subrouter.socket.enabled")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("masked legacy socket remained enabled after repeated cleanup: %v", err)
+	}
+
+	if output, err := run("inactive", "inactive", "loaded", "0", "active", "", "0", "0"); err == nil {
+		t.Fatalf("legacy service activation race was accepted without a control socket:\n%s", output)
+	}
+	logBody, err = os.ReadFile(systemctlLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logText = string(logBody)
+	maskAt = strings.Index(logText, "mask --runtime subrouter.service subrouter.socket")
+	stateAfterMaskAt := strings.LastIndex(logText, "show subrouter.service -p ActiveState --value")
+	if maskAt < 0 || stateAfterMaskAt <= maskAt || strings.Contains(logText, "stop subrouter.service") {
+		t.Fatalf("legacy activation race was not checked under the runtime mask without stopping it:\n%s", logText)
+	}
+	if _, err := os.Stat(filepath.Join(systemctlState, "runtime-mask")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("runtime mask remained after activation race: %v", err)
+	}
+
+	if output, err := run("inactive", "inactive", "loaded", "0", "", "", "1", "0"); err == nil {
+		t.Fatalf("partial runtime mask failure was accepted:\n%s", output)
+	}
+	if _, err := os.Stat(filepath.Join(systemctlState, "runtime-mask")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("runtime mask remained after partial mask failure: %v", err)
+	}
+
+	if output, err := run("inactive", "inactive", "loaded", "0", "", "", "0", "1"); err != nil {
+		t.Fatalf("legacy enable race was not reconciled under the runtime mask: %v\n%s", err, output)
+	}
+	for _, unit := range []string{"subrouter.service", "subrouter.socket"} {
+		if _, err := os.Stat(filepath.Join(systemctlState, unit+".enabled")); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("%s remained enabled after the enable race: %v", unit, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(systemctlState, "runtime-mask")); err != nil {
+		t.Fatalf("runtime mask did not remain after enable race: %v", err)
+	}
+
+	makeStaleSocket()
+	if output, err := run("deactivating", "inactive", "loaded", "0", "", "", "0", "0"); err == nil {
+		t.Fatalf("deactivating legacy control socket was removed:\n%s", output)
+	}
+	if info, err := os.Lstat(controlSocket); err != nil || info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("deactivating legacy control socket did not remain: info=%v err=%v", info, err)
+	}
+	if err := os.Remove(controlSocket); err != nil {
+		t.Fatal(err)
+	}
+
+	makeStaleSocket()
+	if output, err := run("inactive", "active", "loaded", "0", "", "", "0", "0"); err == nil {
+		t.Fatalf("active socket unit control socket was removed:\n%s", output)
+	}
+	if info, err := os.Lstat(controlSocket); err != nil || info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("active socket unit control socket did not remain: info=%v err=%v", info, err)
+	}
+	if err := os.Remove(controlSocket); err != nil {
+		t.Fatal(err)
+	}
+
+	makeStaleSocket()
+	if output, err := run("inactive", "inactive", "loaded", "1", "", "", "0", "0"); err == nil {
+		t.Fatalf("kernel-owned legacy control socket was removed:\n%s", output)
+	}
+	if info, err := os.Lstat(controlSocket); err != nil || info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("kernel-owned legacy control socket did not remain: info=%v err=%v", info, err)
+	}
+	if err := os.Remove(controlSocket); err != nil {
+		t.Fatal(err)
+	}
+
+	makeStaleSocket()
+	if output, err := run("inactive", "inactive", "not-found", "0", "", "", "0", "0"); err != nil {
+		t.Fatalf("clean legacy control socket without optional socket unit: %v\n%s", err, output)
+	}
+	if _, err := os.Lstat(controlSocket); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("legacy control socket remained without optional socket unit: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(systemctlState, "runtime-mask")); err != nil {
+		t.Fatalf("runtime mask did not remain after cleanup without optional socket unit: %v", err)
+	}
+}
+
 func TestFrontSlotInstallerSafelyBeginsDormantStaleMigrationReconciliation(t *testing.T) {
 	requireDeployScriptTools(t, "bash", "curl", "jq", "python3", "sha256sum")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/deploy/gcp/finalize-legacy-retirement.sh
+++ b/deploy/gcp/finalize-legacy-retirement.sh
@@ -43,6 +43,8 @@ CANARY_SECURITY_POLICY_HELPER="${SCRIPT_DIR}/canary-security-policy.py"
 source "${SCRIPT_DIR}/stream-shell-value.sh"
 # shellcheck source=deploy/gcp/deploy-lock.sh
 source "${SCRIPT_DIR}/deploy-lock.sh"
+# shellcheck source=deploy/gcp/systemd-state.sh
+source "${SCRIPT_DIR}/systemd-state.sh"
 
 log() { printf 'gcp-legacy-retirement: %s\n' "$*"; }
 die() { log "$*" >&2; exit 1; }
@@ -175,6 +177,12 @@ sampler_oom_result="/tmp/subrouter-rss-${cutover_run_label}-legacy.oom"
 read_sampler_unit_status() {
   gcloud_ssh "state=\$(systemctl show '${sampler_unit}' -p ActiveState --value); result=\$(systemctl show '${sampler_unit}' -p Result --value); status=\$(systemctl show '${sampler_unit}' -p ExecMainStatus --value); printf '%s|%s|%s\\n' \"\${state}\" \"\${result}\" \"\${status}\"" | tail -n 1
 }
+legacy_active_state() {
+  gcloud_ssh "systemctl show subrouter.service -p ActiveState --value" | tail -n 1
+}
+legacy_socket_active_state() {
+  gcloud_ssh "load=\$(systemctl show subrouter.socket -p LoadState --value); case \"\${load}\" in loaded|masked) systemctl show subrouter.socket -p ActiveState --value ;; not-found) echo not-found ;; *) echo invalid:\${load:-unknown} ;; esac" | tail -n 1
+}
 assert_sampler_completed_successfully() {
   local unit_status state result status
   unit_status="$(read_sampler_unit_status)"
@@ -182,8 +190,11 @@ assert_sampler_completed_successfully() {
   [[ "${state}" == inactive && "${result}" == success && "${status}" == 0 ]] \
     || die "legacy retirement sampler ended as ${unit_status}, expected inactive|success|0"
 }
+cleanup_stopped_legacy_control() {
+  gcloud_ssh "${REMOTE_INSTALL_COMMAND} cleanup-stopped-legacy-control"
+}
 adopt_legacy_sampler() {
-  local unit_status state result status
+  local unit_status state result status legacy_state socket_state
   gcloud_ssh "sudo test -s '${sampler_result}' -a -s '${sampler_oom_result}'" \
     || die "cutover did not leave a continuous legacy sampler"
   unit_status="$(read_sampler_unit_status)"
@@ -191,8 +202,15 @@ adopt_legacy_sampler() {
   if [[ "${state}" != active ]]; then
     [[ "${state}" == inactive && "${result}" == success && "${status}" == 0 ]] \
       || die "cutover legacy sampler is ${unit_status}"
-    gcloud_ssh "! systemctl is-active --quiet subrouter.service && sudo test ! -S /var/lib/subrouter/supervisor.sock" \
-      || die "legacy sampler stopped before legacy service retirement"
+    legacy_state="$(legacy_active_state)"
+    socket_state="$(legacy_socket_active_state)"
+    if [[ "${legacy_state}" == inactive && ( "${socket_state}" == inactive || "${socket_state}" == not-found ) ]]; then
+      cleanup_stopped_legacy_control
+    elif subrouter_legacy_sampler_stop_is_reconcilable "${legacy_state}" "${socket_state}"; then
+      :
+    else
+      die "legacy sampler stopped while legacy units were ${legacy_state:-unknown}/${socket_state:-unknown}"
+    fi
   fi
   sampler_adopted=1
 }
@@ -268,17 +286,30 @@ oom_before="$(jq -r '.metrics.legacy.oom_kill.after' "${CUTOVER_EVIDENCE}")"
 legacy_peak_rss="$(jq -r '.metrics.legacy.run_scoped_peak_rss_bytes' "${CUTOVER_EVIDENCE}")"
 [[ "${restarts_before}" =~ ^[0-9]+$ && "${oom_before}" =~ ^[0-9]+$ && "${legacy_peak_rss}" =~ ^[0-9]+$ ]] \
   || die "cutover evidence has invalid legacy metrics"
+gcloud_ssh "${REMOTE_INSTALL_COMMAND} quiesce-legacy-socket"
 adopt_legacy_sampler
 
 deadline=$(( $(date +%s) + DRAIN_TIMEOUT_SECONDS ))
 while true; do
-  if gcloud_ssh "! systemctl is-active --quiet subrouter.service && sudo test ! -S /var/lib/subrouter/supervisor.sock"; then
+  legacy_state="$(legacy_active_state)"
+  socket_state="$(legacy_socket_active_state)"
+  subrouter_systemd_active_state_is_waitable "${legacy_state}" \
+    || die "legacy service entered unexpected ${legacy_state:-unknown} state while draining"
+  subrouter_systemd_socket_state_is_waitable "${socket_state}" \
+    || die "legacy socket entered unexpected ${socket_state:-unknown} state while draining"
+  if [[ "${legacy_state}" == inactive && ( "${socket_state}" == inactive || "${socket_state}" == not-found ) ]]; then
+    cleanup_stopped_legacy_control
     last_connection_closed_at="$(utc_now)"
     last_connection_closed_ms="$(epoch_millis)"
     break
   fi
-  gcloud_ssh "systemctl is-active --quiet '${sampler_unit}'" \
-    || die "legacy retirement sampler stopped before legacy service retirement"
+  if ! gcloud_ssh "systemctl is-active --quiet '${sampler_unit}'"; then
+    legacy_state="$(legacy_active_state)"
+    socket_state="$(legacy_socket_active_state)"
+    subrouter_legacy_sampler_stop_is_reconcilable "${legacy_state}" "${socket_state}" \
+      || die "legacy retirement sampler stopped before legacy service retirement"
+    assert_sampler_completed_successfully
+  fi
   (( $(date +%s) < deadline )) || die "legacy supervisor did not drain within ${DRAIN_TIMEOUT_SECONDS}s"
   sleep 0.1
 done
@@ -290,7 +321,14 @@ oom_after="${sampled_oom_after}"
 stop_requested_at="$(utc_now)"
 gcloud_ssh "sudo systemctl disable subrouter.service; sudo systemctl disable subrouter.socket >/dev/null 2>&1 || true"
 for _ in $(seq 1 300); do
-  if gcloud_ssh "! systemctl is-active --quiet subrouter.service && sudo test ! -S /var/lib/subrouter/supervisor.sock"; then
+  legacy_state="$(legacy_active_state)"
+  socket_state="$(legacy_socket_active_state)"
+  subrouter_systemd_active_state_is_waitable "${legacy_state}" \
+    || die "legacy service entered unexpected ${legacy_state:-unknown} state during retirement"
+  subrouter_systemd_socket_state_is_waitable "${socket_state}" \
+    || die "legacy socket entered unexpected ${socket_state:-unknown} state during retirement"
+  if [[ "${legacy_state}" == inactive && ( "${socket_state}" == inactive || "${socket_state}" == not-found ) ]]; then
+    cleanup_stopped_legacy_control
     absent_at="$(utc_now)"
     absent_ms="$(epoch_millis)"
     absence_latency_ms=$((absent_ms - last_connection_closed_ms))

--- a/deploy/gcp/install-front-slots.sh
+++ b/deploy/gcp/install-front-slots.sh
@@ -15,6 +15,8 @@ FRONT_ENV="${SUBROUTER_FRONT_ENV:-/etc/default/subrouter-front}"
 FRESH_MARKER="${SUBROUTER_FRESH_TOPOLOGY_MARKER:-${STATE_DIR}/front-topology-prepared}"
 DEFAULTS_FILE="${SUBROUTER_DEFAULTS_FILE:-/etc/default/subrouter}"
 LEGACY_SERVICE="${SUBROUTER_LEGACY_SERVICE:-subrouter.service}"
+LEGACY_SOCKET_SERVICE="${SUBROUTER_LEGACY_SOCKET_SERVICE:-subrouter.socket}"
+LEGACY_CONTROL_SOCKET="${SUBROUTER_LEGACY_CONTROL_SOCKET:-${STATE_DIR}/supervisor.sock}"
 SLOT_UNIT="${SUBROUTER_SLOT_UNIT:-/etc/systemd/system/subrouter-slot@.service}"
 FRONT_UNIT="${SUBROUTER_FRONT_UNIT:-/etc/systemd/system/subrouter-front.service}"
 SLOT_ENV_DIR="${SUBROUTER_SLOT_ENV_DIR:-/etc/subrouter/slots}"
@@ -698,6 +700,129 @@ disable_slot() {
   log "disabled ${slot} without stopping it"
 }
 
+quiesce_legacy_socket() (
+  local socket_load_state socket_state newly_masked=0
+  socket_load_state="$(systemctl show "${LEGACY_SOCKET_SERVICE}" -p LoadState --value)"
+  case "${socket_load_state}" in
+    loaded) newly_masked=1 ;;
+    masked) ;;
+    not-found)
+      log "legacy socket unit is absent"
+      return
+      ;;
+    *) die "refusing legacy socket quiescence with ${LEGACY_SOCKET_SERVICE} load state ${socket_load_state:-unknown}" ;;
+  esac
+  cleanup_runtime_mask() {
+    (( newly_masked == 0 )) \
+      || systemctl unmask --runtime "${LEGACY_SOCKET_SERVICE}" >/dev/null 2>&1 \
+      || true
+  }
+  systemctl disable "${LEGACY_SOCKET_SERVICE}" >/dev/null
+  ! systemctl is-enabled --quiet "${LEGACY_SOCKET_SERVICE}" >/dev/null 2>&1 \
+    || die "legacy socket remained enabled before quiescence"
+  trap cleanup_runtime_mask EXIT
+  if (( newly_masked == 1 )); then
+    systemctl mask --runtime "${LEGACY_SOCKET_SERVICE}" >/dev/null
+  fi
+  socket_state="$(systemctl show "${LEGACY_SOCKET_SERVICE}" -p ActiveState --value)"
+  if [[ "${socket_state}" != inactive ]]; then
+    systemctl --job-mode=ignore-dependencies stop "${LEGACY_SOCKET_SERVICE}"
+  fi
+  socket_state="$(systemctl show "${LEGACY_SOCKET_SERVICE}" -p ActiveState --value)"
+  [[ "${socket_state}" == inactive ]] \
+    || die "legacy socket remained ${socket_state:-unknown} after quiescence"
+  systemctl disable "${LEGACY_SOCKET_SERVICE}" >/dev/null
+  ! systemctl is-enabled --quiet "${LEGACY_SOCKET_SERVICE}" >/dev/null 2>&1 \
+    || die "legacy socket remained enabled after quiescence"
+  trap - EXIT
+  log "legacy socket is inactive, disabled, and runtime-masked"
+)
+
+cleanup_stopped_legacy_control() (
+  local legacy_state socket_state legacy_load_state socket_load_state socket_owners
+  local socket_unit_present=0
+  local -a newly_masked_units
+  [[ "${LEGACY_CONTROL_SOCKET}" == /* ]] \
+    || die "legacy control socket path must be absolute"
+  legacy_load_state="$(systemctl show "${LEGACY_SERVICE}" -p LoadState --value)"
+  socket_load_state="$(systemctl show "${LEGACY_SOCKET_SERVICE}" -p LoadState --value)"
+  newly_masked_units=()
+  case "${legacy_load_state}" in
+    loaded) newly_masked_units+=("${LEGACY_SERVICE}") ;;
+    masked) ;;
+    *) die "refusing legacy control cleanup with ${LEGACY_SERVICE} load state ${legacy_load_state:-unknown}" ;;
+  esac
+  case "${socket_load_state}" in
+    loaded)
+      socket_unit_present=1
+      newly_masked_units+=("${LEGACY_SOCKET_SERVICE}")
+      ;;
+    masked) socket_unit_present=1 ;;
+    not-found) ;;
+    *) die "refusing legacy control cleanup with ${LEGACY_SOCKET_SERVICE} load state ${socket_load_state:-unknown}" ;;
+  esac
+  disable_legacy_units() {
+    systemctl disable "${LEGACY_SERVICE}" >/dev/null
+    if (( socket_unit_present == 1 )); then
+      systemctl disable "${LEGACY_SOCKET_SERVICE}" >/dev/null
+    fi
+  }
+  disable_legacy_units
+  assert_legacy_units_disabled() {
+    ! systemctl is-enabled --quiet "${LEGACY_SERVICE}" >/dev/null 2>&1 \
+      || die "legacy service remained enabled during control socket cleanup"
+    if (( socket_unit_present == 1 )); then
+      ! systemctl is-enabled --quiet "${LEGACY_SOCKET_SERVICE}" >/dev/null 2>&1 \
+        || die "legacy socket remained enabled during control socket cleanup"
+    fi
+  }
+  assert_legacy_units_disabled
+  cleanup_runtime_masks() {
+    (( ${#newly_masked_units[@]} == 0 )) \
+      || systemctl unmask --runtime "${newly_masked_units[@]}" >/dev/null 2>&1 \
+      || true
+  }
+  assert_legacy_units_inactive() {
+    legacy_state="$(systemctl show "${LEGACY_SERVICE}" -p ActiveState --value)"
+    [[ "${legacy_state}" == inactive ]] \
+      || die "refusing legacy control cleanup while ${LEGACY_SERVICE} is ${legacy_state:-unknown}"
+    if (( socket_unit_present == 1 )); then
+      socket_state="$(systemctl show "${LEGACY_SOCKET_SERVICE}" -p ActiveState --value)"
+      [[ "${socket_state}" == inactive ]] \
+        || die "refusing legacy control cleanup while ${LEGACY_SOCKET_SERVICE} is ${socket_state:-unknown}"
+    fi
+  }
+  trap cleanup_runtime_masks EXIT
+  if (( ${#newly_masked_units[@]} > 0 )); then
+    systemctl mask --runtime "${newly_masked_units[@]}" >/dev/null
+  fi
+  assert_legacy_units_inactive
+  if [[ ! -e "${LEGACY_CONTROL_SOCKET}" && ! -L "${LEGACY_CONTROL_SOCKET}" ]]; then
+    assert_legacy_units_inactive
+    disable_legacy_units
+    assert_legacy_units_disabled
+    trap - EXIT
+    log "stopped legacy control socket is already absent; legacy units remain runtime-masked"
+    return
+  fi
+  [[ -S "${LEGACY_CONTROL_SOCKET}" && ! -L "${LEGACY_CONTROL_SOCKET}" ]] \
+    || die "legacy control socket path is not a non-symlink socket"
+  command -v ss >/dev/null 2>&1 || die "ss is required for legacy control socket ownership inspection"
+  assert_legacy_units_inactive
+  socket_owners="$(ss -H -xlpn src "${LEGACY_CONTROL_SOCKET}")"
+  [[ -z "${socket_owners}" ]] \
+    || die "refusing to remove a kernel-owned legacy control socket"
+  assert_legacy_units_inactive
+  rm -f -- "${LEGACY_CONTROL_SOCKET}"
+  [[ ! -e "${LEGACY_CONTROL_SOCKET}" && ! -L "${LEGACY_CONTROL_SOCKET}" ]] \
+    || die "stopped legacy control socket remained after cleanup"
+  assert_legacy_units_inactive
+  disable_legacy_units
+  assert_legacy_units_disabled
+  trap - EXIT
+  log "removed stopped legacy control socket; legacy units remain runtime-masked"
+)
+
 listener_status() {
   local service="$1" port="$2" pid line fd inode
   command -v ss >/dev/null 2>&1 || die "ss is required for listener ownership inspection"
@@ -780,11 +905,19 @@ case "${1:-}" in
     [[ "$#" == 2 ]] || die "usage: $0 disable-slot <slot-a|slot-b>"
     disable_slot "$2"
     ;;
+  quiesce-legacy-socket)
+    [[ "$#" == 1 ]] || die "usage: $0 quiesce-legacy-socket"
+    quiesce_legacy_socket
+    ;;
+  cleanup-stopped-legacy-control)
+    [[ "$#" == 1 ]] || die "usage: $0 cleanup-stopped-legacy-control"
+    cleanup_stopped_legacy_control
+    ;;
   listener-status)
     [[ "$#" == 3 ]] || die "usage: $0 listener-status <service> <port>"
     listener_status "$2" "$3"
     ;;
   *)
-    die "usage: $0 {install-release|install-topology|ensure-migration-topology|prepare-fresh-topology|activate-fresh-topology|prepare-slot|set-front-default|activate-front-takeover|restore-front-bootstrap|configure-verify-front|retire-slot|stop-drained-slot|sample-service-rss|enable-slot|disable-slot|listener-status} ..."
+    die "usage: $0 {install-release|install-topology|ensure-migration-topology|prepare-fresh-topology|activate-fresh-topology|prepare-slot|set-front-default|activate-front-takeover|restore-front-bootstrap|configure-verify-front|retire-slot|stop-drained-slot|sample-service-rss|enable-slot|disable-slot|quiesce-legacy-socket|cleanup-stopped-legacy-control|listener-status} ..."
     ;;
 esac

--- a/deploy/gcp/systemd-state.sh
+++ b/deploy/gcp/systemd-state.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+subrouter_systemd_active_state_is_waitable() {
+  case "${1:-}" in
+    active|activating|deactivating|inactive|maintenance|reloading|refreshing) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+subrouter_systemd_socket_state_is_waitable() {
+  [[ "${1:-}" == not-found ]] || subrouter_systemd_active_state_is_waitable "${1:-}"
+}
+
+subrouter_legacy_sampler_stop_is_reconcilable() {
+  case "${1:-}" in
+    inactive|deactivating) ;;
+    *) return 1 ;;
+  esac
+  subrouter_systemd_socket_state_is_waitable "${2:-}"
+}


### PR DESCRIPTION
Fixes the production continuity gate after a successful listener handoff.

- quiesces an active legacy socket without stopping the service that owns held sessions
- removes a stale legacy supervisor socket only after legacy units are inactive and disabled
- keeps successful retirement runtime-masked and retry-safe
- waits through normal systemd transition states
- ignores normal shutdown timeout metadata while retaining real timeout detection

Regression history:
- `f2a6e69` adds the failing tests
- `09ca5fa` implements the fix

Verification:
- `go test ./...`
- exact-head local review clean on `09ca5fa`
