### PR TITLE
Resolve the latest release tag without the GitHub API

### DIFF
--- a/cmd/subrouter/cli_autoupdate_script_test.go
+++ b/cmd/subrouter/cli_autoupdate_script_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"crypto/sha256"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -125,5 +127,51 @@ func TestCLIAutoupdateReinstallsWhenTheBinaryIsMissing(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(fixture.installDir, "subrouter")); err != nil {
 		t.Fatalf("binary was not restored: %v", err)
+	}
+}
+
+// The GitHub API is rate limited per source IP: a busy address gets 403 on
+// every call, and an updater that only knows the API stops updating silently.
+// The releases/latest redirect answers the same question without a limit, so
+// the updater must prefer it and must not need the API at all.
+func TestCLIAutoupdateResolvesTheTagFromTheReleaseRedirect(t *testing.T) {
+	requireDeployScriptTools(t, "bash", "curl", "python3")
+	fixture := newCLIAutoupdateFixture(t, "v0.1.52")
+
+	redirects := 0
+	releases := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/releases/latest" {
+			redirects++
+			http.Redirect(w, r, "/releases/tag/v0.1.52", http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer releases.Close()
+
+	// No API URL at all, and the environment is otherwise the working fixture:
+	// if the script still needs the API this run fails.
+	env := make([]string, 0, len(fixture.env))
+	for _, entry := range fixture.env {
+		if strings.HasPrefix(entry, "SUBROUTER_RELEASE_API_URL=") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	fixture.env = append(env,
+		"SUBROUTER_RELEASE_LATEST_URL="+releases.URL+"/releases/latest",
+		"SUBROUTER_RELEASE_API_URL=",
+	)
+
+	fixture.run(t)
+	if redirects == 0 {
+		t.Fatal("the updater never asked the releases/latest redirect")
+	}
+	installed, err := os.ReadFile(fixture.versionFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(installed)) != "v0.1.52" {
+		t.Fatalf("installed version = %q, want the tag from the redirect", installed)
 	}
 }

--- a/deploy/gcp/subrouter-autoupdate.sh
+++ b/deploy/gcp/subrouter-autoupdate.sh
@@ -54,9 +54,41 @@ case "$(uname -m)" in
   *) log "unsupported arch $(uname -m)"; exit 1 ;;
 esac
 
-latest_tag="$(curl -fsSL -H 'Accept: application/vnd.github+json' \
-  "https://api.github.com/repos/${REPO}/releases/latest" \
-  | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])')"
+RELEASE_API_URL="${SUBROUTER_RELEASE_API_URL:-https://api.github.com/repos/${REPO}/releases/latest}"
+RELEASE_LATEST_URL="${SUBROUTER_RELEASE_LATEST_URL:-https://github.com/${REPO}/releases/latest}"
+
+# resolve_latest_tag prints the newest release tag.
+#
+# The GitHub API is rate limited per source IP and answers 403 from a busy
+# address. That is not a transient failure: an updater on a timer keeps hitting
+# the same limit, so the host sits on an old release with nothing but a
+# traceback in a log nobody reads. The releases/latest redirect carries the same
+# answer in a Location header, is not rate limited, and needs no credential, so
+# it is tried first. The API remains the fallback, and an explicitly configured
+# API URL wins outright because that is how tests point the updater at a
+# fixture.
+resolve_latest_tag() {
+  if [ -n "${SUBROUTER_RELEASE_API_URL:-}" ]; then
+    resolve_latest_tag_from_api
+    return
+  fi
+  local effective=""
+  effective="$(curl -fsSL -o /dev/null -w '%{url_effective}' "${RELEASE_LATEST_URL}" 2>/dev/null || true)"
+  case "${effective}" in
+    */releases/tag/*)
+      printf '%s\n' "${effective##*/}"
+      return 0
+      ;;
+  esac
+  resolve_latest_tag_from_api
+}
+
+resolve_latest_tag_from_api() {
+  curl -fsSL -H 'Accept: application/vnd.github+json' "${RELEASE_API_URL}" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])'
+}
+
+latest_tag="$(resolve_latest_tag)"
 if [ -z "${latest_tag}" ]; then
   log "could not resolve latest release tag"; exit 1
 fi

--- a/deploy/macos/subrouter-autoupdate.sh
+++ b/deploy/macos/subrouter-autoupdate.sh
@@ -40,9 +40,41 @@ case "$(uname -m)" in
   *) log "unsupported arch $(uname -m)"; exit 1 ;;
 esac
 
-latest_tag="$(curl -fsSL -H 'Accept: application/vnd.github+json' \
-  "https://api.github.com/repos/${REPO}/releases/latest" \
-  | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])')"
+RELEASE_API_URL="${SUBROUTER_RELEASE_API_URL:-https://api.github.com/repos/${REPO}/releases/latest}"
+RELEASE_LATEST_URL="${SUBROUTER_RELEASE_LATEST_URL:-https://github.com/${REPO}/releases/latest}"
+
+# resolve_latest_tag prints the newest release tag.
+#
+# The GitHub API is rate limited per source IP and answers 403 from a busy
+# address. That is not a transient failure: this updater ran every two minutes
+# against the same limit and stayed 403 for days, so the host it updates sat on
+# an old release with nothing but a traceback in a log nobody reads. The
+# releases/latest redirect carries the same answer in a Location header, is not
+# rate limited, and needs no credential, so it is tried first. The API remains
+# the fallback, and an explicitly configured API URL wins outright because that
+# is how the tests point the updater at a fixture.
+resolve_latest_tag() {
+  if [ -n "${SUBROUTER_RELEASE_API_URL:-}" ]; then
+    resolve_latest_tag_from_api
+    return
+  fi
+  local effective=""
+  effective="$(curl -fsSL -o /dev/null -w '%{url_effective}' "$RELEASE_LATEST_URL" 2>/dev/null || true)"
+  case "$effective" in
+    */releases/tag/*)
+      printf '%s\n' "${effective##*/}"
+      return 0
+      ;;
+  esac
+  resolve_latest_tag_from_api
+}
+
+resolve_latest_tag_from_api() {
+  curl -fsSL -H 'Accept: application/vnd.github+json' "$RELEASE_API_URL" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])'
+}
+
+latest_tag="$(resolve_latest_tag)"
 [ -n "$latest_tag" ] || { log "could not resolve latest release tag"; exit 1; }
 
 installed=""

