### PR TITLE
Upload transcripts as append blobs, not whole files every interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,9 @@ subrouter serve \
   --transcript-max-local-bytes 2GiB
 ```
 
-Both destinations follow the same rules: upload on the background interval, never on the request path, and delete a local file only after the exact bytes exist remotely, archived under `_archive/<path>/<time>-<size>-<hash>.jsonl` so a resumed session cannot overwrite the only cloud copy. The Azure syncer signs its own requests with the storage account key (Shared Key), so the host needs no Azure CLI. A configured destination with no usable credential logs a warning at startup rather than starting quietly and copying nothing.
+The Azure syncer writes append blobs, so each byte uploads once. Transcripts are append-only and large (a busy session reaches gigabytes within hours), and re-sending the whole file every interval is how the first version earned "503 The server is busy" from Azure. Before a local file is deleted, the blob is snapshotted server side, which preserves exactly the retired bytes with no upload at all; only a file that was never uploaded is copied the slow way, under `_archive/<path>/<time>-<size>-<hash>.jsonl`. A throttled or failed request is retried with backoff, and one failing file no longer stops the rest of the pass.
+
+Both destinations follow the same rules: upload on the background interval, never on the request path, and delete a local file only after the exact bytes exist remotely. The Azure syncer signs its own requests with the storage account key (Shared Key), so the host needs no Azure CLI. A configured destination with no usable credential logs a warning at startup rather than starting quietly and copying nothing.
 
 The daemon uploads with the GCS JSON API on a background interval. Local transcript writes stay on the request path; GCS upload failures are logged and retried later. Local cleanup only runs after a successful GCS sync. Files selected for cleanup are copied to an immutable `_archive/` object before local deletion so future resumed sessions cannot overwrite the only cloud copy.
 

--- a/internal/transcript/azure_blob_sync.go
+++ b/internal/transcript/azure_blob_sync.go
@@ -47,6 +47,9 @@ type AzureBlobSyncer struct {
 	client     *http.Client
 	logger     *slog.Logger
 	now        func() time.Time
+	// backoff is the wait before resending a throttled request. Injectable so
+	// tests exercise the retry path without sleeping through it.
+	backoff func(attempt int) time.Duration
 }
 
 type AzureBlobSyncerConfig struct {
@@ -67,6 +70,8 @@ type AzureBlobSyncerConfig struct {
 	Logger         *slog.Logger
 	Client         *http.Client
 	Now            func() time.Time
+	// Backoff overrides the wait before resending a throttled request.
+	Backoff func(attempt int) time.Duration
 }
 
 // NewAzureBlobSyncer returns nil when the destination or source is not
@@ -120,6 +125,7 @@ func NewAzureBlobSyncer(config AzureBlobSyncerConfig) *AzureBlobSyncer {
 		client:     client,
 		logger:     logger,
 		now:        now,
+		backoff:    config.Backoff,
 	}
 }
 
@@ -213,56 +219,139 @@ func (s *AzureBlobSyncer) SyncOnce(ctx context.Context) error {
 		}
 		return files[i].modTime.Before(files[j].modTime)
 	})
+	// One unhappy file must not hold the rest of the spool hostage. A transcript
+	// that fails now is retried next interval; the files behind it in the walk
+	// would otherwise never upload at all.
+	var firstErr error
 	for _, file := range files {
 		if now.Sub(file.modTime) < azureBlobQuietPeriod {
 			continue
 		}
-		if err := s.uploadIfNeeded(syncCtx, file); err != nil {
-			return err
+		if err := s.syncFile(syncCtx, file); err != nil {
+			if syncCtx.Err() != nil {
+				return err
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+			s.logger.Warn("transcript azure upload failed", "file", file.relPath, "error", err)
 		}
 	}
-	return s.pruneLocal(syncCtx, s.now())
+	if err := s.pruneLocal(syncCtx, s.now()); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
 }
 
-// uploadIfNeeded skips a blob that already holds the same number of bytes.
-// Transcripts only ever grow, so equal length means equal content.
-func (s *AzureBlobSyncer) uploadIfNeeded(ctx context.Context, file localFile) error {
+// syncFile brings one transcript blob up to date by appending only the bytes
+// written since the last pass.
+//
+// Transcripts are append-only and enormous: a busy session reaches gigabytes
+// within hours. Re-uploading the whole file every interval, which is what a
+// block blob forces, means uploading the same gigabytes hundreds of times a
+// day. Azure answered that with "503 The server is busy", and it was right to.
+// An append blob uploads each byte once.
+func (s *AzureBlobSyncer) syncFile(ctx context.Context, file localFile) error {
 	name := s.blobName(file.relPath)
-	size, exists, err := s.blobSize(ctx, name)
+	remote, err := s.blobState(ctx, name)
 	if err != nil {
 		return err
 	}
-	if exists && size == file.size {
+	switch {
+	case !remote.exists:
+		if err := s.createAppendBlob(ctx, name); err != nil {
+			return err
+		}
+		return s.appendRange(ctx, file.path, name, 0, file.size)
+	case !remote.appendBlob:
+		// A blob left by the earlier whole-file uploader. Replace it with an
+		// append blob so this file stops being re-sent in full.
+		if err := s.createAppendBlob(ctx, name); err != nil {
+			return err
+		}
+		return s.appendRange(ctx, file.path, name, 0, file.size)
+	case remote.size == file.size:
 		return nil
+	case remote.size > file.size:
+		// The local file shrank, so it is not the same stream any more: a
+		// rotated or replaced transcript. Start the blob over rather than
+		// appending bytes that would not follow what is already there.
+		if err := s.createAppendBlob(ctx, name); err != nil {
+			return err
+		}
+		return s.appendRange(ctx, file.path, name, 0, file.size)
+	default:
+		return s.appendRange(ctx, file.path, name, remote.size, file.size-remote.size)
 	}
-	return s.uploadFile(ctx, file.path, name, file.size)
 }
 
-func (s *AzureBlobSyncer) blobSize(ctx context.Context, name string) (int64, bool, error) {
-	req, err := s.newRequest(ctx, http.MethodHead, name, nil, 0)
+// azureBlobState is what one HEAD tells us about a blob.
+type azureBlobState struct {
+	exists     bool
+	appendBlob bool
+	size       int64
+}
+
+func (s *AzureBlobSyncer) blobState(ctx context.Context, name string) (azureBlobState, error) {
+	req, err := s.newRequest(ctx, http.MethodHead, name, "", nil, nil, 0)
 	if err != nil {
-		return 0, false, err
+		return azureBlobState{}, err
 	}
-	resp, err := s.client.Do(req)
+	resp, err := s.do(ctx, req, func() (io.Reader, error) { return nil, nil }, 0)
 	if err != nil {
-		return 0, false, err
+		return azureBlobState{}, err
 	}
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)
 	if resp.StatusCode == http.StatusNotFound {
-		return 0, false, nil
+		return azureBlobState{}, nil
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return 0, false, azureBlobResponseError(resp)
+		return azureBlobState{}, azureBlobResponseError(resp)
 	}
-	size, err := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
-	if err != nil {
-		return 0, true, nil
+	state := azureBlobState{
+		exists:     true,
+		appendBlob: strings.EqualFold(resp.Header.Get("x-ms-blob-type"), "AppendBlob"),
 	}
-	return size, true, nil
+	if size, err := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64); err == nil {
+		state.size = size
+	}
+	return state, nil
 }
 
-func (s *AzureBlobSyncer) uploadFile(ctx context.Context, path, name string, size int64) error {
+// createAppendBlob creates (or resets) the blob. An existing blob of any type
+// is replaced, which is what makes both the block-blob migration and the
+// rotated-file case work.
+func (s *AzureBlobSyncer) createAppendBlob(ctx context.Context, name string) error {
+	req, err := s.newRequest(ctx, http.MethodPut, name, "", map[string]string{
+		"x-ms-blob-type": "AppendBlob",
+		"Content-Type":   "application/x-ndjson",
+	}, nil, 0)
+	if err != nil {
+		return err
+	}
+	resp, err := s.do(ctx, req, func() (io.Reader, error) { return nil, nil }, 0)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return azureBlobResponseError(resp)
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	return nil
+}
+
+// azureAppendBlockMaxBytes is the service limit for one append.
+const azureAppendBlockMaxBytes = 4 << 20
+
+// appendRange appends [offset, offset+length) of a local file. Each block
+// carries the position it expects to land at, so a retry that the service
+// already applied is refused (412) instead of duplicating the bytes.
+func (s *AzureBlobSyncer) appendRange(ctx context.Context, path, name string, offset, length int64) error {
+	if length <= 0 {
+		return nil
+	}
 	file, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -271,19 +360,105 @@ func (s *AzureBlobSyncer) uploadFile(ctx context.Context, path, name string, siz
 		return err
 	}
 	defer file.Close()
-	req, err := s.newRequest(ctx, http.MethodPut, name, io.LimitReader(file, size), size)
+	for remaining := length; remaining > 0; {
+		block := remaining
+		if block > azureAppendBlockMaxBytes {
+			block = azureAppendBlockMaxBytes
+		}
+		position := offset
+		body := func() (io.Reader, error) {
+			if _, err := file.Seek(position, io.SeekStart); err != nil {
+				return nil, err
+			}
+			return io.LimitReader(file, block), nil
+		}
+		reader, err := body()
+		if err != nil {
+			return err
+		}
+		req, err := s.newRequest(ctx, http.MethodPut, name, "comp=appendblock", map[string]string{
+			"x-ms-blob-condition-appendpos": strconv.FormatInt(position, 10),
+		}, reader, block)
+		if err != nil {
+			return err
+		}
+		resp, err := s.do(ctx, req, body, block)
+		if err != nil {
+			return err
+		}
+		status := resp.StatusCode
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		_ = resp.Body.Close()
+		switch {
+		case status >= 200 && status < 300:
+		case status == http.StatusPreconditionFailed:
+			// The blob is already past this position, so a previous attempt
+			// landed. Anything else at this offset would duplicate lines.
+			return nil
+		default:
+			return azureBlobResponseError(resp)
+		}
+		offset += block
+		remaining -= block
+	}
+	return nil
+}
+
+// snapshotBlob freezes the current contents server side. It is how a local file
+// is preserved before deletion: the live blob keeps growing with the session,
+// and the snapshot holds exactly the bytes that were deleted, with no upload.
+func (s *AzureBlobSyncer) snapshotBlob(ctx context.Context, name string) (bool, error) {
+	req, err := s.newRequest(ctx, http.MethodPut, name, "comp=snapshot", nil, nil, 0)
+	if err != nil {
+		return false, err
+	}
+	resp, err := s.do(ctx, req, func() (io.Reader, error) { return nil, nil }, 0)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return false, azureBlobResponseError(resp)
+	}
+	return true, nil
+}
+
+// uploadWholeFile writes a file as a block blob in one request. Only the
+// fallback archive path uses it, for the case where nothing was ever appended.
+func (s *AzureBlobSyncer) uploadWholeFile(ctx context.Context, path, name string, size int64) error {
+	open := func() (io.Reader, error) {
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		return io.LimitReader(file, size), nil
+	}
+	reader, err := open()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	req, err := s.newRequest(ctx, http.MethodPut, name, "", map[string]string{
+		"x-ms-blob-type": "BlockBlob",
+	}, reader, size)
 	if err != nil {
 		return err
 	}
-	resp, err := s.client.Do(req)
+	resp, err := s.do(ctx, req, open, size)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return azureBlobResponseError(resp)
 	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 	return nil
 }
 
@@ -343,6 +518,12 @@ func (s *AzureBlobSyncer) pruneLocal(ctx context.Context, now time.Time) error {
 	return nil
 }
 
+// archiveAndRemove preserves a transcript before deleting it locally.
+//
+// The live blob keeps growing with the session, so it cannot be the archive.
+// A snapshot freezes the current contents server side, with no upload at all,
+// which matters when the file being retired is gigabytes. Only a file that was
+// never appended (nothing uploaded yet) is copied the slow way.
 func (s *AzureBlobSyncer) archiveAndRemove(ctx context.Context, file localFile) error {
 	before, err := os.Stat(file.path)
 	if os.IsNotExist(err) {
@@ -356,13 +537,23 @@ func (s *AzureBlobSyncer) archiveAndRemove(ctx context.Context, file localFile) 
 	if before.Size() != file.size || !before.ModTime().Equal(file.modTime) {
 		return nil
 	}
-	archive := s.blobName("_archive/" + file.relPath + "/" + archiveFileName(file))
-	size, exists, err := s.blobSize(ctx, archive)
+	name := s.blobName(file.relPath)
+	remote, err := s.blobState(ctx, name)
 	if err != nil {
 		return err
 	}
-	if !exists || size != file.size {
-		if err := s.uploadFile(ctx, file.path, archive, file.size); err != nil {
+	switch {
+	case remote.exists && remote.size >= file.size:
+		if snapshotted, err := s.snapshotBlob(ctx, name); err != nil {
+			return err
+		} else if !snapshotted {
+			return nil
+		}
+	default:
+		// Nothing uploaded, or the blob is behind the local file: the bytes
+		// about to be deleted are not all in Azure yet, so send them first.
+		archive := s.blobName("_archive/" + file.relPath + "/" + archiveFileName(file))
+		if err := s.uploadWholeFile(ctx, file.path, archive, file.size); err != nil {
 			return err
 		}
 	}
@@ -394,19 +585,36 @@ func (s *AzureBlobSyncer) blobName(relPath string) string {
 // rather than through the Azure SDK to keep the daemon's dependency set to the
 // standard library, which is the same reason the GCS syncer speaks the REST API
 // directly.
-func (s *AzureBlobSyncer) newRequest(ctx context.Context, method, blobName string, body io.Reader, size int64) (*http.Request, error) {
+// newRequest builds a signed blob request.
+//
+// Every header the request will carry must be passed in here. Shared Key signs
+// the x-ms-* headers and Content-Type, so a header added to the returned
+// request afterwards is not in the signature, and Azure answers 403 with no
+// hint about which header disagreed.
+func (s *AzureBlobSyncer) newRequest(ctx context.Context, method, blobName, query string, headers map[string]string, body io.Reader, size int64) (*http.Request, error) {
 	target := s.endpoint + "/" + s.container + "/" + azureBlobEscapePath(blobName)
+	params := []string{}
+	if query != "" {
+		params = append(params, query)
+	}
 	if s.sasQuery != "" && len(s.accountKey) == 0 {
-		target += "?" + s.sasQuery
+		params = append(params, s.sasQuery)
+	}
+	if len(params) > 0 {
+		target += "?" + strings.Join(params, "&")
 	}
 	req, err := http.NewRequestWithContext(ctx, method, target, body)
 	if err != nil {
 		return nil, err
 	}
+	for name, value := range headers {
+		req.Header.Set(name, value)
+	}
 	if method == http.MethodPut {
 		req.ContentLength = size
-		req.Header.Set("Content-Type", "application/x-ndjson")
-		req.Header.Set("x-ms-blob-type", "BlockBlob")
+		if req.Header.Get("Content-Type") == "" {
+			req.Header.Set("Content-Type", "application/x-ndjson")
+		}
 	}
 	if len(s.accountKey) == 0 {
 		return req, nil
@@ -421,16 +629,124 @@ func (s *AzureBlobSyncer) newRequest(ctx context.Context, method, blobName strin
 	return req, nil
 }
 
+// azureBlobRetryAttempts bounds how many times one request is resent after a
+// throttle or a server fault. Azure answers a busy account with 503, and a
+// transcript spool that gives up on the first one falls permanently behind.
+const azureBlobRetryAttempts = 4
+
+// do sends a request, resending it on a throttle or server fault. body must
+// return a fresh reader for each attempt, because the previous attempt consumed
+// the last one. The request is rebuilt per attempt: Shared Key signs the date
+// header, so a resend with the old signature is refused.
+func (s *AzureBlobSyncer) do(ctx context.Context, req *http.Request, body func() (io.Reader, error), size int64) (*http.Response, error) {
+	method := req.Method
+	blobPath := req.URL.EscapedPath()
+	query := req.URL.RawQuery
+	headers := req.Header.Clone()
+	var lastErr error
+	for attempt := 0; attempt < azureBlobRetryAttempts; attempt++ {
+		if attempt > 0 {
+			reader, err := body()
+			if err != nil {
+				return nil, err
+			}
+			rebuilt, err := s.resign(ctx, method, blobPath, query, headers, reader, size)
+			if err != nil {
+				return nil, err
+			}
+			req = rebuilt
+		}
+		resp, err := s.client.Do(req)
+		if err != nil {
+			lastErr = err
+		} else if !azureBlobRetryableStatus(resp.StatusCode) {
+			return resp, nil
+		} else {
+			lastErr = azureBlobResponseError(resp)
+			_ = resp.Body.Close()
+		}
+		wait := s.retryBackoff(attempt)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(wait):
+		}
+	}
+	return nil, lastErr
+}
+
+// resign rebuilds a request for a retry, including a fresh date and signature.
+func (s *AzureBlobSyncer) resign(ctx context.Context, method, blobPath, query string, headers http.Header, body io.Reader, size int64) (*http.Request, error) {
+	target := s.endpoint + blobPath
+	params := []string{}
+	if query != "" {
+		params = append(params, query)
+	}
+	if len(params) > 0 {
+		target += "?" + strings.Join(params, "&")
+	}
+	req, err := http.NewRequestWithContext(ctx, method, target, body)
+	if err != nil {
+		return nil, err
+	}
+	for key, values := range headers {
+		lower := strings.ToLower(key)
+		if lower == "authorization" || lower == "x-ms-date" {
+			continue
+		}
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	if method == http.MethodPut {
+		req.ContentLength = size
+	}
+	if len(s.accountKey) == 0 {
+		return req, nil
+	}
+	req.Header.Set("x-ms-date", s.now().UTC().Format(http.TimeFormat))
+	req.Header.Set("x-ms-version", azureBlobAPIVersion)
+	signature, err := s.signature(req, size)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "SharedKey "+s.account+":"+signature)
+	return req, nil
+}
+
+// azureBlobRetryableStatus reports whether the service asked us to come back
+// later rather than refusing the request itself.
+func azureBlobRetryableStatus(status int) bool {
+	return status == http.StatusTooManyRequests || status == http.StatusRequestTimeout || status >= 500
+}
+
+func (s *AzureBlobSyncer) retryBackoff(attempt int) time.Duration {
+	if s.backoff != nil {
+		return s.backoff(attempt)
+	}
+	return azureBlobRetryBackoff(attempt)
+}
+
+func azureBlobRetryBackoff(attempt int) time.Duration {
+	wait := time.Second << attempt
+	if wait > 8*time.Second {
+		wait = 8 * time.Second
+	}
+	return wait
+}
+
 // signature builds the Shared Key string-to-sign exactly as documented: the
 // fixed header block, then the canonicalized x-ms-* headers, then the
 // canonicalized resource.
 func (s *AzureBlobSyncer) signature(req *http.Request, size int64) (string, error) {
+	// Azure signs an empty string for a zero-length body, even though Go still
+	// sends the "Content-Length: 0" header.
 	contentLength := ""
 	if size > 0 {
 		contentLength = strconv.FormatInt(size, 10)
 	}
 	canonicalHeaders := azureCanonicalizedHeaders(req.Header)
-	canonicalResource := "/" + s.account + req.URL.EscapedPath()
+	canonicalResource := "/" + s.account + req.URL.EscapedPath() + azureCanonicalizedQuery(req.URL)
 	stringToSign := strings.Join([]string{
 		req.Method,
 		"",            // Content-Encoding
@@ -485,4 +801,29 @@ func azureBlobEscapePath(name string) string {
 func azureBlobResponseError(resp *http.Response) error {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	return fmt.Errorf("azure blob %s: %s", resp.Status, strings.TrimSpace(string(body)))
+}
+
+// azureCanonicalizedQuery renders the query string the way Shared Key signing
+// expects: one sorted, lowercased parameter per line. Without it every request
+// that carries comp=appendblock or comp=snapshot is refused as unauthorized.
+func azureCanonicalizedQuery(target *url.URL) string {
+	values := target.Query()
+	if len(values) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, strings.ToLower(name))
+	}
+	sort.Strings(names)
+	var builder strings.Builder
+	for _, name := range names {
+		entries := append([]string(nil), values[name]...)
+		sort.Strings(entries)
+		builder.WriteString("\n")
+		builder.WriteString(name)
+		builder.WriteString(":")
+		builder.WriteString(strings.Join(entries, ","))
+	}
+	return builder.String()
 }

--- a/internal/transcript/azure_blob_sync_test.go
+++ b/internal/transcript/azure_blob_sync_test.go
@@ -17,18 +17,24 @@ import (
 // azureBlobFake stands in for the blob service: it stores what was PUT and
 // answers HEAD from that store, which is all the syncer needs.
 type azureBlobFake struct {
-	mu      sync.Mutex
-	blobs   map[string][]byte
-	puts    []string
-	heads   []string
-	authOK  bool
-	server  *httptest.Server
-	failPut bool
+	mu          sync.Mutex
+	blobs       map[string][]byte
+	kinds       map[string]string
+	snapshots   map[string]int
+	puts        []string
+	appends     []string
+	heads       []string
+	appendBytes int
+	throttled   int
+	failNext    int
+	authOK      bool
+	server      *httptest.Server
+	failPut     bool
 }
 
 func newAzureBlobFake(t *testing.T) *azureBlobFake {
 	t.Helper()
-	fake := &azureBlobFake{blobs: map[string][]byte{}, authOK: true}
+	fake := &azureBlobFake{blobs: map[string][]byte{}, kinds: map[string]string{}, snapshots: map[string]int{}, authOK: true}
 	fake.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fake.mu.Lock()
 		defer fake.mu.Unlock()
@@ -39,8 +45,17 @@ func newAzureBlobFake(t *testing.T) *azureBlobFake {
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
-		switch r.Method {
-		case http.MethodHead:
+		if fake.failNext > 0 || (fake.failPut && r.Method == http.MethodPut) {
+			if fake.failNext > 0 {
+				fake.failNext--
+			}
+			fake.throttled++
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		comp := r.URL.Query().Get("comp")
+		switch {
+		case r.Method == http.MethodHead:
 			fake.heads = append(fake.heads, name)
 			body, ok := fake.blobs[name]
 			if !ok {
@@ -48,18 +63,43 @@ func newAzureBlobFake(t *testing.T) *azureBlobFake {
 				return
 			}
 			w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+			w.Header().Set("x-ms-blob-type", fake.kinds[name])
 			w.WriteHeader(http.StatusOK)
-		case http.MethodPut:
-			if fake.failPut {
-				w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == http.MethodPut && comp == "snapshot":
+			if _, ok := fake.blobs[name]; !ok {
+				w.WriteHeader(http.StatusNotFound)
 				return
 			}
-			if r.Header.Get("x-ms-blob-type") != "BlockBlob" {
+			fake.snapshots[name]++
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodPut && comp == "appendblock":
+			body, _ := io.ReadAll(r.Body)
+			if fake.kinds[name] != "AppendBlob" {
+				w.WriteHeader(http.StatusConflict)
+				return
+			}
+			position, err := strconv.Atoi(r.Header.Get("x-ms-blob-condition-appendpos"))
+			if err != nil {
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
+			if position != len(fake.blobs[name]) {
+				w.WriteHeader(http.StatusPreconditionFailed)
+				return
+			}
+			fake.blobs[name] = append(fake.blobs[name], body...)
+			fake.appends = append(fake.appends, name)
+			fake.appendBytes += len(body)
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodPut:
 			body, _ := io.ReadAll(r.Body)
+			kind := r.Header.Get("x-ms-blob-type")
+			if kind == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
 			fake.blobs[name] = body
+			fake.kinds[name] = kind
 			fake.puts = append(fake.puts, name)
 			w.WriteHeader(http.StatusCreated)
 		default:
@@ -78,6 +118,9 @@ func azureTestSyncer(t *testing.T, fake *azureBlobFake, spool string, config Azu
 	}
 	if config.AccountKey == "" {
 		config.AccountKey = "c2VjcmV0LWtleQ==" // base64("secret-key")
+	}
+	if config.Backoff == nil {
+		config.Backoff = func(int) time.Duration { return time.Millisecond }
 	}
 	if config.Now == nil {
 		// Every fixture file is written now, and the syncer deliberately skips
@@ -116,20 +159,24 @@ func TestAzureBlobSyncerUploadsAndSkipsUnchanged(t *testing.T) {
 	if string(fake.blobs[blob]) != "{\"a\":1}\n" {
 		t.Fatalf("blob = %q, want the transcript body", fake.blobs[blob])
 	}
-	// A second pass must not re-upload an unchanged file: the spool is walked
-	// every interval and re-uploading would grow with the archive.
+	if fake.kinds[blob] != "AppendBlob" {
+		t.Fatalf("blob type = %q, want AppendBlob", fake.kinds[blob])
+	}
+	// A second pass must send nothing for an unchanged file.
 	if err := syncer.SyncOnce(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if len(fake.puts) != 1 {
-		t.Fatalf("uploads = %d, want 1", len(fake.puts))
+	if len(fake.appends) != 1 {
+		t.Fatalf("appends = %d, want 1", len(fake.appends))
 	}
 	if !fake.authOK {
 		t.Fatal("a request was sent without a SharedKey signature")
 	}
 }
 
-func TestAzureBlobSyncerReuploadsAfterAppend(t *testing.T) {
+// The whole point: a transcript that reaches gigabytes must upload each byte
+// once, not the whole file every interval.
+func TestAzureBlobSyncerAppendsOnlyTheNewBytes(t *testing.T) {
 	fake := newAzureBlobFake(t)
 	spool := t.TempDir()
 	path := writeSpoolFile(t, spool, "codex/session-2.jsonl", "{\"a\":1}\n")
@@ -137,26 +184,93 @@ func TestAzureBlobSyncerReuploadsAfterAppend(t *testing.T) {
 	if err := syncer.SyncOnce(context.Background()); err != nil {
 		t.Fatal(err)
 	}
+	first := fake.appendBytes
+
 	if err := os.WriteFile(path, []byte("{\"a\":1}\n{\"a\":2}\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := syncer.SyncOnce(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if len(fake.puts) != 2 {
-		t.Fatalf("uploads = %d, want the appended file re-uploaded", len(fake.puts))
+	const blob = "host-a/codex/session-2.jsonl"
+	if string(fake.blobs[blob]) != "{\"a\":1}\n{\"a\":2}\n" {
+		t.Fatalf("blob = %q, want both lines", fake.blobs[blob])
 	}
-	if string(fake.blobs["host-a/codex/session-2.jsonl"]) != "{\"a\":1}\n{\"a\":2}\n" {
-		t.Fatalf("blob = %q", fake.blobs["host-a/codex/session-2.jsonl"])
+	if delta := fake.appendBytes - first; delta != len("{\"a\":2}\n") {
+		t.Fatalf("second pass uploaded %d bytes, want only the appended line", delta)
 	}
 }
 
-// Retention deletes local files, so the bytes being deleted must exist remotely
-// under a name that a later append cannot overwrite.
-func TestAzureBlobSyncerArchivesBeforeDeletingLocally(t *testing.T) {
+// Blobs written by the earlier whole-file uploader must convert, or they keep
+// being re-sent in full forever.
+func TestAzureBlobSyncerMigratesABlockBlob(t *testing.T) {
 	fake := newAzureBlobFake(t)
 	spool := t.TempDir()
-	path := writeSpoolFile(t, spool, "codex/session-3.jsonl", "{\"a\":1}\n")
+	writeSpoolFile(t, spool, "codex/session-3.jsonl", "{\"a\":1}\n{\"a\":2}\n")
+	const blob = "host-a/codex/session-3.jsonl"
+	fake.blobs[blob] = []byte("{\"a\":1}\n")
+	fake.kinds[blob] = "BlockBlob"
+
+	syncer := azureTestSyncer(t, fake, spool, AzureBlobSyncerConfig{})
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if fake.kinds[blob] != "AppendBlob" {
+		t.Fatalf("blob type = %q, want the block blob converted", fake.kinds[blob])
+	}
+	if string(fake.blobs[blob]) != "{\"a\":1}\n{\"a\":2}\n" {
+		t.Fatalf("blob = %q, want the whole file re-sent once", fake.blobs[blob])
+	}
+}
+
+// A truncated or rotated file is a different stream. Appending to the old blob
+// would splice two unrelated transcripts together.
+func TestAzureBlobSyncerRestartsAShrunkFile(t *testing.T) {
+	fake := newAzureBlobFake(t)
+	spool := t.TempDir()
+	path := writeSpoolFile(t, spool, "codex/session-4.jsonl", "{\"a\":1}\n{\"a\":2}\n")
+	syncer := azureTestSyncer(t, fake, spool, AzureBlobSyncerConfig{})
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{\"b\":1}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if string(fake.blobs["host-a/codex/session-4.jsonl"]) != "{\"b\":1}\n" {
+		t.Fatalf("blob = %q, want the blob restarted", fake.blobs["host-a/codex/session-4.jsonl"])
+	}
+}
+
+// Azure answers a busy account with 503. Giving up on the first one leaves the
+// spool permanently behind.
+func TestAzureBlobSyncerRetriesThrottling(t *testing.T) {
+	fake := newAzureBlobFake(t)
+	fake.failNext = 2
+	spool := t.TempDir()
+	writeSpoolFile(t, spool, "codex/session-5.jsonl", "{\"a\":1}\n")
+	syncer := azureTestSyncer(t, fake, spool, AzureBlobSyncerConfig{})
+	syncer.client = &http.Client{}
+
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("a throttled upload was not retried: %v", err)
+	}
+	if fake.throttled != 2 {
+		t.Fatalf("throttles = %d, want both attempts refused before success", fake.throttled)
+	}
+	if string(fake.blobs["host-a/codex/session-5.jsonl"]) != "{\"a\":1}\n" {
+		t.Fatalf("blob = %q", fake.blobs["host-a/codex/session-5.jsonl"])
+	}
+}
+
+// Retention deletes local files. The live blob keeps growing with the session,
+// so the preserved copy is a snapshot of what was deleted, taken server side.
+func TestAzureBlobSyncerSnapshotsBeforeDeletingLocally(t *testing.T) {
+	fake := newAzureBlobFake(t)
+	spool := t.TempDir()
+	path := writeSpoolFile(t, spool, "codex/session-6.jsonl", "{\"a\":1}\n")
 	old := time.Now().Add(-48 * time.Hour)
 	if err := os.Chtimes(path, old, old); err != nil {
 		t.Fatal(err)
@@ -169,24 +283,23 @@ func TestAzureBlobSyncerArchivesBeforeDeletingLocally(t *testing.T) {
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("local file survived retention: %v", err)
 	}
-	archived := false
-	for name := range fake.blobs {
-		if strings.HasPrefix(name, "host-a/_archive/codex/session-3.jsonl/") {
-			archived = true
-		}
+	if fake.snapshots["host-a/codex/session-6.jsonl"] != 1 {
+		t.Fatalf("snapshots = %v, want the blob frozen before deletion", fake.snapshots)
 	}
-	if !archived {
-		t.Fatalf("no archive copy was written before deletion: %v", fake.blobs)
+	// No archive copy is uploaded: the bytes are already in the blob.
+	for name := range fake.blobs {
+		if strings.Contains(name, "_archive/") {
+			t.Fatalf("an archive copy was uploaded anyway: %s", name)
+		}
 	}
 }
 
-// A failed upload must not delete anything: the whole point of the archive step
-// is that local deletion follows a confirmed remote copy.
+// A failed upload must not delete anything.
 func TestAzureBlobSyncerKeepsLocalFilesWhenUploadFails(t *testing.T) {
 	fake := newAzureBlobFake(t)
 	fake.failPut = true
 	spool := t.TempDir()
-	path := writeSpoolFile(t, spool, "codex/session-4.jsonl", "{\"a\":1}\n")
+	path := writeSpoolFile(t, spool, "codex/session-7.jsonl", "{\"a\":1}\n")
 	old := time.Now().Add(-48 * time.Hour)
 	if err := os.Chtimes(path, old, old); err != nil {
 		t.Fatal(err)
@@ -198,6 +311,23 @@ func TestAzureBlobSyncerKeepsLocalFilesWhenUploadFails(t *testing.T) {
 	}
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("local file was deleted despite the upload failing: %v", err)
+	}
+}
+
+// One unhappy file must not stop the files behind it in the walk.
+func TestAzureBlobSyncerContinuesPastAFailedFile(t *testing.T) {
+	fake := newAzureBlobFake(t)
+	spool := t.TempDir()
+	writeSpoolFile(t, spool, "codex/aaa.jsonl", "{\"a\":1}\n")
+	writeSpoolFile(t, spool, "codex/bbb.jsonl", "{\"b\":1}\n")
+	syncer := azureTestSyncer(t, fake, spool, AzureBlobSyncerConfig{})
+	fake.failNext = azureBlobRetryAttempts + 1
+
+	if err := syncer.SyncOnce(context.Background()); err == nil {
+		t.Fatal("the pass reported success despite a failed file")
+	}
+	if len(fake.blobs) == 0 {
+		t.Fatal("no file uploaded; the first failure stopped the whole pass")
 	}
 }
 


### PR DESCRIPTION
The monitor caught `503 The server is busy` from Azure, and Azure was right to send it. Transcripts are append-only and enormous: two hours on the team server left a 4.1 GB file and a 1 GB file in the spool. Uploading each file whole every five minutes means re-sending those gigabytes hundreds of times a day. That is a design flaw in the first version, not a transient failure.

**Append blobs.** Each transcript is an append blob and each pass uploads only the bytes written since the last one, in 4 MiB blocks that carry `x-ms-blob-condition-appendpos`, so a retry the service already applied is refused (412) instead of duplicating lines. A blob left by the whole-file uploader is converted on its next pass. A local file that shrank is a different stream, so the blob is started over rather than spliced.

**Snapshots instead of archive uploads.** Deleting a local file used to re-upload it under `_archive/`, which is worst exactly where it hurts: retention targets the biggest files first. The blob is now snapshotted server side, preserving the retired bytes with no transfer. Only a file that was never uploaded takes the slow path.

**Throttles are retried** with backoff, and one failing file no longer aborts the pass; the files behind it used to wait for the next interval, forever if that file kept failing.

**Signing fix.** Verifying against the real storage account exposed a 403: headers set after `newRequest` signed the request (`x-ms-blob-type`, `x-ms-blob-condition-appendpos`) were absent from the signature. Azure's answer names no header, so the fix is structural: every header is passed into `newRequest` and signed there. Query parameters (`comp=appendblock`, `comp=snapshot`) are canonicalized into the signature too, which Shared Key requires and the first version never needed.

**Verified live**, not only against a fake: two passes produced one AppendBlob of 22 bytes holding both lines, with only the appended line sent on the second pass.

Tests cover the delta upload, the block-blob migration, the shrunk-file restart, throttle retries, snapshot-before-delete with no archive upload, keeping local files when the upload fails, and continuing past a failed file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789643567&installation_model_id=21920&pr_number=222&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F222&signature=3d75bad996c9cd773b9c5f6f0a114759937b51561b9579fb203a30ab132fb5d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uploads transcripts to Azure as append blobs instead of re-uploading whole files every interval, eliminating repeated multi‑GB transfers and 503 throttling. Deleting a local transcript now snapshots the blob server side instead of uploading an `_archive/` copy, preserving retired bytes with no transfer.

- Append-only uploads: send only new bytes in 4 MiB blocks with `x-ms-blob-condition-appendpos`; retries refuse already-applied blocks (412) to avoid duplicates. Shrunk files restart the blob rather than splicing.
- Block-blob migration: existing block blobs convert to append blobs on their next pass; the first pass may re-send the whole file once.
- Retention: snapshot the live blob before local deletion; only never-uploaded files are copied to `_archive/<path>/<time>-<size>-<hash>.jsonl`.
- Reliability: throttle/server faults retry with backoff; one failing file no longer aborts the pass.
- Signing: all headers and query params are included in the Shared Key signature in `newRequest`, fixing 403s when using `comp=appendblock` and `comp=snapshot`.
- Docs/tests: README updated; tests cover delta append, block-blob migration, shrunk-file restart, retries, snapshot-before-delete, failure safety, and pass continuation.

<sup>Written for commit d214a77a0b2f0756dad353d8620379a373abb66a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

