### PR TITLE
feat: add version command for sr/subrouter binaries

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -165,6 +165,9 @@ func runForProgram(program string, args []string) error {
 		return installSystemd(args[1:])
 	case "install-launchd":
 		return installLaunchd(args[1:])
+	case "version", "-v", "--version":
+		printVersion(os.Stdout, program)
+		return nil
 	case "help", "-h", "--help":
 		usage(program)
 		return nil
@@ -267,7 +270,10 @@ var directSRCommands = map[string]struct{}{
 	"trace":            {},
 	"usage":            {},
 	"use":              {},
+	"version":          {},
 	"why":              {},
+	"-v":               {},
+	"--version":        {},
 }
 
 func isDirectSRCommand(command string) bool {
@@ -1279,6 +1285,7 @@ Getting started:
                            Set up this machine without shared credentials
   %[1]s doctor             Diagnose login, team vault, daemon, and local egress
   %[1]s cleanup            Remove the local daemon (--yes to apply, --purge for local credentials)
+  %[1]s version            Print build version, commit, and build date
 
 Credential storage:
   %[1]s storage            Show the active credential source

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -96,6 +96,7 @@ Advanced setup:
                         Replace a broken shared credential in place
   sr doctor             Diagnose login, team, daemon, and credential access
   sr cleanup            Remove the local daemon (--yes to apply, --purge for credentials)
+  sr version            Print build version, commit, and build date
 
 Running agents:
   sr codex [args]       Run codex through Subrouter
@@ -191,6 +192,9 @@ func (r srRunner) run(ctx context.Context, args []string) error {
 		switch args[0] {
 		case "help", "-h", "--help":
 			fmt.Fprint(r.out, srHelp)
+			return nil
+		case "version", "-v", "--version":
+			printVersion(r.out, r.programOrSubrouter())
 			return nil
 		case "login":
 			return r.cloudLogin(ctx, args[1:])

--- a/cmd/subrouter/version.go
+++ b/cmd/subrouter/version.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"runtime/debug"
+	"strings"
+)
+
+// These are stamped at link time via:
+//
+//	-ldflags "-X main.version=… -X main.commit=… -X main.buildDate=…"
+//
+// Unset values fall back to module build info or "devel".
+var (
+	version   = ""
+	commit    = ""
+	buildDate = ""
+)
+
+type buildInfo struct {
+	Version   string
+	Commit    string
+	BuildDate string
+	GoVersion string
+}
+
+func resolveBuildInfo() buildInfo {
+	info := buildInfo{
+		Version:   strings.TrimSpace(version),
+		Commit:    strings.TrimSpace(commit),
+		BuildDate: strings.TrimSpace(buildDate),
+		GoVersion: runtime.Version(),
+	}
+	if info.Version == "" || info.Commit == "" || info.BuildDate == "" {
+		if bi, ok := debug.ReadBuildInfo(); ok {
+			if info.Version == "" || info.Version == "devel" {
+				if v := strings.TrimSpace(bi.Main.Version); v != "" && v != "(devel)" {
+					info.Version = v
+				}
+			}
+			for _, setting := range bi.Settings {
+				switch setting.Key {
+				case "vcs.revision":
+					if info.Commit == "" {
+						info.Commit = setting.Value
+						if len(info.Commit) > 12 {
+							info.Commit = info.Commit[:12]
+						}
+					}
+				case "vcs.time":
+					if info.BuildDate == "" {
+						info.BuildDate = setting.Value
+					}
+				}
+			}
+		}
+	}
+	if info.Version == "" {
+		info.Version = "devel"
+	}
+	if info.Commit == "" {
+		info.Commit = "unknown"
+	}
+	if info.BuildDate == "" {
+		info.BuildDate = "unknown"
+	}
+	return info
+}
+
+func printVersion(w io.Writer, program string) {
+	info := resolveBuildInfo()
+	fmt.Fprintf(w, "%s %s (commit %s, built %s, %s)\n",
+		program, info.Version, info.Commit, info.BuildDate, info.GoVersion)
+}
+
+func isVersionCommand(arg string) bool {
+	switch arg {
+	case "version", "-v", "--version":
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/subrouter/version_test.go
+++ b/cmd/subrouter/version_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPrintVersionIncludesProgramAndFields(t *testing.T) {
+	version = "1.2.3"
+	commit = "abcdef012345"
+	buildDate = "2026-08-07T00:00:00Z"
+	t.Cleanup(func() {
+		version, commit, buildDate = "", "", ""
+	})
+
+	var buf bytes.Buffer
+	printVersion(&buf, "sr-gcp")
+	got := buf.String()
+	for _, want := range []string{"sr-gcp", "1.2.3", "abcdef012345", "2026-08-07T00:00:00Z"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("version output %q missing %q", got, want)
+		}
+	}
+}
+
+func TestIsVersionCommand(t *testing.T) {
+	for _, arg := range []string{"version", "-v", "--version"} {
+		if !isVersionCommand(arg) {
+			t.Fatalf("expected %q to be a version command", arg)
+		}
+	}
+	if isVersionCommand("status") {
+		t.Fatal("status must not be treated as a version command")
+	}
+}
+
+func TestRunForProgramVersion(t *testing.T) {
+	version = "9.9.9"
+	commit = "deadbeefcafe"
+	buildDate = "2026-01-01T00:00:00Z"
+	t.Cleanup(func() {
+		version, commit, buildDate = "", "", ""
+	})
+	for _, arg := range []string{"version", "--version"} {
+		if err := runForProgram("subrouter", []string{arg}); err != nil {
+			t.Fatalf("runForProgram(%q): %v", arg, err)
+		}
+	}
+}

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -21,11 +21,16 @@ build() {
     suffix=".exe"
   fi
   local output="${out_dir}/subrouter_${version}_${goos}_${arch_name}${suffix}"
+  local commit
+  commit="$(git -C "${root}" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
+  local built
+  built="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  local ldflags="-s -w -X main.version=${version} -X main.commit=${commit} -X main.buildDate=${built}"
   echo "building ${output}"
   if [[ -n "${goarm}" ]]; then
-    GOOS="${goos}" GOARCH="${goarch}" GOARM="${goarm}" CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o "${output}" ./cmd/subrouter
+    GOOS="${goos}" GOARCH="${goarch}" GOARM="${goarm}" CGO_ENABLED=0 go build -trimpath -ldflags="${ldflags}" -o "${output}" ./cmd/subrouter
   else
-    GOOS="${goos}" GOARCH="${goarch}" CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o "${output}" ./cmd/subrouter
+    GOOS="${goos}" GOARCH="${goarch}" CGO_ENABLED=0 go build -trimpath -ldflags="${ldflags}" -o "${output}" ./cmd/subrouter
   fi
 }
 


### PR DESCRIPTION
Add version / --version so parallel sr, sr-gcp, and subrouter installs can be distinguished by semver, commit, and build date.
Fixes #128

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788694407&installation_model_id=21920&pr_number=207&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F207&signature=8f299e42b26357c8005a9102ff8de6a61feb8c5cc816b26c44f2d524315435ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `version` command to `subrouter`, `sr`, and `sr-gcp` to print semver, commit, build date, and Go version so parallel installs are easy to tell apart. Addresses #128.

- **New Features**
  - Add `version`, `--version`, and `-v` for all binaries; prints "<program> <semver> (commit <12-char>, built <date>, <go version>)".
  - Embed version metadata via `-ldflags` in `scripts/build-release.sh`; falls back to Go build info if unset; help text updated.

<sup>Written for commit 9b632313bc3031f5f3e41e3c6f1c544a009e2e3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

