### PR TITLE
Fall back to Azure OpenAI when the Codex pool fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,31 @@ Live headroom comes from Codex subscription usage. API-key spend comes from the 
 
 See [docs/saturation.md](docs/saturation.md) for the 5h/7d placement strategy and simulation tests.
 
+## Azure fallback for Codex
+
+When the Codex pool cannot serve a Responses request, Subrouter can finish it on Azure OpenAI instead of returning the error. The pool stays primary: Azure runs only after the request has spent five pool retries (account failover and transport retries draw on one shared budget), or when account selection fails outright. Quota (429), broken credentials (401/403), upstream faults (408/5xx), and transport failures qualify; a 400 does not, because Azure would reject it the same way for money.
+
+After Azure answers, the session is pinned to that endpoint for 30 minutes of activity, and the following turns skip the pool entirely. Prompt caching is per-deployment and keyed on an identical prefix, so alternating between ChatGPT and Azure turn by turn would re-upload the whole conversation as a cache miss on both sides. Subrouter forwards the `prompt_cache_key` Codex sends, and derives a stable one from the session when it is absent. With several endpoints configured, a session hashes to one of them and stays there.
+
+One Azure resource:
+
+```bash
+export SUBROUTER_AZURE_CODEX_ENDPOINT="https://YOUR_RESOURCE.openai.azure.com/openai/v1"
+export SUBROUTER_AZURE_CODEX_API_KEY="<azure-key>"          # or SUBROUTER_AZURE_CODEX_API_KEY_FILE
+export SUBROUTER_AZURE_CODEX_DEPLOYMENTS="gpt-5.6-codex=my-codex-deployment"   # only if the deployment name differs from the model
+```
+
+Several resources go in a file named by `SUBROUTER_AZURE_CODEX_CONFIG_FILE`:
+
+```json
+{"endpoints":[
+  {"name":"eastus2","base_url":"https://east.openai.azure.com/openai/v1","api_key":"..."},
+  {"name":"swedencentral","base_url":"https://sweden.openai.azure.com/openai/v1","api_key":"..."}
+]}
+```
+
+`curl -s http://127.0.0.1:31415/_subrouter/health` lists the armed endpoints by name under `azure_codex`. Only `/responses` falls back; `/responses/compact`, the model catalog, and `/alpha/search` are ChatGPT-backend endpoints with no Azure equivalent. Team credential storage (`sr storage team`) refuses this fallback, like the other personal-credential routes.
+
 ## Security defaults
 
 - Bind to `127.0.0.1` unless explicitly exposed.

--- a/README.md
+++ b/README.md
@@ -436,6 +436,20 @@ Several resources go in a file named by `SUBROUTER_AZURE_CODEX_CONFIG_FILE`:
 ]}
 ```
 
+Set `SUBROUTER_AZURE_CODEX_DEFAULT_DEPLOYMENT` to catch models Azure has not shipped yet. Azure trails the ChatGPT model list, and the request that needs the fallback is the one the pool refused, so an unmapped model lands on that deployment instead of 404ing.
+
+Prove the route without waiting for an outage:
+
+```bash
+sr az status          # which endpoints the daemon armed
+sr az test            # one forced request; run twice, the second reports cached tokens
+sr az codex exec "…"  # run Codex with every request forced onto Azure
+```
+
+`sr az test` sends a fixed prompt long enough to be cacheable, so the second run's `cached=` count is real evidence that the prompt cache is being reused. Forced requests skip the pool and never pin the session; a broken endpoint surfaces as an error instead of a silent ChatGPT answer.
+
+Codex bodies carry fields the Responses API does not take (`session_id` on every turn), and a Codex release can send a value an older Azure model version refuses (`reasoning.context="all_turns"`). Known ChatGPT-only fields are stripped, and a 400 that names one field is retried once without it, up to three times.
+
 `curl -s http://127.0.0.1:31415/_subrouter/health` lists the armed endpoints by name under `azure_codex`. Only `/responses` falls back; `/responses/compact`, the model catalog, and `/alpha/search` are ChatGPT-backend endpoints with no Azure equivalent. Team credential storage (`sr storage team`) refuses this fallback, like the other personal-credential routes.
 
 ## Security defaults

--- a/cmd/subrouter/azure_codex_config.go
+++ b/cmd/subrouter/azure_codex_config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -105,7 +106,10 @@ func azureCodexBaseURL(raw string) (*url.URL, error) {
 	if err != nil {
 		return nil, fmt.Errorf("azure codex: parse endpoint %q: %w", trimmed, err)
 	}
-	if parsed.Scheme != "https" || parsed.Host == "" {
+	// Azure itself is always https. http is allowed only against loopback, so a
+	// stub endpoint can be pointed at during local testing without shipping a
+	// key over plaintext to anything else.
+	if parsed.Host == "" || (parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname()))) {
 		return nil, fmt.Errorf("azure codex: endpoint %q must be an https url", trimmed)
 	}
 	path := strings.TrimRight(parsed.Path, "/")
@@ -160,4 +164,14 @@ func azureCodexEndpointNames(config *proxy.AzureCodexConfig) string {
 		names = append(names, endpoint.Name)
 	}
 	return strings.Join(names, ",")
+}
+
+// isLoopbackHost reports whether a host name resolves to this machine without a
+// lookup.
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	address := net.ParseIP(host)
+	return address != nil && address.IsLoopback()
 }

--- a/cmd/subrouter/azure_codex_config.go
+++ b/cmd/subrouter/azure_codex_config.go
@@ -21,10 +21,11 @@ type azureCodexFile struct {
 }
 
 type azureCodexFileEndpoint struct {
-	Name        string            `json:"name"`
-	BaseURL     string            `json:"base_url"`
-	APIKey      string            `json:"api_key"`
-	Deployments map[string]string `json:"deployments"`
+	Name              string            `json:"name"`
+	BaseURL           string            `json:"base_url"`
+	APIKey            string            `json:"api_key"`
+	Deployments       map[string]string `json:"deployments"`
+	DefaultDeployment string            `json:"default_deployment"`
 }
 
 // azureCodexConfigFromEnvironment builds the Codex Azure fallback from the
@@ -49,7 +50,12 @@ func azureCodexConfigFromEnvironment() (*proxy.AzureCodexConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	return azureCodexConfig([]azureCodexFileEndpoint{{BaseURL: endpoint, APIKey: apiKey, Deployments: deployments}})
+	return azureCodexConfig([]azureCodexFileEndpoint{{
+		BaseURL:           endpoint,
+		APIKey:            apiKey,
+		Deployments:       deployments,
+		DefaultDeployment: strings.TrimSpace(os.Getenv("SUBROUTER_AZURE_CODEX_DEFAULT_DEPLOYMENT")),
+	}})
 }
 
 func azureCodexConfigFromFile(path string) (*proxy.AzureCodexConfig, error) {
@@ -82,11 +88,21 @@ func azureCodexConfig(endpoints []azureCodexFileEndpoint) (*proxy.AzureCodexConf
 		if name == "" {
 			name = base.Host
 		}
+		deployments := endpoint.Deployments
+		// A default deployment catches models Azure has not shipped yet, which
+		// is most of them: Azure trails the ChatGPT model list, and the request
+		// that needs the fallback is exactly the one the pool refused.
+		if fallback := strings.TrimSpace(endpoint.DefaultDeployment); fallback != "" {
+			if deployments == nil {
+				deployments = map[string]string{}
+			}
+			deployments[proxy.AzureCodexDefaultDeploymentKey] = fallback
+		}
 		config.Endpoints = append(config.Endpoints, proxy.AzureCodexEndpoint{
 			Name:        name,
 			BaseURL:     base,
 			APIKey:      apiKey,
-			Deployments: endpoint.Deployments,
+			Deployments: deployments,
 		})
 	}
 	return config, nil

--- a/cmd/subrouter/azure_codex_config.go
+++ b/cmd/subrouter/azure_codex_config.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/manaflow-ai/subrouter/internal/proxy"
+)
+
+// azureCodexFile is the on-disk form of the Codex Azure fallback, for the case
+// of several Azure resources (one per region, or one per quota pool). The
+// single-resource case needs no file, only the three environment variables read
+// by azureCodexConfigFromEnvironment.
+type azureCodexFile struct {
+	Endpoints []azureCodexFileEndpoint `json:"endpoints"`
+}
+
+type azureCodexFileEndpoint struct {
+	Name        string            `json:"name"`
+	BaseURL     string            `json:"base_url"`
+	APIKey      string            `json:"api_key"`
+	Deployments map[string]string `json:"deployments"`
+}
+
+// azureCodexConfigFromEnvironment builds the Codex Azure fallback from the
+// environment. It returns nil when nothing is configured, which leaves the
+// Codex pool exactly as it was.
+func azureCodexConfigFromEnvironment() (*proxy.AzureCodexConfig, error) {
+	if path := strings.TrimSpace(os.Getenv("SUBROUTER_AZURE_CODEX_CONFIG_FILE")); path != "" {
+		return azureCodexConfigFromFile(path)
+	}
+	endpoint := strings.TrimSpace(os.Getenv("SUBROUTER_AZURE_CODEX_ENDPOINT"))
+	apiKey, err := secretFromEnvironment("SUBROUTER_AZURE_CODEX_API_KEY", "SUBROUTER_AZURE_CODEX_API_KEY_FILE")
+	if err != nil {
+		return nil, fmt.Errorf("azure codex: %w", err)
+	}
+	if endpoint == "" && apiKey == "" {
+		return nil, nil
+	}
+	if endpoint == "" || apiKey == "" {
+		return nil, errors.New("azure codex: set both SUBROUTER_AZURE_CODEX_ENDPOINT and SUBROUTER_AZURE_CODEX_API_KEY")
+	}
+	deployments, err := parseAzureCodexDeployments(os.Getenv("SUBROUTER_AZURE_CODEX_DEPLOYMENTS"))
+	if err != nil {
+		return nil, err
+	}
+	return azureCodexConfig([]azureCodexFileEndpoint{{BaseURL: endpoint, APIKey: apiKey, Deployments: deployments}})
+}
+
+func azureCodexConfigFromFile(path string) (*proxy.AzureCodexConfig, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("azure codex: read config: %w", err)
+	}
+	var parsed azureCodexFile
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("azure codex: parse config: %w", err)
+	}
+	return azureCodexConfig(parsed.Endpoints)
+}
+
+func azureCodexConfig(endpoints []azureCodexFileEndpoint) (*proxy.AzureCodexConfig, error) {
+	if len(endpoints) == 0 {
+		return nil, errors.New("azure codex: no endpoints configured")
+	}
+	config := &proxy.AzureCodexConfig{}
+	for index, endpoint := range endpoints {
+		base, err := azureCodexBaseURL(endpoint.BaseURL)
+		if err != nil {
+			return nil, err
+		}
+		apiKey := strings.TrimSpace(endpoint.APIKey)
+		if apiKey == "" {
+			return nil, fmt.Errorf("azure codex: endpoint %d has no api key", index)
+		}
+		name := strings.TrimSpace(endpoint.Name)
+		if name == "" {
+			name = base.Host
+		}
+		config.Endpoints = append(config.Endpoints, proxy.AzureCodexEndpoint{
+			Name:        name,
+			BaseURL:     base,
+			APIKey:      apiKey,
+			Deployments: endpoint.Deployments,
+		})
+	}
+	return config, nil
+}
+
+// azureCodexBaseURL normalizes an Azure resource URL onto the v1 surface Codex
+// speaks. Both the bare resource URL and the full ".../openai/v1" form are
+// accepted, because the Azure portal shows the first and the Codex docs show
+// the second, and a fallback that silently 404s is worse than one that refuses
+// to start.
+func azureCodexBaseURL(raw string) (*url.URL, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, errors.New("azure codex: endpoint has no base url")
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("azure codex: parse endpoint %q: %w", trimmed, err)
+	}
+	if parsed.Scheme != "https" || parsed.Host == "" {
+		return nil, fmt.Errorf("azure codex: endpoint %q must be an https url", trimmed)
+	}
+	path := strings.TrimRight(parsed.Path, "/")
+	switch {
+	case path == "":
+		path = "/openai/v1"
+	case strings.HasSuffix(path, "/openai/v1"):
+	case strings.HasSuffix(path, "/openai"):
+		path += "/v1"
+	default:
+		return nil, fmt.Errorf("azure codex: endpoint %q must end in /openai/v1", trimmed)
+	}
+	parsed.Path = path
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed, nil
+}
+
+// parseAzureCodexDeployments reads "model=deployment,model2=deployment2". An
+// unmapped model uses its own name, which is how Foundry names a deployment by
+// default, so this is only needed when a deployment was named something else.
+func parseAzureCodexDeployments(raw string) (map[string]string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, nil
+	}
+	deployments := map[string]string{}
+	for _, pair := range strings.Split(trimmed, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		model, deployment, ok := strings.Cut(pair, "=")
+		model = strings.TrimSpace(model)
+		deployment = strings.TrimSpace(deployment)
+		if !ok || model == "" || deployment == "" {
+			return nil, fmt.Errorf("azure codex: deployment mapping %q must be model=deployment", pair)
+		}
+		deployments[model] = deployment
+	}
+	return deployments, nil
+}
+
+// azureCodexEndpointNames lists the configured endpoints for one startup log
+// line. Keys never appear.
+func azureCodexEndpointNames(config *proxy.AzureCodexConfig) string {
+	if config == nil {
+		return ""
+	}
+	names := make([]string, 0, len(config.Endpoints))
+	for _, endpoint := range config.Endpoints {
+		names = append(names, endpoint.Name)
+	}
+	return strings.Join(names, ",")
+}