--- a/deploy/macos/subrouter-cli-autoupdate.sh
+++ b/deploy/macos/subrouter-cli-autoupdate.sh
@@ -13,11 +13,42 @@ INSTALL_DIR="${SUBROUTER_INSTALL_DIR:-$HOME/bin}"
 VERSION_FILE="${SUBROUTER_VERSION_FILE:-$HOME/.subrouter/cli-version}"
 INSTALL_URL="${SUBROUTER_INSTALL_URL:-https://raw.githubusercontent.com/$REPO/main/install.sh}"
 RELEASE_API_URL="${SUBROUTER_RELEASE_API_URL:-https://api.github.com/repos/${REPO}/releases/latest}"
+RELEASE_LATEST_URL="${SUBROUTER_RELEASE_LATEST_URL:-https://github.com/${REPO}/releases/latest}"
 
 log() { echo "subrouter-cli-autoupdate: $*"; }
 
-latest_tag="$(curl -fsSL -H 'Accept: application/vnd.github+json' "$RELEASE_API_URL" \
-  | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])')"
+# resolve_latest_tag prints the newest release tag.
+#
+# The GitHub API is rate limited per source IP and answers 403 from a busy
+# address. That is not a transient failure: this updater ran every two minutes
+# against the same limit and stayed 403 for days, so the host it updates sat on
+# an old release with nothing but a traceback in a log nobody reads. The
+# releases/latest redirect carries the same answer in a Location header, is not
+# rate limited, and needs no credential, so it is tried first. The API remains
+# the fallback, and an explicitly configured API URL wins outright because that
+# is how the tests point the updater at a fixture.
+resolve_latest_tag() {
+  if [ -n "${SUBROUTER_RELEASE_API_URL:-}" ]; then
+    resolve_latest_tag_from_api
+    return
+  fi
+  local effective=""
+  effective="$(curl -fsSL -o /dev/null -w '%{url_effective}' "$RELEASE_LATEST_URL" 2>/dev/null || true)"
+  case "$effective" in
+    */releases/tag/*)
+      printf '%s\n' "${effective##*/}"
+      return 0
+      ;;
+  esac
+  resolve_latest_tag_from_api
+}
+
+resolve_latest_tag_from_api() {
+  curl -fsSL -H 'Accept: application/vnd.github+json' "$RELEASE_API_URL" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])'
+}
+
+latest_tag="$(resolve_latest_tag)"
 [ -n "$latest_tag" ] || { log "could not resolve latest release tag"; exit 1; }
 
 installed=""


### PR DESCRIPTION
The mac mini running the team Subrouter sat on v0.1.81 while its updater ran every two minutes. The GitHub API rate limits per source IP and had been answering 403, so every run died in a JSON traceback and the host never moved. Nothing surfaced it: the updater logs to a file, and a frozen host looks identical to an up-to-date one.

All three updaters (macOS worker, macOS CLI, GCP) now read the tag from the `releases/latest` redirect, which carries the same answer in a `Location` header with no rate limit and no credential, and fall back to the API. An explicitly set `SUBROUTER_RELEASE_API_URL` still wins, which is how the tests point the updater at a fixture.

Found while deploying v0.1.82 to cmux-lawrence: the release published, the host ignored it, and the worker had to be installed by hand.

New test runs the CLI updater with no API URL at all against an httptest server that redirects, and asserts it installed the tag from the redirect.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789619571&installation_model_id=21920&pr_number=214&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F214&signature=99146baefd4f11f055785a4425cc69aec9f096d687135dc3a20e0eda41ec050b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer the GitHub `releases/latest` redirect to resolve the newest tag and fall back to the API to avoid rate-limit failures. Previously the updaters only queried the API, which returned 403s under shared IP load and silently stopped hosts from updating.

- Updated `deploy/macos/subrouter-autoupdate.sh`, `deploy/macos/subrouter-cli-autoupdate.sh`, and `deploy/gcp/subrouter-autoupdate.sh` with `resolve_latest_tag` that:
  - Tries `https://github.com/<repo>/releases/latest` (parses `Location`), then falls back to the API.
  - Gives precedence to an explicitly set `SUBROUTER_RELEASE_API_URL` (tests depend on this).
  - Supports optional `SUBROUTER_RELEASE_LATEST_URL` override.
- Added `TestCLIAutoupdateResolvesTheTagFromTheReleaseRedirect` to verify the CLI updater installs the tag resolved from a redirect with no API URL configured.

<sup>Written for commit b3cb9871de71881d18d89240c129808ae35bf5a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

