### PR TITLE
Read sticky retention from the measured score, not the live-debited one

### DIFF
--- a/selectacct/scheduler.go
+++ b/selectacct/scheduler.go
@@ -172,8 +172,12 @@ func (s Scheduler) UsableForNewSession(provider account.Provider, accountID stri
 // UsableForStickySession reports whether an account still has enough headroom
 // to keep serving a session already assigned to it. Callers placing a fresh
 // session use UsableForNewSession instead.
+// Retention reads the measured score, not the live-debited one. The debit
+// floors headroom at 0.01, so on any busy account it sits below every
+// retention threshold and would evict the session the debit was only meant to
+// steer new picks away from.
 func (s Scheduler) UsableForStickySession(provider account.Provider, accountID string) bool {
-	return s.score(provider, accountID).usableForStickySession()
+	return s.measuredScore(provider, accountID).usableForStickySession()
 }
 
 func (s Scheduler) Exhausted(provider account.Provider, accountID string) bool {
@@ -217,13 +221,7 @@ func (s Scheduler) WithLiveDebits(debits map[string]int) Scheduler {
 }
 
 func (s Scheduler) score(provider account.Provider, accountID string) Score {
-	score, ok := s.scores[ScoreKey(provider, accountID)]
-	if !ok {
-		score = Score{AccountID: accountID, Provider: provider, Headroom: 1, ShortHeadroom: 1}
-	}
-	if s.sessionCounts != nil {
-		score.Sessions = s.sessionCounts[accountID]
-	}
+	score := s.measuredScore(provider, accountID)
 	if count := s.liveDebits[ScoreKey(provider, accountID)]; count > 0 {
 		// A soft, self-correcting signal: it reorders picks and can push an
 		// account below the new-session threshold, but never onto (or off of)
@@ -237,6 +235,21 @@ func (s Scheduler) score(provider account.Provider, accountID string) Score {
 		if score.ShortHeadroom > 0.01 {
 			score.ShortHeadroom = math.Max(0.01, score.ShortHeadroom-debit)
 		}
+	}
+	return score
+}
+
+// measuredScore is the score from the last usage refresh, with no live debit
+// applied. The debit is our own optimism about requests already in flight, not
+// evidence that an account is empty, so decisions that evict work rather than
+// merely reorder picks read this instead.
+func (s Scheduler) measuredScore(provider account.Provider, accountID string) Score {
+	score, ok := s.scores[ScoreKey(provider, accountID)]
+	if !ok {
+		score = Score{AccountID: accountID, Provider: provider, Headroom: 1, ShortHeadroom: 1}
+	}
+	if s.sessionCounts != nil {
+		score.Sessions = s.sessionCounts[accountID]
 	}
 	return score
 }

--- a/selectacct/sticky_retention_test.go
+++ b/selectacct/sticky_retention_test.go
@@ -1,0 +1,38 @@
+package selectacct
+
+import (
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/account"
+)
+
+// Live debits floor headroom at 0.01, well under every retention threshold.
+// They exist to reorder picks, so they must not evict a session from the
+// account holding its upstream prompt cache.
+func TestUsableForStickySessionIgnoresLiveDebits(t *testing.T) {
+	scheduler := NewScheduler([]Score{
+		{AccountID: "busy@example.com", Provider: account.ProviderCodex, Headroom: 0.13, ShortHeadroom: 0.13},
+	})
+	scheduler = scheduler.WithLiveDebits(map[string]int{
+		ScoreKey(account.ProviderCodex, "busy@example.com"): 20,
+	})
+	if scheduler.UsableForNewSession(account.ProviderCodex, "busy@example.com") {
+		t.Fatal("a debited account at 13% headroom should not take a new session")
+	}
+	if !scheduler.UsableForStickySession(account.ProviderCodex, "busy@example.com") {
+		t.Fatal("a session already on the account should stay while measured headroom is 13%")
+	}
+}
+
+func TestUsableForStickySessionFollowsMeasuredHeadroom(t *testing.T) {
+	scheduler := NewScheduler([]Score{
+		{AccountID: "empty@example.com", Provider: account.ProviderCodex, Headroom: 0.02, ShortHeadroom: 0.02},
+		{AccountID: "short@example.com", Provider: account.ProviderCodex, Headroom: 0.50, ShortHeadroom: 0.02},
+	})
+	if scheduler.UsableForStickySession(account.ProviderCodex, "empty@example.com") {
+		t.Fatal("2% measured headroom is below the retention threshold")
+	}
+	if scheduler.UsableForStickySession(account.ProviderCodex, "short@example.com") {
+		t.Fatal("a spent short window must end retention even when the weekly window is healthy")
+	}
+}


### PR DESCRIPTION
Follow-up to #216, found by watching the live log right after the v0.1.85 deploy.

`score()` applies a live debit of `LiveDebitPerRequest` (0.020) per routed request and floors the result at 0.01. On a busy account the floor is reached within a few requests, so the retention check in #216 saw 1% headroom on every account that was actually at 13-23%, and moved the session anyway:

```
rerouting cold sticky session from constrained account account=austin+36@manaflow.com \
  usable_for_new_session=false usable_for_sticky_session=false exhausted=false
```

austin+36 measured 87% used, so 13% headroom, well above the 5% retention threshold.

The live debit exists to spread concurrent traffic between usage refreshes. Reordering picks with our own optimism is fine; evicting a session from the account holding its upstream prompt cache is not, because the eviction re-bills the whole conversation prefix. Retention now reads `measuredScore`, the score from the last usage refresh with no debit applied. New-session placement, exhaustion, and pick ordering are unchanged.

Tests: `selectacct/sticky_retention_test.go`, added first as a failing commit. `go test ./...` green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789625149&installation_model_id=21920&pr_number=220&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F220&signature=d3d2c1d02034dd7f97393df1a37410ba038321bca719c57c7041250b355603c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sticky session retention now reads the measured score instead of the live-debited score to prevent evicting sessions from busy accounts. Previously retention saw 1% headroom due to the live debit floor and moved sessions off accounts with 13–23% measured headroom, causing unnecessary re-billing.

- `UsableForStickySession` calls `measuredScore`; `score()` delegates to `measuredScore` and then applies live debits only for pick ordering and new-session placement.
- Live debits still floor headroom at 0.01 and reorder picks; they no longer influence retention or evict sessions.
- Added `selectacct/sticky_retention_test.go` covering both ignoring live debits for retention and following measured headroom.
- Changes confined to `selectacct/scheduler.go`; no config or rollout actions required.

<sup>Written for commit 286fd022d46ff2b350517d33d22cfc0f698495e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

