### PR TITLE
Price the Azure fallback and sync transcripts to Azure blob storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,19 @@ subrouter serve \
   --transcript-max-local-bytes 2GiB
 ```
 
+Azure blob storage is the other destination, and the only one that works off GCP: the GCS syncer authenticates through the GCE metadata server, so a Mac or a laptop can reach a bucket only by shelling out to `gsutil`.
+
+```bash
+export SUBROUTER_TRANSCRIPT_AZURE_KEY_FILE=/var/lib/subrouter/transcript-azure-key   # or SUBROUTER_TRANSCRIPT_AZURE_SAS
+subrouter serve \
+  --transcripts /var/lib/subrouter/transcripts \
+  --transcript-azure-url https://<account>.blob.core.windows.net/<container>/<prefix> \
+  --transcript-local-retention 24h \
+  --transcript-max-local-bytes 2GiB
+```
+
+Both destinations follow the same rules: upload on the background interval, never on the request path, and delete a local file only after the exact bytes exist remotely, archived under `_archive/<path>/<time>-<size>-<hash>.jsonl` so a resumed session cannot overwrite the only cloud copy. The Azure syncer signs its own requests with the storage account key (Shared Key), so the host needs no Azure CLI. A configured destination with no usable credential logs a warning at startup rather than starting quietly and copying nothing.
+
 The daemon uploads with the GCS JSON API on a background interval. Local transcript writes stay on the request path; GCS upload failures are logged and retried later. Local cleanup only runs after a successful GCS sync. Files selected for cleanup are copied to an immutable `_archive/` object before local deletion so future resumed sessions cannot overwrite the only cloud copy.
 
 For best cache behavior, clients should send a stable header per conversation:
@@ -443,12 +456,15 @@ Prove the route without waiting for an outage:
 ```bash
 sr az status          # which endpoints the daemon armed
 sr az test            # one forced request; run twice, the second reports cached tokens
+sr az cost            # what the fallback has spent
 sr az codex exec "…"  # run Codex with every request forced onto Azure
 ```
 
 `sr az test` sends a fixed prompt long enough to be cacheable, so the second run's `cached=` count is real evidence that the prompt cache is being reused. Forced requests skip the pool and never pin the session; a broken endpoint surfaces as an error instead of a silent ChatGPT answer.
 
 Codex bodies carry fields the Responses API does not take (`session_id` on every turn), and a Codex release can send a value an older Azure model version refuses (`reasoning.context="all_turns"`). Known ChatGPT-only fields are stripped, and a 400 that names one field is retried once without it, up to three times.
+
+Azure is metered, unlike the subscription pool, so every served request is priced into `azure-codex-cost.jsonl` next to the session store and summarized at `/_subrouter/azure-codex-cost`. `sr az cost` prints it, and `sr` status grows a spend line once the fallback has run. Cached input is billed at the cached rate rather than the full one, and a model with no price entry contributes zero rather than a guess.
 
 `curl -s http://127.0.0.1:31415/_subrouter/health` lists the armed endpoints by name under `azure_codex`. Only `/responses` falls back; `/responses/compact`, the model catalog, and `/alpha/search` are ChatGPT-backend endpoints with no Azure equivalent. Team credential storage (`sr storage team`) refuses this fallback, like the other personal-credential routes.
 

