### PR TITLE
fix: claim OAuth account ownership so dual-host refresh cannot burn tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage.out
 __pycache__/
 dist/
 *.egg-info/
+.tools/

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -278,6 +278,7 @@ func isDirectSRCommand(command string) bool {
 func serve(args []string) error {
 	flags := flag.NewFlagSet("serve", flag.ContinueOnError)
 	addr := flags.String("addr", "127.0.0.1:31415", "listen address")
+	hostID := flags.String("host-id", "", "stable host identity for OAuth owner claims; defaults to SUBROUTER_HOST_ID or the OS hostname")
 	upstreamRaw := flags.String("upstream", "", "force one upstream base URL for all accounts")
 	codexUpstreamRaw := flags.String("codex-upstream", "https://chatgpt.com/backend-api/codex", "Codex subscription upstream base URL")
 	apiUpstreamRaw := flags.String("api-upstream", "https://api.openai.com", "OpenAI API-key upstream base URL")
@@ -324,6 +325,9 @@ func serve(args []string) error {
 	cloudCredentialSource := flags.String("cloud-credential-source", "", "override the credential source loaded from the cloud config: team, local, or legacy")
 	if err := flags.Parse(args); err != nil {
 		return err
+	}
+	if id := strings.TrimSpace(*hostID); id != "" {
+		accounts.SetHostID(id)
 	}
 	if strings.TrimSpace(*transcriptGCSURI) != "" && strings.TrimSpace(*transcriptDir) == "" {
 		return errors.New("--transcripts is required when --transcript-gcs-uri is set")

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -420,7 +420,7 @@ func (r srRunner) runRemoteAccountCommand(ctx context.Context, server srServerCo
 		if err != nil {
 			return err
 		}
-		return r.serverLoginOne(ctx, server, deviceAuth, "")
+		return r.serverLoginOne(ctx, server, deviceAuth, "", false)
 	case "add-key", "add-api-key":
 		return r.addKeyToServer(ctx, server, args[1:])
 	case "list", "ls":
@@ -1951,11 +1951,11 @@ func usageRowErrorHint(row srUsageRow) string {
 		return ""
 	}
 	msg := strings.ToLower(row.err.Error())
-	if strings.Contains(msg, "refresh_token_reused") || strings.Contains(msg, "refresh token has already been used") {
+	if refreshTokenBurned(row.err) {
 		return " (burned: refresh_token_reused — dual-host copy? re-auth required, not a stale token)"
 	}
 	if strings.Contains(msg, "owned by host") && strings.Contains(msg, "refuse refresh") {
-		return " (foreign owner claim — stop the other host or takeover)"
+		return " (foreign owner claim — stop the other host or pass --takeover)"
 	}
 	if !authErrorNeedsReadd(row.err) {
 		return ""
@@ -1985,6 +1985,15 @@ func authErrorNeedsReadd(err error) bool {
 		}
 	}
 	return false
+}
+
+func refreshTokenBurned(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "refresh_token_reused") ||
+		strings.Contains(msg, "refresh token has already been used")
 }
 
 func printUsageGridGroup(out io.Writer, columns []usageGridColumn, label string, colored bool) {
@@ -2211,7 +2220,9 @@ func usageGridState(row srUsageRow) string {
 	} else if row.tempCooked {
 		states = append(states, "temp")
 	}
-	if row.err != nil {
+	if refreshTokenBurned(row.err) {
+		states = append(states, "reauth")
+	} else if row.err != nil {
 		states = append(states, "error")
 	}
 	return strings.Join(states, ", ")
@@ -2256,6 +2267,9 @@ func usageGridError(row srUsageRow) string {
 }
 
 func compactPickReason(row srUsageRow) string {
+	if refreshTokenBurned(row.err) {
+		return "refresh token reused; re-auth"
+	}
 	if row.err != nil {
 		return "usage unavailable"
 	}

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -1947,7 +1947,17 @@ func providerCountNoun(provider accounts.Provider, n int) string {
 }
 
 func usageRowErrorHint(row srUsageRow) string {
-	if row.err == nil || !authErrorNeedsReadd(row.err) {
+	if row.err == nil {
+		return ""
+	}
+	msg := strings.ToLower(row.err.Error())
+	if strings.Contains(msg, "refresh_token_reused") || strings.Contains(msg, "refresh token has already been used") {
+		return " (burned: refresh_token_reused — dual-host copy? re-auth required, not a stale token)"
+	}
+	if strings.Contains(msg, "owned by host") && strings.Contains(msg, "refuse refresh") {
+		return " (foreign owner claim — stop the other host or takeover)"
+	}
+	if !authErrorNeedsReadd(row.err) {
 		return ""
 	}
 	return " (re-add with: " + providerReaddCommand(usageProvider(row)) + ")"
@@ -1966,7 +1976,10 @@ func providerReaddCommand(provider accounts.Provider) string {
 
 func authErrorNeedsReadd(err error) bool {
 	msg := strings.ToLower(err.Error())
-	for _, marker := range []string{"401", "unauthorized", "invalid_grant", "reauth", "refresh failed", "access_expired"} {
+	for _, marker := range []string{
+		"401", "unauthorized", "invalid_grant", "reauth", "refresh failed", "access_expired",
+		"refresh_token_reused", "refresh token has already been used",
+	} {
 		if strings.Contains(msg, marker) {
 			return true
 		}

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -1444,7 +1444,7 @@ func (r srRunner) serverLogin(ctx context.Context, store srServerStore, args []s
 func (r srRunner) serverSync(ctx context.Context, store srServerStore, args []string) error {
 	command := r.serverCommand()
 	if len(args) == 0 {
-		return fmt.Errorf("usage: %s sync <name> [--device-auth] [--all] [--email <email>] [--dry-run] [--yes]", command)
+		return fmt.Errorf("usage: %s sync <name> [--device-auth] [--all] [--email <email>] [--dry-run] [--yes] [--takeover]", command)
 	}
 	name := args[0]
 	var emails repeatedStringFlag
@@ -1454,6 +1454,7 @@ func (r srRunner) serverSync(ctx context.Context, store srServerStore, args []st
 	all := flags.Bool("all", false, "reauth every local OAuth account, including accounts already present on the server")
 	dryRun := flags.Bool("dry-run", false, "show local/server account diff without starting logins")
 	yes := flags.Bool("yes", false, "reauth without confirmation")
+	takeover := flags.Bool("takeover", false, "allow reauth when the server already has a live OAuth chain for the account (explicit cutover)")
 	flags.Var(&emails, "email", "local OAuth email to reauth on the server; can be repeated")
 	if err := flags.Parse(args[1:]); err != nil {
 		return err
@@ -1562,6 +1563,23 @@ func (r srRunner) serverSync(ctx context.Context, store srServerStore, args []st
 		fmt.Fprintln(r.out, "No missing local OAuth accounts to reauth on the server.")
 		fmt.Fprintln(r.out, "Use --all or --email <email> to replace an existing server-owned refresh-token chain.")
 		return nil
+	}
+	liveOnServer := make([]string, 0)
+	for _, email := range targets {
+		status, ok := remoteOAuth[strings.ToLower(email)]
+		if !ok {
+			continue
+		}
+		if status.AuthChecked && status.AuthValid {
+			liveOnServer = append(liveOnServer, email)
+		}
+	}
+	if len(liveOnServer) > 0 && !*takeover {
+		printEmailGroup(r.out, "Already live on server (refusing without --takeover)", liveOnServer)
+		return fmt.Errorf("server %s is already serving %d live OAuth account(s); re-running sync would mint a second refresh-token chain and risk refresh_token_reused — pass --takeover for an explicit cutover", server.Name, len(liveOnServer))
+	}
+	if len(liveOnServer) > 0 && *takeover {
+		printEmailGroup(r.out, "Takeover: replacing live server OAuth chains", liveOnServer)
 	}
 	if !*yes {
 		ok, err := r.confirmServerSync(len(targets), server.Name)
@@ -1726,6 +1744,8 @@ func (r srRunner) serverLoginOne(ctx context.Context, server srServerConfig, dev
 		AddedAt: time.Now().UTC().Format(time.RFC3339),
 		Auth:    auth,
 	}
+	// Leave Owner unset so the destination server stamps itself on import.
+	// Stamping the client host here would make the server refuse to refresh (#129).
 	if err := lock.Close(); err != nil {
 		return err
 	}

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -1422,12 +1422,13 @@ func generateServerControlToken() (string, error) {
 func (r srRunner) serverLogin(ctx context.Context, store srServerStore, args []string) error {
 	command := r.serverCommand()
 	if len(args) == 0 {
-		return fmt.Errorf("usage: %s login <name> [--device-auth]", command)
+		return fmt.Errorf("usage: %s login <name> [--device-auth] [--takeover]", command)
 	}
 	name := args[0]
 	flags := flag.NewFlagSet(command+" login", flag.ContinueOnError)
 	flags.SetOutput(r.errOut)
 	deviceAuth := flags.Bool("device-auth", false, "use codex login --device-auth")
+	takeover := flags.Bool("takeover", false, "allow login when the server already has a live OAuth chain for the account (explicit cutover)")
 	if err := flags.Parse(args[1:]); err != nil {
 		return err
 	}
@@ -1438,7 +1439,7 @@ func (r srRunner) serverLogin(ctx context.Context, store srServerStore, args []s
 	if !ok {
 		return fmt.Errorf("server %q not found", name)
 	}
-	return r.serverLoginOne(ctx, server, *deviceAuth, "")
+	return r.serverLoginOne(ctx, server, *deviceAuth, "", *takeover)
 }
 
 func (r srRunner) serverSync(ctx context.Context, store srServerStore, args []string) error {
@@ -1570,12 +1571,18 @@ func (r srRunner) serverSync(ctx context.Context, store srServerStore, args []st
 		if !ok {
 			continue
 		}
-		if status.AuthChecked && status.AuthValid {
-			liveOnServer = append(liveOnServer, email)
+		// Fail closed: an existing remote account requires --takeover unless we
+		// positively know its chain is already dead (checked and invalid).
+		if status.AuthChecked && !status.AuthValid {
+			continue
 		}
+		liveOnServer = append(liveOnServer, email)
 	}
 	if len(liveOnServer) > 0 && !*takeover {
 		printEmailGroup(r.out, "Already live on server (refusing without --takeover)", liveOnServer)
+		if !statusAvailable {
+			return fmt.Errorf("server %s already has %d OAuth account(s) and account-status is unavailable; pass --takeover for an explicit cutover (or run sr server install %s to enable live-chain checks)", server.Name, len(liveOnServer), server.Name)
+		}
 		return fmt.Errorf("server %s is already serving %d live OAuth account(s); re-running sync would mint a second refresh-token chain and risk refresh_token_reused — pass --takeover for an explicit cutover", server.Name, len(liveOnServer))
 	}
 	if len(liveOnServer) > 0 && *takeover {
@@ -1595,7 +1602,7 @@ func (r srRunner) serverSync(ctx context.Context, store srServerStore, args []st
 	colored := colorEnabled(r.out)
 	for _, email := range targets {
 		fmt.Fprintf(r.out, "\nSign in as %s for server %s.\n", style(colored, ansiBold+ansiMagenta, email), server.Name)
-		if err := r.serverLoginOne(ctx, server, *deviceAuth, email); err != nil {
+		if err := r.serverLoginOne(ctx, server, *deviceAuth, email, *takeover); err != nil {
 			return err
 		}
 	}
@@ -1689,12 +1696,17 @@ func printStatusGroup(w io.Writer, label string, emails []string, statuses map[s
 	}
 }
 
-func (r srRunner) serverLoginOne(ctx context.Context, server srServerConfig, deviceAuth bool, expectedEmail string) error {
+func (r srRunner) serverLoginOne(ctx context.Context, server srServerConfig, deviceAuth bool, expectedEmail string, takeover bool) error {
 	// Fail before opening OAuth when the server cannot securely accept the
 	// resulting refresh-token chain. A completed login must never be discarded
 	// because an old server only knows the retired SSH upload path.
 	if err := r.ensureServerAccountImportAvailable(ctx, server); err != nil {
 		return err
+	}
+	if expectedEmail != "" {
+		if err := r.ensureServerLoginTakeoverAllowed(ctx, server, expectedEmail, takeover); err != nil {
+			return err
+		}
 	}
 	// Serialize concurrent `sr add` / server login. Browser OAuth binds a fixed
 	// localhost callback port, and we must not let one login clobber another's
@@ -1739,6 +1751,11 @@ func (r srRunner) serverLoginOne(ctx context.Context, server srServerConfig, dev
 	if expectedEmail != "" && !strings.EqualFold(email, expectedEmail) {
 		return fmt.Errorf("logged in as %s, expected %s; no account was uploaded", email, expectedEmail)
 	}
+	if expectedEmail == "" {
+		if err := r.ensureServerLoginTakeoverAllowed(ctx, server, email, takeover); err != nil {
+			return err
+		}
+	}
 	account := accounts.StoredCodexAccount{
 		Email:   email,
 		AddedAt: time.Now().UTC().Format(time.RFC3339),
@@ -1762,6 +1779,34 @@ func (r srRunner) serverLoginOne(ctx context.Context, server srServerConfig, dev
 	fmt.Fprintf(r.out, "Uploaded %s to server %s.\n", account.Email, server.Name)
 	fmt.Fprintln(r.out, "Local Codex auth was left unchanged.")
 	fmt.Fprintf(r.out, "The new %s refresh token is stored on %s, not kept as your local active login.\n", account.Email, server.Name)
+	return nil
+}
+
+func (r srRunner) ensureServerLoginTakeoverAllowed(ctx context.Context, server srServerConfig, email string, takeover bool) error {
+	email = strings.TrimSpace(email)
+	if email == "" || takeover {
+		return nil
+	}
+	remoteAccounts, statusAvailable, err := r.fetchServerAccountStatuses(ctx, server, false)
+	if err != nil {
+		return err
+	}
+	for _, account := range remoteAccounts {
+		if account.Provider != accounts.ProviderCodex || account.AuthMode != accounts.AuthModeOAuth {
+			continue
+		}
+		remoteEmail := accountEmail(account.ID, account.Email)
+		if !strings.EqualFold(remoteEmail, email) {
+			continue
+		}
+		if account.AuthChecked && !account.AuthValid {
+			return nil
+		}
+		if !statusAvailable {
+			return fmt.Errorf("server %s already has OAuth account %s and account-status is unavailable; pass --takeover for an explicit cutover", server.Name, remoteEmail)
+		}
+		return fmt.Errorf("server %s is already serving OAuth account %s; pass --takeover for an explicit cutover", server.Name, remoteEmail)
+	}
 	return nil
 }
 

--- a/cmd/subrouter/sr_server_account_import_test.go
+++ b/cmd/subrouter/sr_server_account_import_test.go
@@ -192,7 +192,7 @@ func TestUnsafeHTTPServerFailsBeforeCodexOAuth(t *testing.T) {
 		Name:       "unsafe",
 		URL:        "http://192.168.1.10:31415",
 		AdminToken: "secret",
-	}, false, "")
+	}, false, "", false)
 	if err == nil || !strings.Contains(err.Error(), "restricted to Tailscale or loopback") {
 		t.Fatalf("error = %v, want unsafe plaintext rejection", err)
 	}

--- a/cmd/subrouter/sr_server_test.go
+++ b/cmd/subrouter/sr_server_test.go
@@ -1149,7 +1149,7 @@ func TestSRServerLoginRejectsUnexpectedEmailWithoutUpload(t *testing.T) {
 		AdminToken: "import-secret",
 	}
 
-	err := runner.serverLoginOne(context.Background(), server, true, "alice@example.com")
+	err := runner.serverLoginOne(context.Background(), server, true, "alice@example.com", false)
 	if err == nil || !strings.Contains(err.Error(), "expected alice@example.com") {
 		t.Fatalf("error = %v", err)
 	}
@@ -1813,13 +1813,13 @@ func TestParallelServerLoginSerializesAndPreservesLocalAuth(t *testing.T) {
 	errB := make(chan error, 1)
 	go func() {
 		runner := srRunner{store: store, out: &outA, errOut: &outA, cmd: fakeA, client: remote.Client()}
-		errA <- runner.serverLoginOne(context.Background(), server, true, "")
+		errA <- runner.serverLoginOne(context.Background(), server, true, "", false)
 	}()
 	go func() {
 		// Ensure B contends for the lock while A holds it during login.
 		time.Sleep(20 * time.Millisecond)
 		runner := srRunner{store: store, out: &outB, errOut: &outB, cmd: fakeB, client: remote.Client()}
-		errB <- runner.serverLoginOne(context.Background(), server, true, "")
+		errB <- runner.serverLoginOne(context.Background(), server, true, "", false)
 	}()
 
 	if err := <-errA; err != nil {

--- a/docs/production.md
+++ b/docs/production.md
@@ -38,9 +38,9 @@ sr server add team \
 
 Each OAuth account file records an owner claim (`host` + `epoch`). Only that host may refresh the token chain. Copying account JSON between two live servers burns accounts with `refresh_token_reused`.
 
-- Set `SUBROUTER_HOST_ID` when the OS hostname is unstable across reboots.
+- Set `SUBROUTER_HOST_ID` or `serve --host-id` when the OS hostname is unstable across reboots.
 - Never copy account state between two hosts that are both serving.
-- `sr server sync` refuses to reauth an account that is already live on the destination unless you pass `--takeover`.
+- `sr server sync` and `sr server login` refuse to replace an account that is already live on the destination unless you pass `--takeover`.
 - `refresh_token_reused` in status means the chain is burned (often dual-host), not merely stale — re-authenticate; do not retry refresh.
 
 ## Docker

--- a/docs/production.md
+++ b/docs/production.md
@@ -34,6 +34,15 @@ sr server add team \
 
 `install-systemd` preserves existing admin and account-import tokens when their flags are omitted. `/etc/default/subrouter` is written with mode `0600`.
 
+## OAuth account custody
+
+Each OAuth account file records an owner claim (`host` + `epoch`). Only that host may refresh the token chain. Copying account JSON between two live servers burns accounts with `refresh_token_reused`.
+
+- Set `SUBROUTER_HOST_ID` when the OS hostname is unstable across reboots.
+- Never copy account state between two hosts that are both serving.
+- `sr server sync` refuses to reauth an account that is already live on the destination unless you pass `--takeover`.
+- `refresh_token_reused` in status means the chain is burned (often dual-host), not merely stale — re-authenticate; do not retry refresh.
+
 ## Docker
 
 Use [`deploy/docker/compose.yaml`](../deploy/docker/compose.yaml) for local-account or cmux.com team mode. Both profiles run non-root on a read-only root filesystem, mount credentials as Docker secrets, bind loopback by default, and enforce a 256 MiB memory limit. See [`deploy/docker/README.md`](../deploy/docker/README.md).

--- a/internal/accounts/codex_auth.go
+++ b/internal/accounts/codex_auth.go
@@ -202,7 +202,10 @@ func (s CodexStore) refreshStored(ctx context.Context, client *http.Client, acco
 		logCodexRefreshSkipped(ctx, s, account, force, "missing_tokens")
 		return account, false, nil
 	}
-	if !force && !IsJWTExpired(account.Auth.Tokens.AccessToken, 60*time.Second) {
+	unclaimed := account.Owner == nil || strings.TrimSpace(account.Owner.Host) == ""
+	// Unclaimed legacy files must fall through to the locked path so first serve
+	// can stamp this host before another copy races a refresh (#129).
+	if !force && !unclaimed && !IsJWTExpired(account.Auth.Tokens.AccessToken, 60*time.Second) {
 		logCodexRefreshSkipped(ctx, s, account, force, "access_token_fresh")
 		return account, false, nil
 	}
@@ -230,16 +233,30 @@ func (s CodexStore) refreshStored(ctx context.Context, client *http.Client, acco
 		logCodexRefreshSkipped(ctx, s, account, force, "missing_tokens_after_lock")
 		return account, false, nil
 	}
+	if err := AssertLocalOwner(account.Email, account.Owner); err != nil {
+		logCodexRefreshSkipped(ctx, s, account, force, "foreign_owner_claim")
+		return account, false, err
+	}
+	// First serve of an unclaimed legacy file: stamp this host before any
+	// provider call so a second host copying the file cannot race-refresh.
+	claimedNow := false
+	if account.Owner == nil || strings.TrimSpace(account.Owner.Host) == "" {
+		claim := StampOwnerClaim(nil, false)
+		account.Owner = &claim
+		claimedNow = true
+	}
 	if !force && !IsJWTExpired(account.Auth.Tokens.AccessToken, 60*time.Second) {
+		if claimedNow {
+			if saveErr := s.saveStoredUnlocked(account); saveErr != nil {
+				logCodexRefreshFailed(ctx, s, account, force, saveErr)
+				return account, false, saveErr
+			}
+		}
 		logCodexRefreshSkipped(ctx, s, account, force, "access_token_fresh_after_lock")
 		return account, false, nil
 	}
 	if err := terminalStoredRefreshFailure(account); err != nil {
 		logCodexRefreshSkipped(ctx, s, account, force, "terminal_refresh_failure_after_lock")
-		return account, false, err
-	}
-	if err := AssertLocalOwner(account.Email, account.Owner); err != nil {
-		logCodexRefreshSkipped(ctx, s, account, force, "foreign_owner_claim")
 		return account, false, err
 	}
 

--- a/internal/accounts/codex_auth.go
+++ b/internal/accounts/codex_auth.go
@@ -238,6 +238,10 @@ func (s CodexStore) refreshStored(ctx context.Context, client *http.Client, acco
 		logCodexRefreshSkipped(ctx, s, account, force, "terminal_refresh_failure_after_lock")
 		return account, false, err
 	}
+	if err := AssertLocalOwner(account.Email, account.Owner); err != nil {
+		logCodexRefreshSkipped(ctx, s, account, force, "foreign_owner_claim")
+		return account, false, err
+	}
 
 	previous := account
 	logCodexRefreshStart(ctx, s, previous, force)
@@ -263,6 +267,8 @@ func (s CodexStore) refreshStored(ctx context.Context, client *http.Client, acco
 	}
 	auth.RefreshFailure = nil
 	account.Auth = auth
+	claim := StampOwnerClaim(account.Owner, false)
+	account.Owner = &claim
 	appendCodexAuthBreadcrumb(ctx, s, &account, "refresh_succeeded", "oauth_refresh", force, &previous, &account, nil, nil)
 	if err := s.saveStoredUnlocked(account); err != nil {
 		logCodexRefreshFailed(ctx, s, account, force, err)

--- a/internal/accounts/codex_rotation_test.go
+++ b/internal/accounts/codex_rotation_test.go
@@ -321,3 +321,46 @@ func TestExpiredRefreshHerdCollapsesToOneExchange(t *testing.T) {
 		t.Errorf("expired-path burst reused a token %d times", got)
 	}
 }
+
+// A copied account file that still names another host must never hit the
+// provider: refreshing would race the real owner and burn the chain (#129).
+func TestRefreshRefusesForeignOwnerClaim(t *testing.T) {
+	t.Setenv("SUBROUTER_HOST_ID", "host-b")
+	ResetLocalHostIDForTest()
+	defer ResetLocalHostIDForTest()
+
+	provider := newRotatingOAuthServer("refresh-gen-0")
+	provider.start(t)
+	store := CodexStore{Dir: t.TempDir()}
+	if err := store.SaveStored(StoredCodexAccount{
+		Email:    "copied@example.com",
+		Provider: ProviderCodex,
+		Owner:    &OwnerClaim{Host: "host-a", Epoch: 7, ClaimedAt: "2026-07-18T01:32:01Z"},
+		Auth: CodexAuthFile{Tokens: &CodexTokens{
+			AccessToken:  testJWT("copied@example.com", time.Now().Add(-time.Hour)),
+			RefreshToken: "refresh-gen-0",
+			IDToken:      testJWT("copied@example.com", time.Now().Add(time.Hour)),
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	account, ok, err := store.FindStored("copied@example.com")
+	if err != nil || !ok {
+		t.Fatal("seed failed")
+	}
+	_, _, refreshErr := store.RefreshStored(context.Background(), nil, account)
+	if refreshErr == nil {
+		t.Fatal("expected foreign owner refusal")
+	}
+	if _, ok := refreshErr.(*ForeignOwnerClaimError); !ok {
+		t.Fatalf("want ForeignOwnerClaimError, got %T: %v", refreshErr, refreshErr)
+	}
+	if got := provider.exchanges.Load(); got != 0 {
+		t.Fatalf("provider was contacted %d times; foreign claim must short-circuit", got)
+	}
+	if got := provider.reuseAttempts.Load(); got != 0 {
+		t.Fatalf("reuse attempts=%d", got)
+	}
+}
+

--- a/internal/accounts/codex_store.go
+++ b/internal/accounts/codex_store.go
@@ -35,6 +35,7 @@ type StoredCodexAccount struct {
 	Provider         Provider              `json:"provider,omitempty"`
 	MigrationBatchID string                `json:"migrationBatchId,omitempty"`
 	AddedAt          string                `json:"addedAt"`
+	Owner            *OwnerClaim           `json:"owner,omitempty"`
 	Auth             CodexAuthFile         `json:"auth"`
 	ProjectID        string                `json:"projectId,omitempty"`
 	ProjectName      string                `json:"projectName,omitempty"`
@@ -318,6 +319,12 @@ func (s CodexStore) saveStoredUnlocked(account StoredCodexAccount) error {
 	}
 	if account.AddedAt == "" {
 		account.AddedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	// Stamp only unclaimed OAuth files. Never silently overwrite a foreign
+	// owner claim on ordinary save — that requires an explicit takeover (#129).
+	if !account.IsAPIKey() && (account.Owner == nil || strings.TrimSpace(account.Owner.Host) == "") {
+		claim := StampOwnerClaim(nil, false)
+		account.Owner = &claim
 	}
 	if err := os.MkdirAll(s.Dir, 0o700); err != nil {
 		return err
@@ -718,6 +725,27 @@ func (s CodexStore) MigrateStoredAway(identifier string) (string, bool, error) {
 		return "", false, err
 	}
 	return target, true, nil
+}
+
+// TakeoverStoredOwner bumps the owner-claim epoch onto this host so a copied
+// account file can refresh again after an explicit cutover (#129).
+func (s CodexStore) TakeoverStoredOwner(identifier string) (StoredCodexAccount, error) {
+	account, ok, err := s.FindStored(identifier)
+	if err != nil {
+		return StoredCodexAccount{}, err
+	}
+	if !ok {
+		return StoredCodexAccount{}, fmt.Errorf("account %q not found", identifier)
+	}
+	if account.IsAPIKey() {
+		return account, nil
+	}
+	claim := TakeoverOwnerClaim(account.Owner)
+	account.Owner = &claim
+	if err := s.SaveStored(account); err != nil {
+		return StoredCodexAccount{}, err
+	}
+	return account, nil
 }
 
 func emailToFilename(email string) string {

--- a/internal/accounts/owner_claim.go
+++ b/internal/accounts/owner_claim.go
@@ -1,0 +1,114 @@
+package accounts
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// OwnerClaim records which host is the live writer for an OAuth account file.
+// Refresh tokens rotate; two hosts refreshing the same chain permanently burn
+// the account (refresh_token_reused). The claim is the guard that refuses a
+// foreign refresh unless an explicit takeover bumps the epoch.
+type OwnerClaim struct {
+	Host      string `json:"host"`
+	Epoch     uint64 `json:"epoch"`
+	ClaimedAt string `json:"claimed_at,omitempty"`
+}
+
+// ForeignOwnerClaimError is returned when this host must not refresh an account
+// owned by another host.
+type ForeignOwnerClaimError struct {
+	Account string
+	Claim   OwnerClaim
+	Local   string
+}
+
+func (e *ForeignOwnerClaimError) Error() string {
+	return fmt.Sprintf(
+		"account %q is owned by host %q (epoch %d); this host is %q — refuse refresh to avoid refresh_token_reused (use --takeover to cut over)",
+		e.Account, e.Claim.Host, e.Claim.Epoch, e.Local,
+	)
+}
+
+var (
+	localHostIDOnce sync.Once
+	localHostID     string
+)
+
+// LocalHostID returns the stable host identity used in owner claims.
+// Override with SUBROUTER_HOST_ID when hostname is unstable across reboots.
+func LocalHostID() string {
+	localHostIDOnce.Do(func() {
+		if v := strings.TrimSpace(os.Getenv("SUBROUTER_HOST_ID")); v != "" {
+			localHostID = v
+			return
+		}
+		host, err := os.Hostname()
+		if err != nil || strings.TrimSpace(host) == "" {
+			localHostID = "unknown-host"
+			return
+		}
+		localHostID = host
+	})
+	return localHostID
+}
+
+// ResetLocalHostIDForTest clears the cached host id (tests only).
+func ResetLocalHostIDForTest() {
+	localHostIDOnce = sync.Once{}
+	localHostID = ""
+}
+
+// AssertLocalOwner returns a ForeignOwnerClaimError when claim names another host.
+// A nil or empty-host claim is treated as unclaimed (legacy files) and allowed.
+func AssertLocalOwner(accountEmail string, claim *OwnerClaim) error {
+	if claim == nil || strings.TrimSpace(claim.Host) == "" {
+		return nil
+	}
+	local := LocalHostID()
+	if strings.EqualFold(strings.TrimSpace(claim.Host), local) {
+		return nil
+	}
+	return &ForeignOwnerClaimError{
+		Account: accountEmail,
+		Claim:   *claim,
+		Local:   local,
+	}
+}
+
+// TakeoverOwnerClaim bumps the epoch and assigns this host as the live writer.
+func TakeoverOwnerClaim(claim *OwnerClaim) OwnerClaim {
+	return StampOwnerClaim(claim, true)
+}
+
+// StampOwnerClaim sets this host as owner. When takeover is true, the epoch is
+// always bumped (even if already local) so a previous owner observing a higher
+// epoch knows it lost the claim. When false, an existing local claim is kept
+// and only unclaimed/legacy files are stamped at epoch 1. A foreign claim with
+// takeover=false is left unchanged — callers must use takeover explicitly.
+func StampOwnerClaim(claim *OwnerClaim, takeover bool) OwnerClaim {
+	local := LocalHostID()
+	now := time.Now().UTC().Format(time.RFC3339)
+	if claim == nil || strings.TrimSpace(claim.Host) == "" {
+		return OwnerClaim{Host: local, Epoch: 1, ClaimedAt: now}
+	}
+	sameHost := strings.EqualFold(strings.TrimSpace(claim.Host), local)
+	if sameHost && !takeover {
+		out := *claim
+		if out.ClaimedAt == "" {
+			out.ClaimedAt = now
+		}
+		return out
+	}
+	if !sameHost && !takeover {
+		return *claim
+	}
+	epoch := claim.Epoch + 1
+	if epoch == 0 {
+		epoch = 1
+	}
+	return OwnerClaim{Host: local, Epoch: epoch, ClaimedAt: now}
+}

--- a/internal/accounts/owner_claim.go
+++ b/internal/accounts/owner_claim.go
@@ -28,7 +28,7 @@ type ForeignOwnerClaimError struct {
 
 func (e *ForeignOwnerClaimError) Error() string {
 	return fmt.Sprintf(
-		"account %q is owned by host %q (epoch %d); this host is %q — refuse refresh to avoid refresh_token_reused (use --takeover to cut over)",
+		"account %q is owned by host %q (epoch %d); this host is %q — refuse refresh (use --takeover to cut over)",
 		e.Account, e.Claim.Host, e.Claim.Epoch, e.Local,
 	)
 }
@@ -36,11 +36,29 @@ func (e *ForeignOwnerClaimError) Error() string {
 var (
 	localHostIDOnce sync.Once
 	localHostID     string
+	hostIDOverride  string
+	hostIDMu        sync.RWMutex
 )
 
-// LocalHostID returns the stable host identity used in owner claims.
-// Override with SUBROUTER_HOST_ID when hostname is unstable across reboots.
+// SetHostID pins the host identity used for owner claims (from --host-id).
+// An empty id clears the pin so SUBROUTER_HOST_ID / hostname apply again.
+func SetHostID(id string) {
+	hostIDMu.Lock()
+	defer hostIDMu.Unlock()
+	hostIDOverride = strings.TrimSpace(id)
+	localHostIDOnce = sync.Once{}
+	localHostID = ""
+}
+
+// LocalHostID returns the stable host identity used in owner claims:
+// --host-id (SetHostID), else SUBROUTER_HOST_ID, else os.Hostname().
 func LocalHostID() string {
+	hostIDMu.RLock()
+	override := hostIDOverride
+	hostIDMu.RUnlock()
+	if override != "" {
+		return override
+	}
 	localHostIDOnce.Do(func() {
 		if v := strings.TrimSpace(os.Getenv("SUBROUTER_HOST_ID")); v != "" {
 			localHostID = v
@@ -58,6 +76,9 @@ func LocalHostID() string {
 
 // ResetLocalHostIDForTest clears the cached host id (tests only).
 func ResetLocalHostIDForTest() {
+	hostIDMu.Lock()
+	defer hostIDMu.Unlock()
+	hostIDOverride = ""
 	localHostIDOnce = sync.Once{}
 	localHostID = ""
 }

--- a/internal/accounts/owner_claim_test.go
+++ b/internal/accounts/owner_claim_test.go
@@ -1,0 +1,77 @@
+package accounts
+
+import (
+	"testing"
+)
+
+func TestAssertLocalOwnerAllowsUnclaimedAndLocal(t *testing.T) {
+	t.Setenv("SUBROUTER_HOST_ID", "host-a")
+	ResetLocalHostIDForTest()
+	defer ResetLocalHostIDForTest()
+
+	if err := AssertLocalOwner("a@example.com", nil); err != nil {
+		t.Fatalf("nil claim: %v", err)
+	}
+	local := &OwnerClaim{Host: "host-a", Epoch: 2}
+	if err := AssertLocalOwner("a@example.com", local); err != nil {
+		t.Fatalf("local claim: %v", err)
+	}
+}
+
+func TestAssertLocalOwnerRejectsForeign(t *testing.T) {
+	t.Setenv("SUBROUTER_HOST_ID", "host-a")
+	ResetLocalHostIDForTest()
+	defer ResetLocalHostIDForTest()
+
+	err := AssertLocalOwner("burned@example.com", &OwnerClaim{Host: "host-b", Epoch: 3, ClaimedAt: "2026-07-18T01:32:01Z"})
+	if err == nil {
+		t.Fatal("expected foreign owner error")
+	}
+	var foreign *ForeignOwnerClaimError
+	if !asForeignOwner(err, &foreign) {
+		t.Fatalf("want ForeignOwnerClaimError, got %T %v", err, err)
+	}
+	if foreign.Claim.Host != "host-b" || foreign.Local != "host-a" {
+		t.Fatalf("unexpected foreign error: %+v", foreign)
+	}
+}
+
+func asForeignOwner(err error, target **ForeignOwnerClaimError) bool {
+	if err == nil {
+		return false
+	}
+	e, ok := err.(*ForeignOwnerClaimError)
+	if !ok {
+		return false
+	}
+	*target = e
+	return true
+}
+
+func TestStampOwnerClaimDoesNotSilentTakeover(t *testing.T) {
+	t.Setenv("SUBROUTER_HOST_ID", "host-a")
+	ResetLocalHostIDForTest()
+	defer ResetLocalHostIDForTest()
+
+	foreign := &OwnerClaim{Host: "host-b", Epoch: 4, ClaimedAt: "old"}
+	kept := StampOwnerClaim(foreign, false)
+	if kept.Host != "host-b" || kept.Epoch != 4 {
+		t.Fatalf("silent save must not steal claim: %+v", kept)
+	}
+
+	taken := TakeoverOwnerClaim(foreign)
+	if taken.Host != "host-a" || taken.Epoch != 5 {
+		t.Fatalf("takeover should bump epoch onto local host: %+v", taken)
+	}
+}
+
+func TestStampOwnerClaimStampsUnclaimed(t *testing.T) {
+	t.Setenv("SUBROUTER_HOST_ID", "host-a")
+	ResetLocalHostIDForTest()
+	defer ResetLocalHostIDForTest()
+
+	claim := StampOwnerClaim(nil, false)
+	if claim.Host != "host-a" || claim.Epoch != 1 || claim.ClaimedAt == "" {
+		t.Fatalf("unclaimed stamp: %+v", claim)
+	}
+}

--- a/internal/accounts/owner_first_serve_test.go
+++ b/internal/accounts/owner_first_serve_test.go
@@ -1,0 +1,43 @@
+package accounts
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestFirstServeStampsUnclaimedOwner(t *testing.T) {
+	t.Setenv("SUBROUTER_HOST_ID", "first-serve-host")
+	ResetLocalHostIDForTest()
+	defer ResetLocalHostIDForTest()
+
+	store := CodexStore{Dir: t.TempDir()}
+	// Write a legacy file with no owner claim and a still-fresh access token.
+	writeStoredCodexAccountFile(t, store, StoredCodexAccount{
+		Email: "legacy@example.com",
+		Auth: CodexAuthFile{Tokens: &CodexTokens{
+			AccessToken:  testJWT("legacy@example.com", time.Now().Add(time.Hour)),
+			RefreshToken: "unused-refresh",
+			IDToken:      testJWT("legacy@example.com", time.Now().Add(time.Hour)),
+		}},
+	})
+
+	account, ok, err := store.FindStored("legacy@example.com")
+	if err != nil || !ok {
+		t.Fatal("seed missing")
+	}
+	got, refreshed, err := store.RefreshStoredIfExpired(context.Background(), nil, account)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refreshed {
+		t.Fatal("fresh token must not hit the provider")
+	}
+	if got.Owner == nil || got.Owner.Host != "first-serve-host" || got.Owner.Epoch != 1 {
+		t.Fatalf("first serve did not stamp owner: %+v", got.Owner)
+	}
+	stored, ok, err := store.FindStored("legacy@example.com")
+	if err != nil || !ok || stored.Owner == nil || stored.Owner.Host != "first-serve-host" {
+		t.Fatalf("claim was not persisted: ok=%v owner=%+v err=%v", ok, stored.Owner, err)
+	}
+}

--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -1068,6 +1068,7 @@ func TestIsTerminalCredentialError(t *testing.T) {
 		{fmt.Errorf(`Claude OAuth refresh failed: 400 Bad Request: {"error": "invalid_grant"}`), true},
 		{fmt.Errorf("profile has no refresh token"), true},
 		{fmt.Errorf("dial tcp: connection refused"), false},
+		{&accounts.ForeignOwnerClaimError{Account: "a@example.com", Claim: accounts.OwnerClaim{Host: "other", Epoch: 2}, Local: "here"}, false},
 		{context.Canceled, false},
 		{context.DeadlineExceeded, false},
 		{nil, false},

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1452,6 +1452,15 @@ func (s Server) installImportedAccount(ctx context.Context, input accountImportR
 			return "", err
 		}
 		account.Email = canonicalID
+		if existing, found, findErr := s.AccountRef.store.FindStored(account.Email); findErr != nil {
+			return "", findErr
+		} else if found && !existing.IsAPIKey() {
+			claim := accounts.TakeoverOwnerClaim(existing.Owner)
+			account.Owner = &claim
+		} else {
+			claim := accounts.StampOwnerClaim(nil, false)
+			account.Owner = &claim
+		}
 		if err := s.AccountRef.store.SaveStored(account); err != nil {
 			return "", err
 		}
@@ -1484,6 +1493,15 @@ func (s Server) installImportedAccount(ctx context.Context, input accountImportR
 			return "", err
 		}
 		account.Email = canonicalID
+		if existing, found, findErr := s.AccountRef.store.FindStored(account.Email); findErr != nil {
+			return "", findErr
+		} else if found && !existing.IsAPIKey() {
+			claim := accounts.TakeoverOwnerClaim(existing.Owner)
+			account.Owner = &claim
+		} else {
+			claim := accounts.StampOwnerClaim(nil, false)
+			account.Owner = &claim
+		}
 		if err := s.AccountRef.store.SaveStored(account); err != nil {
 			return "", err
 		}
@@ -5155,6 +5173,12 @@ func isTerminalCredentialError(err error) bool {
 		return false
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	// Wrong host, not a burned credential — keep the account selectable so the
+	// real owner can keep serving once custody is corrected.
+	var foreignOwner *accounts.ForeignOwnerClaimError
+	if errors.As(err, &foreignOwner) {
 		return false
 	}
 	var storedCodexFailure *accounts.CodexStoredRefreshFailureError


### PR DESCRIPTION
## Summary
- Persist a host+epoch owner claim on Codex OAuth account files and refuse provider refresh when another host owns the claim (prevents `refresh_token_reused` burns).
- Stamp unclaimed legacy files on first serve; successful refresh and SaveStored keep the local claim.
- `sr server sync` and `sr server login` refuse replacing an account already present/live on the destination unless `--takeover` is passed (fail closed when account-status is unavailable).
- `serve --host-id` / `SUBROUTER_HOST_ID` sets the claim identity; status UX distinguishes burned `refresh_token_reused` from ordinary expiry.

Fixes #129

## Test plan
- [x] `go test ./internal/accounts/ -run 'OwnerClaim|ForeignOwner|StampOwner|RefreshRefusesForeign|FirstServe|AssertLocal|Takeover'`
- [x] `go test ./internal/proxy/ -run TestIsTerminalCredentialError`
- [ ] Confirm a copied account file with a foreign claim never hits the provider
- [ ] Confirm `sr server sync` / `sr server login` without `--takeover` refuse live remote accounts
- [ ] Confirm status shows burned `refresh_token_reused` distinctly from stale tokens

Made with [Cursor](https://cursor.com)