### PR TITLE
Remember the fields an Azure deployment rejects

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ sr az codex exec "…"  # run Codex with every request forced onto Azure
 
 `sr az test` sends a fixed prompt long enough to be cacheable, so the second run's `cached=` count is real evidence that the prompt cache is being reused. Forced requests skip the pool and never pin the session; a broken endpoint surfaces as an error instead of a silent ChatGPT answer.
 
-Codex bodies carry fields the Responses API does not take (`session_id` on every turn), and a Codex release can send a value an older Azure model version refuses (`reasoning.context="all_turns"`). Known ChatGPT-only fields are stripped, and a 400 that names one field is retried once without it, up to three times.
+Codex bodies carry fields the Responses API does not take (`session_id` on every turn), and a Codex release can send a value an older Azure model version refuses (`reasoning.context="all_turns"`). Known ChatGPT-only fields are stripped, and a 400 that names one field is retried once without it, up to three times. Each rejection is remembered per endpoint and deployment for six hours, so a long session does not re-upload its whole conversation every turn to rediscover the same refusal, and an Azure model upgrade that starts accepting the field is picked up on its own.
 
 Azure is metered, unlike the subscription pool, so every served request is priced into `azure-codex-cost.jsonl` next to the session store and summarized at `/_subrouter/azure-codex-cost`. `sr az cost` prints it, and `sr` status grows a spend line once the fallback has run. Cached input is billed at the cached rate rather than the full one, and a model with no price entry contributes zero rather than a guess.
 

--- a/internal/proxy/azure_codex.go
+++ b/internal/proxy/azure_codex.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -493,9 +494,17 @@ func (s Server) azureCodexEndpointResponse(
 	sessionKey string,
 	model string,
 ) (*http.Response, error) {
-	payload, err := azureCodexPayload(body, endpoint.deployment(model), sessionKey)
+	deployment := endpoint.deployment(model)
+	payload, err := azureCodexPayload(body, deployment, sessionKey)
 	if err != nil {
 		return nil, err
+	}
+	// Fields this deployment has already refused are dropped before the first
+	// attempt, so a long session does not re-upload its whole conversation to
+	// rediscover the same rejection every turn.
+	memoryKey := azureCodexFieldMemoryKey(endpoint.Name, deployment)
+	for _, field := range s.azureCodexRejects.known(memoryKey) {
+		azureCodexDropField(payload, field)
 	}
 	target := *endpoint.BaseURL
 	target.Path = strings.TrimRight(endpoint.BaseURL.Path, "/") + path
@@ -540,9 +549,10 @@ func (s Server) azureCodexEndpointResponse(
 		if rejected == "" || !azureCodexDropField(payload, rejected) {
 			return azureCodexReplayedResponse(response, errorBody), nil
 		}
+		s.azureCodexRejects.remember(memoryKey, rejected)
 		if s.Logger != nil {
 			s.Logger.Warn("azure codex rejected a field; retrying without it",
-				"endpoint", endpoint.Name, "model", model, "field", rejected)
+				"endpoint", endpoint.Name, "model", model, "deployment", deployment, "field", rejected)
 		}
 	}
 }
@@ -733,4 +743,84 @@ func azureCodexForceUnavailableMessage(s Server, leased bool, r *http.Request) s
 	default:
 		return "azure codex route is unavailable for this request"
 	}
