### PR TITLE
fix: remove dormant subrouter-forward LaunchDaemon leftovers

### DIFF
--- a/deploy/macos/remove-dormant-subrouter-forward.sh
+++ b/deploy/macos/remove-dormant-subrouter-forward.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Remove the unfinished ai.manaflow.subrouter-forward LaunchDaemon left on
+# cmux-mac-mini during a migration that never completed (#127).
+#
+# That plist points socat at a dead Tailscale peer, is not currently loaded,
+# and would collide with the real 0.0.0.0:31415 listener if bootstrapped.
+#
+# Usage (on the affected Mac, as root):
+#   sudo ./deploy/macos/remove-dormant-subrouter-forward.sh
+# Optional: also prune inert team plist backups:
+#   sudo ./deploy/macos/remove-dormant-subrouter-forward.sh --prune-team-backups
+set -euo pipefail
+
+label="${1:-ai.manaflow.subrouter-forward}"
+prune_backups=0
+if [[ "${1:-}" == "--prune-team-backups" ]]; then
+  label="ai.manaflow.subrouter-forward"
+  prune_backups=1
+elif [[ "${2:-}" == "--prune-team-backups" ]]; then
+  prune_backups=1
+fi
+
+plist="/Library/LaunchDaemons/${label}.plist"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "remove-dormant-subrouter-forward.sh is macOS-only" >&2
+  exit 1
+fi
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "run as root" >&2
+  exit 1
+fi
+
+if [[ ! -f "${plist}" ]]; then
+  echo "already absent: ${plist}"
+else
+  # Never load a dormant forwarder; only unload if something already registered it.
+  if launchctl print "system/${label}" >/dev/null 2>&1; then
+    echo "bootout system/${label}"
+    launchctl bootout "system/${label}" 2>/dev/null || launchctl unload "${plist}" 2>/dev/null || true
+  fi
+
+  backup="${plist}.removed-$(date +%Y%m%d%H%M%S)"
+  mv "${plist}" "${backup}"
+  echo "moved ${plist} -> ${backup}"
+fi
+
+if [[ "${prune_backups}" -eq 1 ]]; then
+  # launchd ignores files without a .plist suffix; these backups are inert but
+  # obscure the real team configuration during incidents (#127).
+  shopt -s nullglob
+  for f in /Library/LaunchDaemons/ai.manaflow.subrouter-team.plist.*; do
+    case "$f" in
+      *.plist) continue ;; # real plists only — never touch active config
+    esac
+    dest="${f}.pruned-$(date +%Y%m%d%H%M%S)"
+    mv "$f" "$dest"
+    echo "pruned backup $f -> $dest"
+  done
+  shopt -u nullglob
+fi
+
+echo "dormant forwarder removed; team supervisor plist is unchanged"
+echo "note: a loopback socat shim is not a migration step — cut over via servers.json after the destination daemon is live"

--- a/deploy/macos/subrouter-verify.sh
+++ b/deploy/macos/subrouter-verify.sh
@@ -104,6 +104,13 @@ if [ "$import_state" = "disabled" ]; then
   emit ALERT "account import is disabled: this server rejects every sr add (no admin or account-import credential configured)"
 fi
 
+# --- 1c. dormant socat forwarder plists (unfinished host migration leftover) ---
+# These bind loopback-only and point at another host; if present on disk they
+# can activate on reboot and collide with the real *:31415 listener (#127).
+for forward_plist in /Library/LaunchDaemons/*subrouter*forward*.plist; do
+  [ -e "$forward_plist" ] || continue
+  emit ALERT "dormant subrouter-forward LaunchDaemon present: $forward_plist (run deploy/macos/remove-dormant-subrouter-forward.sh)"
+done
 
 # --- read new log lines since last run (byte cursors advance themselves) ---
 lines=""

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -24,6 +24,16 @@ sudo ./deploy/macos/migrate-launchdaemon-to-supervisor.sh --activate
 
 The one-time transition cannot preserve connections accepted by an older, unsupervised process because that process owns their file descriptors. Perform it in a maintenance window. All later worker upgrades preserve connections.
 
+A loopback `socat` LaunchDaemon that forwards `127.0.0.1:31415` to another Tailscale host is not a migration step. It cannot serve the tailnet, collides with the real listener, and leaves a dormant plist that activates on reboot if the destination is still down. If such a leftover appears (`ai.manaflow.subrouter-forward.plist`), remove it with:
+
+```bash
+sudo ./deploy/macos/remove-dormant-subrouter-forward.sh
+# optional: prune inert ai.manaflow.subrouter-team.plist.* backups
+sudo ./deploy/macos/remove-dormant-subrouter-forward.sh --prune-team-backups
+```
+
+Cut over by standing up the daemon on the destination, migrating account state, verifying, then repointing the `team` entry in `servers.json`.
+
 ### Worker upgrade
 
 Replace the worker binary atomically, then ask the stable supervisor to create a generation:


### PR DESCRIPTION
Add deploy/macos/remove-dormant-subrouter-forward.sh, alert from subrouter-verify when a `*forward*.plist` is present, and document that a loopback socat shim is not a cutover step.

Ops on cmux-mac-mini:
```bash
sudo ./deploy/macos/remove-dormant-subrouter-forward.sh --prune-team-backups
```

Fixes #127

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788697772&installation_model_id=21920&pr_number=210&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F210&signature=7711358afd3f34cf881151567bbfd195a272604623e59983f6512bbaea7af5e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes dormant `ai.manaflow.subrouter-forward` LaunchDaemon leftovers on macOS and adds a verify alert so they can’t silently reactivate. Also clarifies that a loopback `socat` shim is not a valid migration step.

- **Bug Fixes**
  - Added `deploy/macos/remove-dormant-subrouter-forward.sh` to uninstall `ai.manaflow.subrouter-forward`; optional `--prune-team-backups` renames inert `ai.manaflow.subrouter-team.plist.*` backups.
  - `deploy/macos/subrouter-verify.sh` now emits ALERT if any `/Library/LaunchDaemons/*subrouter*forward*.plist` exists.
  - Updated `docs/upgrades.md` with cleanup commands and the correct cutover flow.

<sup>Written for commit 7c89514591b25f82e54ec08b60f63ca57d877a05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

