### PR TITLE
Release golden resume pacing after cutover

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -1342,7 +1342,7 @@ func (r *goldenRunner) resumeCycle(ctx context.Context, clientPath string, resul
 		return err
 	}
 	result.resumes = resumes
-	if err := waitGoldenSessions(ctx, resumes); err != nil {
+	if err := waitGoldenResumeSessions(ctx, resumes); err != nil {
 		return err
 	}
 	if err := validateGoldenSessions(resumes, true); err != nil {
@@ -1365,6 +1365,25 @@ func (r *goldenRunner) resumeCycle(ctx context.Context, clientPath string, resul
 		}
 	}
 	return nil
+}
+
+func waitGoldenResumeSessions(ctx context.Context, sessions []*goldenSession) error {
+	var firstErr error
+	for _, session := range sessions {
+		if err := waitGoldenSessionChunks(ctx, session, 1); err != nil {
+			firstErr = err
+			break
+		}
+	}
+	releaseErr := releaseGoldenTestSessions(sessions)
+	completionErr := waitGoldenSessions(ctx, sessions)
+	if firstErr != nil {
+		return firstErr
+	}
+	if releaseErr != nil {
+		return releaseErr
+	}
+	return completionErr
 }
 
 func (r *goldenRunner) validateCompletedCycleSessions(result *goldenCycleResult) error {

--- a/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
@@ -126,6 +126,36 @@ func TestGoldenObserverHoldsRealResponseUntilGateRelease(t *testing.T) {
 	}
 }
 
+func TestGoldenResumeWaitReleasesResponsePacing(t *testing.T) {
+	previousHooks := goldenTestHooks
+	goldenTestHooks.enabled = false
+	t.Cleanup(func() { goldenTestHooks = previousHooks })
+
+	gate := newGoldenResponseGate()
+	pacer := gate.newResponsePacer("0123456789abcdef0123456789abcdef")
+	payload := []byte("resume response retained until its post-deployment gate is released")
+	var delivered bytes.Buffer
+	session := &goldenSession{
+		observer: &runningGoldenObserver{gate: gate},
+		done:     make(chan struct{}),
+	}
+
+	go func() {
+		_, _ = pacer.write(context.Background(), payload, delivered.Write)
+		_ = pacer.waitAndFlush()
+		close(session.done)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := waitGoldenResumeSessions(ctx, []*goldenSession{session}); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(delivered.Bytes(), payload) {
+		t.Fatalf("released resume payload = %q, want %q", delivered.Bytes(), payload)
+	}
+}
+
 func TestGoldenObserverLeavesPostReleaseResponsesIndependent(t *testing.T) {
 	gate := newGoldenResponseGate()
 	gate.releasePacing()

--- a/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
@@ -131,19 +131,70 @@ func TestGoldenResumeWaitReleasesResponsePacing(t *testing.T) {
 	goldenTestHooks.enabled = false
 	t.Cleanup(func() { goldenTestHooks = previousHooks })
 
-	gate := newGoldenResponseGate()
-	pacer := gate.newResponsePacer("0123456789abcdef0123456789abcdef")
-	payload := []byte("resume response retained until its post-deployment gate is released")
-	var delivered bytes.Buffer
-	session := &goldenSession{
-		observer: &runningGoldenObserver{gate: gate},
-		done:     make(chan struct{}),
+	payload := bytes.Repeat([]byte("resume-response-"), 64)
+	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = writer.Write(payload)
+	}))
+	t.Cleanup(upstream.Close)
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
 	}
 