+}
+
+// azureCodexFieldMemory remembers which request fields an Azure deployment has
+// rejected. Without it, every turn of a long Codex session pays for the same
+// discovery twice: Codex re-sends the field, Azure refuses it, and the whole
+// conversation is uploaded a second time before the retry succeeds. The memory
+// expires so an Azure model upgrade that starts accepting a field is picked up
+// on its own.
+type azureCodexFieldMemory struct {
+	mu     sync.Mutex
+	fields map[string]map[string]time.Time
+	now    func() time.Time
+}
+
+// azureCodexFieldMemoryTTL is how long a rejection is trusted. Long enough that
+// a busy session never rediscovers it, short enough that an Azure model upgrade
+// takes effect the same day.
+const azureCodexFieldMemoryTTL = 6 * time.Hour
+
+func newAzureCodexFieldMemory() *azureCodexFieldMemory {
+	return &azureCodexFieldMemory{fields: map[string]map[string]time.Time{}}
+}
+
+func (m *azureCodexFieldMemory) clock() time.Time {
+	if m.now != nil {
+		return m.now()
+	}
+	return time.Now()
+}
+
+func azureCodexFieldMemoryKey(endpoint, deployment string) string {
+	return endpoint + "\x00" + deployment
+}
+
+// remember records that this deployment refused this field.
+func (m *azureCodexFieldMemory) remember(key, field string) {
+	if m == nil || key == "" || field == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := m.clock()
+	for existingKey, fields := range m.fields {
+		for existingField, expiry := range fields {
+			if !expiry.After(now) {
+				delete(fields, existingField)
+			}
+		}
+		if len(fields) == 0 {
+			delete(m.fields, existingKey)
+		}
+	}
+	if m.fields[key] == nil {
+		m.fields[key] = map[string]time.Time{}
+	}
+	m.fields[key][field] = now.Add(azureCodexFieldMemoryTTL)
+}
+
+// known lists the still-trusted rejections for a deployment.
+func (m *azureCodexFieldMemory) known(key string) []string {
+	if m == nil || key == "" {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	fields := m.fields[key]
+	if len(fields) == 0 {
+		return nil
+	}
+	now := m.clock()
+	known := make([]string, 0, len(fields))
+	for field, expiry := range fields {
+		if !expiry.After(now) {
+			delete(fields, field)
+			continue
+		}
+		known = append(known, field)
+	}
+	sort.Strings(known)
+	return known
 }

--- a/internal/proxy/azure_codex_test.go
+++ b/internal/proxy/azure_codex_test.go
@@ -749,3 +749,83 @@ func TestAzureCodexForceWithoutConfigurationExplainsItself(t *testing.T) {
 		t.Fatalf("error body = %q, want the missing configuration named", body)
 	}
 }