--- a/cmd/subrouter/azure_codex_config_test.go
+++ b/cmd/subrouter/azure_codex_config_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAzureCodexBaseURLNormalization(t *testing.T) {
+	cases := map[string]string{
+		"https://res.openai.azure.com":            "https://res.openai.azure.com/openai/v1",
+		"https://res.openai.azure.com/":           "https://res.openai.azure.com/openai/v1",
+		"https://res.openai.azure.com/openai":     "https://res.openai.azure.com/openai/v1",
+		"https://res.openai.azure.com/openai/v1":  "https://res.openai.azure.com/openai/v1",
+		"https://res.openai.azure.com/openai/v1/": "https://res.openai.azure.com/openai/v1",
+	}
+	for input, want := range cases {
+		got, err := azureCodexBaseURL(input)
+		if err != nil {
+			t.Fatalf("%s: %v", input, err)
+		}
+		if got.String() != want {
+			t.Fatalf("%s => %s, want %s", input, got, want)
+		}
+	}
+	for _, bad := range []string{"", "http://res.openai.azure.com", "https://res.openai.azure.com/v1", "not a url"} {
+		if _, err := azureCodexBaseURL(bad); err == nil {
+			t.Fatalf("%q was accepted; a wrong base url 404s every fallback", bad)
+		}
+	}
+}
+
+func TestParseAzureCodexDeployments(t *testing.T) {
+	got, err := parseAzureCodexDeployments("gpt-5.6-codex=codex-max, gpt-5-codex=codex-old")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["gpt-5.6-codex"] != "codex-max" || got["gpt-5-codex"] != "codex-old" {
+		t.Fatalf("deployments = %v", got)
+	}
+	if empty, err := parseAzureCodexDeployments("  "); err != nil || empty != nil {
+		t.Fatalf("empty mapping = %v, %v", empty, err)
+	}
+	if _, err := parseAzureCodexDeployments("gpt-5.6-codex"); err == nil {
+		t.Fatal("a mapping without = was accepted")
+	}
+}
+
+func TestAzureCodexConfigFromEnvironment(t *testing.T) {
+	t.Setenv("SUBROUTER_AZURE_CODEX_CONFIG_FILE", "")
+	t.Setenv("SUBROUTER_AZURE_CODEX_ENDPOINT", "")
+	t.Setenv("SUBROUTER_AZURE_CODEX_API_KEY", "")
+	t.Setenv("SUBROUTER_AZURE_CODEX_DEPLOYMENTS", "")
+	config, err := azureCodexConfigFromEnvironment()
+	if err != nil || config != nil {
+		t.Fatalf("unset environment => %v, %v; the fallback must stay off", config, err)
+	}
+
+	t.Setenv("SUBROUTER_AZURE_CODEX_ENDPOINT", "https://res.openai.azure.com")
+	if _, err := azureCodexConfigFromEnvironment(); err == nil {
+		t.Fatal("an endpoint without a key was accepted")
+	}
+
+	t.Setenv("SUBROUTER_AZURE_CODEX_API_KEY", "azure-key")
+	t.Setenv("SUBROUTER_AZURE_CODEX_DEPLOYMENTS", "gpt-5.6-codex=codex-max")
+	config, err = azureCodexConfigFromEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(config.Endpoints) != 1 {
+		t.Fatalf("endpoints = %d, want 1", len(config.Endpoints))
+	}
+	endpoint := config.Endpoints[0]
+	if endpoint.BaseURL.String() != "https://res.openai.azure.com/openai/v1" {
+		t.Fatalf("base url = %s", endpoint.BaseURL)
+	}
+	if endpoint.Name != "res.openai.azure.com" {
+		t.Fatalf("name = %q, want the host as the default label", endpoint.Name)
+	}
+	if endpoint.Deployments["gpt-5.6-codex"] != "codex-max" {
+		t.Fatalf("deployments = %v", endpoint.Deployments)
+	}
+}
+
+func TestAzureCodexConfigFromFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "azure.json")
+	contents := `{"endpoints":[
+	  {"name":"eastus2","base_url":"https://east.openai.azure.com/openai/v1","api_key":"key-east"},
+	  {"name":"swedencentral","base_url":"https://sweden.openai.azure.com","api_key":"key-sweden","deployments":{"gpt-5.6-codex":"codex"}}
+	]}`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SUBROUTER_AZURE_CODEX_CONFIG_FILE", path)
+	config, err := azureCodexConfigFromEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(config.Endpoints) != 2 {
+		t.Fatalf("endpoints = %d, want 2", len(config.Endpoints))
+	}
+	if config.Endpoints[1].BaseURL.String() != "https://sweden.openai.azure.com/openai/v1" {
+		t.Fatalf("second base url = %s", config.Endpoints[1].BaseURL)
+	}
+	if azureCodexEndpointNames(config) != "eastus2,swedencentral" {
+		t.Fatalf("names = %q", azureCodexEndpointNames(config))
+	}
+}

--- a/cmd/subrouter/azure_codex_config_test.go
+++ b/cmd/subrouter/azure_codex_config_test.go
@@ -106,3 +106,16 @@ func TestAzureCodexConfigFromFile(t *testing.T) {
 		t.Fatalf("names = %q", azureCodexEndpointNames(config))
 	}
 }
+
+// A stub endpoint on loopback is how the fallback is exercised without an Azure
+// subscription; anything else must still be https.
+func TestAzureCodexBaseURLAllowsLoopbackHTTP(t *testing.T) {
+	for _, raw := range []string{"http://127.0.0.1:8080", "http://localhost:8080/openai/v1", "http://[::1]:8080"} {
+		if _, err := azureCodexBaseURL(raw); err != nil {
+			t.Fatalf("%s rejected: %v", raw, err)
+		}
+	}
+	if _, err := azureCodexBaseURL("http://example.com/openai/v1"); err == nil {
+		t.Fatal("plaintext to a remote host was accepted")
+	}
+}

