### PR TITLE
Pin golden continuity gate to v0.1.81

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -51,7 +51,7 @@ const (
 	goldenPinnedBootstrapTag                  = "v0.1.63"
 	goldenPinnedBootstrapLinuxSHA256          = "39fcd2c3a86c7be12759ed0f0b366d9d13f90e538c2af2483dd50230c9ef2bf2"
 	goldenPinnedBootstrapRevision             = "763dcf6c304d9aea7f36659d4fba40ea27f42096"
-	goldenPinnedCandidateTag                  = "v0.1.80"
+	goldenPinnedCandidateTag                  = "v0.1.81"
 	goldenResponseRequestTokenEnv             = "SUBROUTER_GOLDEN_RESPONSE_REQUEST_TOKEN"
 	goldenFakeStreamReleaseTokenEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_TOKEN"
 	goldenFakeStreamReleaseStateEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_STATE"

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -20,7 +20,7 @@ func TestGoldenOptionsRequireProductionPredecessorV0160(t *testing.T) {
 	args := []string{
 		"--predecessor-version", "v0.1.60",
 		"--predecessor-sha256", "769e504b731ef8b43db67e7651dcfe9ae169516570c7d2d2d211a6f997be1a7c",
-		"--candidate-tag", "v0.1.80",
+		"--candidate-tag", "v0.1.81",
 		"--candidate-sha256", strings.Repeat("b", 64),
 		"--candidate-revision", strings.Repeat("c", 40),
 		"--deploy-evidence-validator", "validator",
@@ -38,7 +38,7 @@ func TestGoldenOptionsRequireProductionPredecessorV0160(t *testing.T) {
 	}
 }
 
-func TestGoldenOptionsRequireV0180Candidate(t *testing.T) {
+func TestGoldenOptionsRequireV0181Candidate(t *testing.T) {
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = false
 	t.Cleanup(func() { goldenTestHooks = previousHooks })
@@ -46,7 +46,7 @@ func TestGoldenOptionsRequireV0180Candidate(t *testing.T) {
 	args := []string{
 		"--predecessor-version", "v0.1.60",
 		"--predecessor-sha256", goldenPinnedPredecessorSHA256,
-		"--candidate-tag", "v0.1.80",
+		"--candidate-tag", "v0.1.81",
 		"--candidate-sha256", strings.Repeat("b", 64),
 		"--candidate-revision", strings.Repeat("c", 40),
 		"--deploy-evidence-validator", "validator",
@@ -60,16 +60,16 @@ func TestGoldenOptionsRequireV0180Candidate(t *testing.T) {
 		"--old-generation-check", "true",
 	}
 	if _, err := parseGoldenArgs(args); err != nil {
-		t.Fatalf("v0.1.80 candidate was rejected: %v", err)
+		t.Fatalf("v0.1.81 candidate was rejected: %v", err)
 	}
 	for index := range args {
-		if args[index] == "v0.1.80" {
-			args[index] = "v0.1.79"
+		if args[index] == "v0.1.81" {
+			args[index] = "v0.1.80"
 			break
 		}
 	}
 	if _, err := parseGoldenArgs(args); err == nil {
-		t.Fatal("previous v0.1.79 candidate was accepted")
+		t.Fatal("previous v0.1.80 candidate was accepted")
 	}
 }
 

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify the immutable v0.1.60/v0.1.63/v0.1.80 release inputs, then run the complete
+# Verify the immutable v0.1.60/v0.1.63/v0.1.81 release inputs, then run the complete
 # legacy-to-front migration and slot-upgrade continuity gate from a local Mac.
 set -euo pipefail
 umask 077
@@ -16,7 +16,7 @@ bootstrap_tag="v0.1.63"
 bootstrap_version="0.1.63"
 bootstrap_revision="763dcf6c304d9aea7f36659d4fba40ea27f42096"
 bootstrap_linux_sha="39fcd2c3a86c7be12759ed0f0b366d9d13f90e538c2af2483dd50230c9ef2bf2"
-candidate_tag="v0.1.80"
+candidate_tag="v0.1.81"
 candidate_version="0.1.80"
 
 usage() {

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -17,7 +17,7 @@ bootstrap_version="0.1.63"
 bootstrap_revision="763dcf6c304d9aea7f36659d4fba40ea27f42096"
 bootstrap_linux_sha="39fcd2c3a86c7be12759ed0f0b366d9d13f90e538c2af2483dd50230c9ef2bf2"
 candidate_tag="v0.1.81"
-candidate_version="0.1.80"
+candidate_version="0.1.81"
 
 usage() {
   cat <<'EOF'


### PR DESCRIPTION
## Summary
- require the immutable v0.1.81 candidate in the golden observer
- update the local-Mac continuity wrapper to download and verify v0.1.81
- reject the previous v0.1.80 candidate

## Testing
- `go test ./cmd/subrouter-transport-observer -run "^TestGoldenOptionsRequire(ProductionPredecessorV0160|V0181Candidate)$" -count=1`
- `go test ./...` attempted; the changed observer package passed, while unrelated `TestCreateVMTempFilesSurviveInterruptedAndRepeatedMacOSRuns` exceeded its five-second local deadline under concurrent CPU load. Hosted CI is required before merge.
- `bash -n deploy/gcp/golden-local-mac-production-continuity.sh`

## Release
- https://github.com/manaflow-ai/subrouter/releases/tag/v0.1.81

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788693952&installation_model_id=21920&pr_number=206&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F206&signature=330bfed05f3a610c82c8f2fb4dbe96abaf445b7f0e37fee581b4ee011f44c04d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the golden continuity gate to v0.1.81 so the observer and local Mac continuity workflow use the new candidate and reject v0.1.80. Updates the observer constant and tests, and fixes the local Mac script by aligning the candidate tag and version to v0.1.81.

<sup>Written for commit 434d5e3a91ebabcff9ca526541ed31df6e16afb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned candidate release from v0.1.80 to v0.1.81.
  * Updated release validation and continuity configuration to use the new candidate tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->