### PR TITLE
test: forbid BSD-first stat owner probes that break GNU install

### DIFF
--- a/cmd/subrouter/stat_owner_regression_test.go
+++ b/cmd/subrouter/stat_owner_regression_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// GNU coreutils treats `stat -f` as "filesystem status" and exits 0, so a
+// BSD-first ownership probe never falls back to `stat -c` and poisons
+// `install -o` with a multi-line filesystem report (see #126).
+func TestNoBSDFirstStatOwnerProbeInCmdSources(t *testing.T) {
+	root := "."
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var files []string
+	var walk func(string)
+	walk = func(dir string) {
+		items, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, item := range items {
+			path := filepath.Join(dir, item.Name())
+			if item.IsDir() {
+				walk(path)
+				continue
+			}
+			if strings.HasSuffix(path, ".go") {
+				files = append(files, path)
+			}
+		}
+	}
+	_ = entries
+	walk(root)
+
+	forbidden := []string{
+		"stat -f '%Su'",
+		`stat -f "%Su"`,
+		"stat -f '%Sg'",
+		`stat -f "%Sg"`,
+	}
+	for _, path := range files {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(body)
+		for _, needle := range forbidden {
+			if !strings.Contains(text, needle) {
+				continue
+			}
+			// Allow the pattern only if GNU-first ordering is clearly present
+			// on the same line / nearby. Prefer failing closed.
+			idx := strings.Index(text, needle)
+			windowStart := idx - 80
+			if windowStart < 0 {
+				windowStart = 0
+			}
+			windowEnd := idx + len(needle) + 80
+			if windowEnd > len(text) {
+				windowEnd = len(text)
+			}
+			window := text[windowStart:windowEnd]
+			if strings.Contains(window, "stat -c") && strings.Index(window, "stat -c") < strings.Index(window, "stat -f") {
+				continue
+			}
+			t.Fatalf("%s contains BSD-first ownership probe %q; use GNU-first: stat -c then stat -f (#126)", path, needle)
+		}
+	}
+}


### PR DESCRIPTION
Add a regression test so BSD-first `stat -f '%Su'` ownership probes cannot return silently on GNU coreutils and poison `install -o`.
Fixes #126

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788694511&installation_model_id=21920&pr_number=208&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F208&signature=b3406086ed617fc4cd5cd33c67a6f09470cab9da0ab6460ed086930889d5fce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test that blocks BSD‑first `stat -f` owner probes in `cmd/subrouter` Go sources. Ensures GNU systems use `stat -c` first to avoid multi‑line output that breaks `install -o`. Fixes #126.

<sup>Written for commit 314ff31b06721c04d643b64c51882baca75225ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