--- a/cmd/subrouter/azure_codex_config_test.go
+++ b/cmd/subrouter/azure_codex_config_test.go
@@ -3,7 +3,10 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/proxy"
 )
 
 func TestAzureCodexBaseURLNormalization(t *testing.T) {
@@ -117,5 +120,50 @@ func TestAzureCodexBaseURLAllowsLoopbackHTTP(t *testing.T) {
 	}
 	if _, err := azureCodexBaseURL("http://example.com/openai/v1"); err == nil {
 		t.Fatal("plaintext to a remote host was accepted")
+	}
+}
+
+func TestAzureCodexDefaultDeploymentFromEnvironment(t *testing.T) {
+	t.Setenv("SUBROUTER_AZURE_CODEX_CONFIG_FILE", "")
+	t.Setenv("SUBROUTER_AZURE_CODEX_ENDPOINT", "https://res.openai.azure.com")
+	t.Setenv("SUBROUTER_AZURE_CODEX_API_KEY", "azure-key")
+	t.Setenv("SUBROUTER_AZURE_CODEX_DEPLOYMENTS", "")
+	t.Setenv("SUBROUTER_AZURE_CODEX_DEFAULT_DEPLOYMENT", "gpt-5.3-codex")
+	config, err := azureCodexConfigFromEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := config.Endpoints[0].Deployments[proxy.AzureCodexDefaultDeploymentKey]; got != "gpt-5.3-codex" {
+		t.Fatalf("default deployment = %q", got)
+	}
+}
+
+func TestAzCodexArgsCarryTheForceHeader(t *testing.T) {
+	args := azCodexArgs([]string{"exec", "hello"}, "http://127.0.0.1:31415/v1")
+	joined := strings.Join(args, " ")
+	if args[0] != "exec" {
+		t.Fatalf("codex subcommand lost: %v", args)
+	}
+	if !strings.Contains(joined, `"X-Subrouter-Azure"="force"`) {
+		t.Fatalf("force header missing: %s", joined)
+	}
+	// Azure has no WebSocket Responses surface, so a forced session must not
+	// negotiate one.
+	if !strings.Contains(joined, "supports_websockets=false") {
+		t.Fatalf("websockets not disabled: %s", joined)
+	}
+	if !strings.Contains(joined, `base_url="http://127.0.0.1:31415/v1"`) {
+		t.Fatalf("base url missing: %s", joined)
+	}
+}
+
+func TestAzResponseSummaryReadsJSONAndSSE(t *testing.T) {
+	direct := azResponseSummary([]byte(`{"object":"response","model":"gpt-5.3-codex","usage":{"input_tokens":1738,"output_tokens":5,"input_tokens_details":{"cached_tokens":1536}},"output":[{"type":"message","content":[{"type":"output_text","text":"OK"}]}]}`))
+	if direct.Model != "gpt-5.3-codex" || direct.CachedTokens != 1536 || direct.Text != "OK" {
+		t.Fatalf("json summary = %+v", direct)
+	}
+	sse := azResponseSummary([]byte("event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"object\":\"response\",\"model\":\"gpt-5.3-codex\",\"usage\":{\"input_tokens\":10,\"output_tokens\":2}}}\n\n"))
+	if sse.Model != "gpt-5.3-codex" || sse.InputTokens != 10 {
+		t.Fatalf("sse summary = %+v", sse)
 	}
 }

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -237,6 +237,8 @@ var directSRCommands = map[string]struct{}{
 	"daemon":           {},
 	"doctor":           {},
 	"g":                {},
+	"az":               {},
+	"azure":            {},
 	"gemini":           {},
 	"gui":              {},
 	"gui-switch":       {},

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -468,11 +468,18 @@ func serve(args []string) error {
 	)
 	fableBedrockEnabled := *fableBedrockPrimary ||
 		envTrue("SUBROUTER_FABLE_BEDROCK_PRIMARY")
+	azureCodexConfig, err := azureCodexConfigFromEnvironment()
+	if err != nil {
+		return err
+	}
 	if cloudConfig.TeamModeReady() &&
-		(*bedrockEnable || fableAPIKey != "" || fableBedrockEnabled) {
+		(*bedrockEnable || fableAPIKey != "" || fableBedrockEnabled || azureCodexConfig != nil) {
 		return errors.New(
-			"team credential storage cannot use local Bedrock or personal Fable credential fallback; remove the Bedrock/Fable options or run 'sr storage local'",
+			"team credential storage cannot use local Bedrock, personal Fable, or Azure Codex credential fallback; remove those options or run 'sr storage local'",
 		)
+	}
+	if azureCodexConfig != nil {
+		slog.Info("azure codex fallback enabled", "endpoints", azureCodexEndpointNames(azureCodexConfig))
 	}
 	var credentialBroker proxy.CredentialBroker
 	if cloudConfig.TeamModeReady() {
@@ -612,6 +619,7 @@ func serve(args []string) error {
 		MaxBodyBytes:          *maxBodyBytes,
 		Bedrock:               bedrockConfig,
 		ClaudeFableAPIKey:     fableAPIKey,
+		AzureCodex:            azureCodexConfig,
 		FableBedrockPrimary:   fableBedrockEnabled,
 		Transcripts:           transcript.NewRecorder(*transcriptDir),
 	}

--- a/cmd/subrouter/main_test.go
+++ b/cmd/subrouter/main_test.go
@@ -313,6 +313,8 @@ func TestDirectSRCommandNames(t *testing.T) {
 		"add-key",
 		"admin-keys",
 		"attach-project",
+		"az",
+		"azure",
 		"breadcrumbs",
 		"claude",
 		"claude-aws",

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -63,6 +63,9 @@ Usage:
   sr reset [email]      Redeem a rate-limit reset credit (pick best, or --all, or --dry-run)
   sr usage [days]       Refresh and show API-key spend
   sr trace <email>      Show OAuth refresh breadcrumbs for an account
+  sr az status          Show whether the Azure Codex fallback is armed
+  sr az test [model]    Prove the Azure route with one forced request
+  sr az codex [args]    Run Codex forced onto Azure
 
 Getting started:
   sr login              Authenticate with cmux.com through Stack Auth
@@ -340,6 +343,8 @@ func (r srRunner) run(ctx context.Context, args []string) error {
 		return r.spend(ctx)
 	case "gemini":
 		return r.gemini(args[1:])
+	case "az", "azure":
+		return r.az(ctx, args[1:])
 	default:
 		if strings.Contains(args[0], "@") {
 			return r.statusOne(ctx, args[0])
@@ -358,7 +363,7 @@ func (r srRunner) runSelectedRemoteAccountCommand(ctx context.Context, args []st
 
 func shouldRouteSRCommand(command string) bool {
 	switch command {
-	case "server", "servers", "remote", "remotes", "tenant", "tenants", "claude", "claude-aws", "claude-direct", "spend", "cost", "gemini", "help", "-h", "--help":
+	case "server", "servers", "remote", "remotes", "tenant", "tenants", "claude", "claude-aws", "claude-direct", "spend", "cost", "gemini", "az", "azure", "help", "-h", "--help":
 		return false
 	// Setup, cleanup and doctor act on this machine, never the remote server.
 	case "setup", "cleanup", "daemon", "doctor", "login", "logout", "team", "account", "accounts", "storage":

--- a/cmd/subrouter/sr_az.go
+++ b/cmd/subrouter/sr_az.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+const srAzHelp = `sr az - Route Codex through the Azure OpenAI fallback
+
+Usage:
+  sr az test [model]    Send one request through the daemon, forced to Azure
+  sr az status          Show which Azure endpoints the daemon has armed
+  sr az codex [args]    Run Codex with every request forced to Azure
+
+The fallback normally runs on its own, after the Codex pool has spent its
+retries. These commands force it, so the route can be proven without waiting
+for an outage.
+`
+
+// azureForceHeader is the request header the daemon reads to skip the pool.
+const azureForceHeader = "X-Subrouter-Azure"
+
+const defaultAzureTestModel = "gpt-5.3-codex"
+
+func (r srRunner) az(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return r.azStatus(ctx)
+	}
+	switch args[0] {
+	case "status":
+		return r.azStatus(ctx)
+	case "test", "check":
+		return r.azTest(ctx, args[1:])
+	case "codex":
+		return azCodex(args[1:])
+	case "help", "-h", "--help":
+		fmt.Fprint(r.out, srAzHelp)
+		return nil
+	default:
+		return fmt.Errorf("unknown command: sr az %s\n%s", args[0], srAzHelp)
+	}
+}
+
+// azStatus reports the endpoints the daemon armed, which is the difference
+// between "the fallback is configured" and "the binary supports it".
+func (r srRunner) azStatus(ctx context.Context) error {
+	baseURL, err := azBaseURL()
+	if err != nil {
+		return err
+	}
+	health, err := azHealth(ctx, baseURL)
+	if err != nil {
+		return err
+	}
+	if len(health.AzureCodex) == 0 {
+		fmt.Fprintf(r.out, "Azure fallback is OFF at %s\n", baseURL)
+		fmt.Fprintln(r.out, "Set SUBROUTER_AZURE_CODEX_ENDPOINT and SUBROUTER_AZURE_CODEX_API_KEY on the daemon, then restart it.")
+		return nil
+	}
+	fmt.Fprintf(r.out, "Azure fallback is ON at %s\n", baseURL)
+	for _, endpoint := range health.AzureCodex {
+		fmt.Fprintf(r.out, "  %s\n", endpoint)
+	}
+	return nil
+}
+
+type azHealthResponse struct {
+	AzureCodex []string `json:"azure_codex"`
+}
+
+func azHealth(ctx context.Context, baseURL string) (azHealthResponse, error) {
+	var health azHealthResponse
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+"/_subrouter/health", nil)
+	if err != nil {
+		return health, err
+	}
+	response, err := (&http.Client{Timeout: 10 * time.Second}).Do(request)
+	if err != nil {
+		return health, fmt.Errorf("reach the Subrouter daemon at %s: %w", baseURL, err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, 64<<10))
+	if err != nil {
+		return health, err
+	}
+	if response.StatusCode != http.StatusOK {
+		return health, fmt.Errorf("daemon health at %s returned %d", baseURL, response.StatusCode)
+	}
+	if err := json.Unmarshal(body, &health); err != nil {
+		return health, fmt.Errorf("parse daemon health: %w", err)
+	}
+	return health, nil
+}
+
+// azTest sends one small Responses request with the force header and reports
+// what happened, including the cached-token counts that show whether the prompt
+// cache is being reused across turns.
+func (r srRunner) azTest(ctx context.Context, args []string) error {
+	model := defaultAzureTestModel
+	if len(args) > 0 && strings.TrimSpace(args[0]) != "" {
+		model = strings.TrimSpace(args[0])
+	}
+	baseURL, err := azBaseURL()
+	if err != nil {
+		return err
+	}
+	payload, err := json.Marshal(map[string]any{
+		"model":             model,
+		"instructions":      azCachePrefix(),
+		"input":             "Reply with the single word OK.",
+		"max_output_tokens": 16,
+		"reasoning":         map[string]any{"effort": "low"},
+		"prompt_cache_key":  "sr-az-test",
+	})
+	if err != nil {
+		return err
+	}
+	target := strings.TrimRight(baseURL, "/") + "/responses"
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Subrouter-Agent", "codex")
+	request.Header.Set(azureForceHeader, "force")
+	started := time.Now()
+	response, err := (&http.Client{Timeout: 5 * time.Minute}).Do(request)
+	if err != nil {
+		return fmt.Errorf("reach the Subrouter daemon at %s: %w", baseURL, err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	if response.StatusCode != http.StatusOK {
+		fmt.Fprintf(r.out, "FAILED  %s  status %d\n%s\n", target, response.StatusCode, strings.TrimSpace(string(body)))
+		return errors.New("the Azure route did not serve the request")
+	}
+	summary := azResponseSummary(body)
+	fmt.Fprintf(r.out, "OK  %s  %s  deployment=%s  input=%d cached=%d output=%d\n",
+		target, time.Since(started).Round(time.Millisecond), summary.Model,
+		summary.InputTokens, summary.CachedTokens, summary.OutputTokens)
+	if summary.Text != "" {
+		fmt.Fprintf(r.out, "    reply: %s\n", summary.Text)
+	}
+	if summary.CachedTokens > 0 {
+		fmt.Fprintln(r.out, "    cached tokens > 0: the prompt cache was reused, which is the stickiness working.")
+	} else {
+		fmt.Fprintln(r.out, "    run it again within 30 minutes; the second run should report cached tokens.")
+	}
+	return nil
+}
+
+// azCachePrefix is a fixed instruction block long enough to be cacheable. A
+// provider caches nothing below about 1024 identical leading tokens, so a
+// one-line probe can never show a cache hit and would make a working cache look
+// broken.
+func azCachePrefix() string {
+	const line = "This is a Subrouter Azure fallback cache probe. The text repeats so the prompt prefix is long enough for the provider to cache it, and it is identical on every run so a later run can hit that cache. "
+	return strings.Repeat(line, 40)
+}
+
+type azSummary struct {
+	Model        string
+	Text         string
+	InputTokens  int
+	CachedTokens int
+	OutputTokens int
+}
+
+// azResponseSummary pulls the few fields worth printing out of a Responses
+// body, tolerating both the JSON and SSE forms.
+func azResponseSummary(body []byte) azSummary {
+	summary := azSummary{}
+	payload := azResponseObject(body)
+	if payload == nil {
+		return summary
+	}
+	if model, ok := payload["model"].(string); ok {
+		summary.Model = model
+	}
+	if usage, ok := payload["usage"].(map[string]any); ok {
+		summary.InputTokens = azInt(usage["input_tokens"])
+		summary.OutputTokens = azInt(usage["output_tokens"])
+		if details, ok := usage["input_tokens_details"].(map[string]any); ok {
+			summary.CachedTokens = azInt(details["cached_tokens"])
+		}
+	}
+	summary.Text = azOutputText(payload)
+	return summary
+}
+
+// azResponseObject finds the response object in a plain JSON body or in the
+// final event of an SSE stream.
+func azResponseObject(body []byte) map[string]any {
+	var direct map[string]any
+	if json.Unmarshal(body, &direct) == nil {
+		if response, ok := direct["response"].(map[string]any); ok {
+			return response
+		}
+		if direct["object"] == "response" {
+			return direct
+		}
+	}
+	var last map[string]any
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	scanner.Buffer(make([]byte, 0, 64<<10), 4<<20)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		var event map[string]any
+		if json.Unmarshal([]byte(strings.TrimSpace(strings.TrimPrefix(line, "data:"))), &event) != nil {
+			continue
+		}
+		if response, ok := event["response"].(map[string]any); ok {
+			last = response
+		}
+	}
+	return last
+}
+
+func azOutputText(payload map[string]any) string {
+	output, ok := payload["output"].([]any)
+	if !ok {
+		return ""
+	}
+	for _, item := range output {
+		entry, ok := item.(map[string]any)
+		if !ok || entry["type"] != "message" {
+			continue
+		}
+		contents, ok := entry["content"].([]any)
+		if !ok {
+			continue
+		}
+		for _, content := range contents {
+			block, ok := content.(map[string]any)
+			if !ok {
+				continue
+			}
+			if text, ok := block["text"].(string); ok && strings.TrimSpace(text) != "" {
+				return strings.TrimSpace(text)
+			}
+		}
+	}
+	return ""
+}
+
+func azInt(value any) int {
+	number, ok := value.(float64)
+	if !ok {
+		return 0
+	}
+	return int(number)
+}
+
+// azCodex runs Codex with every request forced onto the Azure route, through
+// the same daemon and session bookkeeping as `sr codex`.
+func azCodex(args []string) error {
+	baseURL, err := azBaseURL()
+	if err != nil {
+		return err
+	}
+	bin := envOrDefault("SUBROUTER_CODEX_BIN", "codex")
+	cmd := exec.CommandContext(context.Background(), bin, azCodexArgs(args, baseURL+"/v1")...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// azCodexArgs pins Codex to a Subrouter provider that carries the force header.
+// WebSockets are off: Azure has no WebSocket Responses surface, so a forced
+// session must speak HTTP.
+func azCodexArgs(args []string, baseURL string) []string {
+	configArgs := []string{
+		"-c", `model_provider="subrouter-azure"`,
+		"-c", `model_providers.subrouter-azure.name="Subrouter Azure"`,
+		"-c", "model_providers.subrouter-azure.base_url=" + strconv.Quote(baseURL),
+		"-c", `model_providers.subrouter-azure.experimental_bearer_token="subrouter"`,
+		"-c", `model_providers.subrouter-azure.wire_api="responses"`,
+		"-c", `model_providers.subrouter-azure.supports_websockets=false`,
+		"-c", `model_providers.subrouter-azure.http_headers={"X-Subrouter-Agent"="codex","` + azureForceHeader + `"="force"}`,
+	}
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") || !isKnownCodexCommand(args[0]) {
+		return append(configArgs, args...)
+	}
+	if !isSubrouterRoutedCodexCommand(args[0]) {
+		return args
+	}
+	return append([]string{args[0]}, append(configArgs, args[1:]...)...)
+}
+
+// azBaseURL resolves the daemon this machine routes Codex through, so `sr az`
+// tests the same server the agents use. The /v1 suffix Codex needs is trimmed:
+// these commands talk to the daemon's own paths.
+func azBaseURL() (string, error) {
+	baseURL, err := codexBaseURL(defaultSRServerStore(accounts.DefaultCodexStore()))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(strings.TrimRight(baseURL, "/"), "/v1"), nil
+}

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -113,3 +113,7 @@ OPENAI_API_KEY=dummy codex exec \
 - `CODEX_HOME`: optional. Use it to test an isolated Codex config.
 - `OPENAI_ORGANIZATION` and `OPENAI_PROJECT`: Codex forwards these as OpenAI headers for the built-in OpenAI provider.
 - `CODEX_OSS_BASE_URL` and `CODEX_OSS_PORT`: only affect OSS providers such as Ollama or LM Studio, not the OpenAI provider.
+
+## Azure fallback
+
+`SUBROUTER_AZURE_CODEX_ENDPOINT` plus `SUBROUTER_AZURE_CODEX_API_KEY` (or `SUBROUTER_AZURE_CODEX_CONFIG_FILE` for several Azure resources) lets Subrouter finish a Codex `/responses` request on Azure OpenAI after the pool has spent five retries or has no usable account. The session then stays on that Azure endpoint for 30 minutes of activity so its prompt cache keeps hitting. See the README for the full behavior and configuration.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -116,4 +116,14 @@ OPENAI_API_KEY=dummy codex exec \
 
 ## Azure fallback
 
-`SUBROUTER_AZURE_CODEX_ENDPOINT` plus `SUBROUTER_AZURE_CODEX_API_KEY` (or `SUBROUTER_AZURE_CODEX_CONFIG_FILE` for several Azure resources) lets Subrouter finish a Codex `/responses` request on Azure OpenAI after the pool has spent five retries or has no usable account. The session then stays on that Azure endpoint for 30 minutes of activity so its prompt cache keeps hitting. See the README for the full behavior and configuration.
+`SUBROUTER_AZURE_CODEX_ENDPOINT` plus `SUBROUTER_AZURE_CODEX_API_KEY` (or `SUBROUTER_AZURE_CODEX_CONFIG_FILE` for several Azure resources) lets Subrouter finish a Codex `/responses` request on Azure OpenAI after the pool has spent five retries or has no usable account. The session then stays on that Azure endpoint for 30 minutes of activity so its prompt cache keeps hitting.
+
+Force the route to test it:
+
+```bash
+sr az status          # which Azure endpoints the daemon armed
+sr az test            # one forced request through the daemon
+sr az codex exec "…"  # Codex with every request forced onto Azure
+```
+
+`sr az codex` pins Codex to a provider that sends `X-Subrouter-Azure: force` and disables WebSockets, because Azure has no WebSocket Responses surface. The daemon rejects a forced request it cannot serve rather than answering from the ChatGPT pool. See the README for the full behavior and configuration.

--- a/internal/proxy/azure_codex.go
+++ b/internal/proxy/azure_codex.go
@@ -57,12 +57,35 @@ func (c *AzureCodexConfig) configured() bool {
 	return false
 }
 
-// deployment resolves the Azure deployment name for a requested model.
+// deployment resolves the Azure deployment name for a requested model: an exact
+// mapping, then the "*" default, then the model's own name. The default matters
+// because Azure lags the ChatGPT model list, so a Codex release the fallback has
+// never heard of would otherwise 404 on the one path meant to rescue it.
 func (e AzureCodexEndpoint) deployment(model string) string {
 	if mapped, ok := e.Deployments[model]; ok && mapped != "" {
 		return mapped
 	}
+	if fallback, ok := e.Deployments[AzureCodexDefaultDeploymentKey]; ok && fallback != "" {
+		return fallback
+	}
 	return model
+}
+
+// AzureCodexDefaultDeploymentKey maps every unlisted model onto one deployment.
+const AzureCodexDefaultDeploymentKey = "*"
+
+// azureCodexForceHeader makes a request skip the pool and go straight to Azure.
+// It is how `sr az codex` and `sr az test` exercise the fallback without
+// waiting for the pool to fail.
+const azureCodexForceHeader = "X-Subrouter-Azure"
+
+// azureCodexForced reports whether the caller demanded the Azure route.
+func azureCodexForced(r *http.Request) bool {
+	switch strings.ToLower(strings.TrimSpace(r.Header.Get(azureCodexForceHeader))) {
+	case "force", "1", "true", "yes", "only":
+		return true
+	}
+	return false
 }
 
 const (
@@ -250,11 +273,18 @@ func azureCodexCacheKey(existing, sessionKey string) string {
 	return "sr-" + hex.EncodeToString(sum[:8])
 }
 
-// azureCodexBody rewrites a Codex Responses body for Azure: model becomes the
-// deployment name, and prompt_cache_key is filled in when the client did not
-// send one. Nothing else changes, because the Azure v1 surface takes the same
-// Responses payload Codex already sends to api.openai.com.
-func azureCodexBody(body []byte, deployment, cacheKey string) ([]byte, error) {
+// azureCodexChatGPTOnlyFields are fields Codex sends to the ChatGPT backend
+// that the Responses API rejects outright ("Unknown parameter: 'session_id'").
+// Every Codex turn carries session_id, so without this the fallback answers a
+// pool outage with a 400 from a second provider.
+var azureCodexChatGPTOnlyFields = []string{"session_id", "conversation_id", "thread_id"}
+
+// azureCodexPayload rewrites a Codex Responses body for Azure: model becomes the
+// deployment name, prompt_cache_key is filled in when the client did not send
+// one, and ChatGPT-backend-only fields are dropped. Everything else is
+// untouched, because the Azure v1 surface takes the same Responses payload
+// Codex already sends to api.openai.com.
+func azureCodexPayload(body []byte, deployment, cacheKey string) (map[string]json.RawMessage, error) {
 	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, fmt.Errorf("decode responses body: %w", err)
@@ -274,7 +304,78 @@ func azureCodexBody(body []byte, deployment, cacheKey string) ([]byte, error) {
 		}
 		payload["prompt_cache_key"] = encodedKey
 	}
+	for _, field := range azureCodexChatGPTOnlyFields {
+		delete(payload, field)
+	}
+	return payload, nil
+}
+
+// azureCodexBody is azureCodexPayload encoded.
+func azureCodexBody(body []byte, deployment, cacheKey string) ([]byte, error) {
+	payload, err := azureCodexPayload(body, deployment, cacheKey)
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(payload)
+}
+
+// azureCodexRejectedField reads the field an Azure 400 names as the problem.
+// Codex ships ahead of the model versions Azure hosts, so a live Codex body
+// carries fields and values a slightly older model refuses ("Unknown parameter:
+// 'session_id'", "'all_turns' is not supported with gpt-5.3-codex"). The error
+// names exactly which field to drop, so retrying without it beats failing the
+// one request the pool already refused, and beats guessing the full list in
+// advance. Dropping the field restores the provider's default for it.
+func azureCodexRejectedField(body []byte) string {
+	var payload struct {
+		Error struct {
+			Code  string `json:"code"`
+			Param string `json:"param"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &payload) != nil {
+		return ""
+	}
+	switch payload.Error.Code {
+	case "unknown_parameter", "unsupported_parameter", "unsupported_value":
+	default:
+		return ""
+	}
+	param := strings.TrimSpace(payload.Error.Param)
+	// Array paths are not dropped: an element of the conversation is content,
+	// not a setting, and removing it would change what the model is asked.
+	if param == "" || strings.ContainsAny(param, "[]") {
+		return ""
+	}
+	return param
+}
+
+// azureCodexDropField removes a dotted field path from a decoded body. It
+// reports false when the path does not exist or does not run through plain
+// objects, which is the caller's signal to stop retrying.
+func azureCodexDropField(payload map[string]json.RawMessage, path string) bool {
+	name, rest, nested := strings.Cut(path, ".")
+	raw, ok := payload[name]
+	if !ok {
+		return false
+	}
+	if !nested {
+		delete(payload, name)
+		return true
+	}
+	var child map[string]json.RawMessage
+	if json.Unmarshal(raw, &child) != nil || child == nil {
+		return false
+	}
+	if !azureCodexDropField(child, rest) {
+		return false
+	}
+	encoded, err := json.Marshal(child)
+	if err != nil {
+		return false
+	}
+	payload[name] = encoded
+	return true
 }
 
 func azureCodexStringField(payload map[string]json.RawMessage, field string) string {
@@ -379,25 +480,12 @@ func (s Server) azureCodexEndpointResponse(
 	sessionKey string,
 	model string,
 ) (*http.Response, error) {
-	rewritten, err := azureCodexBody(body, endpoint.deployment(model), sessionKey)
+	payload, err := azureCodexPayload(body, endpoint.deployment(model), sessionKey)
 	if err != nil {
 		return nil, err
 	}
 	target := *endpoint.BaseURL
 	target.Path = strings.TrimRight(endpoint.BaseURL.Path, "/") + path
-	outReq, err := http.NewRequestWithContext(req.Context(), http.MethodPost, target.String(), bytes.NewReader(rewritten))
-	if err != nil {
-		return nil, err
-	}
-	outReq.Header.Set("Content-Type", "application/json")
-	if accept := req.Header.Get("Accept"); accept != "" {
-		outReq.Header.Set("Accept", accept)
-	}
-	outReq.Header.Set("Api-Key", endpoint.APIKey)
-	outReq.Header.Set("Authorization", "Bearer "+endpoint.APIKey)
-	outReq.Host = target.Host
-	outReq.ContentLength = int64(len(rewritten))
-
 	transport := s.AzureCodex.Transport
 	if transport == nil {
 		transport = s.Transport
@@ -405,7 +493,57 @@ func (s Server) azureCodexEndpointResponse(
 	if transport == nil {
 		transport = http.DefaultTransport
 	}
-	return transport.RoundTrip(outReq)
+	for attempt := 0; ; attempt++ {
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		outReq, err := http.NewRequestWithContext(req.Context(), http.MethodPost, target.String(), bytes.NewReader(encoded))
+		if err != nil {
+			return nil, err
+		}
+		outReq.Header.Set("Content-Type", "application/json")
+		if accept := req.Header.Get("Accept"); accept != "" {
+			outReq.Header.Set("Accept", accept)
+		}
+		outReq.Header.Set("Api-Key", endpoint.APIKey)
+		outReq.Header.Set("Authorization", "Bearer "+endpoint.APIKey)
+		outReq.Host = target.Host
+		outReq.ContentLength = int64(len(encoded))
+
+		response, err := transport.RoundTrip(outReq)
+		if err != nil || response.StatusCode != http.StatusBadRequest || attempt >= azureCodexUnknownParamRetries {
+			return response, err
+		}
+		// Azure names the field it does not know. Drop that one field and send
+		// the request again rather than failing the request the pool already
+		// refused.
+		errorBody, readErr := io.ReadAll(io.LimitReader(response.Body, azureCodexMaxErrorBodyBytes))
+		_ = response.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		rejected := azureCodexRejectedField(errorBody)
+		if rejected == "" || !azureCodexDropField(payload, rejected) {
+			return azureCodexReplayedResponse(response, errorBody), nil
+		}
+		if s.Logger != nil {
+			s.Logger.Warn("azure codex rejected a field; retrying without it",
+				"endpoint", endpoint.Name, "model", model, "field", rejected)
+		}
+	}
+}
+
+// azureCodexUnknownParamRetries bounds how many unknown fields are stripped
+// before the rejection is returned as-is. Small: a body that needs more than a
+// few is not a drifting field name, it is the wrong endpoint.
+const azureCodexUnknownParamRetries = 3
+
+// azureCodexReplayedResponse puts an already-read error body back on the
+// response so the caller can log and close it like any other.
+func azureCodexReplayedResponse(response *http.Response, body []byte) *http.Response {
+	response.Body = io.NopCloser(bytes.NewReader(body))
+	return response
 }
 
 // azureCodexMaxBodyBytes bounds a decoded request body, falling back to the
@@ -440,6 +578,7 @@ func (s Server) serveAzureCodex(
 	sessionKey string,
 	preferred int,
 	reason string,
+	pin bool,
 ) bool {
 	body, err := io.ReadAll(io.LimitReader(r.Body, replayablePostMaxBodyBytes))
 	if err != nil {
@@ -456,7 +595,11 @@ func (s Server) serveAzureCodex(
 		restore()
 		return false
 	}
-	s.azureCodexSessions.pin(sessionKey, endpoint)
+	// A forced request does not pin: forcing is per request, and the pin exists
+	// to keep an involuntary fallback on the cache it just created.
+	if pin {
+		s.azureCodexSessions.pin(sessionKey, endpoint)
+	}
 	if s.Logger != nil {
 		s.Logger.Warn("serving codex via azure fallback",
 			"reason", reason,
@@ -558,4 +701,23 @@ func (c *AzureCodexConfig) endpointNames() []string {
 		names = append(names, endpoint.Name)
 	}
 	return names
+}
+
+// azureCodexForceUnavailableMessage explains why a forced request cannot run,
+// naming the specific blocker rather than a generic 503. Each of these is a
+// different fix: configure the endpoint, drop the session lease, or stop using
+// team credential storage.
+func azureCodexForceUnavailableMessage(s Server, leased bool, r *http.Request) string {
+	switch {
+	case !s.AzureCodex.configured():
+		return "azure codex route is not configured; set SUBROUTER_AZURE_CODEX_ENDPOINT and SUBROUTER_AZURE_CODEX_API_KEY on the server"
+	case leased:
+		return "azure codex route cannot serve a session-leased request, which is bound to one pool account"
+	case s.CredentialBroker != nil:
+		return "azure codex route is disabled under team credential storage; run 'sr storage local'"
+	case !azureCodexRequest(r.Method, r.URL.Path):
+		return "azure codex route serves only POST /responses"
+	default:
+		return "azure codex route is unavailable for this request"
+	}
 }

--- a/internal/proxy/azure_codex.go
+++ b/internal/proxy/azure_codex.go
@@ -1,0 +1,561 @@
+package proxy
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// AzureCodexEndpoint is one Azure OpenAI resource that can serve Codex
+// Responses traffic. BaseURL is the v1 surface documented for Codex CLI
+// (https://<resource>.openai.azure.com/openai/v1), which takes the same request
+// body as api.openai.com with model set to the deployment name.
+type AzureCodexEndpoint struct {
+	// Name labels the endpoint in logs (usually the region or resource name).
+	Name string
+	// BaseURL is the Azure OpenAI v1 base, e.g.
+	// https://my-resource.openai.azure.com/openai/v1.
+	BaseURL *url.URL
+	// APIKey authenticates the call. Sent as both api-key and Authorization
+	// bearer because the v1 surface accepts either.
+	APIKey string
+	// Deployments maps a requested model to the Azure deployment name. A model
+	// with no entry uses its own name, which is how Foundry deployments are
+	// named by default.
+	Deployments map[string]string
+}
+
+// AzureCodexConfig is the Codex fallback route. It serves a Codex Responses
+// request from Azure OpenAI after the subscription pool has failed, and pins
+// the session to Azure afterwards so the follow-up turns keep hitting the same
+// prompt cache instead of flapping between two providers.
+type AzureCodexConfig struct {
+	Endpoints []AzureCodexEndpoint
+	// Transport is the outbound RoundTripper. Nil uses the server transport.
+	Transport http.RoundTripper
+}
+
+func (c *AzureCodexConfig) configured() bool {
+	if c == nil {
+		return false
+	}
+	for _, endpoint := range c.Endpoints {
+		if endpoint.BaseURL != nil && endpoint.APIKey != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// deployment resolves the Azure deployment name for a requested model.
+func (e AzureCodexEndpoint) deployment(model string) string {
+	if mapped, ok := e.Deployments[model]; ok && mapped != "" {
+		return mapped
+	}
+	return model
+}
+
+const (
+	// azureCodexPoolRetryBudget is how many retries the Codex pool gets before
+	// the request is handed to Azure. Attempt 1 plus this many retries, across
+	// account failover (429/usage limit) and transport-level retries (5xx,
+	// connection failures) together, so a request cannot spend 5 retries per
+	// layer.
+	azureCodexPoolRetryBudget = 5
+	// azureCodexStickyTTL is how long a session stays pinned to Azure after a
+	// successful fallback, refreshed on every request. It matches the 30-minute
+	// minimum lifetime Azure gives a cached prompt prefix: pinning for less
+	// would send the next turn back to the pool with a cold cache on both
+	// sides, pinning for much longer would keep a session off the subscription
+	// pool long after the incident that pushed it to Azure.
+	azureCodexStickyTTL = 30 * time.Minute
+	// azureCodexMaxErrorBodyBytes bounds how much of an Azure error body is
+	// read for a log line. Enough for the message field, small enough that a
+	// misbehaving endpoint cannot flood memory.
+	azureCodexMaxErrorBodyBytes = 512
+)
+
+// attemptBudget bounds the retries a single client request may spend on the
+// pool before the fallback takes over. Both retry transports draw from the same
+// budget, so nested retry loops cannot multiply into 5 retries per layer.
+type attemptBudget struct {
+	remaining atomic.Int64
+}
+
+func newAttemptBudget(retries int) *attemptBudget {
+	budget := &attemptBudget{}
+	budget.remaining.Store(int64(retries))
+	return budget
+}
+
+// consume claims one retry. It returns false once the budget is spent, which
+// tells the caller to stop retrying and let the fallback run. A nil budget is
+// unbounded, which is the behaviour when no fallback is configured.
+func (b *attemptBudget) consume() bool {
+	if b == nil {
+		return true
+	}
+	for {
+		remaining := b.remaining.Load()
+		if remaining <= 0 {
+			return false
+		}
+		if b.remaining.CompareAndSwap(remaining, remaining-1) {
+			return true
+		}
+	}
+}
+
+// azureCodexSticky pins a Codex session to an Azure endpoint. Prompt caching is
+// per-deployment and keyed on an identical prefix, so a session that has fallen
+// back must keep going to the same place: alternating providers turn by turn
+// re-uploads the whole conversation as a cache miss every time.
+type azureCodexSticky struct {
+	mu      sync.Mutex
+	entries map[string]azureCodexStickyEntry
+	now     func() time.Time
+}
+
+type azureCodexStickyEntry struct {
+	endpoint  int
+	expiresAt time.Time
+}
+
+func newAzureCodexSticky() *azureCodexSticky {
+	return &azureCodexSticky{entries: map[string]azureCodexStickyEntry{}}
+}
+
+func (s *azureCodexSticky) clock() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+// lookup returns the pinned endpoint index for a session and extends the pin,
+// because the pin exists to keep a live conversation on one cache.
+func (s *azureCodexSticky) lookup(key string) (int, bool) {
+	if s == nil || key == "" {
+		return 0, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.entries[key]
+	if !ok {
+		return 0, false
+	}
+	now := s.clock()
+	if !entry.expiresAt.After(now) {
+		delete(s.entries, key)
+		return 0, false
+	}
+	entry.expiresAt = now.Add(azureCodexStickyTTL)
+	s.entries[key] = entry
+	return entry.endpoint, true
+}
+
+func (s *azureCodexSticky) pin(key string, endpoint int) {
+	if s == nil || key == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.clock()
+	s.sweepLocked(now)
+	s.entries[key] = azureCodexStickyEntry{endpoint: endpoint, expiresAt: now.Add(azureCodexStickyTTL)}
+}
+
+func (s *azureCodexSticky) unpin(key string) {
+	if s == nil || key == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.entries, key)
+}
+
+// sweepLocked drops expired pins. Sessions end without telling the proxy, so
+// without this the map grows for the life of the process.
+func (s *azureCodexSticky) sweepLocked(now time.Time) {
+	for key, entry := range s.entries {
+		if !entry.expiresAt.After(now) {
+			delete(s.entries, key)
+		}
+	}
+}
+
+func azureCodexSessionKeyFor(agentType, sessionID string) string {
+	if sessionID == "" {
+		return ""
+	}
+	return agentType + "\x00" + sessionID
+}
+
+// azureCodexRequest reports whether this Codex request can be served by Azure.
+// Only the Responses endpoint qualifies: /responses/compact is a ChatGPT
+// backend endpoint with no Azure equivalent, and everything else on the Codex
+// surface (catalog, alpha/search) is ChatGPT-specific.
+func azureCodexRequest(method, path string) bool {
+	if method != http.MethodPost {
+		return false
+	}
+	_, ok := azureCodexPath(path)
+	return ok
+}
+
+// azureCodexPath maps a Codex request path onto the Azure v1 surface.
+func azureCodexPath(path string) (string, bool) {
+	switch path {
+	case "/responses", "/v1/responses", "/backend-api/codex/responses":
+		return "/responses", true
+	default:
+		return "", false
+	}
+}
+
+// azureCodexEndpointIndex spreads sessions across configured endpoints while
+// keeping one session on one endpoint, since a prompt cache lives inside a
+// single Azure deployment.
+func azureCodexEndpointIndex(sessionKey string, count int) int {
+	if count <= 1 || sessionKey == "" {
+		return 0
+	}
+	sum := sha256.Sum256([]byte(sessionKey))
+	return int(sum[0]) % count
+}
+
+// azureCodexCacheKey keeps the prompt_cache_key the client already sent, and
+// otherwise derives a stable one from the session so every turn of the same
+// conversation routes to the same cached prefix. The session id is hashed
+// rather than forwarded: it is internal routing state, not something to hand to
+// a third-party provider.
+func azureCodexCacheKey(existing, sessionKey string) string {
+	if existing != "" {
+		return existing
+	}
+	if sessionKey == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(sessionKey))
+	return "sr-" + hex.EncodeToString(sum[:8])
+}
+
+// azureCodexBody rewrites a Codex Responses body for Azure: model becomes the
+// deployment name, and prompt_cache_key is filled in when the client did not
+// send one. Nothing else changes, because the Azure v1 surface takes the same
+// Responses payload Codex already sends to api.openai.com.
+func azureCodexBody(body []byte, deployment, cacheKey string) ([]byte, error) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("decode responses body: %w", err)
+	}
+	if payload == nil {
+		return nil, errors.New("empty responses body")
+	}
+	encodedModel, err := json.Marshal(deployment)
+	if err != nil {
+		return nil, err
+	}
+	payload["model"] = encodedModel
+	if key := azureCodexCacheKey(azureCodexStringField(payload, "prompt_cache_key"), cacheKey); key != "" {
+		encodedKey, err := json.Marshal(key)
+		if err != nil {
+			return nil, err
+		}
+		payload["prompt_cache_key"] = encodedKey
+	}
+	return json.Marshal(payload)
+}
+
+func azureCodexStringField(payload map[string]json.RawMessage, field string) string {
+	raw, ok := payload[field]
+	if !ok {
+		return ""
+	}
+	var value string
+	if json.Unmarshal(raw, &value) != nil {
+		return ""
+	}
+	return value
+}
+
+// azureCodexModel reads the model from a Responses body. The routing model
+// header can be missing on a raw request, and the deployment lookup needs the
+// model the client actually asked for.
+func azureCodexModel(body []byte) string {
+	var payload map[string]json.RawMessage
+	if json.Unmarshal(body, &payload) != nil {
+		return ""
+	}
+	return azureCodexStringField(payload, "model")
+}
+
+// azureCodexResponse sends one Codex Responses body to Azure. It starts at the
+// preferred endpoint (the session's pin, or its hashed home) and walks the
+// remaining endpoints only when one fails outright, so a healthy session never
+// migrates off the endpoint holding its cache. The returned index is the
+// endpoint that answered.
+func (s Server) azureCodexResponse(
+	req *http.Request,
+	body []byte,
+	sessionKey string,
+	preferred int,
+) (*http.Response, int, bool) {
+	if !s.AzureCodex.configured() {
+		return nil, 0, false
+	}
+	path, ok := azureCodexPath(req.URL.Path)
+	if !ok {
+		return nil, 0, false
+	}
+	endpoints := s.AzureCodex.Endpoints
+	// Codex may compress the request body (zstd). Azure takes plain JSON, and
+	// the body has to be parsed anyway to rewrite the model, so decode once
+	// here and send the decoded form.
+	decoded, err := decodedJSONRequestBody(body, req.Header.Get("Content-Encoding"), s.azureCodexMaxBodyBytes())
+	if err != nil {
+		if s.Logger != nil {
+			s.Logger.Warn("azure codex fallback cannot decode the request body", "error", err)
+		}
+		return nil, 0, false
+	}
+	model := azureCodexModel(decoded)
+	if model == "" {
+		return nil, 0, false
+	}
+	if preferred < 0 || preferred >= len(endpoints) {
+		preferred = azureCodexEndpointIndex(sessionKey, len(endpoints))
+	}
+	for offset := range endpoints {
+		index := (preferred + offset) % len(endpoints)
+		endpoint := endpoints[index]
+		if endpoint.BaseURL == nil || endpoint.APIKey == "" {
+			continue
+		}
+		response, err := s.azureCodexEndpointResponse(req, endpoint, path, decoded, sessionKey, model)
+		if err != nil {
+			if req.Context().Err() != nil {
+				return nil, 0, false
+			}
+			if s.Logger != nil {
+				s.Logger.Error("azure codex fallback request failed", "endpoint", endpoint.Name, "model", model, "error", err)
+			}
+			continue
+		}
+		if response.StatusCode >= 200 && response.StatusCode < 300 {
+			return response, index, true
+		}
+		if s.Logger != nil {
+			s.Logger.Warn("azure codex fallback endpoint returned an error",
+				"endpoint", endpoint.Name,
+				"model", model,
+				"status", response.StatusCode,
+				"body", azureCodexErrorSummary(response))
+		}
+		_ = response.Body.Close()
+	}
+	return nil, 0, false
+}
+
+// azureCodexEndpointResponse builds and sends the Azure request. Client headers
+// are not forwarded: they carry ChatGPT session and account identity that means
+// nothing to Azure, and the OAuth Authorization header must never leave for a
+// third-party host.
+func (s Server) azureCodexEndpointResponse(
+	req *http.Request,
+	endpoint AzureCodexEndpoint,
+	path string,
+	body []byte,
+	sessionKey string,
+	model string,
+) (*http.Response, error) {
+	rewritten, err := azureCodexBody(body, endpoint.deployment(model), sessionKey)
+	if err != nil {
+		return nil, err
+	}
+	target := *endpoint.BaseURL
+	target.Path = strings.TrimRight(endpoint.BaseURL.Path, "/") + path
+	outReq, err := http.NewRequestWithContext(req.Context(), http.MethodPost, target.String(), bytes.NewReader(rewritten))
+	if err != nil {
+		return nil, err
+	}
+	outReq.Header.Set("Content-Type", "application/json")
+	if accept := req.Header.Get("Accept"); accept != "" {
+		outReq.Header.Set("Accept", accept)
+	}
+	outReq.Header.Set("Api-Key", endpoint.APIKey)
+	outReq.Header.Set("Authorization", "Bearer "+endpoint.APIKey)
+	outReq.Host = target.Host
+	outReq.ContentLength = int64(len(rewritten))
+
+	transport := s.AzureCodex.Transport
+	if transport == nil {
+		transport = s.Transport
+	}
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	return transport.RoundTrip(outReq)
+}
+
+// azureCodexMaxBodyBytes bounds a decoded request body, falling back to the
+// replay buffer size when the server sets no explicit limit.
+func (s Server) azureCodexMaxBodyBytes() int64 {
+	if s.MaxBodyBytes > 0 {
+		return s.MaxBodyBytes
+	}
+	return replayablePostMaxBodyBytes
+}
+
+// azureCodexErrorSummary reads a bounded prefix of an Azure error body for one
+// log line. Azure reports deployment and parameter mistakes only in the body,
+// so a status code alone leaves a misconfigured fallback undiagnosable.
+func azureCodexErrorSummary(response *http.Response) string {
+	if response == nil || response.Body == nil {
+		return ""
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, azureCodexMaxErrorBodyBytes))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(body))
+}
+
+// serveAzureCodex answers a Codex request from Azure and pins the session on
+// success. It returns false without consuming the request body when Azure could
+// not answer, so the caller continues down its normal path.
+func (s Server) serveAzureCodex(
+	w http.ResponseWriter,
+	r *http.Request,
+	sessionKey string,
+	preferred int,
+	reason string,
+) bool {
+	body, err := io.ReadAll(io.LimitReader(r.Body, replayablePostMaxBodyBytes))
+	if err != nil {
+		return false
+	}
+	restore := func() {
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		r.ContentLength = int64(len(body))
+		r.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(body)), nil }
+	}
+	response, endpoint, ok := s.azureCodexResponse(r, body, sessionKey, preferred)
+	if !ok {
+		s.azureCodexSessions.unpin(sessionKey)
+		restore()
+		return false
+	}
+	s.azureCodexSessions.pin(sessionKey, endpoint)
+	if s.Logger != nil {
+		s.Logger.Warn("serving codex via azure fallback",
+			"reason", reason,
+			"session", sessionKey,
+			"endpoint", s.AzureCodex.Endpoints[endpoint].Name,
+			"status", response.StatusCode)
+	}
+	defer response.Body.Close()
+	for key, values := range response.Header {
+		if isHopByHopHeader(key) {
+			continue
+		}
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	w.WriteHeader(response.StatusCode)
+	flushingCopy(w, response.Body, nil)
+	return true
+}
+
+// azureCodexFallbackTransport hands a Codex request to Azure once the pool has
+// spent its retry budget and still failed. It wraps the whole retry stack, so
+// by the time it sees a failure the account failover and transport retries
+// below it are already finished.
+type azureCodexFallbackTransport struct {
+	base       http.RoundTripper
+	server     *Server
+	sessionKey string
+	// replayBody returns the original request body for the Azure call. The
+	// pool's retry layers have already consumed the reader by this point.
+	replayBody func() ([]byte, bool)
+}
+
+func (t azureCodexFallbackTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	response, err := base.RoundTrip(req)
+	if req.Context().Err() != nil {
+		return response, err
+	}
+	reason := "transport_error"
+	if err == nil {
+		if !azureCodexPoolFailed(response.StatusCode) {
+			return response, nil
+		}
+		reason = fmt.Sprintf("pool_status_%d", response.StatusCode)
+	}
+	body, ok := t.replayBody()
+	if !ok {
+		return response, err
+	}
+	preferred := -1
+	if pinned, found := t.server.azureCodexSessions.lookup(t.sessionKey); found {
+		preferred = pinned
+	}
+	fallback, endpoint, served := t.server.azureCodexResponse(req, body, t.sessionKey, preferred)
+	if !served {
+		return response, err
+	}
+	t.server.azureCodexSessions.pin(t.sessionKey, endpoint)
+	if t.server.Logger != nil {
+		t.server.Logger.Warn("serving codex via azure fallback",
+			"reason", reason,
+			"session", t.sessionKey,
+			"endpoint", t.server.AzureCodex.Endpoints[endpoint].Name,
+			"status", fallback.StatusCode)
+	}
+	if response != nil && response.Body != nil {
+		_ = response.Body.Close()
+	}
+	return fallback, nil
+}
+
+// azureCodexPoolFailed reports whether a pool response is a failure worth
+// paying Azure for. Quota (429), broken credentials (401/403), and upstream
+// faults (408/5xx) qualify; a 4xx caused by the request itself does not,
+// because Azure would reject it the same way for money.
+func azureCodexPoolFailed(status int) bool {
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusRequestTimeout, http.StatusTooManyRequests:
+		return true
+	}
+	return status >= 500
+}
+
+// endpointNames lists the usable endpoints for the health payload.
+func (c *AzureCodexConfig) endpointNames() []string {
+	if !c.configured() {
+		return nil
+	}
+	names := make([]string, 0, len(c.Endpoints))
+	for _, endpoint := range c.Endpoints {
+		if endpoint.BaseURL == nil || endpoint.APIKey == "" {
+			continue
+		}
+		names = append(names, endpoint.Name)
+	}
+	return names
+}

--- a/internal/proxy/azure_codex_test.go
+++ b/internal/proxy/azure_codex_test.go
@@ -1,0 +1,489 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/selectacct"
+	"github.com/manaflow-ai/subrouter/session"
+)
+
+func azureCodexTestServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *url.URL) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	parsed, err := url.Parse(server.URL + "/openai/v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return server, parsed
+}
+
+func TestAzureCodexBodyRewritesModelAndCacheKey(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-codex","stream":true,"input":[]}`)
+	rewritten, err := azureCodexBody(body, "codex-deployment", "codex\x00session-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rewritten, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["model"] != "codex-deployment" {
+		t.Fatalf("model = %v, want the Azure deployment name", payload["model"])
+	}
+	key, _ := payload["prompt_cache_key"].(string)
+	if !strings.HasPrefix(key, "sr-") {
+		t.Fatalf("prompt_cache_key = %q, want a derived key so turns share a cached prefix", key)
+	}
+	if payload["stream"] != true {
+		t.Fatalf("stream flag lost: %s", rewritten)
+	}
+	// The same session must derive the same key, or every turn is a cache miss.
+	again, err := azureCodexBody(body, "codex-deployment", "codex\x00session-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var second map[string]any
+	if err := json.Unmarshal(again, &second); err != nil {
+		t.Fatal(err)
+	}
+	if second["prompt_cache_key"] != payload["prompt_cache_key"] {
+		t.Fatalf("cache key changed between turns: %v then %v", payload["prompt_cache_key"], second["prompt_cache_key"])
+	}
+}
+
+func TestAzureCodexBodyKeepsClientCacheKey(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-codex","prompt_cache_key":"codex-conversation-42"}`)
+	rewritten, err := azureCodexBody(body, "gpt-5.6-codex", "codex\x00session-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rewritten, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["prompt_cache_key"] != "codex-conversation-42" {
+		t.Fatalf("client cache key overwritten: %v", payload["prompt_cache_key"])
+	}
+}
+
+func TestAzureCodexPathAllowlist(t *testing.T) {
+	for _, path := range []string{"/responses", "/v1/responses", "/backend-api/codex/responses"} {
+		if _, ok := azureCodexPath(path); !ok {
+			t.Errorf("%s should be serveable by Azure", path)
+		}
+	}
+	// Compaction and the catalog have no Azure equivalent; sending them would
+	// turn a pool failure into a 404 from a second provider.
+	for _, path := range []string{"/responses/compact", "/v1/responses/compact", "/alpha/search", "/codex/models"} {
+		if _, ok := azureCodexPath(path); ok {
+			t.Errorf("%s must not be routed to Azure", path)
+		}
+	}
+	if azureCodexRequest(http.MethodGet, "/responses") {
+		t.Error("GET /responses took the Azure path")
+	}
+}
+
+func TestAzureCodexStickyPinExpires(t *testing.T) {
+	now := time.Now()
+	sticky := newAzureCodexSticky()
+	sticky.now = func() time.Time { return now }
+	sticky.pin("codex\x00session-1", 1)
+
+	endpoint, ok := sticky.lookup("codex\x00session-1")
+	if !ok || endpoint != 1 {
+		t.Fatalf("lookup = (%d, %v), want the pinned endpoint", endpoint, ok)
+	}
+	// Every request extends the pin, so an active conversation stays on one cache.
+	now = now.Add(azureCodexStickyTTL - time.Minute)
+	if _, ok := sticky.lookup("codex\x00session-1"); !ok {
+		t.Fatal("pin expired while the session was still active")
+	}
+	now = now.Add(azureCodexStickyTTL + time.Minute)
+	if _, ok := sticky.lookup("codex\x00session-1"); ok {
+		t.Fatal("pin outlived its TTL, keeping an idle session off the pool")
+	}
+	sticky.pin("codex\x00session-2", 0)
+	sticky.unpin("codex\x00session-2")
+	if _, ok := sticky.lookup("codex\x00session-2"); ok {
+		t.Fatal("unpin left the session pinned")
+	}
+	// An empty session key is never pinned: it would collide across sessions.
+	sticky.pin("", 0)
+	if _, ok := sticky.lookup(""); ok {
+		t.Fatal("empty session key was pinned")
+	}
+}
+
+func TestAzureCodexEndpointIndexIsStablePerSession(t *testing.T) {
+	first := azureCodexEndpointIndex("codex\x00session-1", 3)
+	if first != azureCodexEndpointIndex("codex\x00session-1", 3) {
+		t.Fatal("endpoint choice is not stable for one session")
+	}
+	if first < 0 || first >= 3 {
+		t.Fatalf("endpoint index %d out of range", first)
+	}
+	if azureCodexEndpointIndex("codex\x00session-1", 1) != 0 {
+		t.Fatal("single endpoint must always be index 0")
+	}
+}
+
+func TestAttemptBudgetIsSharedAndBounded(t *testing.T) {
+	budget := newAttemptBudget(2)
+	if !budget.consume() || !budget.consume() {
+		t.Fatal("budget refused a retry it should allow")
+	}
+	if budget.consume() {
+		t.Fatal("budget allowed a retry past its limit")
+	}
+	var nilBudget *attemptBudget
+	if !nilBudget.consume() {
+		t.Fatal("an absent budget must not bound retries")
+	}
+}
+
+// The pool's own failure statuses decide whether Azure is worth paying for.
+func TestAzureCodexPoolFailedStatuses(t *testing.T) {
+	for _, status := range []int{401, 403, 408, 429, 500, 502, 503} {
+		if !azureCodexPoolFailed(status) {
+			t.Errorf("status %d should trigger the Azure fallback", status)
+		}
+	}
+	for _, status := range []int{200, 201, 400, 404, 422} {
+		if azureCodexPoolFailed(status) {
+			t.Errorf("status %d must not trigger the Azure fallback", status)
+		}
+	}
+}
+
+func azureCodexFallbackServer(t *testing.T, azureURL *url.URL, poolURL *url.URL, accountCount int) Server {
+	t.Helper()
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := make([]accounts.Account, 0, accountCount)
+	for index := range accountCount {
+		pool = append(pool, accounts.Account{
+			ID:       fmt.Sprintf("codex-account-%d", index),
+			AuthMode: accounts.AuthModeOAuth,
+			Token:    fmt.Sprintf("oauth-token-%d", index),
+		})
+	}
+	return Server{
+		CodexUpstream: poolURL,
+		Accounts:      pool,
+		Sessions:      store,
+		Scheduler:     selectacct.NewScheduler(nil),
+		MaxBodyBytes:  1 << 20,
+		Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		AzureCodex: &AzureCodexConfig{
+			Endpoints: []AzureCodexEndpoint{{
+				Name:        "test-azure",
+				BaseURL:     azureURL,
+				APIKey:      "azure-key",
+				Deployments: map[string]string{"gpt-5.6-codex": "codex-deployment"},
+			}},
+		},
+	}
+}
+
+// End to end: the Codex pool answers 429 on every account, the retry budget
+// runs out, and Azure serves the same request. The follow-up turn must go
+// straight to Azure so the conversation keeps hitting one prompt cache.
+func TestAzureCodexFallbackServesAndPinsSession(t *testing.T) {
+	var poolCalls atomic.Int32
+	pool := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		poolCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"type":"usage_limit_reached","message":"quota"}}`)
+	}))
+	defer pool.Close()
+	poolURL, err := url.Parse(pool.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var azureCalls atomic.Int32
+	var azureBody atomic.Value
+	var azureAPIKey atomic.Value
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		azureCalls.Add(1)
+		if r.URL.Path != "/openai/v1/responses" {
+			t.Errorf("azure path = %q, want /openai/v1/responses", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		azureBody.Store(string(body))
+		azureAPIKey.Store(r.Header.Get("Api-Key"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_azure"}`)
+	})
+
+	proxy := httptest.NewServer(azureCodexFallbackServer(t, azureURL, poolURL, 2).Handler())
+	defer proxy.Close()
+
+	request := func() *http.Response {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPost, proxy.URL+"/responses",
+			strings.NewReader(`{"model":"gpt-5.6-codex","session_id":"session-1","input":[]}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		response, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return response
+	}
+
+	first := request()
+	body, _ := io.ReadAll(first.Body)
+	_ = first.Body.Close()
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 from the Azure fallback; body: %s", first.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "resp_azure") {
+		t.Fatalf("body = %s, want the Azure response", body)
+	}
+	if azureCalls.Load() != 1 {
+		t.Fatalf("azure calls = %d, want 1", azureCalls.Load())
+	}
+	if key, _ := azureAPIKey.Load().(string); key != "azure-key" {
+		t.Fatalf("azure api key header = %q", key)
+	}
+	sent, _ := azureBody.Load().(string)
+	if !strings.Contains(sent, `"model":"codex-deployment"`) {
+		t.Fatalf("azure body = %s, want the deployment name", sent)
+	}
+	if poolCalls.Load() != 2 {
+		t.Fatalf("pool attempts = %d, want both accounts tried before Azure", poolCalls.Load())
+	}
+
+	// Sticky: the next turn must not touch the pool at all.
+	poolCalls.Store(0)
+	second := request()
+	_, _ = io.Copy(io.Discard, second.Body)
+	_ = second.Body.Close()
+	if second.StatusCode != http.StatusOK {
+		t.Fatalf("second status = %d, want 200", second.StatusCode)
+	}
+	if poolCalls.Load() != 0 {
+		t.Fatalf("pool calls after pinning = %d, want 0; the session left its Azure cache", poolCalls.Load())
+	}
+	if azureCalls.Load() != 2 {
+		t.Fatalf("azure calls = %d, want 2", azureCalls.Load())
+	}
+}
+
+// A 400 is the client's own fault: paying Azure to repeat it would waste money
+// and hide the error.
+func TestAzureCodexFallbackIgnoresClientErrors(t *testing.T) {
+	pool := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":{"message":"bad input"}}`)
+	}))
+	defer pool.Close()
+	poolURL, err := url.Parse(pool.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var azureCalls atomic.Int32
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		azureCalls.Add(1)
+		_, _ = io.WriteString(w, `{"id":"resp_azure"}`)
+	})
+
+	proxy := httptest.NewServer(azureCodexFallbackServer(t, azureURL, poolURL, 2).Handler())
+	defer proxy.Close()
+
+	response, err := http.Post(proxy.URL+"/responses", "application/json",
+		strings.NewReader(`{"model":"gpt-5.6-codex","session_id":"session-2"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want the pool's 400 passed through", response.StatusCode)
+	}
+	if azureCalls.Load() != 0 {
+		t.Fatalf("azure calls = %d, want 0", azureCalls.Load())
+	}
+}
+
+// Azure failing must not swallow the pool's answer: the client sees the real
+// pool error, and the session is not pinned to a broken endpoint.
+func TestAzureCodexFallbackKeepsPoolResponseWhenAzureFails(t *testing.T) {
+	pool := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"type":"usage_limit_reached"}}`)
+	}))
+	defer pool.Close()
+	poolURL, err := url.Parse(pool.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":{"message":"invalid api key"}}`)
+	})
+
+	server := azureCodexFallbackServer(t, azureURL, poolURL, 2)
+	proxy := httptest.NewServer(server.Handler())
+	defer proxy.Close()
+
+	response, err := http.Post(proxy.URL+"/responses", "application/json",
+		strings.NewReader(`{"model":"gpt-5.6-codex","session_id":"session-3"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want the pool's 429", response.StatusCode)
+	}
+}
+
+// No usable account is a pool failure before the first upstream call, and it is
+// the case that matters most: an expired credential store would otherwise 503
+// every Codex request.
+func TestAzureCodexFallbackWhenPoolHasNoAccount(t *testing.T) {
+	var azureCalls atomic.Int32
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		azureCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_azure"}`)
+	})
+	poolURL, err := url.Parse("https://chatgpt.com/backend-api/codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := azureCodexFallbackServer(t, azureURL, poolURL, 2)
+	server.Accounts = nil
+	proxy := httptest.NewServer(server.Handler())
+	defer proxy.Close()
+
+	response, err := http.Post(proxy.URL+"/responses", "application/json",
+		strings.NewReader(`{"model":"gpt-5.6-codex","session_id":"session-4"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want Azure to answer; body: %s", response.StatusCode, body)
+	}
+	if azureCalls.Load() != 1 {
+		t.Fatalf("azure calls = %d, want 1", azureCalls.Load())
+	}
+}
+
+// The retry budget is what makes "five retries, then Azure" true: with a large
+// pool the failover loop would otherwise walk every account before the fallback
+// ran, and both retry layers would each get a full budget.
+func TestAzureCodexFallbackCapsPoolRetries(t *testing.T) {
+	var poolCalls atomic.Int32
+	pool := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		poolCalls.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"type":"usage_limit_reached"}}`)
+	}))
+	defer pool.Close()
+	poolURL, err := url.Parse(pool.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_azure"}`)
+	})
+
+	proxy := httptest.NewServer(azureCodexFallbackServer(t, azureURL, poolURL, 12).Handler())
+	defer proxy.Close()
+
+	response, err := http.Post(proxy.URL+"/responses", "application/json",
+		strings.NewReader(`{"model":"gpt-5.6-codex","session_id":"session-budget"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), "resp_azure") {
+		t.Fatalf("status = %d, body = %s, want the Azure fallback", response.StatusCode, body)
+	}
+	if got := poolCalls.Load(); got != azureCodexPoolRetryBudget+1 {
+		t.Fatalf("pool attempts = %d, want %d (one attempt plus %d retries)",
+			got, azureCodexPoolRetryBudget+1, azureCodexPoolRetryBudget)
+	}
+}
+
+// Codex compresses large request bodies with zstd. Azure takes plain JSON, so a
+// compressed body must be decoded before it is rewritten; otherwise the whole
+// fallback silently stops working on exactly the long conversations that hit
+// quota first.
+func TestAzureCodexFallbackDecodesZstdBody(t *testing.T) {
+	pool := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"type":"usage_limit_reached"}}`)
+	}))
+	defer pool.Close()
+	poolURL, err := url.Parse(pool.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var azureBody atomic.Value
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		azureBody.Store(string(body))
+		if encoding := r.Header.Get("Content-Encoding"); encoding != "" {
+			t.Errorf("azure request carried Content-Encoding %q", encoding)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_azure"}`)
+	})
+
+	proxy := httptest.NewServer(azureCodexFallbackServer(t, azureURL, poolURL, 1).Handler())
+	defer proxy.Close()
+
+	encoder, err := zstd.NewWriter(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compressed := encoder.EncodeAll([]byte(`{"model":"gpt-5.6-codex","session_id":"session-zstd","input":[]}`), nil)
+	_ = encoder.Close()
+
+	req, err := http.NewRequest(http.MethodPost, proxy.URL+"/responses", bytes.NewReader(compressed))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "zstd")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), "resp_azure") {
+		t.Fatalf("status = %d, body = %s, want the Azure fallback", response.StatusCode, body)
+	}
+	sent, _ := azureBody.Load().(string)
+	if !strings.Contains(sent, `"model":"codex-deployment"`) {
+		t.Fatalf("azure body = %q, want decoded JSON with the deployment name", sent)
+	}
+}

