### PR TITLE
Fix golden daemon transport log classification

### DIFF
--- a/cmd/subrouter-transport-observer/golden_local_daemon.go
+++ b/cmd/subrouter-transport-observer/golden_local_daemon.go
@@ -1,21 +1,27 @@
 package main
 
 import (
+	"bufio"
 	"io"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
 
+var (
+	goldenStructuredLogMessage = regexp.MustCompile(`(?:^|[[:space:]])msg=("(?:\\.|[^"\\])*"|[^[:space:]]+)`)
+	goldenLegacyLogMessage     = regexp.MustCompile(`^[0-9]{4}[-/][0-9]{2}[-/][0-9]{2}(?:T[^[:space:]]+|[[:space:]]+[^[:space:]]+)[[:space:]]+(?:debug|info|warn|error)[[:space:]]+(.*)$`)
+	goldenStructuredAttribute  = regexp.MustCompile(`[[:space:]][a-z_][a-z0-9_]*=`)
+)
+
 func goldenTransportIssueCategories(text string) []string {
-	text = strings.ToLower(text)
-	lines := strings.Split(text, "\n")
-	for index, line := range lines {
-		if strings.Contains(line, "subrouter shutdown signal received") && strings.Contains(line, "signal=terminated") {
-			lines[index] = ""
-		}
+	text = strings.ToLower(strings.TrimSpace(text))
+	if strings.Contains(text, "subrouter shutdown signal received") && strings.Contains(text, "signal=terminated") {
+		return nil
 	}
-	text = strings.Join(lines, "\n")
+	text = goldenLocalDaemonLogMessage(text)
 	categories := map[string][]string{
 		"reconnect": {"reconnect", "disconnected", "connection reset"},
 		"retry":     {"retry", "retrying"},
@@ -40,6 +46,26 @@ func goldenTransportIssueCategories(text string) []string {
 	return result
 }
 
+func goldenLocalDaemonLogMessage(line string) string {
+	if match := goldenStructuredLogMessage.FindStringSubmatch(line); len(match) == 2 {
+		if strings.HasPrefix(match[1], `"`) {
+			if message, err := strconv.Unquote(match[1]); err == nil {
+				return message
+			}
+		}
+		return match[1]
+	}
+	match := goldenLegacyLogMessage.FindStringSubmatch(line)
+	if len(match) != 2 {
+		return line
+	}
+	message := match[1]
+	if attribute := goldenStructuredAttribute.FindStringIndex(message); attribute != nil {
+		message = message[:attribute[0]]
+	}
+	return strings.TrimSpace(message)
+}
+
 func containsString(values []string, target string) bool {
 	for _, value := range values {
 		if value == target {
@@ -50,13 +76,11 @@ func containsString(values []string, target string) bool {
 }
 
 func (r *goldenRunner) consumeGoldenLocalDaemonStderr(reader io.Reader) {
-	buffer := make([]byte, 32<<10)
-	tail := ""
+	buffered := bufio.NewReaderSize(reader, 32<<10)
 	for {
-		n, err := reader.Read(buffer)
-		if n > 0 {
-			text := tail + string(buffer[:n])
-			for _, category := range goldenTransportIssueCategories(text) {
+		line, err := buffered.ReadString('\n')
+		if len(line) > 0 {
+			for _, category := range goldenTransportIssueCategories(line) {
 				r.localIssueMu.Lock()
 				if r.localIssues == nil {
 					r.localIssues = make(map[string]int)
@@ -70,11 +94,6 @@ func (r *goldenRunner) consumeGoldenLocalDaemonStderr(reader io.Reader) {
 						"category": category,
 					})
 				}
-			}
-			if len(text) > 128 {
-				tail = text[len(text)-128:]
-			} else {
-				tail = text
 			}
 		}
 		if err != nil {

--- a/cmd/subrouter-transport-observer/golden_local_daemon.go
+++ b/cmd/subrouter-transport-observer/golden_local_daemon.go
@@ -16,6 +16,8 @@ var (
 	goldenStructuredAttribute  = regexp.MustCompile(`[[:space:]][a-z_][a-z0-9_]*=`)
 )
 
+const goldenLocalDaemonMaxLogRecordBytes = 256 << 10
+
 func goldenTransportIssueCategories(text string) []string {
 	text = strings.ToLower(strings.TrimSpace(text))
 	if strings.Contains(text, "subrouter shutdown signal received") && strings.Contains(text, "signal=terminated") {
@@ -76,29 +78,31 @@ func containsString(values []string, target string) bool {
 }
 
 func (r *goldenRunner) consumeGoldenLocalDaemonStderr(reader io.Reader) {
-	buffered := bufio.NewReaderSize(reader, 32<<10)
-	for {
-		line, err := buffered.ReadString('\n')
-		if len(line) > 0 {
-			for _, category := range goldenTransportIssueCategories(line) {
-				r.localIssueMu.Lock()
-				if r.localIssues == nil {
-					r.localIssues = make(map[string]int)
-				}
-				first := r.localIssues[category] == 0
-				r.localIssues[category]++
-				r.localIssueMu.Unlock()
-				if first {
-					_ = r.evidence.write(map[string]any{
-						"kind": "local_daemon_transport_issue", "timestamp": time.Now().UTC().Format(time.RFC3339Nano),
-						"category": category,
-					})
-				}
-			}
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 32<<10), goldenLocalDaemonMaxLogRecordBytes)
+	for scanner.Scan() {
+		for _, category := range goldenTransportIssueCategories(scanner.Text()) {
+			r.recordGoldenLocalDaemonIssue(category)
 		}
-		if err != nil {
-			return
-		}
+	}
+	if scanner.Err() != nil {
+		r.recordGoldenLocalDaemonIssue("error")
+	}
+}
+
+func (r *goldenRunner) recordGoldenLocalDaemonIssue(category string) {
+	r.localIssueMu.Lock()
+	if r.localIssues == nil {
+		r.localIssues = make(map[string]int)
+	}
+	first := r.localIssues[category] == 0
+	r.localIssues[category]++
+	r.localIssueMu.Unlock()
+	if first {
+		_ = r.evidence.write(map[string]any{
+			"kind": "local_daemon_transport_issue", "timestamp": time.Now().UTC().Format(time.RFC3339Nano),
+			"category": category,
+		})
 	}
 }
 

--- a/cmd/subrouter-transport-observer/golden_local_daemon.go
+++ b/cmd/subrouter-transport-observer/golden_local_daemon.go
@@ -49,7 +49,15 @@ func goldenTransportIssueCategories(text string) []string {
 }
 
 func goldenLocalDaemonLogMessage(line string) string {
-	if match := goldenStructuredLogMessage.FindStringSubmatch(line); len(match) == 2 {
+	match := goldenLegacyLogMessage.FindStringSubmatch(line)
+	if len(match) == 2 {
+		message := match[1]
+		if attribute := goldenStructuredAttribute.FindStringIndex(message); attribute != nil {
+			message = message[:attribute[0]]
+		}
+		return strings.TrimSpace(message)
+	}
+	if match = goldenStructuredLogMessage.FindStringSubmatch(line); len(match) == 2 {
 		if strings.HasPrefix(match[1], `"`) {
 			if message, err := strconv.Unquote(match[1]); err == nil {
 				return message
@@ -57,15 +65,7 @@ func goldenLocalDaemonLogMessage(line string) string {
 		}
 		return match[1]
 	}
-	match := goldenLegacyLogMessage.FindStringSubmatch(line)
-	if len(match) != 2 {
-		return line
-	}
-	message := match[1]
-	if attribute := goldenStructuredAttribute.FindStringIndex(message); attribute != nil {
-		message = message[:attribute[0]]
-	}
-	return strings.TrimSpace(message)
+	return line
 }
 
 func containsString(values []string, target string) bool {

--- a/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
+++ b/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
@@ -563,6 +563,20 @@ func TestGoldenLocalDaemonStderrClassifiesMessagesAcrossFragmentedReads(t *testi
 	}
 }
 
+func TestGoldenLocalDaemonStderrRejectsOversizedRecord(t *testing.T) {
+	var evidence bytes.Buffer
+	runner := &goldenRunner{evidence: &jsonlRecorder{writer: &evidence}}
+	runner.consumeGoldenLocalDaemonStderr(strings.NewReader(
+		strings.Repeat("x", goldenLocalDaemonMaxLogRecordBytes+1),
+	))
+	if got := fixedGoldenFailure(runner.requireGoldenLocalDaemonTransportClean()); got != "local_daemon_transport_issue_error" {
+		t.Fatalf("oversized record failure = %q, want local_daemon_transport_issue_error", got)
+	}
+	if strings.Contains(evidence.String(), strings.Repeat("x", 32)) {
+		t.Fatal("oversized record contents leaked into evidence")
+	}
+}
+
 func TestGoldenCounterContinuityRejectsActionRebaselining(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
+++ b/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
@@ -533,6 +533,20 @@ func TestGoldenLocalDaemonStderrIgnoresShutdownTimeoutConfiguration(t *testing.T
 	}
 }
 
+func TestGoldenLocalDaemonStderrIgnoresStructuredRequestMetadata(t *testing.T) {
+	var evidence bytes.Buffer
+	runner := &goldenRunner{evidence: &jsonlRecorder{writer: &evidence}}
+	runner.consumeGoldenLocalDaemonStderr(strings.NewReader(
+		"2026/08/07 10:04:57 INFO proxy request agent=codex session=fallback:0123456789abcdef user=\"\" account=account-timeout method=POST path=/responses upstream=example.test remote_addr=127.0.0.1:1234 user_agent=retry-client\n",
+	))
+	if err := runner.requireGoldenLocalDaemonTransportClean(); err != nil {
+		t.Fatalf("ordinary structured request metadata was treated as a transport failure: %v", err)
+	}
+	if evidence.Len() != 0 {
+		t.Fatalf("ordinary structured request metadata emitted issue evidence: %s", evidence.String())
+	}
+}
+
 func TestGoldenCounterContinuityRejectsActionRebaselining(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
+++ b/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/iotest"
 	"time"
 )
 
@@ -544,6 +545,21 @@ func TestGoldenLocalDaemonStderrIgnoresStructuredRequestMetadata(t *testing.T) {
 	}
 	if evidence.Len() != 0 {
 		t.Fatalf("ordinary structured request metadata emitted issue evidence: %s", evidence.String())
+	}
+}
+
+func TestGoldenLocalDaemonStderrClassifiesMessagesAcrossFragmentedReads(t *testing.T) {
+	var evidence bytes.Buffer
+	runner := &goldenRunner{evidence: &jsonlRecorder{writer: &evidence}}
+	runner.consumeGoldenLocalDaemonStderr(iotest.OneByteReader(strings.NewReader(
+		"time=2026-08-07T10:04:57Z level=INFO msg=\"proxy request\" session=fallback:0123456789abcdef\n" +
+			"time=2026-08-07T10:04:58Z level=WARN msg=\"retrying replayable upstream request after transport failure\" session=ordinary\n",
+	)))
+	if runner.localIssues["fallback"] != 0 {
+		t.Fatalf("structured fallback metadata was classified: %+v", runner.localIssues)
+	}
+	if runner.localIssues["retry"] != 1 || runner.localIssues["error"] != 1 {
+		t.Fatalf("transport message categories = %+v, want one retry and one error", runner.localIssues)
 	}
 }
 

--- a/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
+++ b/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
@@ -538,7 +538,7 @@ func TestGoldenLocalDaemonStderrIgnoresStructuredRequestMetadata(t *testing.T) {
 	var evidence bytes.Buffer
 	runner := &goldenRunner{evidence: &jsonlRecorder{writer: &evidence}}
 	runner.consumeGoldenLocalDaemonStderr(strings.NewReader(
-		"2026/08/07 10:04:57 INFO proxy request agent=codex session=fallback:0123456789abcdef user=\"\" account=account-timeout method=POST path=/responses upstream=example.test remote_addr=127.0.0.1:1234 user_agent=retry-client\n",
+		"2026/08/07 10:04:57 INFO proxy request agent=codex session=fallback:0123456789abcdef user=\"\" account=account-timeout method=POST path=/responses upstream=example.test remote_addr=127.0.0.1:1234 user_agent=\"client msg=retry-client\"\n",
 	))
 	if err := runner.requireGoldenLocalDaemonTransportClean(); err != nil {
 		t.Fatalf("ordinary structured request metadata was treated as a transport failure: %v", err)


### PR DESCRIPTION
A successful local Codex request uses a generated session ID prefixed with `fallback:`. The golden gate scanned every stderr field value, so it canceled a healthy stream as a transport fallback.

This change buffers complete daemon log records and classifies the message text only. It keeps real retry, disconnect, timeout, OOM, and error messages fatal while treating routing metadata as data.

Regression history: `84e5365` adds the failing behavior test, then `cf0d2c0` implements the fix. `go test ./...` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788689493&installation_model_id=21920&pr_number=202&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F202&signature=c8c98e6e725f7d5443183caf8ddccb8f00bc1d888d5555da599e1702b48f740a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes daemon stderr classification by parsing full log lines and classifying only the message text. Adds a 256 KiB record limit so oversized lines are treated as an error without leaking contents.

- **Bug Fixes**
  - Read stderr line-by-line with a 256 KiB bound; treat oversized lines as an `error`.
  - Extract and classify only the message; parse legacy logs first, then structured `msg=`; strip attributes.
  - Ignore request metadata (e.g., `session=fallback:*`) and shutdown signals.
  - Added tests for metadata ignore, fragmented reads, and oversized records.

<sup>Written for commit 9bcf5c977e32ae8610126dc3ef5d3411342abef7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of daemon error output, including structured and legacy messages.
  * Suppressed expected shutdown messages to reduce misleading transport issue reports.
  * Preserved accurate classification of retryable and transport-related errors, even when output arrives in small increments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->