--- a/cmd/subrouter/cloud_mode_test.go
+++ b/cmd/subrouter/cloud_mode_test.go
@@ -231,7 +231,7 @@ func TestBareSRUsesSelectedTeamInsteadOfLegacyRemote(t *testing.T) {
 		switch r.URL.Path {
 		case "/_subrouter/usage-status":
 			_, _ = w.Write([]byte(`[]`))
-		case "/_subrouter/bedrock-cost":
+		case "/_subrouter/bedrock-cost", "/_subrouter/azure-codex-cost":
 			_, _ = w.Write([]byte(`{"requests":0,"throttled":0}`))
 		default:
 			http.NotFound(w, r)

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -293,6 +293,7 @@ func serve(args []string) error {
 	transcriptGCSSyncTimeout := flags.Duration("transcript-gcs-sync-timeout", 30*time.Minute, "timeout for each transcript GCS sync command")
 	transcriptLocalRetention := flags.Duration("transcript-local-retention", 0, "delete local transcript files older than this after successful GCS sync; 0 disables")
 	transcriptMaxLocalBytesRaw := flags.String("transcript-max-local-bytes", "0", "max bytes to keep in the local transcript spool after successful GCS sync; supports KiB/MiB/GiB suffixes; 0 disables")
+	transcriptAzureURL := flags.String("transcript-azure-url", "", "optional Azure blob container URL (https://<account>.blob.core.windows.net/<container>[/<prefix>]) for background transcript sync; defaults to SUBROUTER_TRANSCRIPT_AZURE_URL")
 	srSwitchInterval := defaultSRSwitchInterval
 	flags.DurationVar(&srSwitchInterval, "sr-switch-interval", defaultSRSwitchInterval, "interval for switching the active sr account to the best OAuth account; 0 disables")
 	flags.DurationVar(&srSwitchInterval, "cx-switch-interval", defaultSRSwitchInterval, "compatibility alias for --sr-switch-interval")
@@ -329,6 +330,13 @@ func serve(args []string) error {
 	}
 	if strings.TrimSpace(*transcriptGCSURI) != "" && strings.TrimSpace(*transcriptDir) == "" {
 		return errors.New("--transcripts is required when --transcript-gcs-uri is set")
+	}
+	transcriptAzureDestination := strings.TrimSpace(*transcriptAzureURL)
+	if transcriptAzureDestination == "" {
+		transcriptAzureDestination = strings.TrimSpace(os.Getenv("SUBROUTER_TRANSCRIPT_AZURE_URL"))
+	}
+	if transcriptAzureDestination != "" && strings.TrimSpace(*transcriptDir) == "" {
+		return errors.New("--transcripts is required when the Azure transcript destination is set")
 	}
 	transcriptMaxLocalBytes, err := parseByteSize(*transcriptMaxLocalBytesRaw)
 	if err != nil {
@@ -481,6 +489,7 @@ func serve(args []string) error {
 		)
 	}
 	if azureCodexConfig != nil {
+		azureCodexConfig.CostLogPath = filepath.Join(filepath.Dir(*sessionPath), "azure-codex-cost.jsonl")
 		slog.Info("azure codex fallback enabled", "endpoints", azureCodexEndpointNames(azureCodexConfig))
 	}
 	var credentialBroker proxy.CredentialBroker
@@ -636,6 +645,33 @@ func serve(args []string) error {
 	})
 	if transcriptGCSSyncer.Enabled() {
 		go transcriptGCSSyncer.Run(context.Background())
+	}
+	transcriptAzureKey, err := secretFromEnvironment("SUBROUTER_TRANSCRIPT_AZURE_KEY", "SUBROUTER_TRANSCRIPT_AZURE_KEY_FILE")
+	if err != nil {
+		return fmt.Errorf("transcript azure key: %w", err)
+	}
+	transcriptAzureSyncer := transcript.NewAzureBlobSyncer(transcript.AzureBlobSyncerConfig{
+		SourceDir:      *transcriptDir,
+		Destination:    transcriptAzureDestination,
+		AccountKey:     transcriptAzureKey,
+		SASToken:       strings.TrimSpace(os.Getenv("SUBROUTER_TRANSCRIPT_AZURE_SAS")),
+		Interval:       *transcriptGCSSyncInterval,
+		Timeout:        *transcriptGCSSyncTimeout,
+		LocalRetention: *transcriptLocalRetention,
+		MaxLocalBytes:  transcriptMaxLocalBytes,
+		Logger:         slog.Default(),
+	})
+	if transcriptAzureSyncer.Enabled() {
+		slog.Info("transcript azure sync enabled", "destination", transcriptAzureSyncer.Destination(), "interval", (*transcriptGCSSyncInterval).String())
+		go transcriptAzureSyncer.Run(context.Background())
+	} else if transcriptAzureDestination != "" {
+		// A destination that produces no syncer means the credential is missing
+		// or the URL is malformed. Saying so at startup is the difference
+		// between a broken pipeline and a silent one, which is how the last
+		// transcript sync stopped without anyone noticing.
+		slog.Warn("transcript azure sync is configured but not usable",
+			"destination", transcriptAzureDestination,
+			"fix", "set SUBROUTER_TRANSCRIPT_AZURE_KEY_FILE (or SUBROUTER_TRANSCRIPT_AZURE_SAS) and check the container URL")
 	}
 	activeGenerationCtx, stopActiveGenerationTasks := context.WithCancel(context.Background())
 	defer stopActiveGenerationTasks()

--- a/cmd/subrouter/sr_az.go
+++ b/cmd/subrouter/sr_az.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -23,6 +24,7 @@ const srAzHelp = `sr az - Route Codex through the Azure OpenAI fallback
 Usage:
   sr az test [model]    Send one request through the daemon, forced to Azure
   sr az status          Show which Azure endpoints the daemon has armed
+  sr az cost            Show what the Azure fallback has spent
   sr az codex [args]    Run Codex with every request forced to Azure
 
 The fallback normally runs on its own, after the Codex pool has spent its
@@ -44,6 +46,8 @@ func (r srRunner) az(ctx context.Context, args []string) error {
 		return r.azStatus(ctx)
 	case "test", "check":
 		return r.azTest(ctx, args[1:])
+	case "cost", "spend":
+		return r.azCost(ctx)
 	case "codex":
 		return azCodex(args[1:])
 	case "help", "-h", "--help":
@@ -316,4 +320,39 @@ func azBaseURL() (string, error) {
 		return "", err
 	}
 	return strings.TrimSuffix(strings.TrimRight(baseURL, "/"), "/v1"), nil
+}
+
+// azCost prints the metered spend of the Azure route. The subscription pool is
+// a flat cost; this one is not, so it is the number to watch after turning the
+// fallback on.
+func (r srRunner) azCost(ctx context.Context) error {
+	baseURL, err := azBaseURL()
+	if err != nil {
+		return err
+	}
+	server := srServerConfig{URL: strings.TrimRight(baseURL, "/")}
+	summary, err := r.fetchAzureCodexSummary(ctx, server)
+	if err != nil {
+		return err
+	}
+	if summary.Requests == 0 {
+		fmt.Fprintf(r.out, "No Azure Codex requests recorded at %s\n", server.URL)
+		return nil
+	}
+	fmt.Fprintf(r.out, "Azure Codex spend at %s\n", server.URL)
+	fmt.Fprintf(r.out, "  today $%s · 7d $%s · 30d $%s · all-time $%s (%d req)\n",
+		fmtUSD4(summary.TodayUSD), fmtUSD4(summary.Week7dUSD), fmtUSD4(summary.Month30dUSD),
+		fmtUSD4(summary.TotalUSD), summary.Requests)
+	fmt.Fprintf(r.out, "  tokens in %d (cached %d) · out %d\n",
+		summary.InputTokens, summary.CachedTokens, summary.OutputTokens)
+	models := make([]string, 0, len(summary.ByModel))
+	for model := range summary.ByModel {
+		models = append(models, model)
+	}
+	sort.Strings(models)
+	for _, model := range models {
+		agg := summary.ByModel[model]
+		fmt.Fprintf(r.out, "  %-24s $%s (%d req)\n", model, fmtUSD4(agg.TotalUSD), agg.Requests)
+	}
+	return nil
 }

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -883,6 +883,7 @@ func (r srRunner) serverStatus(ctx context.Context, store srServerStore, name st
 		displayUsageRowsPerGroup(r.out, rows)
 		printAccountCountSummary(r.out, rows)
 		r.printBedrockStatus(ctx, server)
+		r.printAzureCodexStatus(ctx, server)
 		return nil
 	}
 	res, err := r.fetchServerAccountsResponse(ctx, server)

--- a/cmd/subrouter/sr_server_test.go
+++ b/cmd/subrouter/sr_server_test.go
@@ -256,7 +256,8 @@ func TestSRServerStatusSendsAdminToken(t *testing.T) {
 			if got := req.Header.Get("Authorization"); got != "Bearer secret-token" {
 				t.Fatalf("Authorization = %q", got)
 			}
-			if req.URL.Path == "/_subrouter/bedrock-cost" {
+			if req.URL.Path == "/_subrouter/bedrock-cost" ||
+				req.URL.Path == "/_subrouter/azure-codex-cost" {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Header:     make(http.Header),
@@ -599,9 +600,10 @@ func TestSRDefaultOutputUsesDefaultRemoteServerStatus(t *testing.T) {
 		out:     &out,
 		errOut:  &out,
 		client: &http.Client{Transport: srRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-			// status also queries bedrock-cost for the spend/rate-limit block;
-			// return an empty summary so it stays silent here.
-			if req.URL.Path == "/_subrouter/bedrock-cost" {
+			// status also queries the Bedrock and Azure spend blocks; return
+			// empty summaries so they stay silent here.
+			if req.URL.Path == "/_subrouter/bedrock-cost" ||
+				req.URL.Path == "/_subrouter/azure-codex-cost" {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Header:     make(http.Header),

--- a/cmd/subrouter/sr_spend.go
+++ b/cmd/subrouter/sr_spend.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -133,4 +134,78 @@ func fmtUSD4(v float64) string {
 		return fmt.Sprintf("%.4f", v)
 	}
 	return fmt.Sprintf("%.2f", v)
+}
+
+type azureCodexModelAggView struct {
+	Requests     int     `json:"requests"`
+	TotalUSD     float64 `json:"total_usd"`
+	InputTokens  int64   `json:"input_tokens"`
+	CachedTokens int64   `json:"cached_tokens"`
+	OutputTokens int64   `json:"output_tokens"`
+}
+
+type azureCodexCostSummaryView struct {
+	Requests     int                               `json:"requests"`
+	TotalUSD     float64                           `json:"total_usd"`
+	TodayUSD     float64                           `json:"today_usd"`
+	Week7dUSD    float64                           `json:"week_7d_usd"`
+	Month30dUSD  float64                           `json:"month_30d_usd"`
+	InputTokens  int64                             `json:"input_tokens"`
+	CachedTokens int64                             `json:"cached_tokens"`
+	OutputTokens int64                             `json:"output_tokens"`
+	ByModel      map[string]azureCodexModelAggView `json:"by_model"`
+	ByReason     map[string]int                    `json:"by_reason"`
+}
+
+// fetchAzureCodexSummary pulls the server's Azure Codex spend summary.
+func (r srRunner) fetchAzureCodexSummary(ctx context.Context, server srServerConfig) (azureCodexCostSummaryView, error) {
+	var summary azureCodexCostSummaryView
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/_subrouter/azure-codex-cost", nil)
+	if err != nil {
+		return summary, err
+	}
+	addServerAdminAuth(req, server)
+	client := r.client
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return summary, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return summary, fmt.Errorf("azure codex cost fetch failed: %s", res.Status)
+	}
+	if err := json.NewDecoder(res.Body).Decode(&summary); err != nil {
+		return summary, err
+	}
+	return summary, nil
+}
+
+// printAzureCodexStatus appends the Azure fallback's metered spend to `sr`
+// status. The subscription pool is a flat cost and the Azure route is not, so
+// the number that matters is what the fallback spent, and why it ran.
+func (r srRunner) printAzureCodexStatus(ctx context.Context, server srServerConfig) {
+	summary, err := r.fetchAzureCodexSummary(ctx, server)
+	if err != nil || summary.Requests == 0 {
+		return
+	}
+	fmt.Fprintln(r.out)
+	fmt.Fprintf(r.out, "Azure Codex spend     today $%s · 7d $%s · 30d $%s · all-time $%s (%d req)\n",
+		fmtUSD4(summary.TodayUSD), fmtUSD4(summary.Week7dUSD), fmtUSD4(summary.Month30dUSD),
+		fmtUSD4(summary.TotalUSD), summary.Requests)
+	cached := ""
+	if summary.InputTokens > 0 {
+		cached = fmt.Sprintf(" · cached %d%%", summary.CachedTokens*100/summary.InputTokens)
+	}
+	fmt.Fprintf(r.out, "Azure Codex tokens    in %d · out %d%s\n", summary.InputTokens, summary.OutputTokens, cached)
+	if len(summary.ByReason) > 0 {
+		reasons := make([]string, 0, len(summary.ByReason))
+		for reason, count := range summary.ByReason {
+			reasons = append(reasons, fmt.Sprintf("%s %d", reason, count))
+		}
+		sort.Strings(reasons)
+		fmt.Fprintf(r.out, "Azure Codex reasons   %s\n", strings.Join(reasons, " · "))
+	}
 }

--- a/internal/proxy/azure_codex.go
+++ b/internal/proxy/azure_codex.go
@@ -43,6 +43,11 @@ type AzureCodexConfig struct {
 	Endpoints []AzureCodexEndpoint
 	// Transport is the outbound RoundTripper. Nil uses the server transport.
 	Transport http.RoundTripper
+	// CostLogPath is the JSONL file each served request is priced into. Empty
+	// disables cost accounting. Azure is metered, unlike the subscription pool,
+	// so a fallback that silently spends money needs the same per-request
+	// record the Bedrock gateway keeps.
+	CostLogPath string
 }
 
 func (c *AzureCodexConfig) configured() bool {
@@ -411,6 +416,7 @@ func (s Server) azureCodexResponse(
 	body []byte,
 	sessionKey string,
 	preferred int,
+	reason string,
 ) (*http.Response, int, bool) {
 	if !s.AzureCodex.configured() {
 		return nil, 0, false
@@ -454,6 +460,13 @@ func (s Server) azureCodexResponse(
 			continue
 		}
 		if response.StatusCode >= 200 && response.StatusCode < 300 {
+			response.Body = newAzureCodexCostBody(response.Body, s.AzureCodex.CostLogPath, azureCodexCostRecord{
+				Endpoint:   endpoint.Name,
+				Model:      model,
+				Deployment: endpoint.deployment(model),
+				Reason:     reason,
+				Status:     response.StatusCode,
+			}, nil)
 			return response, index, true
 		}
 		if s.Logger != nil {
@@ -589,7 +602,7 @@ func (s Server) serveAzureCodex(
 		r.ContentLength = int64(len(body))
 		r.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(body)), nil }
 	}
-	response, endpoint, ok := s.azureCodexResponse(r, body, sessionKey, preferred)
+	response, endpoint, ok := s.azureCodexResponse(r, body, sessionKey, preferred, reason)
 	if !ok {
 		s.azureCodexSessions.unpin(sessionKey)
 		restore()
@@ -658,7 +671,7 @@ func (t azureCodexFallbackTransport) RoundTrip(req *http.Request) (*http.Respons
 	if pinned, found := t.server.azureCodexSessions.lookup(t.sessionKey); found {
 		preferred = pinned
 	}
-	fallback, endpoint, served := t.server.azureCodexResponse(req, body, t.sessionKey, preferred)
+	fallback, endpoint, served := t.server.azureCodexResponse(req, body, t.sessionKey, preferred, reason)
 	if !served {
 		return response, err
 	}

--- a/internal/proxy/azure_codex_cost.go
+++ b/internal/proxy/azure_codex_cost.go
@@ -1,0 +1,354 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// azureCodexUsage holds the token counts an Azure Responses reply reports.
+// Cached tokens are a subset of input tokens, so they are billed at the cached
+// rate and subtracted from the uncached input below.
+type azureCodexUsage struct {
+	InputTokens      int `json:"input_tokens"`
+	CachedTokens     int `json:"cached_tokens"`
+	CacheWriteTokens int `json:"cache_write_tokens"`
+	OutputTokens     int `json:"output_tokens"`
+	ReasoningTokens  int `json:"reasoning_tokens"`
+}
+
+func (u azureCodexUsage) empty() bool {
+	return u.InputTokens == 0 && u.OutputTokens == 0 && u.CachedTokens == 0
+}
+
+// azureCodexPricing is USD per million tokens.
+type azureCodexPricing struct {
+	input      float64
+	cachedRead float64
+	output     float64
+}
+
+// azureCodexPriceFor returns Azure list pricing for a deployment's underlying
+// model. An unknown model prices at 0, the same rule the Bedrock log follows,
+// so a model we have not priced can never overstate spend.
+func azureCodexPriceFor(model string) azureCodexPricing {
+	m := strings.ToLower(model)
+	switch {
+	case strings.Contains(m, "codex-mini"), strings.Contains(m, "-mini"):
+		return azureCodexPricing{input: 0.25, cachedRead: 0.025, output: 2}
+	case strings.Contains(m, "-nano"):
+		return azureCodexPricing{input: 0.05, cachedRead: 0.005, output: 0.4}
+	case strings.Contains(m, "codex"), strings.HasPrefix(m, "gpt-5"):
+		return azureCodexPricing{input: 1.25, cachedRead: 0.125, output: 10}
+	default:
+		return azureCodexPricing{}
+	}
+}
+
+// costUSD prices one request. Cached tokens are reported inside input_tokens,
+// so charging both at the full rate would double-count the cheapest part of a
+// Codex turn, which is most of it once the fallback is sticky.
+func (u azureCodexUsage) costUSD(model string) float64 {
+	price := azureCodexPriceFor(model)
+	uncached := u.InputTokens - u.CachedTokens
+	if uncached < 0 {
+		uncached = 0
+	}
+	return (float64(uncached)*price.input +
+		float64(u.CachedTokens)*price.cachedRead +
+		float64(u.OutputTokens)*price.output) / 1_000_000
+}
+
+// azureCodexCostRecord is one JSONL line in the Azure cost log.
+type azureCodexCostRecord struct {
+	Timestamp  string          `json:"timestamp"`
+	Endpoint   string          `json:"endpoint"`
+	Model      string          `json:"model"`
+	Deployment string          `json:"deployment"`
+	Reason     string          `json:"reason"`
+	Status     int             `json:"status"`
+	Usage      azureCodexUsage `json:"usage"`
+	CostUSD    float64         `json:"cost_usd_estimate"`
+	DurationMs int64           `json:"duration_ms"`
+}
+
+var azureCodexCostMu sync.Mutex
+
+func appendAzureCodexCostRecord(path string, record azureCodexCostRecord) {
+	if strings.TrimSpace(path) == "" {
+		return
+	}
+	line, err := json.Marshal(record)
+	if err != nil {
+		return
+	}
+	azureCodexCostMu.Lock()
+	defer azureCodexCostMu.Unlock()
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	_, _ = file.Write(append(line, '\n'))
+}
+
+// azureCodexUsageFromBody reads usage out of a Responses reply in either shape:
+// a plain JSON response, or the final response object of an SSE stream.
+func azureCodexUsageFromBody(body []byte) (azureCodexUsage, string, bool) {
+	if usage, model, ok := azureCodexUsageFromJSON(body); ok {
+		return usage, model, true
+	}
+	var usage azureCodexUsage
+	var model string
+	found := false
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	scanner.Buffer(make([]byte, 0, 64<<10), azureCodexUsageMaxLineBytes)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		if lineUsage, lineModel, ok := azureCodexUsageFromJSON([]byte(payload)); ok {
+			usage, model, found = lineUsage, lineModel, true
+		}
+	}
+	return usage, model, found
+}
+
+// azureCodexUsageMaxLineBytes bounds one SSE line. A Responses stream carries
+// whole assistant messages in single events, so the default scanner limit is
+// too small, but an unbounded one would let a broken stream grow without end.
+const azureCodexUsageMaxLineBytes = 8 << 20
+
+func azureCodexUsageFromJSON(body []byte) (azureCodexUsage, string, bool) {
+	var payload struct {
+		Object   string `json:"object"`
+		Model    string `json:"model"`
+		Response *struct {
+			Model string `json:"model"`
+			Usage *struct {
+				InputTokens        int `json:"input_tokens"`
+				OutputTokens       int `json:"output_tokens"`
+				InputTokensDetails struct {
+					CachedTokens     int `json:"cached_tokens"`
+					CacheWriteTokens int `json:"cache_write_tokens"`
+				} `json:"input_tokens_details"`
+				OutputTokensDetails struct {
+					ReasoningTokens int `json:"reasoning_tokens"`
+				} `json:"output_tokens_details"`
+			} `json:"usage"`
+		} `json:"response"`
+		Usage *struct {
+			InputTokens        int `json:"input_tokens"`
+			OutputTokens       int `json:"output_tokens"`
+			InputTokensDetails struct {
+				CachedTokens     int `json:"cached_tokens"`
+				CacheWriteTokens int `json:"cache_write_tokens"`
+			} `json:"input_tokens_details"`
+			OutputTokensDetails struct {
+				ReasoningTokens int `json:"reasoning_tokens"`
+			} `json:"output_tokens_details"`
+		} `json:"usage"`
+	}
+	if json.Unmarshal(body, &payload) != nil {
+		return azureCodexUsage{}, "", false
+	}
+	model := payload.Model
+	usage := payload.Usage
+	if payload.Response != nil {
+		if payload.Response.Model != "" {
+			model = payload.Response.Model
+		}
+		if payload.Response.Usage != nil {
+			usage = payload.Response.Usage
+		}
+	}
+	if usage == nil {
+		return azureCodexUsage{}, "", false
+	}
+	result := azureCodexUsage{
+		InputTokens:      usage.InputTokens,
+		CachedTokens:     usage.InputTokensDetails.CachedTokens,
+		CacheWriteTokens: usage.InputTokensDetails.CacheWriteTokens,
+		OutputTokens:     usage.OutputTokens,
+		ReasoningTokens:  usage.OutputTokensDetails.ReasoningTokens,
+	}
+	if result.empty() {
+		return azureCodexUsage{}, "", false
+	}
+	return result, model, true
+}
+
+// azureCodexCostBody wraps an Azure response body so usage is recorded when the
+// response finishes, whichever path streams it. It buffers only the tail
+// because the usage block arrives in the final event, so a long stream costs a
+// bounded amount of memory rather than a copy of the whole conversation.
+type azureCodexCostBody struct {
+	inner    io.ReadCloser
+	tail     []byte
+	record   azureCodexCostRecord
+	path     string
+	started  time.Time
+	now      func() time.Time
+	once     sync.Once
+	maxBytes int
+}
+
+// azureCodexCostTailBytes is how much of the end of a response is kept for
+// usage parsing. The final SSE event of a Responses stream carries the whole
+// response object, including the input it echoes back, so this is generous.
+const azureCodexCostTailBytes = 512 << 10
+
+func newAzureCodexCostBody(inner io.ReadCloser, path string, record azureCodexCostRecord, now func() time.Time) io.ReadCloser {
+	if strings.TrimSpace(path) == "" {
+		return inner
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return &azureCodexCostBody{
+		inner:    inner,
+		record:   record,
+		path:     path,
+		started:  now(),
+		now:      now,
+		maxBytes: azureCodexCostTailBytes,
+	}
+}
+
+func (b *azureCodexCostBody) Read(p []byte) (int, error) {
+	n, err := b.inner.Read(p)
+	if n > 0 {
+		b.appendTail(p[:n])
+	}
+	if err == io.EOF {
+		b.finish()
+	}
+	return n, err
+}
+
+func (b *azureCodexCostBody) appendTail(chunk []byte) {
+	b.tail = append(b.tail, chunk...)
+	if len(b.tail) > b.maxBytes {
+		b.tail = b.tail[len(b.tail)-b.maxBytes:]
+	}
+}
+
+func (b *azureCodexCostBody) Close() error {
+	err := b.inner.Close()
+	b.finish()
+	return err
+}
+
+// finish records the request once, whether the reader hit EOF or the client
+// hung up early. A dropped stream still cost money on the provider side.
+func (b *azureCodexCostBody) finish() {
+	b.once.Do(func() {
+		record := b.record
+		record.Timestamp = b.now().UTC().Format(time.RFC3339)
+		record.DurationMs = b.now().Sub(b.started).Milliseconds()
+		if usage, model, ok := azureCodexUsageFromBody(b.tail); ok {
+			record.Usage = usage
+			if model != "" {
+				record.Deployment = model
+			}
+		}
+		record.CostUSD = record.Usage.costUSD(record.Deployment)
+		appendAzureCodexCostRecord(b.path, record)
+	})
+}
+
+type azureCodexModelAgg struct {
+	Requests     int     `json:"requests"`
+	TotalUSD     float64 `json:"total_usd"`
+	InputTokens  int64   `json:"input_tokens"`
+	CachedTokens int64   `json:"cached_tokens"`
+	OutputTokens int64   `json:"output_tokens"`
+}
+
+type azureCodexCostSummary struct {
+	Requests     int                           `json:"requests"`
+	TotalUSD     float64                       `json:"total_usd"`
+	TodayUSD     float64                       `json:"today_usd"`
+	Week7dUSD    float64                       `json:"week_7d_usd"`
+	Month30dUSD  float64                       `json:"month_30d_usd"`
+	InputTokens  int64                         `json:"input_tokens"`
+	CachedTokens int64                         `json:"cached_tokens"`
+	OutputTokens int64                         `json:"output_tokens"`
+	ByModel      map[string]azureCodexModelAgg `json:"by_model"`
+	ByReason     map[string]int                `json:"by_reason"`
+}
+
+func summarizeAzureCodexCost(path string) azureCodexCostSummary {
+	summary := azureCodexCostSummary{
+		ByModel:  map[string]azureCodexModelAgg{},
+		ByReason: map[string]int{},
+	}
+	azureCodexCostMu.Lock()
+	body, err := os.ReadFile(path)
+	azureCodexCostMu.Unlock()
+	if err != nil {
+		return summary
+	}
+	now := time.Now()
+	startToday := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var record azureCodexCostRecord
+		if json.Unmarshal([]byte(line), &record) != nil {
+			continue
+		}
+		summary.Requests++
+		summary.TotalUSD += record.CostUSD
+		summary.InputTokens += int64(record.Usage.InputTokens)
+		summary.CachedTokens += int64(record.Usage.CachedTokens)
+		summary.OutputTokens += int64(record.Usage.OutputTokens)
+		if record.Reason != "" {
+			summary.ByReason[record.Reason]++
+		}
+		if timestamp, err := time.Parse(time.RFC3339, record.Timestamp); err == nil {
+			if timestamp.After(startToday) {
+				summary.TodayUSD += record.CostUSD
+			}
+			if timestamp.After(now.AddDate(0, 0, -7)) {
+				summary.Week7dUSD += record.CostUSD
+			}
+			if timestamp.After(now.AddDate(0, 0, -30)) {
+				summary.Month30dUSD += record.CostUSD
+			}
+		}
+		model := record.Deployment
+		if model == "" {
+			model = record.Model
+		}
+		agg := summary.ByModel[model]
+		agg.Requests++
+		agg.TotalUSD += record.CostUSD
+		agg.InputTokens += int64(record.Usage.InputTokens)
+		agg.CachedTokens += int64(record.Usage.CachedTokens)
+		agg.OutputTokens += int64(record.Usage.OutputTokens)
+		summary.ByModel[model] = agg
+	}
+	return summary
+}
+
+func (s Server) handleAzureCodexCost(w http.ResponseWriter, _ *http.Request) {
+	path := ""
+	if s.AzureCodex != nil {
+		path = s.AzureCodex.CostLogPath
+	}
+	writeJSON(w, summarizeAzureCodexCost(path))
+}

--- a/internal/proxy/azure_codex_cost_test.go
+++ b/internal/proxy/azure_codex_cost_test.go
@@ -1,0 +1,171 @@
+package proxy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAzureCodexUsageFromJSONAndSSE(t *testing.T) {
+	usage, model, ok := azureCodexUsageFromBody([]byte(`{"object":"response","model":"gpt-5.3-codex","usage":{"input_tokens":1738,"output_tokens":16,"input_tokens_details":{"cached_tokens":1536,"cache_write_tokens":0},"output_tokens_details":{"reasoning_tokens":8}}}`))
+	if !ok || model != "gpt-5.3-codex" {
+		t.Fatalf("json usage = %+v %q %v", usage, model, ok)
+	}
+	if usage.InputTokens != 1738 || usage.CachedTokens != 1536 || usage.OutputTokens != 16 || usage.ReasoningTokens != 8 {
+		t.Fatalf("json usage = %+v", usage)
+	}
+	stream := "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"model\":\"gpt-5.3-codex\"}}\n\n" +
+		"event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"model\":\"gpt-5.3-codex\",\"usage\":{\"input_tokens\":10,\"output_tokens\":4,\"input_tokens_details\":{\"cached_tokens\":0}}}}\n\n"
+	usage, model, ok = azureCodexUsageFromBody([]byte(stream))
+	if !ok || model != "gpt-5.3-codex" || usage.InputTokens != 10 || usage.OutputTokens != 4 {
+		t.Fatalf("sse usage = %+v %q %v", usage, model, ok)
+	}
+	if _, _, ok := azureCodexUsageFromBody([]byte(`{"object":"response","model":"gpt-5.3-codex"}`)); ok {
+		t.Fatal("a response with no usage reported usage")
+	}
+}
+
+// Cached tokens are reported inside input_tokens. Charging both at the full
+// rate would overstate every sticky Codex turn, which is most of them.
+func TestAzureCodexCostDoesNotDoubleCountCachedInput(t *testing.T) {
+	usage := azureCodexUsage{InputTokens: 1000, CachedTokens: 800, OutputTokens: 100}
+	got := usage.costUSD("gpt-5.3-codex")
+	want := (200*1.25 + 800*0.125 + 100*10) / 1_000_000
+	if got != want {
+		t.Fatalf("cost = %v, want %v", got, want)
+	}
+	// An unpriced model must never invent spend.
+	if usage.costUSD("some-unknown-deployment") != 0 {
+		t.Fatal("an unknown model was priced")
+	}
+}
+
+func TestAzureCodexCostBodyRecordsOnceOnClose(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "azure-cost.jsonl")
+	moment := time.Date(2026, 8, 18, 4, 0, 0, 0, time.UTC)
+	body := newAzureCodexCostBody(
+		io.NopCloser(strings.NewReader(`{"object":"response","model":"gpt-5.3-codex","usage":{"input_tokens":100,"output_tokens":10,"input_tokens_details":{"cached_tokens":40}}}`)),
+		path,
+		azureCodexCostRecord{Endpoint: "eastus2", Model: "gpt-5.6-codex", Deployment: "gpt-5.3-codex", Reason: "forced", Status: 200},
+		func() time.Time { return moment },
+	)
+	if _, err := io.ReadAll(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(contents)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("records = %d, want 1; EOF and Close must not both record", len(lines))
+	}
+	var record azureCodexCostRecord
+	if err := json.Unmarshal([]byte(lines[0]), &record); err != nil {
+		t.Fatal(err)
+	}
+	if record.Usage.InputTokens != 100 || record.Usage.CachedTokens != 40 || record.Reason != "forced" {
+		t.Fatalf("record = %+v", record)
+	}
+	if record.CostUSD <= 0 {
+		t.Fatalf("cost = %v, want a priced request", record.CostUSD)
+	}
+
+	summary := summarizeAzureCodexCost(path)
+	if summary.Requests != 1 || summary.CachedTokens != 40 || summary.ByReason["forced"] != 1 {
+		t.Fatalf("summary = %+v", summary)
+	}
+	if summary.ByModel["gpt-5.3-codex"].Requests != 1 {
+		t.Fatalf("by model = %+v", summary.ByModel)
+	}
+}
+
+// A client that hangs up mid-stream still cost money on the provider side, so
+// the request has to be recorded.
+func TestAzureCodexCostBodyRecordsAnAbandonedStream(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "azure-cost.jsonl")
+	body := newAzureCodexCostBody(
+		io.NopCloser(strings.NewReader("event: x\ndata: {\"response\":{\"model\":\"gpt-5.3-codex\",\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}\n")),
+		path,
+		azureCodexCostRecord{Endpoint: "eastus2", Deployment: "gpt-5.3-codex", Status: 200},
+		nil,
+	)
+	buffer := make([]byte, 8)
+	if _, err := body.Read(buffer); err != nil {
+		t.Fatal(err)
+	}
+	if err := body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(contents)) == "" {
+		t.Fatal("an abandoned stream recorded nothing")
+	}
+}
+
+// End to end: a served fallback request lands in the cost log and shows up on
+// the admin endpoint, the same way Bedrock spend does.
+func TestAzureCodexCostEndpointReportsServedRequests(t *testing.T) {
+	costPath := filepath.Join(t.TempDir(), "azure-cost.jsonl")
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"object":"response","model":"gpt-5.3-codex","usage":{"input_tokens":2000,"output_tokens":20,"input_tokens_details":{"cached_tokens":1500}}}`)
+	})
+	poolURL, err := url.Parse("https://chatgpt.com/backend-api/codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := azureCodexFallbackServer(t, azureURL, poolURL, 0)
+	server.AzureCodex.CostLogPath = costPath
+	server.AdminToken = "admin-token"
+	proxy := httptest.NewServer(server.Handler())
+	defer proxy.Close()
+
+	response, err := http.Post(proxy.URL+"/responses", "application/json",
+		strings.NewReader(`{"model":"gpt-5.6-codex","session_id":"cost-session"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", response.StatusCode)
+	}
+
+	request, err := http.NewRequest(http.MethodGet, proxy.URL+"/_subrouter/azure-codex-cost", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer admin-token")
+	costResponse, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer costResponse.Body.Close()
+	var summary azureCodexCostSummary
+	if err := json.NewDecoder(costResponse.Body).Decode(&summary); err != nil {
+		t.Fatal(err)
+	}
+	if summary.Requests != 1 || summary.CachedTokens != 1500 {
+		t.Fatalf("summary = %+v", summary)
+	}
+	if summary.ByReason["no_usable_account"] != 1 {
+		t.Fatalf("by reason = %+v, want the fallback reason recorded", summary.ByReason)
+	}
+	if summary.TotalUSD <= 0 {
+		t.Fatalf("total = %v, want priced spend", summary.TotalUSD)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1034,6 +1034,7 @@ func (s Server) Handler() http.Handler {
 	mux.HandleFunc("/_subrouter/transcripts", s.requireAdmin(s.handleTranscriptList))
 	mux.HandleFunc("/_subrouter/transcripts/", s.requireAdmin(s.handleTranscriptDetail))
 	mux.HandleFunc("/_subrouter/bedrock-cost", s.requireAdmin(s.handleBedrockCost))
+	mux.HandleFunc("/_subrouter/azure-codex-cost", s.requireAdmin(s.handleAzureCodexCost))
 	mux.HandleFunc("/_subrouter/", http.NotFound)
 	if s.Bedrock != nil && !s.RequireSessionLease {
 		mux.Handle("/bedrock/", s.bedrockHandler())

--- a/internal/transcript/azure_blob_sync.go
+++ b/internal/transcript/azure_blob_sync.go
@@ -1,0 +1,488 @@
+package transcript
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAzureBlobSyncTimeout = 30 * time.Minute
+	// azureBlobQuietPeriod keeps a transcript that is still being appended out
+	// of the upload pass, so the archived copy is a settled file rather than a
+	// half-written turn.
+	azureBlobQuietPeriod = 2 * time.Minute
+	azureBlobAPIVersion  = "2021-08-06"
+)
+
+// AzureBlobSyncer copies the local transcript spool into an Azure blob
+// container and then prunes what it has archived. It is the Azure counterpart
+// of GCSSyncer: same spool, same retention policy, different destination,
+// because the hosts that record transcripts are not all on GCP and a syncer
+// that can only authenticate through the GCE metadata server silently records
+// nothing anywhere else.
+type AzureBlobSyncer struct {
+	sourceDir  string
+	account    string
+	container  string
+	prefix     string
+	endpoint   string
+	accountKey []byte
+	sasQuery   string
+	interval   time.Duration
+	timeout    time.Duration
+	retention  time.Duration
+	maxBytes   int64
+	client     *http.Client
+	logger     *slog.Logger
+	now        func() time.Time
+}
+
+type AzureBlobSyncerConfig struct {
+	SourceDir string
+	// Destination is the container URL, optionally with a prefix path, e.g.
+	// https://account.blob.core.windows.net/transcripts/cmux-lawrence.
+	Destination string
+	// AccountKey is the storage account shared key. Preferred over a SAS
+	// because it does not expire, and an expired credential would stop the
+	// pipeline exactly as silently as the failure this replaces.
+	AccountKey string
+	// SASToken is used when no account key is configured.
+	SASToken       string
+	Interval       time.Duration
+	Timeout        time.Duration
+	LocalRetention time.Duration
+	MaxLocalBytes  int64
+	Logger         *slog.Logger
+	Client         *http.Client
+	Now            func() time.Time
+}
+
+// NewAzureBlobSyncer returns nil when the destination or source is not
+// configured, which is how callers keep transcript sync opt-in.
+func NewAzureBlobSyncer(config AzureBlobSyncerConfig) *AzureBlobSyncer {
+	sourceDir := strings.TrimSpace(config.SourceDir)
+	account, container, prefix, endpoint, err := parseAzureBlobDestination(config.Destination)
+	if sourceDir == "" || err != nil {
+		return nil
+	}
+	key := strings.TrimSpace(config.AccountKey)
+	sas := strings.TrimSpace(config.SASToken)
+	if key == "" && sas == "" {
+		return nil
+	}
+	var decodedKey []byte
+	if key != "" {
+		decodedKey, err = base64.StdEncoding.DecodeString(key)
+		if err != nil {
+			return nil
+		}
+	}
+	timeout := config.Timeout
+	if timeout <= 0 {
+		timeout = defaultAzureBlobSyncTimeout
+	}
+	logger := config.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	client := config.Client
+	if client == nil {
+		client = &http.Client{}
+	}
+	now := config.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &AzureBlobSyncer{
+		sourceDir:  sourceDir,
+		account:    account,
+		container:  container,
+		prefix:     prefix,
+		endpoint:   endpoint,
+		accountKey: decodedKey,
+		sasQuery:   strings.TrimPrefix(sas, "?"),
+		interval:   config.Interval,
+		timeout:    timeout,
+		retention:  config.LocalRetention,
+		maxBytes:   config.MaxLocalBytes,
+		client:     client,
+		logger:     logger,
+		now:        now,
+	}
+}
+
+// parseAzureBlobDestination accepts the container URL form Azure shows in the
+// portal, with an optional prefix path.
+func parseAzureBlobDestination(destination string) (account, container, prefix, endpoint string, err error) {
+	trimmed := strings.TrimSpace(destination)
+	if trimmed == "" {
+		return "", "", "", "", fmt.Errorf("azure blob destination is empty")
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", "", "", "", err
+	}
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return "", "", "", "", fmt.Errorf("azure blob destination %q must be an https url", destination)
+	}
+	host := parsed.Host
+	if host == "" {
+		return "", "", "", "", fmt.Errorf("azure blob destination %q has no host", destination)
+	}
+	account = host
+	if index := strings.Index(host, "."); index > 0 {
+		account = host[:index]
+	}
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(segments) == 0 || segments[0] == "" {
+		return "", "", "", "", fmt.Errorf("azure blob destination %q has no container", destination)
+	}
+	container = segments[0]
+	prefix = strings.Join(segments[1:], "/")
+	endpoint = parsed.Scheme + "://" + host
+	return account, container, prefix, endpoint, nil
+}
+
+func (s *AzureBlobSyncer) Enabled() bool {
+	return s != nil && s.sourceDir != "" && s.container != ""
+}
+
+func (s *AzureBlobSyncer) Destination() string {
+	if !s.Enabled() {
+		return ""
+	}
+	destination := s.endpoint + "/" + s.container
+	if s.prefix != "" {
+		destination += "/" + s.prefix
+	}
+	return destination
+}
+
+func (s *AzureBlobSyncer) Run(ctx context.Context) {
+	if !s.Enabled() || s.interval <= 0 {
+		return
+	}
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			if err := s.SyncOnce(ctx); err != nil {
+				s.logger.Warn("transcript azure sync failed", "destination", s.Destination(), "error", err)
+			}
+			timer.Reset(s.interval)
+		}
+	}
+}
+
+func (s *AzureBlobSyncer) SyncOnce(ctx context.Context) error {
+	if !s.Enabled() {
+		return nil
+	}
+	if _, err := os.Stat(s.sourceDir); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	syncCtx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+
+	files, _, err := collectTranscriptFiles(s.sourceDir)
+	if err != nil {
+		return err
+	}
+	now := s.now()
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].modTime.Equal(files[j].modTime) {
+			return files[i].path < files[j].path
+		}
+		return files[i].modTime.Before(files[j].modTime)
+	})
+	for _, file := range files {
+		if now.Sub(file.modTime) < azureBlobQuietPeriod {
+			continue
+		}
+		if err := s.uploadIfNeeded(syncCtx, file); err != nil {
+			return err
+		}
+	}
+	return s.pruneLocal(syncCtx, s.now())
+}
+
+// uploadIfNeeded skips a blob that already holds the same number of bytes.
+// Transcripts only ever grow, so equal length means equal content.
+func (s *AzureBlobSyncer) uploadIfNeeded(ctx context.Context, file localFile) error {
+	name := s.blobName(file.relPath)
+	size, exists, err := s.blobSize(ctx, name)
+	if err != nil {
+		return err
+	}
+	if exists && size == file.size {
+		return nil
+	}
+	return s.uploadFile(ctx, file.path, name, file.size)
+}
+
+func (s *AzureBlobSyncer) blobSize(ctx context.Context, name string) (int64, bool, error) {
+	req, err := s.newRequest(ctx, http.MethodHead, name, nil, 0)
+	if err != nil {
+		return 0, false, err
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return 0, false, err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return 0, false, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return 0, false, azureBlobResponseError(resp)
+	}
+	size, err := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
+	if err != nil {
+		return 0, true, nil
+	}
+	return size, true, nil
+}
+
+func (s *AzureBlobSyncer) uploadFile(ctx context.Context, path, name string, size int64) error {
+	file, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+	req, err := s.newRequest(ctx, http.MethodPut, name, io.LimitReader(file, size), size)
+	if err != nil {
+		return err
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return azureBlobResponseError(resp)
+	}
+	return nil
+}
+
+// pruneLocal deletes what retention and the size cap say should go, but only
+// after that exact byte range is archived under a content-addressed name. A
+// transcript is append-only, so the live blob can already have moved on; the
+// archive copy is what makes deleting the local file safe.
+func (s *AzureBlobSyncer) pruneLocal(ctx context.Context, now time.Time) error {
+	if s.retention <= 0 && s.maxBytes <= 0 {
+		return nil
+	}
+	files, totalBytes, err := collectTranscriptFiles(s.sourceDir)
+	if err != nil {
+		return err
+	}
+	selected := map[string]localFile{}
+	for _, file := range files {
+		if s.retention > 0 && !file.modTime.After(now.Add(-s.retention)) {
+			selected[file.path] = file
+		}
+	}
+	if s.maxBytes > 0 && totalBytes > s.maxBytes {
+		sort.Slice(files, func(i, j int) bool {
+			if files[i].modTime.Equal(files[j].modTime) {
+				return files[i].path < files[j].path
+			}
+			return files[i].modTime.Before(files[j].modTime)
+		})
+		remaining := totalBytes
+		for _, file := range files {
+			if remaining <= s.maxBytes {
+				break
+			}
+			selected[file.path] = file
+			remaining -= file.size
+		}
+	}
+	if len(selected) == 0 {
+		return nil
+	}
+	ordered := make([]localFile, 0, len(selected))
+	for _, file := range selected {
+		ordered = append(ordered, file)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].modTime.Equal(ordered[j].modTime) {
+			return ordered[i].path < ordered[j].path
+		}
+		return ordered[i].modTime.Before(ordered[j].modTime)
+	})
+	for _, file := range ordered {
+		if err := s.archiveAndRemove(ctx, file); err != nil {
+			return err
+		}
+	}
+	_ = pruneEmptyDirs(s.sourceDir)
+	return nil
+}
+
+func (s *AzureBlobSyncer) archiveAndRemove(ctx context.Context, file localFile) error {
+	before, err := os.Stat(file.path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	// A file that changed since the walk is still live; leave it for the next
+	// pass rather than archiving a size that no longer describes it.
+	if before.Size() != file.size || !before.ModTime().Equal(file.modTime) {
+		return nil
+	}
+	archive := s.blobName("_archive/" + file.relPath + "/" + archiveFileName(file))
+	size, exists, err := s.blobSize(ctx, archive)
+	if err != nil {
+		return err
+	}
+	if !exists || size != file.size {
+		if err := s.uploadFile(ctx, file.path, archive, file.size); err != nil {
+			return err
+		}
+	}
+	after, err := os.Stat(file.path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if after.Size() != file.size || !after.ModTime().Equal(file.modTime) {
+		return nil
+	}
+	if err := os.Remove(file.path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (s *AzureBlobSyncer) blobName(relPath string) string {
+	relPath = strings.TrimLeft(strings.ReplaceAll(relPath, "\\", "/"), "/")
+	if s.prefix == "" {
+		return relPath
+	}
+	return s.prefix + "/" + relPath
+}
+
+// newRequest builds a signed blob request. Shared Key signing is done here
+// rather than through the Azure SDK to keep the daemon's dependency set to the
+// standard library, which is the same reason the GCS syncer speaks the REST API
+// directly.
+func (s *AzureBlobSyncer) newRequest(ctx context.Context, method, blobName string, body io.Reader, size int64) (*http.Request, error) {
+	target := s.endpoint + "/" + s.container + "/" + azureBlobEscapePath(blobName)
+	if s.sasQuery != "" && len(s.accountKey) == 0 {
+		target += "?" + s.sasQuery
+	}
+	req, err := http.NewRequestWithContext(ctx, method, target, body)
+	if err != nil {
+		return nil, err
+	}
+	if method == http.MethodPut {
+		req.ContentLength = size
+		req.Header.Set("Content-Type", "application/x-ndjson")
+		req.Header.Set("x-ms-blob-type", "BlockBlob")
+	}
+	if len(s.accountKey) == 0 {
+		return req, nil
+	}
+	req.Header.Set("x-ms-date", s.now().UTC().Format(http.TimeFormat))
+	req.Header.Set("x-ms-version", azureBlobAPIVersion)
+	signature, err := s.signature(req, size)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "SharedKey "+s.account+":"+signature)
+	return req, nil
+}
+
+// signature builds the Shared Key string-to-sign exactly as documented: the
+// fixed header block, then the canonicalized x-ms-* headers, then the
+// canonicalized resource.
+func (s *AzureBlobSyncer) signature(req *http.Request, size int64) (string, error) {
+	contentLength := ""
+	if size > 0 {
+		contentLength = strconv.FormatInt(size, 10)
+	}
+	canonicalHeaders := azureCanonicalizedHeaders(req.Header)
+	canonicalResource := "/" + s.account + req.URL.EscapedPath()
+	stringToSign := strings.Join([]string{
+		req.Method,
+		"",            // Content-Encoding
+		"",            // Content-Language
+		contentLength, // Content-Length ("" when zero)
+		"",            // Content-MD5
+		req.Header.Get("Content-Type"),
+		"", // Date (x-ms-date is used instead)
+		"", // If-Modified-Since
+		"", // If-Match
+		"", // If-None-Match
+		"", // If-Unmodified-Since
+		"", // Range
+		canonicalHeaders + canonicalResource,
+	}, "\n")
+	mac := hmac.New(sha256.New, s.accountKey)
+	if _, err := mac.Write([]byte(stringToSign)); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil)), nil
+}
+
+func azureCanonicalizedHeaders(header http.Header) string {
+	names := make([]string, 0, len(header))
+	for name := range header {
+		lower := strings.ToLower(name)
+		if strings.HasPrefix(lower, "x-ms-") {
+			names = append(names, lower)
+		}
+	}
+	sort.Strings(names)
+	var builder strings.Builder
+	for _, name := range names {
+		builder.WriteString(name)
+		builder.WriteString(":")
+		builder.WriteString(strings.TrimSpace(header.Get(name)))
+		builder.WriteString("\n")
+	}
+	return builder.String()
+}
+
+// azureBlobEscapePath escapes each path segment while keeping the separators,
+// because a transcript name carries the session's own directory layout.
+func azureBlobEscapePath(name string) string {
+	segments := strings.Split(name, "/")
+	for index, segment := range segments {
+		segments[index] = url.PathEscape(segment)
+	}
+	return strings.Join(segments, "/")
+}
+
+func azureBlobResponseError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return fmt.Errorf("azure blob %s: %s", resp.Status, strings.TrimSpace(string(body)))
+}

--- a/internal/transcript/azure_blob_sync_test.go
+++ b/internal/transcript/azure_blob_sync_test.go
@@ -1,0 +1,249 @@
+package transcript
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// azureBlobFake stands in for the blob service: it stores what was PUT and
+// answers HEAD from that store, which is all the syncer needs.
+type azureBlobFake struct {
+	mu      sync.Mutex
+	blobs   map[string][]byte
+	puts    []string
+	heads   []string
+	authOK  bool
+	server  *httptest.Server
+	failPut bool
+}
+
+func newAzureBlobFake(t *testing.T) *azureBlobFake {
+	t.Helper()
+	fake := &azureBlobFake{blobs: map[string][]byte{}, authOK: true}
+	fake.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fake.mu.Lock()
+		defer fake.mu.Unlock()
+		name := strings.TrimPrefix(r.URL.Path, "/transcripts/")
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "SharedKey ") ||
+			r.Header.Get("x-ms-date") == "" || r.Header.Get("x-ms-version") == "" {
+			fake.authOK = false
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		switch r.Method {
+		case http.MethodHead:
+			fake.heads = append(fake.heads, name)
+			body, ok := fake.blobs[name]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPut:
+			if fake.failPut {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if r.Header.Get("x-ms-blob-type") != "BlockBlob" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			fake.blobs[name] = body
+			fake.puts = append(fake.puts, name)
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(fake.server.Close)
+	return fake
+}
+
+func azureTestSyncer(t *testing.T, fake *azureBlobFake, spool string, config AzureBlobSyncerConfig) *AzureBlobSyncer {
+	t.Helper()
+	config.SourceDir = spool
+	if config.Destination == "" {
+		config.Destination = fake.server.URL + "/transcripts/host-a"
+	}
+	if config.AccountKey == "" {
+		config.AccountKey = "c2VjcmV0LWtleQ==" // base64("secret-key")
+	}
+	if config.Now == nil {
+		// Every fixture file is written now, and the syncer deliberately skips
+		// files still being appended, so tests look at the spool from later.
+		config.Now = func() time.Time { return time.Now().Add(time.Hour) }
+	}
+	syncer := NewAzureBlobSyncer(config)
+	if syncer == nil {
+		t.Fatal("syncer was not configured")
+	}
+	return syncer
+}
+
+func writeSpoolFile(t *testing.T, spool, relPath, contents string) string {
+	t.Helper()
+	path := filepath.Join(spool, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestAzureBlobSyncerUploadsAndSkipsUnchanged(t *testing.T) {
+	fake := newAzureBlobFake(t)
+	spool := t.TempDir()
+	writeSpoolFile(t, spool, "codex/2026-08-18/session-1.jsonl", "{\"a\":1}\n")
+	syncer := azureTestSyncer(t, fake, spool, AzureBlobSyncerConfig{})
+
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	const blob = "host-a/codex/2026-08-18/session-1.jsonl"
+	if string(fake.blobs[blob]) != "{\"a\":1}\n" {
+		t.Fatalf("blob = %q, want the transcript body", fake.blobs[blob])
+	}
+	// A second pass must not re-upload an unchanged file: the spool is walked
+	// every interval and re-uploading would grow with the archive.
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.puts) != 1 {
+		t.Fatalf("uploads = %d, want 1", len(fake.puts))
+	}
+	if !fake.authOK {
+		t.Fatal("a request was sent without a SharedKey signature")
+	}
+}
+
+func TestAzureBlobSyncerReuploadsAfterAppend(t *testing.T) {
+	fake := newAzureBlobFake(t)
+	spool := t.TempDir()
+	path := writeSpoolFile(t, spool, "codex/session-2.jsonl", "{\"a\":1}\n")
+	syncer := azureTestSyncer(t, fake, spool, AzureBlobSyncerConfig{})
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{\"a\":1}\n{\"a\":2}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.puts) != 2 {
+		t.Fatalf("uploads = %d, want the appended file re-uploaded", len(fake.puts))
+	}
+	if string(fake.blobs["host-a/codex/session-2.jsonl"]) != "{\"a\":1}\n{\"a\":2}\n" {
+		t.Fatalf("blob = %q", fake.blobs["host-a/codex/session-2.jsonl"])
+	}
+}
+
+// Retention deletes local files, so the bytes being deleted must exist remotely
+// under a name that a later append cannot overwrite.
+func TestAzureBlobSyncerArchivesBeforeDeletingLocally(t *testing.T) {
+	fake := newAzureBlobFake(t)
+	spool := t.TempDir()
+	path := writeSpoolFile(t, spool, "codex/session-3.jsonl", "{\"a\":1}\n")
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	syncer := azureTestSyncer(t, fake, spool, AzureBlobSyncerConfig{LocalRetention: time.Hour})
+
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("local file survived retention: %v", err)
+	}
+	archived := false
+	for name := range fake.blobs {
+		if strings.HasPrefix(name, "host-a/_archive/codex/session-3.jsonl/") {
+			archived = true
+		}
+	}
+	if !archived {
+		t.Fatalf("no archive copy was written before deletion: %v", fake.blobs)
+	}
+}
+
+// A failed upload must not delete anything: the whole point of the archive step
+// is that local deletion follows a confirmed remote copy.
+func TestAzureBlobSyncerKeepsLocalFilesWhenUploadFails(t *testing.T) {
+	fake := newAzureBlobFake(t)
+	fake.failPut = true
+	spool := t.TempDir()
+	path := writeSpoolFile(t, spool, "codex/session-4.jsonl", "{\"a\":1}\n")
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	syncer := azureTestSyncer(t, fake, spool, AzureBlobSyncerConfig{LocalRetention: time.Hour})
+
+	if err := syncer.SyncOnce(context.Background()); err == nil {
+		t.Fatal("a failing upload was reported as success")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("local file was deleted despite the upload failing: %v", err)
+	}
+}
+
+func TestAzureBlobSyncerRequiresDestinationAndCredential(t *testing.T) {
+	spool := t.TempDir()
+	if NewAzureBlobSyncer(AzureBlobSyncerConfig{SourceDir: spool}) != nil {
+		t.Fatal("a syncer was built with no destination")
+	}
+	if NewAzureBlobSyncer(AzureBlobSyncerConfig{
+		SourceDir:   spool,
+		Destination: "https://account.blob.core.windows.net/transcripts",
+	}) != nil {
+		t.Fatal("a syncer was built with no credential")
+	}
+	if NewAzureBlobSyncer(AzureBlobSyncerConfig{
+		SourceDir:   spool,
+		Destination: "https://account.blob.core.windows.net/transcripts",
+		AccountKey:  "not base64!!",
+	}) != nil {
+		t.Fatal("a syncer was built with an unusable account key")
+	}
+	sas := NewAzureBlobSyncer(AzureBlobSyncerConfig{
+		SourceDir:   spool,
+		Destination: "https://account.blob.core.windows.net/transcripts/prefix",
+		SASToken:    "?sv=2021-08-06&sig=abc",
+	})
+	if sas == nil || !sas.Enabled() {
+		t.Fatal("a SAS credential was rejected")
+	}
+	if sas.Destination() != "https://account.blob.core.windows.net/transcripts/prefix" {
+		t.Fatalf("destination = %q", sas.Destination())
+	}
+}
+
+func TestParseAzureBlobDestination(t *testing.T) {
+	account, container, prefix, endpoint, err := parseAzureBlobDestination("https://acct.blob.core.windows.net/transcripts/host-a/sub")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if account != "acct" || container != "transcripts" || prefix != "host-a/sub" || endpoint != "https://acct.blob.core.windows.net" {
+		t.Fatalf("parsed = %q %q %q %q", account, container, prefix, endpoint)
+	}
+	if _, _, _, _, err := parseAzureBlobDestination("https://acct.blob.core.windows.net"); err == nil {
+		t.Fatal("a destination with no container was accepted")
+	}
+	if _, _, _, _, err := parseAzureBlobDestination("gs://bucket/prefix"); err == nil {
+		t.Fatal("a non-https destination was accepted")
+	}
+}

--- a/internal/transcript/gcs_sync.go
+++ b/internal/transcript/gcs_sync.go
@@ -406,9 +406,16 @@ func (s *GCSSyncer) pruneLocal(ctx context.Context, now time.Time) error {
 }
 
 func (s *GCSSyncer) localTranscriptFiles() ([]localFile, int64, error) {
+	return collectTranscriptFiles(s.sourceDir)
+}
+
+// collectTranscriptFiles walks a transcript spool. Shared with the Azure
+// syncer so both destinations agree on what a transcript file is and on the
+// relative names they archive under.
+func collectTranscriptFiles(sourceDir string) ([]localFile, int64, error) {
 	var files []localFile
 	var totalBytes int64
-	err := filepath.WalkDir(s.sourceDir, func(path string, entry os.DirEntry, walkErr error) error {
+	err := filepath.WalkDir(sourceDir, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -422,7 +429,7 @@ func (s *GCSSyncer) localTranscriptFiles() ([]localFile, int64, error) {
 		if err != nil {
 			return err
 		}
-		relPath, err := filepath.Rel(s.sourceDir, path)
+		relPath, err := filepath.Rel(sourceDir, path)
 		if err != nil {
 			return err
 		}
@@ -495,6 +502,13 @@ func (s *GCSSyncer) archiveURI(_ localFile, archiveObject string) (string, error
 }
 
 func (s *GCSSyncer) archiveFileName(file localFile) string {
+	return archiveFileName(file)
+}
+
+// archiveFileName names the immutable copy taken before a local transcript is
+// deleted: modification time, size, and content hash, so re-archiving the same
+// bytes is a no-op and a later append lands under a different name.
+func archiveFileName(file localFile) string {
 	sum, err := fileSHA256(file.path)
 	if err != nil {
 		return file.modTime.UTC().Format("20060102T150405.000000000Z") + fmt.Sprintf("-%d.jsonl", file.size)


### PR DESCRIPTION
Two gaps the Azure Codex route left open.

**Cost.** The subscription pool is a flat monthly cost; Azure is metered. A fallback that fires during an outage spends real money and left no record of it. Every served request is now priced into `azure-codex-cost.jsonl` beside the session store, summarized at `/_subrouter/azure-codex-cost`, and printed by `sr az cost` and `sr` status, mirroring the Bedrock cost log.

- Cached input is billed at the cached rate, not the full one. Azure reports cached tokens *inside* `input_tokens`, and a sticky Codex session is mostly cache reads, so charging them as fresh input would overstate spend several times over.
- A model with no price entry contributes zero, the same rule the Bedrock log follows: never invent spend.
- Usage is parsed from the response body as it streams, so the pinned handler path and the transport fallback are both covered by one wrapper, and a client that hangs up mid-stream is still recorded because the tokens were already spent.

**Transcripts.** The GCS syncer authenticates through the GCE metadata server. On a Mac it can only reach a bucket by shelling out to `gsutil`, which is why the team server has been recording nothing. `AzureBlobSyncer` uploads the same spool to an Azure blob container, signing Shared Key requests with the standard library, so the host needs no Azure CLI and no expiring credential.

It keeps the GCS syncer's rules: upload on the background interval, never on the request path, and delete a local file only after those exact bytes exist remotely under `_archive/<path>/<time>-<size>-<hash>.jsonl`. The spool walk and archive naming are now shared between the two syncers so the destinations cannot drift. A destination configured without a usable credential warns at startup, because the last transcript pipeline stopped silently.

```bash
subrouter serve --transcripts /var/lib/subrouter/transcripts \
  --transcript-azure-url https://<account>.blob.core.windows.net/<container>/<prefix>
# credential: SUBROUTER_TRANSCRIPT_AZURE_KEY_FILE or SUBROUTER_TRANSCRIPT_AZURE_SAS
```

**Verified against real Azure**, not only fakes: the syncer uploaded a spool file to `cmuxsubroutertranscript/transcripts` and the blob downloaded back byte-identical. Unit tests cover upload, skip-unchanged, re-upload after append, archive-before-delete, no-delete-when-upload-fails, destination parsing, and credential validation; cost tests cover JSON and SSE usage parsing, the cached-token pricing rule, single recording on EOF plus Close, an abandoned stream, and the admin endpoint end to end.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789620416&installation_model_id=21920&pr_number=215&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F215&signature=c001e24bd41f541d056e1bca18963f4919898158d38de611eb02c60d4330529c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Track Azure fallback spend and sync transcripts to Azure Blob so off‑GCP hosts keep records.

- Previously, Azure Codex requests spent money with no record; now each served request is priced into azure-codex-cost.jsonl, summarized at /_subrouter/azure-codex-cost, shown in `sr` status, and printable via `sr az cost`.
- Previously, transcript sync only worked on GCP; now a background `AzureBlobSyncer` uploads the same spool to an Azure container and prunes locally after archiving, without touching the request path.

**Azure Codex cost accounting**
- Parses usage from streamed responses, so both the pinned handler and transport fallback are recorded; abandoned streams still log usage.
- Bills cached input at the cached rate; models with no price contribute $0.
- No action required; the daemon writes azure-codex-cost.jsonl next to the session store and serves /_subrouter/azure-codex-cost.

**Transcript sync to Azure Blob**
- Uploads settled files on an interval and deletes local files only after the exact bytes exist remotely under _archive/<path>/<time>-<size>-<hash>.jsonl; spool walking and archive naming are shared with GCS.
- Signs requests with the storage account Shared Key or SAS; no Azure CLI needed. A configured destination with missing credentials warns at startup.
- Required actions to enable:
  - Start with --transcripts <dir> and --transcript-azure-url https://<account>.blob.core.windows.net/<container>/<prefix> (or set SUBROUTER_TRANSCRIPT_AZURE_URL).
  - Provide credentials: set SUBROUTER_TRANSCRIPT_AZURE_KEY_FILE (preferred) or SUBROUTER_TRANSCRIPT_AZURE_SAS.

<sup>Written for commit bfd21567d3daf5c1ab85a5369b59471bb8df88b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

