### PR TITLE
Delete a block blob before replacing it with an append blob

### DIFF
--- a/internal/transcript/azure_blob_sync.go
+++ b/internal/transcript/azure_blob_sync.go
@@ -264,8 +264,13 @@ func (s *AzureBlobSyncer) syncFile(ctx context.Context, file localFile) error {
 		}
 		return s.appendRange(ctx, file.path, name, 0, file.size)
 	case !remote.appendBlob:
-		// A blob left by the earlier whole-file uploader. Replace it with an
-		// append blob so this file stops being re-sent in full.
+		// A blob left by the earlier whole-file uploader. Azure refuses to
+		// change a blob's type in place ("InvalidBlobType"), so the old block
+		// blob is deleted first. The local file still holds every byte, and it
+		// is re-sent immediately below.
+		if err := s.deleteBlob(ctx, name); err != nil {
+			return err
+		}
 		if err := s.createAppendBlob(ctx, name); err != nil {
 			return err
 		}
@@ -335,6 +340,28 @@ func (s *AzureBlobSyncer) createAppendBlob(ctx context.Context, name string) err
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return azureBlobResponseError(resp)
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	return nil
+}
+
+// deleteBlob removes a blob. A missing blob is success: the caller only wants
+// it gone.
+func (s *AzureBlobSyncer) deleteBlob(ctx context.Context, name string) error {
+	req, err := s.newRequest(ctx, http.MethodDelete, name, "", nil, nil, 0)
+	if err != nil {
+		return err
+	}
+	resp, err := s.do(ctx, req, func() (io.Reader, error) { return nil, nil }, 0)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return azureBlobResponseError(resp)
 	}

--- a/internal/transcript/azure_blob_sync_test.go
+++ b/internal/transcript/azure_blob_sync_test.go
@@ -23,6 +23,7 @@ type azureBlobFake struct {
 	snapshots   map[string]int
 	puts        []string
 	appends     []string
+	deletes     []string
 	heads       []string
 	appendBytes int
 	throttled   int
@@ -91,11 +92,25 @@ func newAzureBlobFake(t *testing.T) *azureBlobFake {
 			fake.appends = append(fake.appends, name)
 			fake.appendBytes += len(body)
 			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodDelete:
+			if _, ok := fake.blobs[name]; !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			delete(fake.blobs, name)
+			delete(fake.kinds, name)
+			fake.deletes = append(fake.deletes, name)
+			w.WriteHeader(http.StatusAccepted)
 		case r.Method == http.MethodPut:
 			body, _ := io.ReadAll(r.Body)
 			kind := r.Header.Get("x-ms-blob-type")
 			if kind == "" {
 				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			// Azure refuses to change a blob's type in place.
+			if existing, ok := fake.kinds[name]; ok && existing != kind {
+				w.WriteHeader(http.StatusConflict)
 				return
 			}
 			fake.blobs[name] = body
@@ -220,6 +235,11 @@ func TestAzureBlobSyncerMigratesABlockBlob(t *testing.T) {
 	}
 	if string(fake.blobs[blob]) != "{\"a\":1}\n{\"a\":2}\n" {
 		t.Fatalf("blob = %q, want the whole file re-sent once", fake.blobs[blob])
+	}
+	// Azure refuses to change a blob's type in place, so the conversion must
+	// delete first. Without it every pass fails with InvalidBlobType.
+	if len(fake.deletes) != 1 || fake.deletes[0] != blob {
+		t.Fatalf("deletes = %v, want the block blob removed before the append blob was created", fake.deletes)
 	}
 }
 


### PR DESCRIPTION
Azure refuses to change a blob's type in place: creating an append blob over an existing block blob answers `409 InvalidBlobType`. Every transcript uploaded by the first version of the syncer therefore failed on every pass after the append-blob change, which the live server reported within a minute of the deploy.

The conversion now deletes the old blob first. The local file still holds every byte and is re-sent immediately, so nothing is lost.

The test fake accepted the in-place type change, which is why this passed CI. It now refuses it the way Azure does, and the migration test asserts the delete happened. Verified live: a real block blob in the container converted to an AppendBlob holding the file's contents.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789644701&installation_model_id=21920&pr_number=223&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F223&signature=6093ba9636b6db9cc7d6aa7bb06a1fed2573dfac5f094ef8df16201b0975913e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deletes an existing block blob before creating an append blob to stop Azure’s 409 InvalidBlobType errors. Previously we tried to create an append blob over a block blob and every sync failed; now we delete, recreate as append, and resend the file, so uploads proceed without data loss.

- Introduces `deleteBlob` that treats 404 as success and validates non-2xx responses.
- Sync path: detect legacy block blob → delete → `createAppendBlob` → append the entire local file once.
- Test fake now rejects in-place type changes and records deletes; migration test asserts the delete occurred.

**Rollout**
- Existing block blobs will be deleted and recreated on the next sync; no action needed to preserve data, but storage credentials must allow deletes.

<sup>Written for commit 648497f2768969309f06b2157154fb56c44baf94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure Blob synchronization when converting an existing blob to append-blob format.
  * Existing incompatible blobs are now removed before recreation, preventing conversion failures.
  * Missing blobs are handled gracefully during deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->