--- a/internal/proxy/azure_codex_test.go
+++ b/internal/proxy/azure_codex_test.go
@@ -487,3 +487,265 @@ func TestAzureCodexFallbackDecodesZstdBody(t *testing.T) {
 		t.Fatalf("azure body = %q, want decoded JSON with the deployment name", sent)
 	}
 }
+
+// Every Codex turn against the ChatGPT backend carries session_id, which the
+// Responses API rejects outright. Without stripping it the fallback answers a
+// pool outage with a 400 from a second provider.
+func TestAzureCodexBodyDropsChatGPTOnlyFields(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-codex","session_id":"abc","conversation_id":"def","input":[],"store":false}`)
+	rewritten, err := azureCodexBody(body, "codex-deployment", "codex\x00session-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rewritten, &payload); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"session_id", "conversation_id", "thread_id"} {
+		if _, present := payload[field]; present {
+			t.Fatalf("%s survived: %s", field, rewritten)
+		}
+	}
+	if payload["store"] != false {
+		t.Fatalf("store dropped: %s", rewritten)
+	}
+}
+
+func TestAzureCodexRejectedFieldAndDrop(t *testing.T) {
+	unknown := []byte(`{"error":{"message":"Unknown parameter: 'session_id'.","code":"unknown_parameter","param":"session_id"}}`)
+	if got := azureCodexRejectedField(unknown); got != "session_id" {
+		t.Fatalf("rejected field = %q", got)
+	}
+	nested := []byte(`{"error":{"message":"'all_turns' is not supported","code":"unsupported_value","param":"reasoning.context"}}`)
+	if got := azureCodexRejectedField(nested); got != "reasoning.context" {
+		t.Fatalf("nested rejected field = %q", got)
+	}
+	// Conversation content is never dropped: removing an input element would
+	// change what the model was asked.
+	indexed := []byte(`{"error":{"code":"unsupported_value","param":"input[3].content"}}`)
+	if got := azureCodexRejectedField(indexed); got != "" {
+		t.Fatalf("array path %q was accepted for dropping", got)
+	}
+	other := []byte(`{"error":{"code":"context_length_exceeded","param":"input"}}`)
+	if got := azureCodexRejectedField(other); got != "" {
+		t.Fatalf("unrelated 400 named a field to drop: %q", got)
+	}
+
+	payload := map[string]json.RawMessage{
+		"reasoning": json.RawMessage(`{"effort":"high","context":"all_turns"}`),
+		"model":     json.RawMessage(`"gpt-5.6-codex"`),
+	}
+	if !azureCodexDropField(payload, "reasoning.context") {
+		t.Fatal("nested field was not dropped")
+	}
+	if string(payload["reasoning"]) != `{"effort":"high"}` {
+		t.Fatalf("reasoning = %s, want only effort left", payload["reasoning"])
+	}
+	if azureCodexDropField(payload, "reasoning.missing") || azureCodexDropField(payload, "model.name") {
+		t.Fatal("dropping a missing or non-object path reported success")
+	}
+}
+
+func TestAzureCodexEndpointDefaultDeployment(t *testing.T) {
+	endpoint := AzureCodexEndpoint{Deployments: map[string]string{
+		"gpt-5.6-codex":                "codex-max",
+		AzureCodexDefaultDeploymentKey: "codex-default",
+	}}
+	if got := endpoint.deployment("gpt-5.6-codex"); got != "codex-max" {
+		t.Fatalf("exact mapping = %q", got)
+	}
+	// Azure trails the ChatGPT model list, so an unlisted model must still land
+	// on a real deployment instead of 404ing the request that needed rescue.
+	if got := endpoint.deployment("gpt-6-codex-unreleased"); got != "codex-default" {
+		t.Fatalf("default mapping = %q", got)
+	}
+	bare := AzureCodexEndpoint{}
+	if got := bare.deployment("gpt-5.6-codex"); got != "gpt-5.6-codex" {
+		t.Fatalf("identity mapping = %q", got)
+	}
+}
+
+// The daemon retries once without the field Azure named, which is how a live
+// Codex body survives an Azure model version that is a release behind.
+func TestAzureCodexRetriesWithoutRejectedField(t *testing.T) {
+	var bodies []string
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(body))
+		if strings.Contains(string(body), "all_turns") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, `{"error":{"code":"unsupported_value","param":"reasoning.context","message":"'all_turns' is not supported"}}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_azure"}`)
+	})
+	poolURL, err := url.Parse("https://chatgpt.com/backend-api/codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := azureCodexFallbackServer(t, azureURL, poolURL, 0)
+	proxy := httptest.NewServer(server.Handler())
+	defer proxy.Close()
+
+	response, err := http.Post(proxy.URL+"/responses", "application/json",
+		strings.NewReader(`{"model":"gpt-5.6-codex","session_id":"s","reasoning":{"effort":"high","context":"all_turns"},"input":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), "resp_azure") {
+		t.Fatalf("status = %d, body = %s, want the retry to succeed", response.StatusCode, body)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("azure attempts = %d, want 2", len(bodies))
+	}
+	if strings.Contains(bodies[1], "all_turns") {
+		t.Fatalf("retry kept the rejected field: %s", bodies[1])
+	}
+	if !strings.Contains(bodies[1], `"effort":"high"`) {
+		t.Fatalf("retry dropped a sibling field: %s", bodies[1])
+	}
+}
+
+// Forcing is how the route is proven without waiting for an outage: the pool is
+// skipped entirely, and a broken Azure surfaces as an error instead of a
+// ChatGPT answer.
+func TestAzureCodexForceHeaderSkipsPool(t *testing.T) {
+	var poolCalls atomic.Int32
+	pool := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		poolCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_pool"}`)
+	}))
+	defer pool.Close()
+	poolURL, err := url.Parse(pool.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var azureCalls atomic.Int32
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		azureCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_azure"}`)
+	})
+
+	proxy := httptest.NewServer(azureCodexFallbackServer(t, azureURL, poolURL, 2).Handler())
+	defer proxy.Close()
+
+	forced := func(path string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPost, proxy.URL+path,
+			strings.NewReader(`{"model":"gpt-5.6-codex","session_id":"forced-session"}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Subrouter-Azure", "force")
+		response, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return response
+	}
+
+	response := forced("/responses")
+	body, _ := io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	if !strings.Contains(string(body), "resp_azure") {
+		t.Fatalf("body = %s, want the Azure answer", body)
+	}
+	if poolCalls.Load() != 0 {
+		t.Fatalf("pool calls = %d, want 0 on a forced request", poolCalls.Load())
+	}
+	// A forced request must not pin: forcing is per request, and the pin exists
+	// to preserve a cache created by an involuntary fallback.
+	plain, err := http.Post(proxy.URL+"/responses", "application/json",
+		strings.NewReader(`{"model":"gpt-5.6-codex","session_id":"forced-session"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plainBody, _ := io.ReadAll(plain.Body)
+	_ = plain.Body.Close()
+	if !strings.Contains(string(plainBody), "resp_pool") {
+		t.Fatalf("unforced turn = %s, want the pool", plainBody)
+	}
+}
+
+// Codex sends the force header on every request of a forced session, including
+// the model catalog, which Azure cannot serve. Those must keep taking the pool
+// path instead of failing the session.
+func TestAzureCodexForceIgnoresNonResponsesPaths(t *testing.T) {
+	var poolPaths []string
+	pool := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		poolPaths = append(poolPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[]}`)
+	}))
+	defer pool.Close()
+	poolURL, err := url.Parse(pool.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("the model catalog reached Azure")
+	})
+	proxy := httptest.NewServer(azureCodexFallbackServer(t, azureURL, poolURL, 1).Handler())
+	defer proxy.Close()
+
+	req, err := http.NewRequest(http.MethodGet, proxy.URL+"/v1/models", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Subrouter-Azure", "force")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want the pool to answer the catalog", response.StatusCode)
+	}
+	if len(poolPaths) == 0 {
+		t.Fatal("the catalog request never reached the pool")
+	}
+}
+
+// A forced request with no Azure configured must fail loudly, naming the fix.
+func TestAzureCodexForceWithoutConfigurationExplainsItself(t *testing.T) {
+	pool := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"id":"resp_pool"}`)
+	}))
+	defer pool.Close()
+	poolURL, err := url.Parse(pool.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, r *http.Request) {})
+	server := azureCodexFallbackServer(t, azureURL, poolURL, 1)
+	server.AzureCodex = nil
+	proxy := httptest.NewServer(server.Handler())
+	defer proxy.Close()
+
+	req, err := http.NewRequest(http.MethodPost, proxy.URL+"/responses",
+		strings.NewReader(`{"model":"gpt-5.6-codex"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Subrouter-Azure", "force")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", response.StatusCode)
+	}
+	if !strings.Contains(string(body), "SUBROUTER_AZURE_CODEX_ENDPOINT") {
+		t.Fatalf("error body = %q, want the missing configuration named", body)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -107,6 +107,13 @@ type Server struct {
 	// ONLY to Fable; Opus/Sonnet/etc. continue to use the OAuth pool and never
 	// touch this key.
 	ClaudeFableAPIKey string
+	// AzureCodex, when set, serves Codex Responses requests from Azure OpenAI
+	// after the subscription pool has spent its retry budget and still failed,
+	// and pins the session to Azure afterwards so later turns keep hitting the
+	// same prompt cache. It never preempts the pool.
+	AzureCodex *AzureCodexConfig
+	// azureCodexSessions holds those pins.
+	azureCodexSessions *azureCodexSticky
 	// FableBedrockPrimary, when true, routes Claude Fable requests to AWS Bedrock
 	// FIRST, before the subscription pool, instead of using Bedrock only as a
 	// fallback. It only takes effect when the Bedrock gateway is configured; a
@@ -1004,6 +1011,9 @@ func (s Server) Handler() http.Handler {
 	if s.CacheFlight == nil {
 		s.CacheFlight = newSingleFlight()
 	}
+	if s.azureCodexSessions == nil {
+		s.azureCodexSessions = newAzureCodexSticky()
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/internal/v1/session-leases", s.requireSessionLeaseAdmin(s.handleSessionLeases))
 	mux.HandleFunc("/internal/v1/session-leases/", s.requireSessionLeaseAdmin(s.handleSessionLease))
@@ -1040,11 +1050,18 @@ func normalizedCredentialBroker(value CredentialBroker) CredentialBroker {
 }
 
 func (s Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, map[string]any{
+	payload := map[string]any{
 		"ok":             true,
 		"account_import": s.AccountImportState(),
 		"auth":           s.AuthMode(),
-	})
+	}
+	// Whether the Codex Azure fallback is armed is otherwise invisible until a
+	// pool outage, which is exactly when nobody wants to discover it was
+	// misconfigured. Endpoint names only; keys never leave the process.
+	if names := s.AzureCodex.endpointNames(); len(names) > 0 {
+		payload["azure_codex"] = names
+	}
+	writeJSON(w, payload)
 }
 
 // AccountImportState reports whether this server can accept `sr add` uploads.
@@ -2321,6 +2338,23 @@ func (s Server) proxyHandler() http.Handler {
 			}
 		}
 		sessionAgentType := agentTypeForProviderSession(agentType, requestProvider)
+		// Codex Azure fallback: the pool stays primary, and Azure answers only
+		// after the pool has spent its retry budget or cannot start. Once it
+		// has answered, the session is pinned so the following turns reuse the
+		// same Azure prompt cache instead of alternating providers, which would
+		// re-upload the whole conversation as a cache miss every turn.
+		azureCodexConfigured := boundLease == nil && s.CredentialBroker == nil &&
+			requestProvider == accounts.ProviderCodex && s.AzureCodex.configured() &&
+			azureCodexRequest(r.Method, r.URL.Path)
+		azureCodexSessionKey := ""
+		if azureCodexConfigured {
+			azureCodexSessionKey = azureCodexSessionKeyFor(sessionAgentType, sessionID)
+			if pinned, found := s.azureCodexSessions.lookup(azureCodexSessionKey); found {
+				if s.serveAzureCodex(w, r, azureCodexSessionKey, pinned, "sticky_session") {
+					return
+				}
+			}
+		}
 		userEmail := session.ExtractUserEmail(r)
 		var account accounts.Account
 		var credentialLease *broker.Lease
@@ -2373,6 +2407,9 @@ func (s Server) proxyHandler() http.Handler {
 			if fableFallbackConfigured && s.serveClaudeFableFallback(w, r) {
 				return
 			}
+			if azureCodexConfigured && s.serveAzureCodex(w, r, azureCodexSessionKey, -1, "no_usable_account") {
+				return
+			}
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 			return
 		}
@@ -2388,6 +2425,9 @@ func (s Server) proxyHandler() http.Handler {
 		auth := account.AuthorizationHeader()
 		if auth == "" {
 			if fableFallbackConfigured && s.serveClaudeFableFallback(w, r) {
+				return
+			}
+			if azureCodexConfigured && s.serveAzureCodex(w, r, azureCodexSessionKey, -1, "no_usable_credential") {
 				return
 			}
 			http.Error(w, "selected account has no usable credential", http.StatusServiceUnavailable)
@@ -2445,6 +2485,14 @@ func (s Server) proxyHandler() http.Handler {
 			},
 		}
 		transport := s.transport()
+		// One retry budget per client request, shared by both retry layers, so
+		// the Azure fallback runs after 5 pool retries in total rather than 5
+		// per layer.
+		var azureCodexBudget *attemptBudget
+		azureCodexFallbackReady := azureCodexConfigured && retryPost && postReplayable
+		if azureCodexFallbackReady {
+			azureCodexBudget = newAttemptBudget(azureCodexPoolRetryBudget)
+		}
 		if boundLease == nil && retryPost && postReplayable &&
 			(requestProvider == accounts.ProviderCodex || requestProvider == accounts.ProviderClaude) &&
 			account.AuthMode == accounts.AuthModeOAuth &&
@@ -2479,6 +2527,7 @@ func (s Server) proxyHandler() http.Handler {
 				maxAttempts:   s.usageLimitRetryMaxAttempts(r.Context(), requestProvider),
 				poolModel:     retryPoolModel,
 				fableFallback: fableFallback,
+				budget:        azureCodexBudget,
 			}
 		}
 		if retryPost && postReplayable {
@@ -2493,6 +2542,26 @@ func (s Server) proxyHandler() http.Handler {
 				upstream:    upstream.Host,
 				maxAttempts: replayablePostMaxAttempts,
 				limiter:     replayablePostUploadLimiter,
+				budget:      azureCodexBudget,
+			}
+		}
+		if azureCodexFallbackReady {
+			transport = azureCodexFallbackTransport{
+				base:       transport,
+				server:     &s,
+				sessionKey: azureCodexSessionKey,
+				replayBody: func() ([]byte, bool) {
+					rc, err := proxyRequest.GetBody()
+					if err != nil {
+						return nil, false
+					}
+					defer rc.Close()
+					body, err := io.ReadAll(rc)
+					if err != nil {
+						return nil, false
+					}
+					return body, true
+				},
 			}
 		}
 		rp.Transport = transport
@@ -4650,6 +4719,12 @@ type replayablePostRetryTransport struct {
 	upstream    string
 	maxAttempts int
 	limiter     chan struct{}
+	// budget is the request's shared pool-retry allowance. It is set only when
+	// a fallback route is waiting behind the pool, and it is shared with the
+	// usage-limit transport below so nested retry loops cannot multiply into
+	// one full budget per layer. Nil means unbounded, the behaviour when there
+	// is nothing to fall back to.
+	budget *attemptBudget
 }
 
 type usageLimitRetryTransport struct {
@@ -4679,6 +4754,9 @@ type usageLimitRetryTransport struct {
 	// it also restricts account failover to OAuth accounts so metered API-key
 	// pool accounts never preempt the Bedrock stage.
 	fableFallback func() (*http.Response, bool)
+	// budget is the request's shared pool-retry allowance; see
+	// replayablePostRetryTransport.budget.
+	budget *attemptBudget
 }
 
 // fableFallbackResponse swaps the pool's give-up response for one served by the
@@ -5021,10 +5099,17 @@ func (t usageLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, 
 			// to the default TTL inside claudeExhaustionExpiry).
 			t.server.markAccountExhaustedFromResponse(t.provider, accountID, exhaustionPool, response.StatusCode, response.Header)
 		}
-		if attempt == maxAttempts || t.server == nil {
+		budgetExhausted := false
+		if attempt < maxAttempts && t.server != nil {
+			budgetExhausted = !t.budget.consume()
+		}
+		if attempt == maxAttempts || t.server == nil || budgetExhausted {
 			reason := "max_attempts"
-			if t.server == nil {
+			switch {
+			case t.server == nil:
 				reason = "no_server"
+			case budgetExhausted:
+				reason = "retry_budget"
 			}
 			if fallback, ok := t.fableFallbackResponse(response, accountID, reason); ok {
 				return fallback, nil
@@ -5377,7 +5462,7 @@ func (t replayablePostRetryTransport) RoundTrip(req *http.Request) (*http.Respon
 		response, err := t.roundTrip(trace.attach(attemptReq))
 		retryStatus := err == nil && retryablePostUpstreamStatus(response)
 		retryTransportErr := err != nil && retryablePostTransportError(err)
-		if (!retryStatus && !retryTransportErr) || req.GetBody == nil || req.Context().Err() != nil || attempt == maxAttempts {
+		if (!retryStatus && !retryTransportErr) || req.GetBody == nil || req.Context().Err() != nil || attempt == maxAttempts || !t.budget.consume() {
 			// The last attempt's failure is what the client sees as a 502, so
 			// record how the transport got there before giving up.
 			if err != nil && t.logger != nil {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2347,10 +2347,25 @@ func (s Server) proxyHandler() http.Handler {
 			requestProvider == accounts.ProviderCodex && s.AzureCodex.configured() &&
 			azureCodexRequest(r.Method, r.URL.Path)
 		azureCodexSessionKey := ""
+		// A forced request must never quietly fall through to the pool: it is
+		// the command that proves the Azure route works, so a misconfigured
+		// endpoint has to surface as an error rather than a ChatGPT answer.
+		if azureCodexForced(r) && requestProvider == accounts.ProviderCodex &&
+			azureCodexRequest(r.Method, r.URL.Path) {
+			if !azureCodexConfigured {
+				http.Error(w, azureCodexForceUnavailableMessage(s, boundLease != nil, r), http.StatusServiceUnavailable)
+				return
+			}
+			if s.serveAzureCodex(w, r, azureCodexSessionKeyFor(sessionAgentType, sessionID), -1, "forced", false) {
+				return
+			}
+			http.Error(w, "azure codex route could not serve this request; see the daemon log for the endpoint status", http.StatusBadGateway)
+			return
+		}
 		if azureCodexConfigured {
 			azureCodexSessionKey = azureCodexSessionKeyFor(sessionAgentType, sessionID)
 			if pinned, found := s.azureCodexSessions.lookup(azureCodexSessionKey); found {
-				if s.serveAzureCodex(w, r, azureCodexSessionKey, pinned, "sticky_session") {
+				if s.serveAzureCodex(w, r, azureCodexSessionKey, pinned, "sticky_session", true) {
 					return
 				}
 			}
@@ -2407,7 +2422,7 @@ func (s Server) proxyHandler() http.Handler {
 			if fableFallbackConfigured && s.serveClaudeFableFallback(w, r) {
 				return
 			}
-			if azureCodexConfigured && s.serveAzureCodex(w, r, azureCodexSessionKey, -1, "no_usable_account") {
+			if azureCodexConfigured && s.serveAzureCodex(w, r, azureCodexSessionKey, -1, "no_usable_account", true) {
 				return
 			}
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -2427,7 +2442,7 @@ func (s Server) proxyHandler() http.Handler {
 			if fableFallbackConfigured && s.serveClaudeFableFallback(w, r) {
 				return
 			}
-			if azureCodexConfigured && s.serveAzureCodex(w, r, azureCodexSessionKey, -1, "no_usable_credential") {
+			if azureCodexConfigured && s.serveAzureCodex(w, r, azureCodexSessionKey, -1, "no_usable_credential", true) {
 				return
 			}
 			http.Error(w, "selected account has no usable credential", http.StatusServiceUnavailable)

--- a/session/extract.go
+++ b/session/extract.go
@@ -177,6 +177,7 @@ func StripSubrouterHeaders(headers http.Header) {
 	headers.Del("X-Subrouter-Account")
 	headers.Del("X-Subrouter-Model")
 	headers.Del("X-Model")
+	headers.Del("X-Subrouter-Azure")
 }
 
 func ExtractID(r *http.Request, maxBodyBytes int64) string {


### PR DESCRIPTION
A Codex `/responses` request the subscription pool cannot serve now finishes on Azure OpenAI instead of returning the error. The pool stays primary.

**When Azure runs.** After the request has spent five pool retries and still failed (429 quota, 401/403 broken credentials, 408/5xx upstream faults, transport failures), or when account selection cannot start at all. A 400 does not trigger it: Azure would reject the same request for money.

**One shared retry budget.** Account failover and transport retries each had their own cap, so "five retries" would have meant up to thirty upstream calls. Both layers now draw from one `attemptBudget` created per client request. The budget is nil, and behaviour unchanged, when no Azure fallback is configured.

**Stickiness.** After Azure answers, the session is pinned to that endpoint for 30 minutes of activity (refreshed per request), and later turns skip the pool entirely. Prompt caching is per-deployment and keyed on an identical prefix, so alternating between ChatGPT and Azure turn by turn would re-upload the whole conversation as a cache miss on both sides. The `prompt_cache_key` Codex sends is forwarded unchanged; when absent, a stable one is derived from a hash of the session key. With several endpoints configured, a session hashes to one and stays there.

**Request shape.** Azure's v1 surface (`https://<resource>.openai.azure.com/openai/v1/responses`) takes the same Responses body Codex already sends to api.openai.com, so only `model` is rewritten to the deployment name. zstd-compressed bodies are decoded first. Client headers are not forwarded; the OAuth Authorization header never leaves for a third-party host.

**Configuration.**

```bash
export SUBROUTER_AZURE_CODEX_ENDPOINT="https://YOUR_RESOURCE.openai.azure.com/openai/v1"
export SUBROUTER_AZURE_CODEX_API_KEY="<azure-key>"
export SUBROUTER_AZURE_CODEX_DEPLOYMENTS="gpt-5.6-codex=my-deployment"   # only when names differ
```

`SUBROUTER_AZURE_CODEX_CONFIG_FILE` takes a JSON list for several Azure resources. `/_subrouter/health` lists the armed endpoint names. Team credential storage refuses this fallback, like the other personal-credential routes.

**Limits.**

- Only `/responses` falls back. `/responses/compact`, the model catalog, and `/alpha/search` are ChatGPT backend endpoints with no Azure equivalent.
- Responses over WebSocket cannot fall back: Azure has no WebSocket Responses surface. Codex must use HTTP (`supports_websockets=false`) for the fallback to apply.
- The pinned path does not record a transcript; the transport-level fallback does, through the existing `ModifyResponse` capture.

**Tests.** `internal/proxy/azure_codex_test.go` covers the body rewrite, the path allowlist, the sticky store, the shared budget, and four end-to-end handler cases: pool 429 → Azure then a pinned second turn that never touches the pool, a 12-account pool capped at 1 attempt + 5 retries, a 400 passed straight through, Azure failing without swallowing the pool's answer, no usable account, and a zstd body. `cmd/subrouter/azure_codex_config_test.go` covers base-URL normalization and the two configuration forms. `CGO_ENABLED=0 go test ./...` is green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789616907&installation_model_id=21920&pr_number=213&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F213&signature=715b8d5f7ae6c6351c8e52305ad0f0dcf191fb4968c28e24550b4e5e0594b8f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Falls back Codex `/responses` to Azure OpenAI when the subscription pool fails, keeping the pool primary. Previously we returned the pool’s 429/5xx; now we serve from Azure after five total pool retries or when account selection cannot start, then pin the session to Azure for 30 minutes to keep its prompt cache hot.

- Triggers and limits: runs after a shared five‑retry budget across account failover and transport retries, or when no usable account is available. 401/403/408/429/5xx trigger; 400 does not. Only `/responses` over HTTP is eligible; WebSocket and `/responses/compact`, catalog, and `/alpha/search` do not fall back.
- Stickiness and caching: pins the session to one Azure endpoint for 30 minutes of activity (refreshed per turn). When multiple endpoints are configured, sessions hash to one endpoint. We forward `prompt_cache_key` unchanged; otherwise we derive a stable key from the session so turns share the cached prefix.
- Request shaping and safety: decodes zstd bodies, rewrites `model` to the Azure deployment name, and sends plain JSON to `https://<resource>.openai.azure.com/openai/v1/responses`. Does not forward client headers; the OAuth Authorization header never leaves our host. Allows `http://` only for loopback hosts to enable local testing; all remote endpoints must be `https://`.
- Retry budget change: both retry layers now draw from one per‑request attempt budget. Behavior is unchanged when no Azure fallback is configured.
- Operational visibility: `/_subrouter/health` lists armed Azure endpoint names under `azure_codex`. The pinned path does not record a transcript; transport‑level fallback does.

**Configuration and rollout**
- Set `SUBROUTER_AZURE_CODEX_ENDPOINT` and `SUBROUTER_AZURE_CODEX_API_KEY` (or `SUBROUTER_AZURE_CODEX_API_KEY_FILE`), or provide multiple resources via `SUBROUTER_AZURE_CODEX_CONFIG_FILE`. Optionally map model→deployment with `SUBROUTER_AZURE_CODEX_DEPLOYMENTS`.
- Team credential storage cannot run with this fallback. Remove the Azure options or run `sr storage local`.

<sup>Written for commit 6ecbc805e9b0362d055601825fe625c17b4036bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

