### PR TITLE
Stop active tasks when a worker retires

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -627,8 +627,10 @@ func serve(args []string) error {
 	if transcriptGCSSyncer.Enabled() {
 		go transcriptGCSSyncer.Run(context.Background())
 	}
+	activeGenerationCtx, stopActiveGenerationTasks := context.WithCancel(context.Background())
+	defer stopActiveGenerationTasks()
 	if srSwitchInterval > 0 && *fetchUsage && credentialBroker == nil {
-		go runSRAutoSwitch(context.Background(), srAutoSwitchConfig{
+		go runSRAutoSwitch(activeGenerationCtx, srAutoSwitchConfig{
 			Interval:             srSwitchInterval,
 			AccountsSnapshotFunc: accountRef.Snapshot,
 			Sessions:             store,
@@ -709,7 +711,7 @@ func serve(args []string) error {
 	} else {
 		slog.Info("subrouter listening", "addr", *addr, "codex_upstream", codexUpstream.String(), "api_upstream", apiUpstream.String(), "claude_upstream", claudeUpstream.String(), "codex_accounts", len(codexAccounts), "claude_accounts", len(claudeAccounts), "cloud_team", cloudConfig.TeamID, "transcripts", *transcriptDir, "transcript_gcs_uri", *transcriptGCSURI)
 	}
-	return listenAndServeWithSignals(httpServer, server.Lifecycle, *shutdownTimeout, slog.Default())
+	return listenAndServeWithSignals(httpServer, server.Lifecycle, *shutdownTimeout, slog.Default(), stopActiveGenerationTasks)
 }
 
 func validatePublicSubrouterURL(raw string) error {
@@ -943,7 +945,7 @@ func numericAWSProfileSuffix(name string) (int, bool) {
 // Retired generations still drain once their load-balancer connections expire.
 const workerIdleTimeout = 620 * time.Second
 
-func listenAndServeWithSignals(server *http.Server, lifecycle *proxy.Lifecycle, shutdownTimeout time.Duration, logger *slog.Logger) error {
+func listenAndServeWithSignals(server *http.Server, lifecycle *proxy.Lifecycle, shutdownTimeout time.Duration, logger *slog.Logger, stopActiveGenerationTasks ...func()) error {
 	errCh := make(chan error, 1)
 	go func() {
 		err := listenAndServeHTTP(server, logger)
@@ -974,7 +976,7 @@ func listenAndServeWithSignals(server *http.Server, lifecycle *proxy.Lifecycle, 
 				// response carry "Connection: close", so each client finishes
 				// its current request and reconnects onto the new generation.
 				// In-flight requests and streams are unaffected.
-				retireServer(server, logger)
+				retireServer(server, logger, stopActiveGenerationTasks...)
 				continue
 			}
 			return shutdownOnSignal(server, lifecycle, sig, shutdownTimeout, logger, errCh)
@@ -983,7 +985,12 @@ func listenAndServeWithSignals(server *http.Server, lifecycle *proxy.Lifecycle, 
 }
 
 // retireServer stops connection reuse without interrupting anything in flight.
-func retireServer(server *http.Server, logger *slog.Logger) {
+func retireServer(server *http.Server, logger *slog.Logger, stopActiveGenerationTasks ...func()) {
+	for _, stop := range stopActiveGenerationTasks {
+		if stop != nil {
+			stop()
+		}
+	}
 	server.SetKeepAlivesEnabled(false)
 	if logger != nil {
 		logger.Info("subrouter worker retired; closing idle connections and asking clients to reconnect")

--- a/cmd/subrouter/retire_worker_test.go
+++ b/cmd/subrouter/retire_worker_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -10,6 +11,21 @@ import (
 	"testing"
 	"time"
 )
+
+// A retired generation may keep serving an in-flight stream, but it no longer
+// owns shared background mutations such as the active Codex account sweep.
+func TestRetireServerStopsActiveGenerationTasks(t *testing.T) {
+	ctx, stopActiveGenerationTasks := context.WithCancel(context.Background())
+	server := &http.Server{}
+
+	retireServer(server, nil, stopActiveGenerationTasks)
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("retired worker kept active-generation background tasks running")
+	}
+}
 
 // A retired worker must stop connection reuse so clients migrate to the new
 // generation. Without this, the supervisor's drain never completes (WaitIdle


### PR DESCRIPTION
Retired workers keep serving in-flight connections, but they also kept running the shared Codex auto-switch loop. An old generation could therefore overwrite the active account after a corrected worker was deployed.

Give active-generation tasks a cancellable context and cancel it on supervisor retirement. Keep existing streams intact.

Tests: `go test ./...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788676356&installation_model_id=21920&pr_number=196&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F196&signature=6ec5d83c1cf906a2f00eda13f983a279a2b82a37113cfd5d6a5e2de11a7734d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops active-generation background tasks when a worker retires to prevent old generations from overwriting the active Codex account. In-flight requests and streams continue; only keep-alive reuse is disabled.

- **Bug Fixes**
  - Use a cancellable context for active-generation tasks and cancel it on retirement via `listenAndServeWithSignals` and `retireServer`.
  - Added a test to ensure retirement cancels active-generation tasks while keeping streams intact.

<sup>Written for commit c8c92006fc32c928b8980fc6c01af5470595e80d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

