### PR TITLE
Migrate a snapshotted blob instead of failing on it

### DIFF
--- a/internal/transcript/azure_blob_sync.go
+++ b/internal/transcript/azure_blob_sync.go
@@ -265,9 +265,13 @@ func (s *AzureBlobSyncer) syncFile(ctx context.Context, file localFile) error {
 		return s.appendRange(ctx, file.path, name, 0, file.size)
 	case !remote.appendBlob:
 		// A blob left by the earlier whole-file uploader. Azure refuses to
-		// change a blob's type in place ("InvalidBlobType"), so the old block
-		// blob is deleted first. The local file still holds every byte, and it
-		// is re-sent immediately below.
+		// change a blob's type in place ("InvalidBlobType"), so the old blob
+		// has to go. Its contents are preserved first, server side, because it
+		// may hold bytes no longer on disk and it may carry snapshots that
+		// block the delete ("SnapshotsPresent").
+		if err := s.preserveBeforeReplacing(ctx, name, file, remote.size); err != nil {
+			return err
+		}
 		if err := s.deleteBlob(ctx, name); err != nil {
 			return err
 		}
@@ -347,10 +351,61 @@ func (s *AzureBlobSyncer) createAppendBlob(ctx context.Context, name string) err
 	return nil
 }
 
-// deleteBlob removes a blob. A missing blob is success: the caller only wants
-// it gone.
+// preserveBeforeReplacing copies a blob to an archive name before it is
+// deleted, so no bytes are lost when the type changes.
+//
+// The copy is server side: these files reach gigabytes, and the point of the
+// whole change is to stop moving them twice. Any snapshots the blob carries are
+// dropped with it, which is safe for a transcript: the file only ever grows, so
+// every snapshot is a prefix of the base blob being archived here.
+func (s *AzureBlobSyncer) preserveBeforeReplacing(ctx context.Context, name string, file localFile, remoteSize int64) error {
+	if remoteSize <= 0 {
+		return nil
+	}
+	archive := s.blobName("_archive/" + file.relPath + "/" + archiveFileName(file) + ".migrated")
+	state, err := s.blobState(ctx, archive)
+	if err != nil {
+		return err
+	}
+	if state.exists && state.size == remoteSize {
+		return nil
+	}
+	return s.copyBlob(ctx, name, archive)
+}
+
+// copyBlob asks the service to copy one blob to another name within the same
+// container, so the bytes never travel through this process.
+func (s *AzureBlobSyncer) copyBlob(ctx context.Context, source, destination string) error {
+	sourceURL := s.endpoint + "/" + s.container + "/" + azureBlobEscapePath(source)
+	req, err := s.newRequest(ctx, http.MethodPut, destination, "", map[string]string{
+		"x-ms-copy-source": sourceURL,
+	}, nil, 0)
+	if err != nil {
+		return err
+	}
+	resp, err := s.do(ctx, req, func() (io.Reader, error) { return nil, nil }, 0)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return azureBlobResponseError(resp)
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	return nil
+}
+
+// deleteBlob removes a blob and any snapshots it carries. A missing blob is
+// success: the caller only wants it gone. Azure refuses to delete a snapshotted
+// blob unless the request says what to do with the snapshots, and leaving them
+// would keep the name occupied by the wrong blob type forever.
 func (s *AzureBlobSyncer) deleteBlob(ctx context.Context, name string) error {
-	req, err := s.newRequest(ctx, http.MethodDelete, name, "", nil, nil, 0)
+	req, err := s.newRequest(ctx, http.MethodDelete, name, "", map[string]string{
+		"x-ms-delete-snapshots": "include",
+	}, nil, 0)
 	if err != nil {
 		return err
 	}

--- a/internal/transcript/azure_blob_sync_test.go
+++ b/internal/transcript/azure_blob_sync_test.go
@@ -24,6 +24,7 @@ type azureBlobFake struct {
 	puts        []string
 	appends     []string
 	deletes     []string
+	copies      []string
 	heads       []string
 	appendBytes int
 	throttled   int
@@ -97,9 +98,28 @@ func newAzureBlobFake(t *testing.T) *azureBlobFake {
 				w.WriteHeader(http.StatusNotFound)
 				return
 			}
+			// Azure refuses to delete a blob that carries snapshots unless the
+			// request says what to do with them.
+			if fake.snapshots[name] > 0 && r.Header.Get("x-ms-delete-snapshots") == "" {
+				w.WriteHeader(http.StatusConflict)
+				return
+			}
 			delete(fake.blobs, name)
 			delete(fake.kinds, name)
+			delete(fake.snapshots, name)
 			fake.deletes = append(fake.deletes, name)
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodPut && r.Header.Get("x-ms-copy-source") != "":
+			source := r.Header.Get("x-ms-copy-source")
+			sourceName := source[strings.Index(source, "/transcripts/")+len("/transcripts/"):]
+			body, ok := fake.blobs[sourceName]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			fake.blobs[name] = append([]byte(nil), body...)
+			fake.kinds[name] = fake.kinds[sourceName]
+			fake.copies = append(fake.copies, name)
 			w.WriteHeader(http.StatusAccepted)
 		case r.Method == http.MethodPut:
 			body, _ := io.ReadAll(r.Body)
@@ -395,5 +415,40 @@ func TestParseAzureBlobDestination(t *testing.T) {
 	}
 	if _, _, _, _, err := parseAzureBlobDestination("gs://bucket/prefix"); err == nil {
 		t.Fatal("a non-https destination was accepted")
+	}
+}
+
+// Retention snapshots a blob before deleting the local file, and the earlier
+// uploader left block blobs behind. A blob that is both cannot simply be
+// deleted: Azure answers "SnapshotsPresent", and every later pass failed.
+func TestAzureBlobSyncerMigratesASnapshottedBlockBlob(t *testing.T) {
+	fake := newAzureBlobFake(t)
+	spool := t.TempDir()
+	writeSpoolFile(t, spool, "codex/session-8.jsonl", "{\"a\":1}\n{\"a\":2}\n")
+	const blob = "host-a/codex/session-8.jsonl"
+	fake.blobs[blob] = []byte("{\"a\":1}\n")
+	fake.kinds[blob] = "BlockBlob"
+	fake.snapshots[blob] = 1
+
+	syncer := azureTestSyncer(t, fake, spool, AzureBlobSyncerConfig{})
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("a snapshotted block blob was not migrated: %v", err)
+	}
+	if fake.kinds[blob] != "AppendBlob" {
+		t.Fatalf("blob type = %q, want the blob converted", fake.kinds[blob])
+	}
+	if string(fake.blobs[blob]) != "{\"a\":1}\n{\"a\":2}\n" {
+		t.Fatalf("blob = %q", fake.blobs[blob])
+	}
+	// The bytes that were there before the delete must survive under an
+	// archive name, because the blob could hold what the spool no longer does.
+	preserved := false
+	for name, body := range fake.blobs {
+		if strings.Contains(name, "_archive/") && string(body) == "{\"a\":1}\n" {
+			preserved = true
+		}
+	}
+	if !preserved {
+		t.Fatalf("the old contents were deleted without being preserved: %v", fake.copies)
 	}
 }


