### PR TITLE
fix: keep supervisor listen socket reusable across restarts

### DIFF
--- a/cmd/subrouter/front.go
+++ b/cmd/subrouter/front.go
@@ -325,22 +325,6 @@ func disableAutomaticUnixUnlink(listener net.Listener) {
 	}
 }
 
-func openFreshPublicListener(address string) (net.Listener, error) {
-	host, _, err := net.SplitHostPort(address)
-	if err != nil {
-		return nil, err
-	}
-	network := "tcp"
-	if ip := net.ParseIP(host); ip != nil {
-		if ip.To4() != nil {
-			network = "tcp4"
-		} else {
-			network = "tcp6"
-		}
-	}
-	return (&net.ListenConfig{}).Listen(context.Background(), network, address)
-}
-
 func openFrontPublicListener(address string) (net.Listener, bool, error) {
 	listeners, err := inheritedSystemdListeners()
 	if err != nil {

--- a/cmd/subrouter/listener_reuseport_other.go
+++ b/cmd/subrouter/listener_reuseport_other.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package main
+
+import (
+	"context"
+	"net"
+)
+
+// openFreshPublicListener falls back to a plain Listen where SO_REUSEPORT is unavailable.
+func openFreshPublicListener(address string) (net.Listener, error) {
+	return (&net.ListenConfig{}).Listen(context.Background(), "tcp", address)
+}

--- a/cmd/subrouter/listener_reuseport_unix.go
+++ b/cmd/subrouter/listener_reuseport_unix.go
@@ -1,0 +1,42 @@
+//go:build unix
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"syscall"
+)
+
+// openFreshPublicListener binds with SO_REUSEPORT so a replacement supervisor
+// can take the address before the draining process exits (see #125).
+func openFreshPublicListener(address string) (net.Listener, error) {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	network := "tcp"
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.To4() != nil {
+			network = "tcp4"
+		} else {
+			network = "tcp6"
+		}
+	}
+	config := net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			var setErr error
+			if err := c.Control(func(fd uintptr) {
+				setErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEPORT, 1)
+			}); err != nil {
+				return err
+			}
+			if setErr != nil {
+				return fmt.Errorf("SO_REUSEPORT: %w", setErr)
+			}
+			return nil
+		},
+	}
+	return config.Listen(context.Background(), network, address)
+}

--- a/cmd/subrouter/supervisor.go
+++ b/cmd/subrouter/supervisor.go
@@ -370,6 +370,10 @@ func (s *supervisor) run() error {
 				}()
 				continue
 			}
+			// Closing the public listener here is what makes a launchd
+			// KeepAlive restart an outage for the whole drain window (#125).
+			// Prefer deploy/macos/overlap-restart-supervisor.sh: the
+			// replacement binds with SO_REUSEPORT before SIGTERM arrives.
 			_ = listener.Close()
 			_ = controlServer.Close()
 			s.beginShutdown()

--- a/deploy/macos/overlap-restart-supervisor.sh
+++ b/deploy/macos/overlap-restart-supervisor.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Overlap-restart a LaunchDaemon supervisor without a multi-minute outage (#125).
+#
+# The supervisor binds with SO_REUSEPORT, so this script can start the
+# replacement before SIGTERM reaches the draining process. launchd KeepAlive
+# alone cannot do that: it waits for exit, and today SIGTERM closes the TCP
+# listener immediately, so the whole drain window is an outage.
+set -euo pipefail
+
+label="${1:-ai.manaflow.subrouter-team}"
+plist="/Library/LaunchDaemons/${label}.plist"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "overlap-restart-supervisor.sh is macOS-only" >&2
+  exit 1
+fi
+
+if [[ ! -f "${plist}" ]]; then
+  echo "missing plist: ${plist}" >&2
+  exit 1
+fi
+
+bin="$(/usr/libexec/PlistBuddy -c 'Print :ProgramArguments:0' "${plist}" 2>/dev/null || true)"
+if [[ -z "${bin}" || ! -x "${bin}" ]]; then
+  echo "could not resolve ProgramArguments[0] from ${plist}" >&2
+  exit 1
+fi
+
+# Collect remaining ProgramArguments for the successor.
+args=()
+i=1
+while value="$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:${i}" "${plist}" 2>/dev/null)"; do
+  args+=("${value}")
+  i=$((i + 1))
+done
+
+echo "starting overlapping successor: ${bin} ${args[*]}"
+sudo "${bin}" "${args[@]}" &
+successor_pid=$!
+
+# Give the successor a moment to bind with SO_REUSEPORT before draining the old process.
+sleep 1
+if ! kill -0 "${successor_pid}" 2>/dev/null; then
+  echo "successor exited immediately" >&2
+  exit 1
+fi
+
+echo "signaling launchd to stop ${label} (successor pid ${successor_pid} already listening)"
+sudo launchctl bootout "system/${label}" 2>/dev/null || sudo launchctl unload "${plist}" 2>/dev/null || true
+
+# Prefer the managed plist again once the old process is gone.
+sudo launchctl bootstrap system "${plist}" 2>/dev/null || sudo launchctl load -w "${plist}" 2>/dev/null || true
+echo "overlap restart requested for ${label}"


### PR DESCRIPTION
Bind with SO_REUSEPORT and add deploy/macos/overlap-restart-supervisor.sh so SIGTERM drain is not a hard outage.
Fixes #125

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788694878&installation_model_id=21920&pr_number=209&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F209&signature=96985800a787ac1c346fad8b3fdb613daa455523e63b045681d01144afbd9680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make supervisor restarts seamless by binding the public TCP listener with SO_REUSEPORT and adding a macOS overlap-restart helper. The new process can now bind before the old one drains, avoiding the drain-window outage.

- **Bug Fixes**
  - On Unix, bind the public listener with SO_REUSEPORT so a replacement supervisor can listen before SIGTERM closes the old process; non-Unix falls back to a normal Listen.
  - Add deploy/macos/overlap-restart-supervisor.sh to start a successor via launchd using the same ProgramArguments, then stop the old service, removing the multi-minute outage during restarts.

<sup>Written for commit ef4e3ddd0dbe1a3ec3b6cc43b0cb887af9f2de1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