+
+// Rediscovering a rejection every turn means re-uploading the whole
+// conversation to learn what the last request already proved. The second
+// request must go out clean on the first attempt.
+func TestAzureCodexRemembersRejectedFields(t *testing.T) {
+	var bodies []string
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(body))
+		if strings.Contains(string(body), "all_turns") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, `{"error":{"code":"unsupported_value","param":"reasoning.context"}}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_azure"}`)
+	})
+	poolURL, err := url.Parse("https://chatgpt.com/backend-api/codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy := httptest.NewServer(azureCodexFallbackServer(t, azureURL, poolURL, 0).Handler())
+	defer proxy.Close()
+
+	send := func(session string) {
+		t.Helper()
+		response, err := http.Post(proxy.URL+"/responses", "application/json",
+			strings.NewReader(`{"model":"gpt-5.6-codex","session_id":"`+session+`","reasoning":{"effort":"high","context":"all_turns"},"input":[]}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		body, _ := io.ReadAll(response.Body)
+		_ = response.Body.Close()
+		if response.StatusCode != http.StatusOK || !strings.Contains(string(body), "resp_azure") {
+			t.Fatalf("status = %d, body = %s", response.StatusCode, body)
+		}
+	}
+
+	send("memory-1")
+	if len(bodies) != 2 {
+		t.Fatalf("first request attempts = %d, want the discovery retry", len(bodies))
+	}
+	send("memory-2")
+	if len(bodies) != 3 {
+		t.Fatalf("attempts after learning = %d, want one clean attempt", len(bodies))
+	}
+	if strings.Contains(bodies[2], "all_turns") {
+		t.Fatalf("the remembered field came back: %s", bodies[2])
+	}
+	if !strings.Contains(bodies[2], `"effort":"high"`) {
+		t.Fatalf("a sibling field was dropped with it: %s", bodies[2])
+	}
+}
+
+func TestAzureCodexFieldMemoryExpires(t *testing.T) {
+	now := time.Now()
+	memory := newAzureCodexFieldMemory()
+	memory.now = func() time.Time { return now }
+	key := azureCodexFieldMemoryKey("eastus2", "gpt-5.3-codex")
+	memory.remember(key, "reasoning.context")
+
+	if got := memory.known(key); len(got) != 1 || got[0] != "reasoning.context" {
+		t.Fatalf("known = %v", got)
+	}
+	if got := memory.known(azureCodexFieldMemoryKey("eastus2", "other-deployment")); len(got) != 0 {
+		t.Fatalf("a rejection leaked to another deployment: %v", got)
+	}
+	// An Azure model upgrade that accepts the field again must take effect
+	// without a restart.
+	now = now.Add(azureCodexFieldMemoryTTL + time.Minute)
+	if got := memory.known(key); len(got) != 0 {
+		t.Fatalf("known after expiry = %v", got)
+	}
+	var absent *azureCodexFieldMemory
+	absent.remember(key, "x")
+	if got := absent.known(key); got != nil {
+		t.Fatalf("a nil memory returned %v", got)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -114,6 +114,8 @@ type Server struct {
 	AzureCodex *AzureCodexConfig
 	// azureCodexSessions holds those pins.
 	azureCodexSessions *azureCodexSticky
+	// azureCodexRejects remembers request fields an Azure deployment refused.
+	azureCodexRejects *azureCodexFieldMemory
 	// FableBedrockPrimary, when true, routes Claude Fable requests to AWS Bedrock
 	// FIRST, before the subscription pool, instead of using Bedrock only as a
 	// fallback. It only takes effect when the Bedrock gateway is configured; a
@@ -1013,6 +1015,9 @@ func (s Server) Handler() http.Handler {
 	}
 	if s.azureCodexSessions == nil {
 		s.azureCodexSessions = newAzureCodexSticky()
+	}
+	if s.azureCodexRejects == nil {
+		s.azureCodexRejects = newAzureCodexFieldMemory()
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/internal/v1/session-leases", s.requireSessionLeaseAdmin(s.handleSessionLeases))


### PR DESCRIPTION
Live traffic on cmux-lawrence showed the self-healing retry firing on every single turn: Codex sends `reasoning.context="all_turns"`, gpt-5.3-codex refuses it, subrouter drops the field and retries. Correct, but it re-uploads the entire conversation to rediscover what the previous turn already proved, and a Codex conversation is megabytes by mid-session.

Rejections are now remembered per endpoint and deployment and stripped before the first attempt. The memory expires after six hours, so an Azure model version that starts accepting the field is picked up without a restart, and nothing is stripped forever by a hard-coded list.

Test asserts the first request takes two attempts and the second takes one, with the sibling field (`reasoning.effort`) intact. A second test covers expiry, per-deployment isolation, and a nil memory.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789623721&installation_model_id=21920&pr_number=218&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F218&signature=d2eeedc6fbf294865689d4ff303080c5361b7b43850a012d4e1a57e9aab17416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remembers Azure field rejections per endpoint and deployment and strips them before the first attempt. Previously we always sent the field (e.g., reasoning.context="all_turns"), received a 400, then retried; long Codex sessions re-uploaded megabytes every turn.

- Adds in-memory `azureCodexFieldMemory` (6h TTL) keyed by endpoint+deployment; `azureCodexRejects` applies known drops before sending and updates on 400s; logs include deployment.
- Initializes `azureCodexRejects` in `Server` by default; nil-safe and isolated per deployment; expiry picks up Azure model upgrades automatically.
- Tests cover: first request needs retry, second goes through in one; expiry; per-deployment isolation; sibling fields (e.g., `reasoning.effort`) preserved. README notes updated.

<sup>Written for commit c4911a0895bf57f7b2e2bebae7bd44d09a28a803. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