### PR DESCRIPTION
Retention snapshots a blob before deleting the local file, and the first uploader left block blobs behind. A blob that is both cannot be deleted: Azure answers `409 SnapshotsPresent`, so every sync pass failed on the live server once retention had run.

The delete now says what to do with the snapshots, and the blob's contents are copied server side to `_archive/<path>/<name>.migrated` first, because the blob can hold bytes the spool no longer does. Dropping the snapshots with it is safe for a transcript: the file only grows, so every snapshot is a prefix of the base blob being preserved. The copy never passes through the daemon, which matters because these files reach gigabytes.

Verified against the real storage account: a snapshotted block blob became an AppendBlob holding the whole local file, with its earlier contents preserved under the archive name. The test fake now refuses the delete the way Azure does.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789681696&installation_model_id=21920&pr_number=224&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F224&signature=3907be631a2f23bdd05356b848463b1590ade74f43c282c08ace162f1ed19710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates snapshotted block blobs instead of failing sync passes. Previously deletes returned 409 SnapshotsPresent and stopped sync; now we server-side copy the old blob to `_archive/<path>/<name>.migrated`, delete including snapshots, and recreate as an AppendBlob to append the full local file.

- Adds preserveBeforeReplacing: copies to `_archive/... .migrated` if remoteSize > 0 and no same-sized archive exists; bytes never pass through the daemon.
- Deletes now include `x-ms-delete-snapshots: include` to remove snapshotted blobs that block type changes.
- Implements intra-container server-side copy via `x-ms-copy-source`; name remains occupied only by the new AppendBlob.
- Updates the test fake to enforce Azure’s snapshot delete behavior and to support copy; adds a migration test that verifies data preservation and type conversion.

<sup>Written for commit 0e97ed884eaa9b862c10da2f3942552e1be0ddc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript blob migration to preserve existing content when converting storage types.
  * Ensured blobs with snapshots can be removed cleanly during migration.
  * Prevented transcript data loss when replacing existing non-append blobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->