### PR TITLE
Fix Codex session identity, model routing, and sticky retention

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4193,6 +4193,13 @@ func (s Server) accountForSessionProviderWithOptions(provider accounts.Provider,
 	if options.oauthOnly {
 		availableAccounts = oauthAccounts(availableAccounts)
 	}
+	// The upstream prompt cache is per account, so moving a session to another
+	// account re-bills its whole conversation prefix as uncached input. Record
+	// where the session was before any branch can reassign it.
+	previousAccountID := ""
+	if assignment, ok := s.Sessions.Get(agentType, sessionID); ok {
+		previousAccountID = assignment.AccountID
+	}
 	if forcedAccountID != "" {
 		account, ok := findAccount(availableAccounts, forcedAccountID)
 		if !ok {
@@ -4201,6 +4208,7 @@ func (s Server) accountForSessionProviderWithOptions(provider accounts.Provider,
 		if provider == accounts.ProviderCodex && chatGPTBackendPath(r.URL.Path) && account.AuthMode != accounts.AuthModeOAuth {
 			return accounts.Account{}, sessionID, userEmail, fmt.Errorf("requested account %q cannot be used for ChatGPT backend paths", forcedAccountID)
 		}
+		s.logAccountMove(agentType, sessionID, model, previousAccountID, account.ID, provider, nil)
 		assignment, err := s.Sessions.Put(agentType, sessionID, account.ID, userEmail)
 		if err != nil {
 			return accounts.Account{}, sessionID, userEmail, err
@@ -4229,13 +4237,7 @@ func (s Server) accountForSessionProviderWithOptions(provider accounts.Provider,
 		s.Logger.Info("model quota pool matched", "agent", agentType, "model", model, "pool", selectacct.ModelKey(poolModel))
 	}
 	scheduler := base.ForModel(poolModel).WithSessionCounts(s.Sessions.CountByAccount())
-	// The upstream prompt cache is per account, so moving a session to another
-	// account re-bills its whole conversation prefix as uncached input. Track
-	// where the session was so every move is visible, not just the reroute the
-	// scheduler makes deliberately.
-	previousAccountID := ""
 	if assignment, ok := s.Sessions.Get(agentType, sessionID); ok {
-		previousAccountID = assignment.AccountID
 		if userEmail != "" && userEmail != assignment.UserEmail {
 			updated, err := s.Sessions.Put(agentType, sessionID, assignment.AccountID, userEmail)
 			if err != nil {
@@ -4288,23 +4290,38 @@ func (s Server) accountForSessionProviderWithOptions(provider accounts.Provider,
 			"exhausted", scheduler.Exhausted(account.Provider, account.ID),
 			"threshold", selectacct.MinNewSessionHeadroom)
 	}
-	if previousAccountID != "" && previousAccountID != account.ID && s.Logger != nil {
-		s.Logger.Warn("session moved to another account; upstream prompt cache is cold",
-			"agent", agentType,
-			"session", sessionID,
-			"model", model,
-			"from_account", previousAccountID,
-			"to_account", account.ID,
-			"from_exhausted", scheduler.Exhausted(provider, previousAccountID),
-			"from_usable_for_new_session", scheduler.UsableForNewSession(provider, previousAccountID),
-			"threshold", selectacct.MinNewSessionHeadroom,
-		)
-	}
+	s.logAccountMove(agentType, sessionID, model, previousAccountID, account.ID, provider, &scheduler)
 	assignment, err := s.Sessions.Put(agentType, sessionID, account.ID, userEmail)
 	if err != nil {
 		return accounts.Account{}, sessionID, userEmail, err
 	}
 	return account, sessionID, assignment.UserEmail, nil
+}
+
+// logAccountMove records that a session left the account holding its upstream
+// prompt cache. scheduler is nil when the caller forced the account and no
+// routing scores were consulted.
+func (s Server) logAccountMove(agentType, sessionID, model, fromAccountID, toAccountID string, provider accounts.Provider, scheduler *selectacct.Scheduler) {
+	if s.Logger == nil || fromAccountID == "" || fromAccountID == toAccountID {
+		return
+	}
+	fields := []any{
+		"agent", agentType,
+		"session", sessionID,
+		"model", model,
+		"from_account", fromAccountID,
+		"to_account", toAccountID,
+	}
+	if scheduler == nil {
+		fields = append(fields, "forced", true)
+	} else {
+		fields = append(fields,
+			"from_exhausted", scheduler.Exhausted(provider, fromAccountID),
+			"from_usable_for_sticky_session", scheduler.UsableForStickySession(provider, fromAccountID),
+			"retention_threshold", selectacct.MinStickyRetentionHeadroom,
+		)
+	}
+	s.Logger.Warn("session moved to another account; upstream prompt cache is cold", fields...)
 }
 
 func (s Server) logStickyReuse(agentType, sessionID string, account accounts.Account, scheduler selectacct.Scheduler) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4258,6 +4258,7 @@ func (s Server) accountForSessionProviderWithOptions(provider accounts.Provider,
 					"account", account.ID,
 					"active", s.activeSession(agentType, sessionID),
 					"usable_for_new_session", scheduler.UsableForNewSession(account.Provider, account.ID),
+					"usable_for_sticky_session", scheduler.UsableForStickySession(account.Provider, account.ID),
 					"exhausted", scheduler.Exhausted(account.Provider, account.ID),
 				)
 			}
@@ -4330,7 +4331,12 @@ func (s Server) reuseStickyAssignment(agentType, sessionID string, account accou
 		return true
 	}
 	if accountProviderOrCodex(account) == accounts.ProviderCodex && account.AuthMode == accounts.AuthModeOAuth {
-		return scheduler.UsableForNewSession(account.Provider, account.ID)
+		// Retention, not placement: this session already built the upstream
+		// prompt cache on this account. Gating it on the new-session threshold
+		// moved every idle session off any account past 60% used, which in a
+		// busy pool is all of them, so stickiness stopped existing exactly
+		// when the pool could least afford re-billing whole prefixes.
+		return scheduler.UsableForStickySession(account.Provider, account.ID)
 	}
 	return true
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4229,7 +4229,13 @@ func (s Server) accountForSessionProviderWithOptions(provider accounts.Provider,
 		s.Logger.Info("model quota pool matched", "agent", agentType, "model", model, "pool", selectacct.ModelKey(poolModel))
 	}
 	scheduler := base.ForModel(poolModel).WithSessionCounts(s.Sessions.CountByAccount())
+	// The upstream prompt cache is per account, so moving a session to another
+	// account re-bills its whole conversation prefix as uncached input. Track
+	// where the session was so every move is visible, not just the reroute the
+	// scheduler makes deliberately.
+	previousAccountID := ""
 	if assignment, ok := s.Sessions.Get(agentType, sessionID); ok {
+		previousAccountID = assignment.AccountID
 		if userEmail != "" && userEmail != assignment.UserEmail {
 			updated, err := s.Sessions.Put(agentType, sessionID, assignment.AccountID, userEmail)
 			if err != nil {
@@ -4280,6 +4286,18 @@ func (s Server) accountForSessionProviderWithOptions(provider accounts.Provider,
 			"account", account.ID,
 			"exhausted", scheduler.Exhausted(account.Provider, account.ID),
 			"threshold", selectacct.MinNewSessionHeadroom)
+	}
+	if previousAccountID != "" && previousAccountID != account.ID && s.Logger != nil {
+		s.Logger.Warn("session moved to another account; upstream prompt cache is cold",
+			"agent", agentType,
+			"session", sessionID,
+			"model", model,
+			"from_account", previousAccountID,
+			"to_account", account.ID,
+			"from_exhausted", scheduler.Exhausted(provider, previousAccountID),
+			"from_usable_for_new_session", scheduler.UsableForNewSession(provider, previousAccountID),
+			"threshold", selectacct.MinNewSessionHeadroom,
+		)
 	}
 	assignment, err := s.Sessions.Put(agentType, sessionID, account.ID, userEmail)
 	if err != nil {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -2932,7 +2932,7 @@ func TestHandlerReroutesStickySessionWhenAssignedAccountExhausted(t *testing.T) 
 	}
 }
 
-func TestHandlerReroutesColdStickySessionWhenAssignedAccountBelowHeadroom(t *testing.T) {
+func TestHandlerReroutesColdStickySessionWhenAssignedAccountBelowRetentionHeadroom(t *testing.T) {
 	var auths []string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		auths = append(auths, r.Header.Get("Authorization"))
@@ -2959,7 +2959,7 @@ func TestHandlerReroutesColdStickySessionWhenAssignedAccountBelowHeadroom(t *tes
 		},
 		Sessions: store,
 		Scheduler: selectacct.NewScheduler([]selectacct.Score{
-			{AccountID: "low@example.com", Headroom: 0.10, ShortHeadroom: 0.10},
+			{AccountID: "low@example.com", Headroom: 0.02, ShortHeadroom: 0.02},
 			{AccountID: "healthy@example.com", Headroom: 0.90, ShortHeadroom: 0.90},
 		}),
 		MaxBodyBytes: 1024,
@@ -3060,7 +3060,7 @@ func TestHandlerRoutesSparkModelUsingSparkQuota(t *testing.T) {
 	}
 }
 
-func TestHandlerKeepsActiveStickySessionWhenAssignedAccountBelowHeadroom(t *testing.T) {
+func TestHandlerKeepsActiveStickySessionWhenAssignedAccountBelowRetentionHeadroom(t *testing.T) {
 	var mu sync.Mutex
 	var auths []string
 	firstStarted := make(chan struct{})
@@ -3146,7 +3146,7 @@ func TestHandlerKeepsActiveStickySessionWhenAssignedAccountBelowHeadroom(t *test
 	}
 
 	schedulerRef.Set(selectacct.NewScheduler([]selectacct.Score{
-		{AccountID: "low@example.com", Headroom: 0.10, ShortHeadroom: 0.10},
+		{AccountID: "low@example.com", Headroom: 0.02, ShortHeadroom: 0.02},
 		{AccountID: "healthy@example.com", Headroom: 0.90, ShortHeadroom: 0.90},
 	}))
 

--- a/internal/proxy/session_account_move_test.go
+++ b/internal/proxy/session_account_move_test.go
@@ -31,7 +31,7 @@ func TestAccountForSessionLogsAccountMove(t *testing.T) {
 		},
 		Sessions: store,
 		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
-			{AccountID: "spent@example.com", Provider: accounts.ProviderCodex, Headroom: 0.2, ShortHeadroom: 0.2},
+			{AccountID: "spent@example.com", Provider: accounts.ProviderCodex, Headroom: 0.02, ShortHeadroom: 0.02},
 			{AccountID: "fresh@example.com", Provider: accounts.ProviderCodex, Headroom: 1, ShortHeadroom: 1},
 		})),
 		MaxBodyBytes: 1024,
@@ -97,5 +97,91 @@ func TestAccountForSessionDoesNotLogStickyReuseAsMove(t *testing.T) {
 	}
 	if strings.Contains(logs.String(), "session moved to another account") {
 		t.Fatalf("sticky reuse was logged as a move: %s", logs.String())
+	}
+}
+
+// Every account in a busy pool sits well past the new-session threshold. An
+// idle session must still stay where its upstream prompt cache lives.
+func TestStickyCodexSessionSurvivesConstrainedAccount(t *testing.T) {
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("codex", "session-1", "busy@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	var logs bytes.Buffer
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: "busy@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "tok-busy"},
+			{ID: "other@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "tok-other"},
+		},
+		Sessions: store,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+			// 23% and 26% headroom: both are below MinNewSessionHeadroom, which
+			// is the normal state of a pool under load.
+			{AccountID: "busy@example.com", Provider: accounts.ProviderCodex, Headroom: 0.23, ShortHeadroom: 0.23},
+			{AccountID: "other@example.com", Provider: accounts.ProviderCodex, Headroom: 0.26, ShortHeadroom: 0.26},
+		})),
+		MaxBodyBytes: 1024,
+		Logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://subrouter.test/v1/responses", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Subrouter-Agent", "codex")
+	req.Header.Set("X-Subrouter-Session", "session-1")
+	account, _, _, err := server.accountForSessionProvider(accounts.ProviderCodex, "codex", "session-1", req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if account.ID != "busy@example.com" {
+		t.Fatalf("account = %q, want the session held on busy@example.com", account.ID)
+	}
+	if strings.Contains(logs.String(), "session moved to another account") {
+		t.Fatalf("session was moved off a merely constrained account: %s", logs.String())
+	}
+}
+
+// An account with almost nothing left cannot serve the session any more, so
+// the move happens there instead.
+func TestStickyCodexSessionLeavesNearlyEmptyAccount(t *testing.T) {
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("codex", "session-1", "empty@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	var logs bytes.Buffer
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: "empty@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "tok-empty"},
+			{ID: "other@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "tok-other"},
+		},
+		Sessions: store,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+			{AccountID: "empty@example.com", Provider: accounts.ProviderCodex, Headroom: 0.01, ShortHeadroom: 0.01},
+			{AccountID: "other@example.com", Provider: accounts.ProviderCodex, Headroom: 0.26, ShortHeadroom: 0.26},
+		})),
+		MaxBodyBytes: 1024,
+		Logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://subrouter.test/v1/responses", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Subrouter-Agent", "codex")
+	req.Header.Set("X-Subrouter-Session", "session-1")
+	account, _, _, err := server.accountForSessionProvider(accounts.ProviderCodex, "codex", "session-1", req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if account.ID != "other@example.com" {
+		t.Fatalf("account = %q, want the session moved off the empty account", account.ID)
+	}
+	if !strings.Contains(logs.String(), "session moved to another account") {
+		t.Fatalf("account move was not logged: %s", logs.String())
 	}
 }

--- a/internal/proxy/session_account_move_test.go
+++ b/internal/proxy/session_account_move_test.go
@@ -1,0 +1,101 @@
+package proxy
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/selectacct"
+	"github.com/manaflow-ai/subrouter/session"
+)
+
+// A Codex session that moves to another account loses the upstream prompt
+// cache and re-bills its whole prefix, so the move has to be logged.
+func TestAccountForSessionLogsAccountMove(t *testing.T) {
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("codex", "session-1", "spent@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	var logs bytes.Buffer
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: "spent@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "tok-spent"},
+			{ID: "fresh@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "tok-fresh"},
+		},
+		Sessions: store,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+			{AccountID: "spent@example.com", Provider: accounts.ProviderCodex, Headroom: 0.2, ShortHeadroom: 0.2},
+			{AccountID: "fresh@example.com", Provider: accounts.ProviderCodex, Headroom: 1, ShortHeadroom: 1},
+		})),
+		MaxBodyBytes: 1024,
+		Logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://subrouter.test/v1/responses", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Subrouter-Agent", "codex")
+	req.Header.Set("X-Subrouter-Session", "session-1")
+	account, _, _, err := server.accountForSessionProvider(accounts.ProviderCodex, "codex", "session-1", req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if account.ID != "fresh@example.com" {
+		t.Fatalf("account = %q, want the session rerouted to fresh@example.com", account.ID)
+	}
+	if !strings.Contains(logs.String(), "session moved to another account") {
+		t.Fatalf("account move was not logged: %s", logs.String())
+	}
+	if !strings.Contains(logs.String(), "from_account=spent@example.com") ||
+		!strings.Contains(logs.String(), "to_account=fresh@example.com") {
+		t.Fatalf("account move log is missing the from/to accounts: %s", logs.String())
+	}
+}
+
+// A session that stays on its account must not report a cache-breaking move.
+func TestAccountForSessionDoesNotLogStickyReuseAsMove(t *testing.T) {
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("codex", "session-1", "healthy@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	var logs bytes.Buffer
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: "healthy@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "tok-healthy"},
+			{ID: "other@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "tok-other"},
+		},
+		Sessions: store,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+			{AccountID: "healthy@example.com", Provider: accounts.ProviderCodex, Headroom: 1, ShortHeadroom: 1},
+			{AccountID: "other@example.com", Provider: accounts.ProviderCodex, Headroom: 1, ShortHeadroom: 1},
+		})),
+		MaxBodyBytes: 1024,
+		Logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://subrouter.test/v1/responses", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Subrouter-Agent", "codex")
+	req.Header.Set("X-Subrouter-Session", "session-1")
+	account, _, _, err := server.accountForSessionProvider(accounts.ProviderCodex, "codex", "session-1", req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if account.ID != "healthy@example.com" {
+		t.Fatalf("account = %q, want the sticky account reused", account.ID)
+	}
+	if strings.Contains(logs.String(), "session moved to another account") {
+		t.Fatalf("sticky reuse was logged as a move: %s", logs.String())
+	}
+}

