### PR TITLE
Retry immutable release asset verification

### DIFF
--- a/cmd/subrouter/release_publish_test.go
+++ b/cmd/subrouter/release_publish_test.go
@@ -128,6 +128,7 @@ case "$operation" in
   *) exit 2 ;;
 esac
 `)
+			writeExecutableTestFile(t, filepath.Join(fakeBin, "sleep"), "#!/bin/sh\nexit 0\n")
 
 			command := exec.Command(mustLookPath(t, "bash"), script, assetDir)
 			command.Env = append(os.Environ(),

--- a/cmd/subrouter/release_publish_test.go
+++ b/cmd/subrouter/release_publish_test.go
@@ -16,19 +16,28 @@ func TestGitHubReleasePublisherRecoversDraftAndVerifiesImmutableRerun(t *testing
 	script := filepath.Join(repoRoot, "scripts", "publish-github-release.sh")
 
 	for _, test := range []struct {
-		name          string
-		initialState  string
-		wantMutations map[string]bool
+		name               string
+		initialState       string
+		verifyFailures     int
+		wantVerifyAttempts int
+		wantMutations      map[string]bool
 	}{
 		{
 			name: "publish missing release", initialState: "missing",
-			wantMutations: map[string]bool{"release create": true, "release upload": true, "release edit": true},
+			wantVerifyAttempts: 2,
+			wantMutations:      map[string]bool{"release create": true, "release upload": true, "release edit": true},
 		},
 		{
 			name: "replace incomplete draft", initialState: "draft",
-			wantMutations: map[string]bool{"release delete": true, "release create": true, "release upload": true, "release edit": true},
+			wantVerifyAttempts: 2,
+			wantMutations:      map[string]bool{"release delete": true, "release create": true, "release upload": true, "release edit": true},
 		},
-		{name: "verify completed immutable release", initialState: "immutable"},
+		{name: "verify completed immutable release", initialState: "immutable", wantVerifyAttempts: 2},
+		{
+			name: "retry verification while attestations propagate", initialState: "missing",
+			verifyFailures: 2, wantVerifyAttempts: 4,
+			wantMutations: map[string]bool{"release create": true, "release upload": true, "release edit": true},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			assetDir := t.TempDir()
@@ -51,6 +60,10 @@ func TestGitHubReleasePublisherRecoversDraftAndVerifiesImmutableRerun(t *testing
 				t.Fatal(err)
 			}
 			logPath := filepath.Join(t.TempDir(), "gh.log")
+			verifyCountPath := filepath.Join(t.TempDir(), "verify-count")
+			if err := os.WriteFile(verifyCountPath, []byte("0\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
 			writeExecutableTestFile(t, filepath.Join(fakeBin, "gh"), `#!/bin/sh
 set -eu
 printf '%s\n' "$*" >>"$FAKE_GH_LOG"
@@ -100,6 +113,13 @@ case "$operation" in
     ;;
   "release verify-asset")
     [ "$state" = immutable ] || exit 1
+		count="$(cat "$FAKE_VERIFY_COUNT")"
+		count=$((count + 1))
+		printf '%s\n' "$count" >"$FAKE_VERIFY_COUNT"
+		if [ "$count" -le "$FAKE_VERIFY_FAILURES" ]; then
+			printf 'attestation index has not propagated\n' >&2
+			exit 1
+		fi
     printf '{}\n'
     ;;
   "attestation verify")
@@ -119,6 +139,8 @@ esac
 				"FAKE_RELEASE_STATE="+statePath,
 				"FAKE_GH_LOG="+logPath,
 				"FAKE_DIGEST="+fmt.Sprintf("%x", digest),
+				"FAKE_VERIFY_COUNT="+verifyCountPath,
+				fmt.Sprintf("FAKE_VERIFY_FAILURES=%d", test.verifyFailures),
 			)
 			if output, err := command.CombinedOutput(); err != nil {
 				t.Fatalf("publish release: %v\n%s", err, output)
@@ -139,6 +161,9 @@ esac
 			}
 			if !strings.Contains(callLog, "release verify-asset") {
 				t.Fatalf("publisher did not verify immutable release assets:\n%s", callLog)
+			}
+			if attempts := strings.Count(callLog, "release verify-asset"); attempts != test.wantVerifyAttempts {
+				t.Fatalf("immutable verification attempts = %d, want %d:\n%s", attempts, test.wantVerifyAttempts, callLog)
 			}
 		})
 	}

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -24,6 +24,27 @@ release_error="${work_dir}/release-view.stderr"
 verification_dir="${work_dir}/attestation-verification"
 mkdir -p "${verification_dir}"
 
+verify_immutable_asset() {
+  local asset="$1"
+  local max_attempts=12
+  local retry_delay_seconds=5
+  local attempt
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if gh release verify-asset "${TAG_NAME}" "${asset}" \
+        --repo "${GH_REPO}" --format json >/dev/null
+    then
+      return 0
+    fi
+    if (( attempt == max_attempts )); then
+      echo "immutable release asset verification failed after ${max_attempts} attempts: $(basename "${asset}")" >&2
+      return 1
+    fi
+    echo "immutable release asset verification is pending for $(basename "${asset}"); retrying (${attempt}/${max_attempts})" >&2
+    sleep "${retry_delay_seconds}"
+  done
+}
+
 release_state=""
 release_found=false
 if release_state="$(gh release view "${TAG_NAME}" --repo "${GH_REPO}" --json isDraft,isImmutable 2>"${release_error}")"; then
@@ -84,5 +105,5 @@ fi
 gh release view "${TAG_NAME}" --repo "${GH_REPO}" --json isDraft,isImmutable \
   --jq '(.isDraft == false and .isImmutable == true) or error("published release is not immutable")'
 while IFS= read -r -d '' asset; do
-  gh release verify-asset "${TAG_NAME}" "${asset}" --repo "${GH_REPO}" --format json >/dev/null
+  verify_immutable_asset "${asset}"
 done < <(find "${asset_dir}" -maxdepth 1 -type f -print0 | sort -z)


### PR DESCRIPTION
## Summary
- retry final immutable asset verification while GitHub attestation indexing catches up
- cap retries at 12 attempts with a five-second interval
- cover transient propagation with a red-then-green regression

## Testing
- `go test ./...`
- `bash -n scripts/publish-github-release.sh`

## Context
- v0.1.80 publishing completed with intact immutable assets, but the immediate final verification raced GitHub attestation indexing; the unchanged assets verified on retry.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788691981&installation_model_id=21920&pr_number=204&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F204&signature=f587c6b08a5c5df45abe144a85afd09e9a1ff1b58795250427a2dfe1d3eaf611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add retry logic for immutable release asset verification in `scripts/publish-github-release.sh` to handle GitHub attestation indexing lag and prevent flaky publish failures. Tests simulate transient failures and assert the expected verification attempts.

- **Bug Fixes**
  - Verify each asset with up to 12 attempts, 5s between retries; fail with a clear error after max attempts.
  - Log pending verification with attempt counts for visibility.
  - Tests now simulate attestation propagation delays and check `verify-asset` call counts.

<sup>Written for commit 6487c9986c0b10abfb2c0f4253b262dce0ec5566. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

