### PR TITLE
Tolerate RSS sampler process exits

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -2431,6 +2431,76 @@ exit 0
 	}
 }
 
+func TestFrontSlotRSSSamplerToleratesProcessExitDuringStatusRead(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("RSS sampler reads Linux cgroup and procfs state")
+	}
+	if _, err := os.Stat("/sys/fs/cgroup/cgroup.procs"); err != nil {
+		t.Skipf("root cgroup process list is unavailable: %v", err)
+	}
+	requireDeployScriptTools(t, "bash")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	fakeBin := t.TempDir()
+	runLabel := "rss-exit-race-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	sentinel := filepath.Join("/tmp", "subrouter-rss-"+runLabel+"-legacy.running")
+	peak := filepath.Join("/tmp", "subrouter-rss-"+runLabel+"-legacy.peak")
+	oom := filepath.Join("/tmp", "subrouter-rss-"+runLabel+"-legacy.oom")
+	for _, path := range []string{sentinel, peak, peak + ".tmp", oom, oom + ".tmp"} {
+		path := path
+		t.Cleanup(func() { _ = os.Remove(path) })
+	}
+	if err := os.WriteFile(sentinel, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "id"), "#!/bin/sh\nprintf '0\\n'\n")
+	for _, name := range []string{"curl", "jq", "python3", "sha256sum"} {
+		writeExecutableTestFile(t, filepath.Join(fakeBin, name), "#!/bin/sh\nexit 0\n")
+	}
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "systemctl"), `#!/bin/sh
+if [ "$1" = show ]; then
+  printf '/\n'
+  exit 0
+fi
+exit 2
+`)
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "awk"), `#!/bin/sh
+last=''
+for argument in "$@"; do last="$argument"; done
+case "$last" in
+  */memory.events) printf '0\n' ;;
+  */proc/*/status)
+    printf 'awk: cannot open %s (No such file or directory)\n' "$last" >&2
+    exit 2
+    ;;
+  *) exit 2 ;;
+esac
+`)
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "sleep"), `#!/bin/sh
+rm -f -- "$RSS_SAMPLER_SENTINEL"
+`)
+
+	command := exec.Command(mustLookPath(t, "bash"),
+		filepath.Join(repoRoot, "deploy", "gcp", "install-front-slots.sh"),
+		"sample-service-rss", "legacy", runLabel)
+	command.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"RSS_SAMPLER_SENTINEL="+sentinel,
+		"SUBROUTER_DEPLOYMENT_CONTRACT="+filepath.Join(repoRoot, "deploy", "gcp", "deployment-contract.py"),
+	)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("sample process exit race: %v\n%s", err, output)
+	}
+	for _, path := range []string{peak, oom} {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(body) != "0\n" {
+			t.Fatalf("sampler result %s = %q, want zero", path, body)
+		}
+	}
+}
+
 func TestFrontSlotInstallerDetachesVerifierFromRetiredLegacyService(t *testing.T) {
 	requireDeployScriptTools(t, "bash", "curl", "jq", "python3", "sha256sum")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/deploy/gcp/install-front-slots.sh
+++ b/deploy/gcp/install-front-slots.sh
@@ -659,8 +659,10 @@ sample_service_rss() {
     [[ -r "/sys/fs/cgroup${cg}/cgroup.procs" ]] || break
     total=0
     while IFS= read -r pid; do
-      [[ "${pid}" =~ ^[0-9]+$ && -r "/proc/${pid}/status" ]] || continue
-      rss_kib="$(awk '$1 == "VmRSS:" {print $2; exit}' "/proc/${pid}/status")"
+      [[ "${pid}" =~ ^[0-9]+$ ]] || continue
+      if ! rss_kib="$(awk '$1 == "VmRSS:" {print $2; exit}' "/proc/${pid}/status" 2>/dev/null)"; then
+        continue
+      fi
       [[ "${rss_kib:-}" =~ ^[0-9]+$ ]] || continue
       total=$((total + rss_kib * 1024))
     done <"/sys/fs/cgroup${cg}/cgroup.procs"


### PR DESCRIPTION
## Summary
- treat a process disappearing between cgroup enumeration and `/proc` status read as an expected retirement race
- preserve the last valid peak RSS and OOM evidence
- reproduce the Linux race with a red-then-green behavioral test

## Testing
- `go test ./...`
- `docker run --rm -v "$PWD:/src" -w /src golang:1.25 go test ./cmd/subrouter -run "^TestFrontSlotRSSSamplerToleratesProcessExitDuringStatusRead$" -count=1`
- `bash -n deploy/gcp/install-front-slots.sh`

## Incident
- staging v0.1.80 continuity preserved both held streams, then legacy retirement stopped because `/proc/<pid>/status` vanished after the PID snapshot.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the RSS sampler tolerate processes that exit between cgroup enumeration and /proc reads. This prevents stalled legacy retirement and preserves the last valid peak RSS and OOM markers.

- **Bug Fixes**
  - In deploy/gcp/install-front-slots.sh, skip PIDs whose /proc/<pid>/status vanishes and ignore awk errors while reading VmRSS.
  - Add a Linux test that reproduces the race and verifies peak and OOM files remain stable.

<sup>Written for commit aeb5eeeb1acc0300e7bee497aaccf196512b0a18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