+	runner := &goldenRunner{artifactDir: t.TempDir()}
+	observation, err := runner.startObserver("resume-stream-pacing", upstreamURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := observation.stop(ctx); err != nil {
+			t.Errorf("stop observer: %v", err)
+		}
+	})
+
+	session := &goldenSession{
+		observer: observation,
+		done:     make(chan struct{}),
+	}
+	result := make(chan struct {
+		body []byte
+		err  error
+	}, 1)
 	go func() {
-		_, _ = pacer.write(context.Background(), payload, delivered.Write)
-		_ = pacer.waitAndFlush()
-		close(session.done)
+		defer close(session.done)
+		request, requestErr := http.NewRequest(
+			http.MethodPost,
+			observation.baseURL+"/v1/responses",
+			bytes.NewReader([]byte("{}")),
+		)
+		if requestErr != nil {
+			result <- struct {
+				body []byte
+				err  error
+			}{err: requestErr}
+			return
+		}
+		request.Header.Set(goldenResponseAttemptTokenHeader, "0123456789abcdef0123456789abcdef")
+		response, requestErr := http.DefaultClient.Do(request)
+		if requestErr != nil {
+			result <- struct {
+				body []byte
+				err  error
+			}{err: requestErr}
+			return
+		}
+		body, readErr := io.ReadAll(response.Body)
+		closeErr := response.Body.Close()
+		if readErr == nil {
+			readErr = closeErr
+		}
+		result <- struct {
+			body []byte
+			err  error
+		}{body: body, err: readErr}
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -151,8 +202,70 @@ func TestGoldenResumeWaitReleasesResponsePacing(t *testing.T) {
 	if err := waitGoldenResumeSessions(ctx, []*goldenSession{session}); err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(delivered.Bytes(), payload) {
-		t.Fatalf("released resume payload = %q, want %q", delivered.Bytes(), payload)
+	response := <-result
+	if response.err != nil {
+		t.Fatal(response.err)
+	}
+	if !bytes.Equal(response.body, payload) {
+		t.Fatalf("released resume payload = %q, want %q", response.body, payload)
+	}
+}
+
+func TestGoldenResumeWaitReleasesEveryGateAfterChunkFailure(t *testing.T) {
+	previousHooks := goldenTestHooks
+	goldenTestHooks.enabled = false
+	t.Cleanup(func() { goldenTestHooks = previousHooks })
+
+	failedDone := make(chan struct{})
+	close(failedDone)
+	failed := &goldenSession{
+		observer: &runningGoldenObserver{
+			gate:  newGoldenResponseGate(),
+			stats: newObserverStats(),
+		},
+		done: failedDone,
+	}
+
+	blockedGate := newGoldenResponseGate()
+	blockedPacer := blockedGate.newResponsePacer("0123456789abcdef0123456789abcdef")
+	blockedDone := make(chan struct{})
+	blockedReleased := make(chan struct{})
+	allowBlockedFinish := make(chan struct{})
+	go func() {
+		_, _ = blockedPacer.write(context.Background(), []byte("held resume"), io.Discard.Write)
+		_ = blockedPacer.waitAndFlush()
+		close(blockedReleased)
+		<-allowBlockedFinish
+		close(blockedDone)
+	}()
+	blocked := &goldenSession{
+		observer: &runningGoldenObserver{gate: blockedGate, stats: newObserverStats()},
+		done:     blockedDone,
+	}
+
+	waitResult := make(chan error, 1)
+	go func() {
+		waitResult <- waitGoldenResumeSessions(context.Background(), []*goldenSession{failed, blocked})
+	}()
+	select {
+	case <-blockedReleased:
+	case <-time.After(5 * time.Second):
+		t.Fatal("another resume gate remained held after chunk failure")
+	}
+	select {
+	case err := <-waitResult:
+		t.Fatalf("resume wait returned before every released session finished: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(allowBlockedFinish)
+	err := <-waitResult
+	if got := fixedGoldenFailure(err); got != "stream_baseline_ended_early" {
+		t.Fatalf("resume wait failure = %q, want stream_baseline_ended_early", got)
+	}
+	select {
+	case <-blockedDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("another resume gate remained held after chunk failure")
 	}
 }
 


### PR DESCRIPTION
The golden verifier created fresh response gates for resumed Codex turns but never released them, leaving the final response tail blocked until the overall timeout. Wait for each resumed request to produce a real response chunk, release its pacing gate, then wait for completion. The regression preserves deployment-overlap pacing and covers both the real observer and the fake Mac harness.\n\nTests: go test ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788682362&installation_model_id=21920&pr_number=198&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F198&signature=b80b862d9e030b5cd47133efdac8c645f675f6098d2b204644abf0e0d00af559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hang where resumed golden sessions kept response gates held, stalling streams until timeout. We now release pacing after the first real chunk per resumed session, always release gates on early failure, then wait for completion.

- **Bug Fixes**
  - Added waitGoldenResumeSessions: wait for 1 chunk, release all gates, then wait for completion; releases gates even if chunk waiting fails.
  - Updated resumeCycle to use the new resume-wait logic.
  - Added tests: TestGoldenResumeWaitReleasesResponsePacing and TestGoldenResumeWaitReleasesEveryGateAfterChunkFailure.
  - Preserves deployment-overlap pacing behavior.

<sup>Written for commit bfb3dc7791deebce92c30e6252efe35058f7df22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