--- a/internal/proxy/session_account_move_test.go
+++ b/internal/proxy/session_account_move_test.go
@@ -185,3 +185,43 @@ func TestStickyCodexSessionLeavesNearlyEmptyAccount(t *testing.T) {
 		t.Fatalf("account move was not logged: %s", logs.String())
 	}
 }
+
+// A forced account header also moves the session off its cached account, so
+// the move must still be logged.
+func TestForcedAccountMoveIsLogged(t *testing.T) {
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("codex", "session-1", "cached@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	var logs bytes.Buffer
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: "cached@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "tok-cached"},
+			{ID: "forced@example.com", Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "tok-forced"},
+		},
+		Sessions:     store,
+		MaxBodyBytes: 1024,
+		Logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://subrouter.test/v1/responses", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Subrouter-Agent", "codex")
+	req.Header.Set("X-Subrouter-Session", "session-1")
+	req.Header.Set("X-Subrouter-Account-ID", "forced@example.com")
+	account, _, _, err := server.accountForSessionProvider(accounts.ProviderCodex, "codex", "session-1", req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if account.ID != "forced@example.com" {
+		t.Fatalf("account = %q, want the forced account", account.ID)
+	}
+	if !strings.Contains(logs.String(), "session moved to another account") ||
+		!strings.Contains(logs.String(), "forced=true") {
+		t.Fatalf("forced account move was not logged: %s", logs.String())
+	}
+}

--- a/selectacct/scheduler.go
+++ b/selectacct/scheduler.go
@@ -35,6 +35,15 @@ type Scheduler struct {
 
 const MinNewSessionHeadroom = 0.40
 
+// MinStickyRetentionHeadroom is the headroom an account must still have for an
+// idle session to stay on it. It sits far below MinNewSessionHeadroom on
+// purpose. Placing a NEW session on an account needs room for a whole
+// conversation, but a session that is already running built the upstream
+// prompt cache on that account, and the cache is per account: moving the
+// session re-bills its entire conversation prefix as uncached input. Holding
+// the session until its account is nearly empty costs less than moving it.
+const MinStickyRetentionHeadroom = 0.05
+
 // ScoreKey is the scheduler's identity for an account. A Codex account's ID is
 // its bare email and a Claude account's ID is its profile name, which can also
 // be an email, so the same string routinely identifies one account per
@@ -160,6 +169,13 @@ func (s Scheduler) UsableForNewSession(provider account.Provider, accountID stri
 	return s.score(provider, accountID).usableForNewSession()
 }
 
+// UsableForStickySession reports whether an account still has enough headroom
+// to keep serving a session already assigned to it. Callers placing a fresh
+// session use UsableForNewSession instead.
+func (s Scheduler) UsableForStickySession(provider account.Provider, accountID string) bool {
+	return s.score(provider, accountID).usableForStickySession()
+}
+
 func (s Scheduler) Exhausted(provider account.Provider, accountID string) bool {
 	return s.score(provider, accountID).exhausted()
 }
@@ -227,6 +243,10 @@ func (s Scheduler) score(provider account.Provider, accountID string) Score {
 
 func (s Score) usableForNewSession() bool {
 	return s.Headroom >= MinNewSessionHeadroom && s.ShortHeadroom >= MinNewSessionHeadroom
+}
+
+func (s Score) usableForStickySession() bool {
+	return s.Headroom >= MinStickyRetentionHeadroom && s.ShortHeadroom >= MinStickyRetentionHeadroom
 }
 
 func (s Score) exhausted() bool {

--- a/session/extract.go
+++ b/session/extract.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"bytes"
+	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -11,6 +12,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/klauspost/compress/zstd"
 )
 
 var headerCandidates = []string{
@@ -28,6 +31,12 @@ var headerCandidates = []string{
 	"OpenAI-Conversation-ID",
 	"Anthropic-Conversation-ID",
 	"Google-Conversation-ID",
+	// Codex sends bare session-id/thread-id on every responses request and on
+	// the websocket upgrade. They come last so the existing window-scoped
+	// headers keep priority, but they keep session identity working if the
+	// x-codex-* compatibility headers ever go away.
+	"Session-Id",
+	"Thread-Id",
 	"Idempotency-Key",
 }
 
@@ -217,22 +226,11 @@ func extractJSONModel(r *http.Request, maxBodyBytes int64) string {
 }
 
 func extractJSONValue(r *http.Request, maxBodyBytes int64) any {
-	if r.Body == nil || maxBodyBytes <= 0 {
-		return nil
-	}
 	if r.ContentLength < 0 || r.ContentLength > maxBodyBytes {
 		return nil
 	}
-	if contentType := r.Header.Get("Content-Type"); !strings.Contains(contentType, "json") {
-		return nil
-	}
-
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes+1))
-	if err != nil {
-		return nil
-	}
-	r.Body = io.NopCloser(bytes.NewReader(body))
-	if int64(len(body)) > maxBodyBytes {
+	body, truncated := readDecodedJSONBody(r, maxBodyBytes)
+	if body == nil || truncated {
 		return nil
 	}
 
@@ -242,6 +240,75 @@ func extractJSONValue(r *http.Request, maxBodyBytes int64) any {
 	}
 	return value
 }
+
+// readDecodedJSONBody reads at most maxWireBytes of the request body, restores
+// the body for the proxy, and returns it decoded per Content-Encoding. Codex
+// sends `content-encoding: zstd` on every responses request, so without this
+// step every body inspection here sees compressed bytes and silently finds
+// neither the session id nor the model. truncated reports that the decoded body
+// was cut short, so callers that need a complete JSON document give up while
+// prefix scanners can still use what came back.
+func readDecodedJSONBody(r *http.Request, maxWireBytes int64) (body []byte, truncated bool) {
+	if r == nil || r.Body == nil || maxWireBytes <= 0 {
+		return nil, false
+	}
+	if contentType := r.Header.Get("Content-Type"); !strings.Contains(contentType, "json") {
+		return nil, false
+	}
+	wire, err := io.ReadAll(io.LimitReader(r.Body, maxWireBytes+1))
+	if err != nil {
+		return nil, false
+	}
+	// Anything past the read limit stays on the original body so the proxied
+	// request is still byte-identical upstream.
+	r.Body = struct {
+		io.Reader
+		io.Closer
+	}{Reader: io.MultiReader(bytes.NewReader(wire), r.Body), Closer: r.Body}
+	if int64(len(wire)) > maxWireBytes {
+		return wire[:maxWireBytes], true
+	}
+	return decodeRequestBody(wire, r.Header.Get("Content-Encoding"))
+}
+
+func decodeRequestBody(wire []byte, contentEncoding string) (body []byte, truncated bool) {
+	switch strings.ToLower(strings.TrimSpace(contentEncoding)) {
+	case "", "identity":
+		return wire, false
+	case "zstd":
+		decoder, err := zstd.NewReader(bytes.NewReader(wire), zstd.WithDecoderMaxMemory(uint64(decodedBodyMaxBytes)))
+		if err != nil {
+			return nil, false
+		}
+		defer decoder.Close()
+		return readDecodedLimit(decoder)
+	case "gzip":
+		reader, err := gzip.NewReader(bytes.NewReader(wire))
+		if err != nil {
+			return nil, false
+		}
+		defer reader.Close()
+		return readDecodedLimit(reader)
+	default:
+		return nil, false
+	}
+}
+
+func readDecodedLimit(reader io.Reader) (body []byte, truncated bool) {
+	decoded, err := io.ReadAll(io.LimitReader(reader, decodedBodyMaxBytes+1))
+	if err != nil && int64(len(decoded)) <= decodedBodyMaxBytes {
+		return nil, false
+	}
+	if int64(len(decoded)) > decodedBodyMaxBytes {
+		return decoded[:decodedBodyMaxBytes], true
+	}
+	return decoded, false
+}
+
+// decodedBodyMaxBytes bounds how much decompressed request body is held in
+// memory per inspection. A compressed body well under the wire limit can expand
+// far past it, so the decoded size needs its own ceiling.
+const decodedBodyMaxBytes = int64(16 << 20)
 
 func findJSONID(value any) string {
 	switch typed := value.(type) {
@@ -304,11 +371,10 @@ func extractJSONModelScan(r *http.Request, maxBodyBytes int64) string {
 	if limit < modelScanMaxBodyBytes {
 		limit = modelScanMaxBodyBytes
 	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, limit))
-	if err != nil {
+	body, _ := readDecodedJSONBody(r, limit)
+	if body == nil {
 		return ""
 	}
-	r.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), r.Body))
 	match := jsonModelFieldPattern.FindSubmatch(body)
 	if len(match) != 2 {
 		return ""

--- a/session/extract_compressed_test.go
+++ b/session/extract_compressed_test.go
@@ -1,0 +1,89 @@
+package session
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// codexResponsesBody mirrors the shape codex-cli sends to /v1/responses: the
+// model first, the session id nested in client_metadata at the end.
+const codexResponsesBody = `{"model":"gpt-5.3-codex","instructions":"be helpful","input":[],` +
+	`"prompt_cache_key":"01a01336-3c47-7791-8883-ca794f5bd7c1",` +
+	`"client_metadata":{"session_id":"01a01336-3c47-7791-8883-ca794f5bd7c1",` +
+	`"thread_id":"01a01336-3c47-7791-8883-ca794f5bd7c1"}}`
+
+func zstdBytes(t *testing.T, body string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	encoder, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatalf("new zstd writer: %v", err)
+	}
+	if _, err := encoder.Write([]byte(body)); err != nil {
+		t.Fatalf("write zstd body: %v", err)
+	}
+	if err := encoder.Close(); err != nil {
+		t.Fatalf("close zstd writer: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func zstdCodexRequest(t *testing.T) *http.Request {
+	t.Helper()
+	wire := zstdBytes(t, codexResponsesBody)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(wire))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "zstd")
+	req.ContentLength = int64(len(wire))
+	return req
+}
+
+func TestExtractIDReadsZstdCodexBody(t *testing.T) {
+	req := zstdCodexRequest(t)
+	if got := ExtractID(req, 1<<20); got != "01a01336-3c47-7791-8883-ca794f5bd7c1" {
+		t.Fatalf("ExtractID = %q, want the codex session id", got)
+	}
+}
+
+func TestExtractModelReadsZstdCodexBody(t *testing.T) {
+	req := zstdCodexRequest(t)
+	if got := ExtractModel(req, 1<<20); got != "gpt-5.3-codex" {
+		t.Fatalf("ExtractModel = %q, want gpt-5.3-codex", got)
+	}
+}
+
+func TestExtractLeavesCompressedBodyIntactForUpstream(t *testing.T) {
+	wire := zstdBytes(t, codexResponsesBody)
+	req := zstdCodexRequest(t)
+	_ = ExtractID(req, 1<<20)
+	_ = ExtractModel(req, 1<<20)
+	forwarded, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read forwarded body: %v", err)
+	}
+	if !bytes.Equal(forwarded, wire) {
+		t.Fatalf("forwarded body changed: got %d bytes, want %d", len(forwarded), len(wire))
+	}
+}
+
+func TestExtractIDUsesBareSessionIDHeader(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	req.Header.Set("session-id", "01a01336-3c47-7791-8883-ca794f5bd7c1")
+	if got := ExtractID(req, 1<<20); got != "01a01336-3c47-7791-8883-ca794f5bd7c1" {
+		t.Fatalf("ExtractID = %q, want the session-id header value", got)
+	}
+}
+
+func TestExtractIDPrefersCodexWindowHeaderOverBareSessionID(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	req.Header.Set("X-Codex-Window-ID", "01a01336-3c47-7791-8883-ca794f5bd7c1:0")
+	req.Header.Set("session-id", "01a01336-3c47-7791-8883-ca794f5bd7c1")
+	if got := ExtractID(req, 1<<20); got != "01a01336-3c47-7791-8883-ca794f5bd7c1:0" {
+		t.Fatalf("ExtractID = %q, want the window-scoped id", got)
+	}
+}


### PR DESCRIPTION
### What is wrong

codex-cli sends `/v1/responses` bodies with `content-encoding: zstd`. The session and model extractors ran `json.Unmarshal` on the compressed wire bytes, so both silently failed on every Codex request.

- Session identity survived only through the `x-codex-window-id` compatibility header. Without it the session falls back to `fallbackID` (a hash of remote addr, user agent, method, path), and because `BaseSessionID` cuts at the first `:`, every fallback Codex session collapses onto the single store key `codex:fallback`. That key exists live on cmux-lawrence today.
- Model extraction failed outright, since no Codex header carries the model. Model-specific quota pools were never consulted on the HTTP path: `model quota pool matched` does not appear once in 17 days of daemon logs. The websocket path was unaffected, because it reads the model from the `response.create` event.

Separately, sticky retention reused `MinNewSessionHeadroom` (0.40). Placing a new session and keeping an existing one are different questions. On cmux-lawrence all 14 non-exhausted Codex accounts sit between 74% and 88% used, so no account cleared the gate: every idle session was rerouted on every request, and `Pick` could not find a better account either. Each move drops the upstream prompt cache, which is per account, and re-bills the whole conversation prefix as uncached input.

### Changes

- Decode the request body per `Content-Encoding` (`zstd`, `gzip`, identity) before inspecting it, with its own decoded-size ceiling, keeping the wire bytes for the upstream request.
- Accept bare `session-id` / `thread-id` headers as a last-resort session source, after the existing window-scoped headers.
- Add `MinStickyRetentionHeadroom` (0.05) and gate retention on it instead of the new-session threshold. New-session placement is unchanged at 0.40.
- Log every move of a session between accounts, with the from and to account. Only the deliberate cold-sticky reroute was visible before.

### Measurements behind this

From 7 hours of transcripts on cmux-lawrence: 758 Codex turns, 121.3M input tokens, 98.0% cached, 2.37M uncached. Sessions that stayed on one account ran at 97-99%. Sessions that changed account ran at 43-85%, and the largest single uncached turn was 207k tokens. No double-billed retries: 0 repeated usage records across all sessions.

### Tests

`session/extract_compressed_test.go` (added first as a failing commit) and `internal/proxy/session_account_move_test.go`. Two existing websocket tests encoded the old retention policy and now drop the account below the retention threshold instead. `go test ./...` green.