### PR TITLE
Fix Codex auto-switch provider boundary

### DIFF
--- a/cmd/subrouter/sr_auto_switch.go
+++ b/cmd/subrouter/sr_auto_switch.go
@@ -102,7 +102,7 @@ func srAutoSwitchOnce(ctx context.Context, cfg srAutoSwitchConfig) (string, erro
 	} else if cfg.AccountsFunc != nil {
 		allAccounts = cfg.AccountsFunc()
 	}
-	candidates := oauthAccounts(allAccounts)
+	candidates := codexOAuthAccounts(allAccounts)
 	if len(candidates) == 0 {
 		return "", fmt.Errorf("no OAuth Codex accounts available for sr auto-switch")
 	}
@@ -138,10 +138,11 @@ func srAutoSwitchOnce(ctx context.Context, cfg srAutoSwitchConfig) (string, erro
 	return picked.ID, nil
 }
 
-func oauthAccounts(all []accounts.Account) []accounts.Account {
+func codexOAuthAccounts(all []accounts.Account) []accounts.Account {
 	out := make([]accounts.Account, 0, len(all))
 	for _, account := range all {
-		if account.AuthMode == accounts.AuthModeOAuth {
+		if account.AuthMode == accounts.AuthModeOAuth &&
+			(account.Provider == "" || account.Provider == accounts.ProviderCodex) {
 			out = append(out, account)
 		}
 	}

--- a/cmd/subrouter/sr_auto_switch_test.go
+++ b/cmd/subrouter/sr_auto_switch_test.go
@@ -65,6 +65,41 @@ func TestSRAutoSwitchPicksBestOAuthAccount(t *testing.T) {
 	}
 }
 
+func TestSRAutoSwitchIgnoresClaudeAccountWithSameID(t *testing.T) {
+	var switchedTo string
+	picked, err := srAutoSwitchOnce(context.Background(), srAutoSwitchConfig{
+		Accounts: []accounts.Account{
+			{ID: "shared@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth},
+			{ID: "healthy@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth},
+			{ID: "shared@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth},
+		},
+		FetchScores: func(_ context.Context, candidates []accounts.Account) ([]selectacct.Score, int) {
+			if len(candidates) != 2 {
+				t.Fatalf("candidates = %#v, want only two Codex accounts", candidates)
+			}
+			for _, candidate := range candidates {
+				if candidate.Provider != accounts.ProviderCodex {
+					t.Fatalf("auto-switch scored non-Codex account: %#v", candidate)
+				}
+			}
+			return []selectacct.Score{
+				{AccountID: "shared@example.com", Provider: accounts.ProviderCodex, Headroom: 0, ShortHeadroom: 0},
+				{AccountID: "healthy@example.com", Provider: accounts.ProviderCodex, Headroom: 0.30, ShortHeadroom: 0.30},
+			}, 2
+		},
+		SwitchActive: func(_ context.Context, accountID string) error {
+			switchedTo = accountID
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if picked != "healthy@example.com" || switchedTo != "healthy@example.com" {
+		t.Fatalf("picked=%q switchedTo=%q, want healthy@example.com", picked, switchedTo)
+	}
+}
+
 func TestSRAutoSwitchUsesLiveAccountsFunc(t *testing.T) {
 	var switchedTo string
 	picked, err := srAutoSwitchOnce(context.Background(), srAutoSwitchConfig{


### PR DESCRIPTION
The Codex auto-switch received the combined Codex and Claude account list. A healthy Claude profile with the same ID as a cooked Codex account could win selection, after which the switch wrote the cooked Codex credential.

Filter auto-switch candidates to Codex OAuth accounts. Keep empty providers as Codex for compatibility.

Tests: `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex auto-switch to only evaluate Codex OAuth accounts. Prevents selecting a Claude account with the same ID and writing the wrong credential.

- **Bug Fixes**
  - Filter candidates to Codex OAuth accounts (Provider is Codex or empty).
  - Treat empty Provider as Codex for compatibility.
  - Add test to ensure Claude accounts with the same ID are ignored and the correct Codex account is picked.

<sup>Written for commit 572f301acca5baf1302b73dadf9d7b01091740b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

