### PR TITLE
Fix legacy absence evidence timing

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -2521,6 +2521,51 @@ fi
 	}
 }
 
+func TestLegacyRetirementProvesAbsenceBeforeSlowSamplerTeardown(t *testing.T) {
+	requireDeployScriptTools(t, "bash")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	helper := filepath.Join(repoRoot, "deploy", "gcp", "legacy-retirement-lifecycle.sh")
+	events := filepath.Join(t.TempDir(), "events.log")
+	command := exec.Command(mustLookPath(t, "bash"), "-c", `
+set -euo pipefail
+source "$1"
+events="$2"
+fake_ms=1000
+utc_now() { printf 't-%s\n' "$fake_ms"; }
+epoch_millis() { printf '%s\n' "$fake_ms"; }
+disable_legacy_units() {
+  printf 'disable\n' >>"$events"
+  fake_ms=$((fake_ms + 250))
+}
+wait_for_legacy_absence() {
+  printf 'absent\n' >>"$events"
+  fake_ms=$((fake_ms + 250))
+}
+stop_legacy_sampler() {
+  printf 'sampler\n' >>"$events"
+  fake_ms=$((fake_ms + 45000))
+}
+last_connection_closed_ms="$fake_ms"
+subrouter_finalize_legacy_after_drain "$last_connection_closed_ms" 30000
+printf 'stop=%s absent=%s latency=%s final=%s\n' \
+  "$stop_requested_at" "$absent_at" "$absence_latency_ms" "$fake_ms"
+`, "legacy-retirement-lifecycle-test", helper, events)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("finalize legacy lifecycle: %v\n%s", err, output)
+	}
+	if got, want := string(output), "stop=t-1000 absent=t-1500 latency=500 final=46500\n"; got != want {
+		t.Fatalf("unexpected lifecycle timing:\n%s\nwant:\n%s", got, want)
+	}
+	eventBody, err := os.ReadFile(events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(eventBody), "disable\nabsent\nsampler\n"; got != want {
+		t.Fatalf("unexpected lifecycle order:\n%s\nwant:\n%s", got, want)
+	}
+}
+
 func TestFrontSlotInstallerQuiescesLegacySocketWithoutStoppingService(t *testing.T) {
 	requireDeployScriptTools(t, "bash", "curl", "jq", "python3", "sha256sum")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/deploy/gcp/finalize-legacy-retirement.sh
+++ b/deploy/gcp/finalize-legacy-retirement.sh
@@ -45,6 +45,8 @@ source "${SCRIPT_DIR}/stream-shell-value.sh"
 source "${SCRIPT_DIR}/deploy-lock.sh"
 # shellcheck source=deploy/gcp/systemd-state.sh
 source "${SCRIPT_DIR}/systemd-state.sh"
+# shellcheck source=deploy/gcp/legacy-retirement-lifecycle.sh
+source "${SCRIPT_DIR}/legacy-retirement-lifecycle.sh"
 
 log() { printf 'gcp-legacy-retirement: %s\n' "$*"; }
 die() { log "$*" >&2; exit 1; }
@@ -229,6 +231,26 @@ stop_legacy_sampler() {
     || die "legacy retirement sampler returned invalid metrics"
   sampler_adopted=0
 }
+disable_legacy_units() {
+  cleanup_stopped_legacy_control
+}
+wait_for_legacy_absence() {
+  local legacy_state socket_state
+  for _ in $(seq 1 300); do
+    legacy_state="$(legacy_active_state)"
+    socket_state="$(legacy_socket_active_state)"
+    subrouter_systemd_active_state_is_waitable "${legacy_state}" \
+      || die "legacy service entered unexpected ${legacy_state:-unknown} state during retirement"
+    subrouter_systemd_socket_state_is_waitable "${socket_state}" \
+      || die "legacy socket entered unexpected ${socket_state:-unknown} state during retirement"
+    if [[ "${legacy_state}" == inactive && ( "${socket_state}" == inactive || "${socket_state}" == not-found ) ]]; then
+      gcloud_ssh "sudo test ! -S /var/lib/subrouter/supervisor.sock"
+      return
+    fi
+    sleep 0.1
+  done
+  return 1
+}
 
 lock_holder_pid=""
 acquire_lock() {
@@ -298,7 +320,6 @@ while true; do
   subrouter_systemd_socket_state_is_waitable "${socket_state}" \
     || die "legacy socket entered unexpected ${socket_state:-unknown} state while draining"
   if [[ "${legacy_state}" == inactive && ( "${socket_state}" == inactive || "${socket_state}" == not-found ) ]]; then
-    cleanup_stopped_legacy_control
     last_connection_closed_at="$(utc_now)"
     last_connection_closed_ms="$(epoch_millis)"
     break
@@ -314,30 +335,10 @@ while true; do
   sleep 0.1
 done
 
-stop_legacy_sampler
+subrouter_finalize_legacy_after_drain "${last_connection_closed_ms}" 30000
 oom_after="${sampled_oom_after}"
 [[ "${oom_after}" == "${oom_before}" ]] || die "legacy service was OOM-killed while draining"
 (( legacy_peak_rss <= 201326592 )) || die "legacy run-scoped RSS exceeded 192 MiB"
-stop_requested_at="$(utc_now)"
-gcloud_ssh "sudo systemctl disable subrouter.service; sudo systemctl disable subrouter.socket >/dev/null 2>&1 || true"
-for _ in $(seq 1 300); do
-  legacy_state="$(legacy_active_state)"
-  socket_state="$(legacy_socket_active_state)"
-  subrouter_systemd_active_state_is_waitable "${legacy_state}" \
-    || die "legacy service entered unexpected ${legacy_state:-unknown} state during retirement"
-  subrouter_systemd_socket_state_is_waitable "${socket_state}" \
-    || die "legacy socket entered unexpected ${socket_state:-unknown} state during retirement"
-  if [[ "${legacy_state}" == inactive && ( "${socket_state}" == inactive || "${socket_state}" == not-found ) ]]; then
-    cleanup_stopped_legacy_control
-    absent_at="$(utc_now)"
-    absent_ms="$(epoch_millis)"
-    absence_latency_ms=$((absent_ms - last_connection_closed_ms))
-    break
-  fi
-  sleep 0.1
-done
-[[ -n "${absence_latency_ms:-}" ]] || die "legacy service remained present 30 seconds after drain"
-(( absence_latency_ms >= 0 && absence_latency_ms < 30000 )) || die "legacy absence was not strictly below 30 seconds"
 restarts_after="$(legacy_restarts)"
 [[ "${restarts_after}" == "${restarts_before}" ]] || die "legacy service restarted during retirement"
 service_result="$(gcloud_ssh "systemctl show subrouter.service -p Result --value" | tail -n 1)"

--- a/deploy/gcp/legacy-retirement-lifecycle.sh
+++ b/deploy/gcp/legacy-retirement-lifecycle.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Finalize an already-drained legacy service while its sampler is still live.
+# The caller provides utc_now, epoch_millis, disable_legacy_units,
+# wait_for_legacy_absence, stop_legacy_sampler, and die.
+subrouter_finalize_legacy_after_drain() {
+  local last_connection_closed_ms="${1:-}"
+  local maximum_absence_latency_ms="${2:-}"
+  local absent_ms
+
+  [[ "${last_connection_closed_ms}" =~ ^[0-9]+$ ]] \
+    || die "legacy retirement has no valid last-connection timestamp"
+  [[ "${maximum_absence_latency_ms}" =~ ^[1-9][0-9]*$ ]] \
+    || die "legacy retirement has no valid absence limit"
+
+  stop_requested_at="$(utc_now)"
+  disable_legacy_units
+  wait_for_legacy_absence \
+    || die "legacy service remained present before its absence deadline"
+  absent_at="$(utc_now)"
+  absent_ms="$(epoch_millis)"
+  absence_latency_ms=$((absent_ms - last_connection_closed_ms))
+  (( absence_latency_ms >= 0 && absence_latency_ms < maximum_absence_latency_ms )) \
+    || die "legacy absence was not strictly below 30 seconds"
+
+  # Sampler teardown can cross IAP many times. It must not consume the service
+  # absence budget after systemd and the control socket already proved absence.
+  stop_legacy_sampler
+}


### PR DESCRIPTION
The legacy retirement verifier started its 30-second absence clock before a potentially slow IAP-driven sampler teardown. A healthy retirement could therefore fail after systemd had already proved the service absent.

This records and validates service plus control-socket absence before tearing down the sampler. The sampler still spans the complete retirement lifecycle, and its shutdown latency no longer contaminates service lifecycle evidence.

Tests: go test ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788686063&installation_model_id=21920&pr_number=200&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F200&signature=cf7fa36306c7b82846f81f416cc90bb9acd983f2987f34326103290ef2432479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes legacy retirement timing by proving service/socket absence before tearing down the sampler. Prevents false failures when sampler teardown is slow and ensures the 30s absence budget is applied correctly.

- **Bug Fixes**
  - Absence is now recorded after disabling legacy units and before sampler teardown, with `<30s` enforced from the last connection close.
  - Extracted lifecycle logic to `deploy/gcp/legacy-retirement-lifecycle.sh` via `subrouter_finalize_legacy_after_drain`, and wired it into `finalize-legacy-retirement.sh`.
  - Added a test that verifies the order: disable → absent → sampler, and confirms sampler shutdown latency doesn’t affect absence timing.

<sup>Written for commit 5c1530ea29ccce5d45a5cf8d42cf3519669b4bd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

