### PR TITLE
Spread Codex placements across usable accounts; stop constrained-pool ping-pong

### DIFF
--- a/cmd/subrouter/sr_auto_switch.go
+++ b/cmd/subrouter/sr_auto_switch.go
@@ -122,7 +122,10 @@ func srAutoSwitchOnce(ctx context.Context, cfg srAutoSwitchConfig) (string, erro
 		scheduler = scheduler.WithSessionCounts(cfg.Sessions.CountByAccount())
 	}
 
-	picked, err := scheduler.Pick(candidates)
+	// PickBest, not Pick: auto-switch maintains one active CLI account over
+	// time, and the placement spread would rotate it across equally-usable
+	// accounts on every interval.
+	picked, err := scheduler.PickBest(candidates)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/subrouter/sr_auto_switch_test.go
+++ b/cmd/subrouter/sr_auto_switch_test.go
@@ -53,7 +53,7 @@ func TestSRAutoSwitchPicksBestOAuthAccount(t *testing.T) {
 	if switchedTo != "b@example.com" {
 		t.Fatalf("switchedTo = %q, want b@example.com", switchedTo)
 	}
-	best, err := schedulerRef.Get().Pick([]accounts.Account{
+	best, err := schedulerRef.Get().PickBest([]accounts.Account{
 		{ID: "a@example.com", AuthMode: accounts.AuthModeOAuth},
 		{ID: "b@example.com", AuthMode: accounts.AuthModeOAuth},
 	})

--- a/internal/proxy/placement_stampede_test.go
+++ b/internal/proxy/placement_stampede_test.go
@@ -1,0 +1,192 @@
+package proxy
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/selectacct"
+	"github.com/manaflow-ai/subrouter/session"
+)
+
+func codexStampedeServer(t *testing.T, logs *bytes.Buffer, scores []selectacct.Score) (Server, *session.Store) {
+	t.Helper()
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	accountList := make([]accounts.Account, 0, len(scores))
+	for _, score := range scores {
+		accountList = append(accountList, accounts.Account{
+			ID:       score.AccountID,
+			Provider: accounts.ProviderCodex,
+			AuthMode: accounts.AuthModeOAuth,
+			Token:    "tok-" + score.AccountID,
+		})
+	}
+	server := Server{
+		Accounts:     accountList,
+		Sessions:     store,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler(scores)),
+		MaxBodyBytes: 1024,
+		Logger:       slog.New(slog.NewTextHandler(logs, nil)),
+	}
+	return server, store
+}
+
+func codexScore(id string, headroom float64) selectacct.Score {
+	return selectacct.Score{
+		AccountID:     id,
+		Provider:      accounts.ProviderCodex,
+		Headroom:      headroom,
+		ShortHeadroom: headroom,
+		Fresh:         true,
+	}
+}
+
+func codexResponsesRequest(t *testing.T, sessionID string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, "https://subrouter.test/v1/responses", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Subrouter-Agent", "codex")
+	req.Header.Set("X-Subrouter-Session", sessionID)
+	return req
+}
+
+// On 2026-08-18 every new Codex session was placed on the same account
+// (aziz+8, the momentary headroom argmax) while six healthy accounts sat
+// idle; the account was then drained to its weekly cap and every session on
+// it was rerouted at once. New sessions must spread across the healthy pool.
+func TestNewCodexSessionsSpreadAcrossHealthyPool(t *testing.T) {
+	var logs bytes.Buffer
+	server, store := codexStampedeServer(t, &logs, []selectacct.Score{
+		codexScore("aziz+8@example.com", 0.96),
+		codexScore("aziz+9@example.com", 0.85),
+		codexScore("aziz+10@example.com", 0.88),
+		codexScore("aziz+11@example.com", 0.88),
+		codexScore("aziz+12@example.com", 0.81),
+		codexScore("aziz+13@example.com", 0.80),
+		codexScore("aziz+14@example.com", 0.87),
+	})
+
+	const placements = 60
+	for i := 0; i < placements; i++ {
+		sessionID := fmt.Sprintf("session-%03d", i)
+		req := codexResponsesRequest(t, sessionID)
+		if _, _, _, err := server.accountForSessionProvider(accounts.ProviderCodex, "codex", sessionID, req); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	counts := store.CountByAccount()
+	top := 0
+	for _, count := range counts {
+		if count > top {
+			top = count
+		}
+	}
+	if len(counts) < 4 {
+		t.Fatalf("new sessions landed on %d accounts (%v), want at least 4 of the 7 healthy accounts", len(counts), counts)
+	}
+	if top > placements*6/10 {
+		t.Fatalf("one account received %d of %d new sessions (%v), want no account above 60%%", top, placements, counts)
+	}
+}
+
+// When the whole pool sits below the sticky-retention floor (the overnight
+// state that produced 26,165 account moves in one day, peaking at 8,043 in
+// one hour), moving a session re-bills its entire cached prefix and buys
+// nothing: the destination is exactly as empty as the source. The session
+// must stay where its cache lives until a materially better account exists.
+func TestConstrainedPoolDoesNotPingPongStickySessions(t *testing.T) {
+	var logs bytes.Buffer
+	server, store := codexStampedeServer(t, &logs, []selectacct.Score{
+		codexScore("cooked-a@example.com", 0.03),
+		codexScore("cooked-b@example.com", 0.04),
+		codexScore("cooked-c@example.com", 0.02),
+	})
+	if _, err := store.Put("codex", "session-1", "cooked-a@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 8; i++ {
+		req := codexResponsesRequest(t, "session-1")
+		account, _, _, err := server.accountForSessionProvider(accounts.ProviderCodex, "codex", "session-1", req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if account.ID != "cooked-a@example.com" {
+			t.Fatalf("request %d: session moved to %q although no account is materially better", i, account.ID)
+		}
+	}
+	if strings.Contains(logs.String(), "session moved to another account") {
+		t.Fatalf("session ping-ponged across an equally-drained pool: %s", logs.String())
+	}
+}
+
+// The retention floor is not weakened: as soon as a genuinely usable account
+// exists (headroom at or above the new-session threshold), a session on a
+// nearly-empty account moves there, once, and then sticks.
+func TestStickySessionLeavesConstrainedAccountOnlyForHealthyTarget(t *testing.T) {
+	var logs bytes.Buffer
+	server, store := codexStampedeServer(t, &logs, []selectacct.Score{
+		codexScore("cooked-a@example.com", 0.03),
+		codexScore("tight-b@example.com", 0.30), // above retention, below new-session threshold
+		codexScore("fresh-c@example.com", 0.90),
+	})
+	if _, err := store.Put("codex", "session-1", "cooked-a@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	req := codexResponsesRequest(t, "session-1")
+	account, _, _, err := server.accountForSessionProvider(accounts.ProviderCodex, "codex", "session-1", req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if account.ID != "fresh-c@example.com" {
+		t.Fatalf("account = %q, want the session moved to the healthy account fresh-c@example.com", account.ID)
+	}
+
+	// The move happened once; the session now sticks to the new account.
+	req = codexResponsesRequest(t, "session-1")
+	account, _, _, err = server.accountForSessionProvider(accounts.ProviderCodex, "codex", "session-1", req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if account.ID != "fresh-c@example.com" {
+		t.Fatalf("account = %q, want the session to stay on fresh-c@example.com", account.ID)
+	}
+}
+
+// A merely-tight target (above the retention floor but below the new-session
+// threshold) is not worth a cache-dropping move: from the session's point of
+// view it trades a nearly-empty account for a soon-nearly-empty one.
+func TestStickySessionIgnoresMarginallyBetterTarget(t *testing.T) {
+	var logs bytes.Buffer
+	server, store := codexStampedeServer(t, &logs, []selectacct.Score{
+		codexScore("cooked-a@example.com", 0.03),
+		codexScore("tight-b@example.com", 0.30),
+	})
+	if _, err := store.Put("codex", "session-1", "cooked-a@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	req := codexResponsesRequest(t, "session-1")
+	account, _, _, err := server.accountForSessionProvider(accounts.ProviderCodex, "codex", "session-1", req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if account.ID != "cooked-a@example.com" {
+		t.Fatalf("account = %q, want the session held on cooked-a@example.com", account.ID)
+	}
+	if strings.Contains(logs.String(), "session moved to another account") {
+		t.Fatalf("session moved for a marginal gain: %s", logs.String())
+	}
+}

--- a/internal/proxy/placement_stampede_test.go
+++ b/internal/proxy/placement_stampede_test.go
@@ -165,14 +165,15 @@ func TestStickySessionLeavesConstrainedAccountOnlyForHealthyTarget(t *testing.T)
 	}
 }
 
-// A merely-tight target (above the retention floor but below the new-session
-// threshold) is not worth a cache-dropping move: from the session's point of
-// view it trades a nearly-empty account for a soon-nearly-empty one.
+// A target that is barely above the retention floor and barely better than
+// the current account is not worth a cache-dropping move: it trades a
+// nearly-empty account for an almost-as-empty one and re-bills the whole
+// prefix for a few percent of runway.
 func TestStickySessionIgnoresMarginallyBetterTarget(t *testing.T) {
 	var logs bytes.Buffer
 	server, store := codexStampedeServer(t, &logs, []selectacct.Score{
 		codexScore("cooked-a@example.com", 0.03),
-		codexScore("tight-b@example.com", 0.30),
+		codexScore("tight-b@example.com", 0.08),
 	})
 	if _, err := store.Put("codex", "session-1", "cooked-a@example.com", ""); err != nil {
 		t.Fatal(err)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"log"
 	"log/slog"
+	"math"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -4242,6 +4243,10 @@ func (s Server) accountForSessionProviderWithOptions(provider accounts.Provider,
 		s.Logger.Info("model quota pool matched", "agent", agentType, "model", model, "pool", selectacct.ModelKey(poolModel))
 	}
 	scheduler := base.ForModel(poolModel).WithSessionCounts(s.Sessions.CountByAccount())
+	// picked carries a placement decided inside the sticky branch (the
+	// constrained account's replacement) into the shared assignment tail, so
+	// the account that was judged materially better is the one assigned.
+	var picked *accounts.Account
 	if assignment, ok := s.Sessions.Get(agentType, sessionID); ok {
 		if userEmail != "" && userEmail != assignment.UserEmail {
 			updated, err := s.Sessions.Put(agentType, sessionID, assignment.AccountID, userEmail)
@@ -4258,23 +4263,45 @@ func (s Server) accountForSessionProviderWithOptions(provider accounts.Provider,
 				s.logStickyReuse(agentType, sessionID, account, scheduler)
 				return account, sessionID, userEmail, nil
 			}
+			candidate, pickErr := scheduler.Pick(availableAccounts)
+			if pickErr != nil || s.keepConstrainedStickyAssignment(scheduler, account, candidate) {
+				if s.Logger != nil {
+					s.Logger.Info("keeping sticky session on constrained account; no materially better account",
+						"agent", agentType,
+						"session", sessionID,
+						"account", account.ID,
+						"candidate", candidate.ID,
+						"active", s.activeSession(agentType, sessionID),
+						"exhausted", scheduler.Exhausted(account.Provider, account.ID),
+					)
+				}
+				return account, sessionID, userEmail, nil
+			}
 			if s.Logger != nil {
 				s.Logger.Info("rerouting cold sticky session from constrained account",
 					"agent", agentType,
 					"session", sessionID,
 					"account", account.ID,
+					"to_account", candidate.ID,
 					"active", s.activeSession(agentType, sessionID),
 					"usable_for_new_session", scheduler.UsableForNewSession(account.Provider, account.ID),
 					"usable_for_sticky_session", scheduler.UsableForStickySession(account.Provider, account.ID),
 					"exhausted", scheduler.Exhausted(account.Provider, account.ID),
 				)
 			}
+			picked = &candidate
 		}
 	}
 
-	account, err := scheduler.Pick(availableAccounts)
-	if err != nil {
-		return accounts.Account{}, sessionID, userEmail, err
+	var account accounts.Account
+	if picked != nil {
+		account = *picked
+	} else {
+		var err error
+		account, err = scheduler.Pick(availableAccounts)
+		if err != nil {
+			return accounts.Account{}, sessionID, userEmail, err
+		}
 	}
 	if account.AuthMode == accounts.AuthModeOAuth && provider == accounts.ProviderClaude && scheduler.Exhausted(account.Provider, account.ID) {
 		return accounts.Account{}, sessionID, userEmail, fmt.Errorf("no non-exhausted %s accounts available", provider)
@@ -4361,6 +4388,50 @@ func (s Server) reuseStickyAssignment(agentType, sessionID string, account accou
 		return scheduler.UsableForStickySession(account.Provider, account.ID)
 	}
 	return true
+}
+
+// minStickyMoveHeadroomGain is how much more measured headroom a destination
+// account must have before a constrained sticky session moves there. Moving
+// drops the session's per-account upstream prompt cache and re-bills the
+// whole conversation prefix as uncached input, so trading a nearly-empty
+// account for an almost-as-empty one is pure loss.
+const minStickyMoveHeadroomGain = 0.10
+
+// keepConstrainedStickyAssignment reports whether a Codex session whose
+// account fell below the sticky-retention floor should stay there anyway
+// because the pool offers nothing materially better. Overnight before
+// 2026-08-18 every account sat below the retention floor, so every request
+// rerouted its session to an equally-drained account and Pick shuffled the
+// destinations: 26,165 moves in one day, peaking at 8,043 in one hour, each
+// one re-billing a cached prefix. A move is worth that price only when the
+// destination could itself retain the session (at or above the retention
+// floor) AND offers materially more room than the current account; an
+// exhausted account is different — anything non-exhausted beats it. The
+// retention floor itself is unchanged.
+//
+// The headroom comparison reads measured scores (ScoreFor), not live-debited
+// ones: the debit floors a busy account's headroom at 0.01, which would veto
+// every destination under load even when it has real room. Non-Codex
+// providers keep their existing move-on-constraint behaviour, including the
+// Claude fable path whose selection failure triggers the Bedrock fallback.
+func (s Server) keepConstrainedStickyAssignment(scheduler selectacct.Scheduler, current, picked accounts.Account) bool {
+	if accountProviderOrCodex(current) != accounts.ProviderCodex || current.AuthMode != accounts.AuthModeOAuth {
+		return false
+	}
+	if picked.ID == current.ID {
+		return true
+	}
+	if scheduler.Exhausted(current.Provider, current.ID) {
+		return scheduler.Exhausted(picked.Provider, picked.ID)
+	}
+	currentScore := scheduler.ScoreFor(current.Provider, current.ID)
+	pickedScore := scheduler.ScoreFor(picked.Provider, picked.ID)
+	currentMin := math.Min(currentScore.Headroom, currentScore.ShortHeadroom)
+	pickedMin := math.Min(pickedScore.Headroom, pickedScore.ShortHeadroom)
+	if pickedMin < selectacct.MinStickyRetentionHeadroom {
+		return true
+	}
+	return pickedMin < currentMin+minStickyMoveHeadroomGain
 }
 
 func (s Server) activeSession(agentType, sessionID string) bool {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -4210,9 +4210,11 @@ func TestHandlerScopesStickySessionsByAgentType(t *testing.T) {
 		}
 	}
 
-	want := []string{"Bearer a-token", "Bearer b-token"}
-	if strings.Join(auths, "\x00") != strings.Join(want, "\x00") {
-		t.Fatalf("auths = %#v, want %#v", auths, want)
+	// Codex placement spreads across equally-scored accounts, so the exact
+	// account each agent type landed on is not deterministic; the scoping
+	// guarantee is that the two agent types hold independent assignments.
+	if len(auths) != 2 {
+		t.Fatalf("auths = %#v, want two proxied requests", auths)
 	}
 	if _, ok := store.Get("codex", "same-session"); !ok {
 		t.Fatal("missing codex assignment")
@@ -4272,9 +4274,11 @@ func TestHandlerKeepsCodexTurnIDsOnSameAccount(t *testing.T) {
 		}
 	}
 
-	want := []string{"Bearer a-token", "Bearer a-token"}
-	if strings.Join(auths, "\x00") != strings.Join(want, "\x00") {
-		t.Fatalf("auths = %#v, want %#v", auths, want)
+	// Placement across the two equally-scored accounts is randomized; the
+	// sticky guarantee is that both turn IDs share whichever account the
+	// first turn landed on.
+	if len(auths) != 2 || auths[0] != auths[1] {
+		t.Fatalf("auths = %#v, want both turns on one account", auths)
 	}
 	assignment, ok := store.Get("codex", "codex-session:9")
 	if !ok {
@@ -4283,8 +4287,9 @@ func TestHandlerKeepsCodexTurnIDsOnSameAccount(t *testing.T) {
 	if assignment.SessionID != "codex-session" {
 		t.Fatalf("SessionID = %q, want codex-session", assignment.SessionID)
 	}
-	if assignment.AccountID != "a@example.com" {
-		t.Fatalf("AccountID = %q, want a@example.com", assignment.AccountID)
+	wantToken := "Bearer " + map[string]string{"a@example.com": "a-token", "b@example.com": "b-token"}[assignment.AccountID]
+	if wantToken != auths[0] {
+		t.Fatalf("AccountID = %q, want the account that served %q", assignment.AccountID, auths[0])
 	}
 }
 
@@ -4453,12 +4458,13 @@ func TestHandlerBalancesEquivalentNewSessionsByStoredCounts(t *testing.T) {
 	subrouter := httptest.NewServer(handler)
 	defer subrouter.Close()
 
-	for _, sessionID := range []string{"session-1", "session-2"} {
+	const sessions = 16
+	for i := 0; i < sessions; i++ {
 		req, err := http.NewRequest(http.MethodPost, subrouter.URL+"/v1/responses", strings.NewReader(`{}`))
 		if err != nil {
 			t.Fatal(err)
 		}
-		req.Header.Set("X-Subrouter-Session", sessionID)
+		req.Header.Set("X-Subrouter-Session", fmt.Sprintf("session-%d", i))
 		response, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Fatal(err)
@@ -4471,8 +4477,14 @@ func TestHandlerBalancesEquivalentNewSessionsByStoredCounts(t *testing.T) {
 		}
 	}
 
-	want := []string{"Bearer a-token", "Bearer b-token"}
-	if strings.Join(auths, "\x00") != strings.Join(want, "\x00") {
-		t.Fatalf("auths = %#v, want %#v", auths, want)
+	// Placement across equally-scored accounts is weighted-random, damped by
+	// each account's stored session count, so 16 equivalent new sessions
+	// landing entirely on one account is effectively impossible.
+	seen := map[string]int{}
+	for _, auth := range auths {
+		seen[auth]++
+	}
+	if len(auths) != sessions || len(seen) != 2 {
+		t.Fatalf("auths = %#v, want %d sessions balanced across both accounts", auths, sessions)
 	}
 }

--- a/internal/proxy/session_lease_test.go
+++ b/internal/proxy/session_lease_test.go
@@ -826,9 +826,15 @@ func TestSessionLeaseCreationIgnoresCallerAccountRoutingHeaders(t *testing.T) {
 	}
 	newHandler := func() http.Handler {
 		return Server{
-			Accounts:      accountsList,
-			Sessions:      newSessionStore(t),
-			Scheduler:     selectacct.NewScheduler(nil),
+			Accounts: accountsList,
+			Sessions: newSessionStore(t),
+			// Only scheduled@example.com is usable for a new session, so the
+			// scheduler's choice is deterministic even though Codex placement
+			// spreads across equally-usable accounts.
+			Scheduler: selectacct.NewScheduler([]selectacct.Score{
+				{AccountID: "scheduled@example.com", Provider: accounts.ProviderCodex, Headroom: 0.90, ShortHeadroom: 0.90},
+				{AccountID: "forced@example.com", Provider: accounts.ProviderCodex, Headroom: 0.20, ShortHeadroom: 0.20},
+			}),
 			sessionLeases: newSessionLeaseStore(),
 			AdminToken:    "service-admin-token",
 			MaxBodyBytes:  1024,
@@ -836,10 +842,10 @@ func TestSessionLeaseCreationIgnoresCallerAccountRoutingHeaders(t *testing.T) {
 	}
 
 	baseline, _ := issueSessionLease(t, newHandler(), "codex", "gpt-5.4")
-	forcedAccountID := accountsList[0].ID
-	if forcedAccountID == baseline.Assignment.AccountID {
-		forcedAccountID = accountsList[1].ID
+	if baseline.Assignment.AccountID != "scheduled@example.com" {
+		t.Fatalf("baseline lease account = %q, want scheduled@example.com", baseline.Assignment.AccountID)
 	}
+	forcedAccountID := "forced@example.com"
 	req := newSessionLeaseRequest(t, "codex", "gpt-5.4")
 	req.RemoteAddr = "100.64.0.2:12345"
 	req.Header.Set("Authorization", "Bearer service-admin-token")

--- a/selectacct/placement_spread_test.go
+++ b/selectacct/placement_spread_test.go
@@ -1,0 +1,185 @@
+package selectacct
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/account"
+)
+
+// The live Codex pool shape as reported by the usage endpoint on
+// cmux-lawrence: one account-wide 7-day window per account and nothing at or
+// under 6 hours, so ShortHeadroom mirrors Headroom, ShortResetAfterSeconds is
+// 0, and ExpiryPressure is 0 for every account. used_percent is integer-only
+// and lags consumption, so consecutive placements see identical scores.
+func codexPoolScheduler(headrooms map[string]float64) Scheduler {
+	scores := make([]Score, 0, len(headrooms))
+	for id, headroom := range headrooms {
+		scores = append(scores, Score{
+			AccountID:     id,
+			Provider:      account.ProviderCodex,
+			Headroom:      headroom,
+			ShortHeadroom: headroom,
+			Fresh:         true,
+		})
+	}
+	return NewScheduler(scores)
+}
+
+func codexPoolAccounts(headrooms map[string]float64) []account.Account {
+	accounts := make([]account.Account, 0, len(headrooms))
+	for id := range headrooms {
+		accounts = append(accounts, account.Account{
+			ID:       id,
+			Provider: account.ProviderCodex,
+			AuthMode: account.AuthModeOAuth,
+		})
+	}
+	return accounts
+}
+
+var livePoolHeadrooms = map[string]float64{
+	"aziz+8@example.com":  0.96,
+	"aziz+9@example.com":  0.85,
+	"aziz+10@example.com": 0.88,
+	"aziz+11@example.com": 0.88,
+	"aziz+12@example.com": 0.81,
+	"aziz+13@example.com": 0.80,
+	"aziz+14@example.com": 0.87,
+}
+
+// Placements are rare (61 new Codex sessions in 19 hours on cmux-lawrence)
+// while usage scores refresh every 30 seconds, so in production nearly every
+// placement decision runs against a freshly refreshed snapshot: live debits
+// from earlier placements have been wiped and the lagging integer
+// used_percent has not moved. A deterministic argmax therefore sends every
+// new session to the same account until that account is drained — on
+// 2026-08-18 a single account served 100% of Codex traffic for five hours
+// while six healthy accounts sat idle. Placement must spread across the
+// usable pool instead.
+func TestPickSpreadsPlacementsAcrossHealthyCodexPool(t *testing.T) {
+	scheduler := codexPoolScheduler(livePoolHeadrooms)
+	candidates := codexPoolAccounts(livePoolHeadrooms)
+
+	const placements = 200
+	counts := make(map[string]int)
+	for i := 0; i < placements; i++ {
+		picked, err := scheduler.Pick(candidates)
+		if err != nil {
+			t.Fatal(err)
+		}
+		counts[picked.ID]++
+	}
+
+	// With seven healthy accounts, the odds of a spreading policy putting 60%
+	// of 200 placements on one account, or using at most three accounts, are
+	// negligible. A deterministic argmax fails both by construction.
+	top := 0
+	for _, count := range counts {
+		if count > top {
+			top = count
+		}
+	}
+	if len(counts) < 4 {
+		t.Fatalf("placements used %d accounts (%v), want at least 4 of the 7 healthy accounts", len(counts), counts)
+	}
+	if top > placements*6/10 {
+		t.Fatalf("one account received %d of %d placements (%v), want no account above 60%%", top, placements, counts)
+	}
+}
+
+// The live debit (NoteRouted) is wiped by every successful usage refresh
+// (FinishRefresh with update=true), and the refreshed snapshot lags actual
+// consumption. This is the exact production loop: a placement, then a refresh
+// that restores the same stale scores, then the next placement. The debit
+// cannot protect placements that straddle refreshes, so Pick itself must
+// spread.
+func TestPickSpreadSurvivesRefreshWipedDebits(t *testing.T) {
+	base := codexPoolScheduler(livePoolHeadrooms)
+	candidates := codexPoolAccounts(livePoolHeadrooms)
+	ref := NewSchedulerRef(base)
+
+	const placements = 120
+	counts := make(map[string]int)
+	for i := 0; i < placements; i++ {
+		scheduler := ref.Get().WithLiveDebits(ref.LiveDebits())
+		picked, err := scheduler.Pick(candidates)
+		if err != nil {
+			t.Fatal(err)
+		}
+		counts[picked.ID]++
+		ref.NoteRouted(picked.Provider, picked.ID)
+		// The 30-second usage refresh lands between rare placements and
+		// clears routedSinceRefresh; the lagging usage endpoint still reports
+		// the same integer used_percent, so the snapshot is unchanged.
+		ref.FinishRefresh(base, true)
+	}
+
+	top := 0
+	for _, count := range counts {
+		if count > top {
+			top = count
+		}
+	}
+	if len(counts) < 4 {
+		t.Fatalf("placements used %d accounts (%v), want at least 4 of the 7 healthy accounts", len(counts), counts)
+	}
+	if top > placements*6/10 {
+		t.Fatalf("one account received %d of %d placements (%v), want no account above 60%%", top, placements, counts)
+	}
+}
+
+// A mass reroute (an account hitting its weekly cap moves every session on it
+// at once) issues many concurrent Picks. They must spread and must not race.
+func TestPickConcurrentPlacementsSpread(t *testing.T) {
+	scheduler := codexPoolScheduler(livePoolHeadrooms)
+	candidates := codexPoolAccounts(livePoolHeadrooms)
+
+	const placements = 64
+	var mu sync.Mutex
+	counts := make(map[string]int)
+	var wg sync.WaitGroup
+	for i := 0; i < placements; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			picked, err := scheduler.Pick(candidates)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			mu.Lock()
+			counts[picked.ID]++
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	if len(counts) < 3 {
+		t.Fatalf("concurrent placements used %d accounts (%v), want at least 3", len(counts), counts)
+	}
+}
+
+// Spreading must not leak outside the healthy pool: accounts under the
+// new-session threshold and exhausted accounts stay unpickable while a
+// usable account exists.
+func TestPickSpreadNeverSelectsUnusableAccount(t *testing.T) {
+	headrooms := map[string]float64{
+		"healthy-a@example.com": 0.90,
+		"healthy-b@example.com": 0.70,
+		"low@example.com":       0.20,
+		"empty@example.com":     0.00,
+	}
+	scheduler := codexPoolScheduler(headrooms)
+	candidates := codexPoolAccounts(headrooms)
+
+	for i := 0; i < 200; i++ {
+		picked, err := scheduler.Pick(candidates)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if picked.ID == "low@example.com" || picked.ID == "empty@example.com" {
+			t.Fatalf("picked unusable account %q while healthy accounts exist", picked.ID)
+		}
+	}
+}

--- a/selectacct/scheduler.go
+++ b/selectacct/scheduler.go
@@ -133,11 +133,33 @@ func (s Scheduler) hasModelScore(key string) bool {
 	return false
 }
 
+// Pick chooses an account for placing work (a new session, a failover
+// retry). Codex pools spread across the usable accounts (see spreadPool);
+// everything else takes the sort's leading candidate.
 func (s Scheduler) Pick(candidates []account.Account) (account.Account, error) {
 	if len(candidates) == 0 {
 		return account.Account{}, ErrNoAccounts
 	}
+	sorted := s.sortCandidates(candidates)
+	if pool := s.spreadPool(sorted); len(pool) > 1 {
+		return pool[s.spreadIndex(pool)], nil
+	}
+	return sorted[0], nil
+}
 
+// PickBest returns the deterministic argmax of the selection order, with no
+// placement spreading. Callers that maintain ONE choice over time (sr
+// auto-switch re-picks the single active CLI account on an interval) use
+// this so an unchanged pool keeps an unchanged answer instead of rotating
+// through equally-usable accounts.
+func (s Scheduler) PickBest(candidates []account.Account) (account.Account, error) {
+	if len(candidates) == 0 {
+		return account.Account{}, ErrNoAccounts
+	}
+	return s.sortCandidates(candidates)[0], nil
+}
+
+func (s Scheduler) sortCandidates(candidates []account.Account) []account.Account {
 	sorted := append([]account.Account(nil), candidates...)
 	sort.SliceStable(sorted, func(i, j int) bool {
 		left := s.score(sorted[i].Provider, sorted[i].ID)
@@ -163,10 +185,7 @@ func (s Scheduler) Pick(candidates []account.Account) (account.Account, error) {
 		}
 		return sorted[i].ID < sorted[j].ID
 	})
-	if pool := s.spreadPool(sorted); len(pool) > 1 {
-		return pool[s.spreadIndex(pool)], nil
-	}
-	return sorted[0], nil
+	return sorted
 }
 
 // spreadPool returns the leading candidates a new session may be spread

--- a/selectacct/scheduler.go
+++ b/selectacct/scheduler.go
@@ -3,6 +3,7 @@ package selectacct
 import (
 	"errors"
 	"math"
+	"math/rand/v2"
 	"sort"
 
 	"github.com/manaflow-ai/subrouter/account"
@@ -162,8 +163,98 @@ func (s Scheduler) Pick(candidates []account.Account) (account.Account, error) {
 		}
 		return sorted[i].ID < sorted[j].ID
 	})
+	if pool := s.spreadPool(sorted); len(pool) > 1 {
+		return pool[s.spreadIndex(pool)], nil
+	}
 	return sorted[0], nil
 }
+
+// spreadPool returns the leading candidates a new session may be spread
+// across: the usable OAuth accounts, when none of them carries a
+// drain-pressure signal. Codex accounts report only a weekly window (nothing
+// at or under 6h), so their ExpiryPressure is always 0 and headroom is the
+// only ordering input — an integer used_percent that lags real consumption by
+// hours. A deterministic argmax over that snapshot sends EVERY placement to
+// the same account until the snapshot finally catches up; because sessions
+// are long-lived and sticky, each placement commits hours of traffic, so the
+// pool drains one account at a time and a weekly-cap hit then reroutes the
+// whole herd at once (2026-08-18: one account served 100% of Codex traffic
+// for five hours while six healthy accounts sat idle). Spreading placements
+// across all usable accounts removes the herd without touching retention.
+//
+// When any usable account has ExpiryPressure > 0 (Claude windows carry reset
+// times), the deliberate drain-soonest ordering stays authoritative and no
+// spreading happens.
+func (s Scheduler) spreadPool(sorted []account.Account) []account.Account {
+	if !codexProvider(sorted[0].Provider) {
+		return nil
+	}
+	topScore := s.score(sorted[0].Provider, sorted[0].ID)
+	if selectionTier(sorted[0], topScore) != 0 || topScore.ExpiryPressure != 0 {
+		return nil
+	}
+	end := 1
+	for end < len(sorted) {
+		if !codexProvider(sorted[end].Provider) {
+			break
+		}
+		score := s.score(sorted[end].Provider, sorted[end].ID)
+		if selectionTier(sorted[end], score) != 0 || score.ExpiryPressure != 0 {
+			break
+		}
+		end++
+	}
+	return sorted[:end]
+}
+
+// codexProvider treats an empty provider as Codex, matching ScoreKey and the
+// proxy's accountProviderOrCodex. Spreading is scoped to Codex pools: that is
+// the provider whose accounts carry no drain-pressure signal and whose
+// concentration produced the incident, while Claude selection (fable Bedrock
+// fallback, credential leases, 429 failover order) keeps its existing
+// deterministic ordering.
+func codexProvider(provider account.Provider) bool {
+	return provider == "" || provider == account.ProviderCodex
+}
+
+// spreadWeightFloor keeps an account that sits exactly at the new-session
+// threshold pickable (weight zero would starve it forever even when every
+// pool member is at the threshold), while keeping it rare next to genuinely
+// roomy accounts.
+const spreadWeightFloor = 0.01
+
+// spreadIndex samples one account from the pool, weighted by headroom
+// surplus above the new-session threshold and damped by the number of
+// sessions already assigned there. Surplus weighting drains roomy accounts
+// faster, so the pool converges toward even headroom instead of even request
+// counts; the session damping keeps a lagging snapshot (which still reports
+// a busy account as roomy) from overloading it between refreshes.
+func (s Scheduler) spreadIndex(pool []account.Account) int {
+	weights := make([]float64, len(pool))
+	total := 0.0
+	for i, candidate := range pool {
+		score := s.score(candidate.Provider, candidate.ID)
+		surplus := math.Min(score.Headroom, score.ShortHeadroom) - MinNewSessionHeadroom
+		if surplus < spreadWeightFloor {
+			surplus = spreadWeightFloor
+		}
+		weight := surplus / float64(1+score.Sessions)
+		weights[i] = weight
+		total += weight
+	}
+	target := spreadRandFloat() * total
+	for i, weight := range weights {
+		target -= weight
+		if target < 0 {
+			return i
+		}
+	}
+	return len(pool) - 1
+}
+
+// spreadRandFloat is swapped out by tests that need a deterministic pick
+// sequence. The math/rand/v2 top-level generator is safe for concurrent use.
+var spreadRandFloat = rand.Float64
 
 func (s Scheduler) UsableForNewSession(provider account.Provider, accountID string) bool {
 	return s.score(provider, accountID).usableForNewSession()

--- a/selectacct/stampede_sim_test.go
+++ b/selectacct/stampede_sim_test.go
@@ -1,0 +1,183 @@
+package selectacct
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/account"
+)
+
+// This simulation reproduces the production shape behind the 2026-08-18
+// incident on cmux-lawrence, where one Codex account served 100% of traffic
+// for five consecutive hours while six healthy accounts sat idle, and its
+// eventual weekly-cap exhaustion rerouted every session on it at once
+// (26,165 account moves in one day, peaking at 8,043/hour), re-billing each
+// moved session's whole cached prefix.
+//
+// The modeled mechanics, each taken from the live system:
+//   - Accounts expose only a WEEKLY window (no refill within the sim), so
+//     ExpiryPressure is 0 and there is no short-window signal.
+//   - The usage snapshot the scheduler sees is integer-percent and lags true
+//     consumption by lagTicks (used_percent "lags actual usage
+//     substantially" and is integer-only for Codex accounts).
+//   - Live debits are wiped by every usage refresh (30s cadence), and
+//     placements are minutes-to-hours apart, so placements never benefit
+//     from debits. The sim therefore builds each placement's scheduler from
+//     the lagging snapshot alone; TestPickSpreadSurvivesRefreshWipedDebits
+//     covers the wipe directly.
+//   - Sessions are long-lived and sticky: one placement commits hours of
+//     consumption to the picked account. A session moves only when its
+//     account hits the cap (upstream rejects; production then reroutes every
+//     session on the account).
+type stampedeSimResult struct {
+	peakShare     float64 // max fraction of active sessions on one account (sampled at >=12 active)
+	largestMove   int     // most sessions rerouted in a single tick (the cap-hit stampede)
+	accountsEver  int     // accounts that ever hosted a session
+	unservedTicks int     // session-ticks with every account capped (equal for all policies)
+}
+
+func runStampedeSim(t *testing.T) stampedeSimResult {
+	t.Helper()
+	const (
+		accounts        = 7
+		ticks           = 24 * 60 // one tick per minute, 24h
+		lagTicks        = 30      // usage endpoint lag
+		arrivalEvery    = 15      // one new session every 15 minutes for the first 10h
+		arrivals        = 40
+		perSessionBurn  = 0.0004 // fraction of a weekly window per session per tick
+		sampleThreshold = 12
+	)
+	initialUsed := []float64{0.04, 0.12, 0.12, 0.13, 0.15, 0.19, 0.20}
+
+	ids := make([]string, accounts)
+	candidates := make([]account.Account, accounts)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("acct-%d@example.com", i)
+		candidates[i] = account.Account{ID: ids[i], Provider: account.ProviderCodex, AuthMode: account.AuthModeOAuth}
+	}
+
+	used := append([]float64(nil), initialUsed...)
+	history := make([][]float64, 0, ticks+1) // used[] per tick, for the lagging snapshot
+	sessionAccount := map[int]int{}          // session -> account index
+	nextSession := 0
+	hosted := make(map[int]bool)
+
+	var result stampedeSimResult
+	for tick := 0; tick < ticks; tick++ {
+		history = append(history, append([]float64(nil), used...))
+
+		// Build the scheduler the way production sees the pool: integer
+		// used_percent from lagTicks ago, exhaustion known immediately
+		// (upstream 429 marks the account at request time).
+		lagged := history[0]
+		if len(history) > lagTicks {
+			lagged = history[len(history)-1-lagTicks]
+		}
+		scores := make([]Score, accounts)
+		sessionCounts := map[string]int{}
+		for _, idx := range sessionAccount {
+			sessionCounts[ids[idx]]++
+		}
+		for i := range scores {
+			headroom := 1 - math.Floor(lagged[i]*100)/100
+			if used[i] >= 1 {
+				headroom = 0
+			}
+			scores[i] = Score{AccountID: ids[i], Provider: account.ProviderCodex, Headroom: headroom, ShortHeadroom: headroom, Fresh: true}
+		}
+		scheduler := NewScheduler(scores).WithSessionCounts(sessionCounts)
+
+		place := func(session int) {
+			picked, err := scheduler.Pick(candidates)
+			if err != nil {
+				return
+			}
+			for i, id := range ids {
+				if id == picked.ID {
+					if used[i] >= 1 {
+						// Whole pool capped: the request is unservable no
+						// matter the policy.
+						delete(sessionAccount, session)
+						result.unservedTicks++
+						return
+					}
+					sessionAccount[session] = i
+					hosted[i] = true
+					return
+				}
+			}
+		}
+
+		// New arrival.
+		if tick%arrivalEvery == 0 && nextSession < arrivals {
+			place(nextSession)
+			nextSession++
+		}
+
+		// Sticky consumption.
+		for _, idx := range sessionAccount {
+			used[idx] += perSessionBurn
+		}
+
+		// Cap hits: every session on a newly capped account reroutes at once.
+		moved := 0
+		for session, idx := range sessionAccount {
+			if used[idx] >= 1 {
+				moved++
+				delete(sessionAccount, session)
+				place(session)
+			}
+		}
+		if moved > result.largestMove {
+			result.largestMove = moved
+		}
+
+		// Concentration sample.
+		if len(sessionAccount) >= sampleThreshold {
+			perAccount := map[int]int{}
+			for _, idx := range sessionAccount {
+				perAccount[idx]++
+			}
+			for _, count := range perAccount {
+				share := float64(count) / float64(len(sessionAccount))
+				if share > result.peakShare {
+					result.peakShare = share
+				}
+			}
+		}
+	}
+	result.accountsEver = len(hosted)
+	return result
+}
+
+// A healthy pool must absorb a day of arriving sticky sessions without
+// herding them onto one account, and a weekly-cap hit must not stampede a
+// large batch of sessions at once. The deterministic-argmax policy fails
+// both: it concentrates every placement on the momentarily-best account
+// (peak share well above one half) and then moves that whole herd together
+// when the account caps.
+func TestStampedeSimSpreadsSessionsAndBoundsMassMoves(t *testing.T) {
+	const runs = 6
+	var peakShare float64
+	var largestMove float64
+	accountsEver := 0
+	for i := 0; i < runs; i++ {
+		result := runStampedeSim(t)
+		peakShare += result.peakShare
+		largestMove += float64(result.largestMove)
+		if result.accountsEver > accountsEver {
+			accountsEver = result.accountsEver
+		}
+	}
+	peakShare /= runs
+	largestMove /= runs
+
+	t.Logf("avg peak share %.2f, avg largest mass move %.1f, accounts ever hosting %d", peakShare, largestMove, accountsEver)
+	if peakShare > 0.50 {
+		t.Fatalf("average peak concentration %.2f: more than half of all active sessions sat on one account", peakShare)
+	}
+	if largestMove > 9 {
+		t.Fatalf("average largest single-tick mass move %.1f sessions: a cap hit stampedes the herd", largestMove)
+	}
+}

--- a/selectacct/stampede_sim_test.go
+++ b/selectacct/stampede_sim_test.go
@@ -79,10 +79,14 @@ func runStampedeSim(t *testing.T) stampedeSimResult {
 		for _, idx := range sessionAccount {
 			sessionCounts[ids[idx]]++
 		}
+		usableAccounts := 0
 		for i := range scores {
 			headroom := 1 - math.Floor(lagged[i]*100)/100
 			if used[i] >= 1 {
 				headroom = 0
+			}
+			if headroom >= MinNewSessionHeadroom {
+				usableAccounts++
 			}
 			scores[i] = Score{AccountID: ids[i], Provider: account.ProviderCodex, Headroom: headroom, ShortHeadroom: headroom, Fresh: true}
 		}
@@ -129,12 +133,16 @@ func runStampedeSim(t *testing.T) stampedeSimResult {
 				place(session)
 			}
 		}
-		if moved > result.largestMove {
+		// Metrics cover the phase where spreading is possible at all: once
+		// demand has drained the pool to fewer than three usable accounts,
+		// every policy is forced to pile the survivors onto whatever is
+		// left, so the endgame says nothing about placement quality.
+		if moved > result.largestMove && usableAccounts >= 3 {
 			result.largestMove = moved
 		}
 
 		// Concentration sample.
-		if len(sessionAccount) >= sampleThreshold {
+		if usableAccounts >= 3 && len(sessionAccount) >= sampleThreshold {
 			perAccount := map[int]int{}
 			for _, idx := range sessionAccount {
 				perAccount[idx]++

--- a/selectacct/stampede_sim_test.go
+++ b/selectacct/stampede_sim_test.go
@@ -188,4 +188,7 @@ func TestStampedeSimSpreadsSessionsAndBoundsMassMoves(t *testing.T) {
 	if largestMove > 9 {
 		t.Fatalf("average largest single-tick mass move %.1f sessions: a cap hit stampedes the herd", largestMove)
 	}
+	if accountsEver < 6 {
+		t.Fatalf("only %d of 7 accounts ever hosted a session: the pool is not being spread across", accountsEver)
+	}
 }


### PR DESCRIPTION
## Symptom

Codex accounts drain one at a time. On 2026-08-18 one account served 100% of Codex tokens for five consecutive hours while six healthy accounts sat idle, and 26,165 session moves were logged in one day (peak 8,043/hour), each move re-billing the session's whole cached prefix as uncached input.

## Root cause

Two mechanisms, both verified against live cmux-lawrence logs and `/_subrouter/usage-status`.

### 1. Placement is a deterministic argmax over a lagging snapshot

`Scheduler.Pick` (`selectacct/scheduler.go:135`) sorts by tier, usable, `ExpiryPressure`, `Headroom`, `Sessions`, ID and always returns `sorted[0]`.

- Live Codex accounts report **only a weekly window**: `usage-status` shows every account with a single `primary` window of `LimitWindowSeconds: 604800` and nothing at or under 6h. `isShortWindow` (`selectacct/limits.go:131`) is therefore false for every window, `shortResetAfterSeconds` stays 0, and `expiryPressure(headroom, 0)` returns 0. **ExpiryPressure is 0 for every Codex account**, so ordering reduces to `Headroom` alone.
- `Headroom` comes from `used_percent`, which is integer-only for Codex and lags real consumption by hours (confirmed against transcripts).
- The anti-herd live debit (`NoteRouted` → `WithLiveDebits`, 0.020/request) is wiped by **every successful usage refresh**: `finishRefreshLocked` sets `routedSinceRefresh = nil` (`selectacct/scheduler_ref.go:533`), and the refresh TTL is 30s (`cmd/subrouter/main.go:301`). Placements are minutes-to-hours apart (61 new Codex sessions in 19h), so essentially every placement runs against a freshly wiped, still-lagging snapshot. The debit only ever protected picks made within the same 30s window.

Deterministic argmax + zero pressure signal + lagging integer snapshot + rare placements ⇒ every placement (new sessions and cap-hit reroutes alike) lands on the same account until its lagging `used_percent` finally crosses the runner-up's. Sessions are long-lived and sticky by design (#216/#220), so each placement commits hours of traffic; the account is driven to its weekly cap, then every session on it reroutes at once — to the next argmax account.

Observed live while writing this fix: between 18:53 and 19:31 on 2026-08-18, **every** new session was placed on `aziz+8` (measured headroom 0.96, the pool argmax) while `aziz+9..14` (headroom 0.80–0.88) received none — the incident shape reproducing in real time.

### 2. A fully-constrained pool ping-pongs every session on every request

When the whole pool sits below the sticky-retention floor (0.05), `reuseStickyAssignment` rejects every assignment and every request falls through to `Pick`, which happily moves the session to an account exactly as drained as the one it left (`Pick` routes optimistically by design; there was no "is the destination actually better" check). The daemon log shows the storm: 03:00–10:00 PDT on 2026-08-18, 6,279 + 8,043 + 2,448 + 2,530 + 2,186 + 1,561 + 1,562 + 1,463 moves while serving only a few hundred requests per hour, with individual sessions moving 800–4,000 times. Every move is a full prefix re-bill.

## Fix

1. **Weighted placement spread** (`selectacct/scheduler.go`): when the sort's leading candidate is a usable OAuth account with `ExpiryPressure == 0` and the pool is Codex, `Pick` samples from the leading usable run instead of taking `sorted[0]`. Weight = headroom surplus above `MinNewSessionHeadroom` (floored at 0.01 so a threshold-straddling account stays pickable), damped by `1 + Sessions` so a lagging snapshot does not overload an already-busy account between refreshes. Surplus weighting drains roomy accounts faster, so the pool converges toward even headroom. Claude ordering is untouched: any account with pressure > 0 keeps the deliberate drain-soonest argmax, and non-Codex pools never spread (fable Bedrock fallback, credential leases, and 429 failover order keep their existing deterministic behaviour).
2. **Move-worthiness gate** (`internal/proxy/proxy.go`, `keepConstrainedStickyAssignment`): a Codex session whose account fell below the retention floor moves only if the picked destination could itself retain the session (≥ 0.05 measured) **and** offers ≥ 10pp more measured headroom — or, if the current account is exhausted, to any non-exhausted account. Otherwise the session stays where its prompt cache lives. Retention thresholds are unchanged; this strengthens cache affinity rather than weakening it (#216/#220 intact: the 0.01→0.26 escape in `TestStickyCodexSessionLeavesNearlyEmptyAccount` still moves). The gate reads measured scores (`ScoreFor`), not live-debited ones, per the #220 rule that evict-class decisions must ignore the debit floor.

Steady-state traffic is untouched: sticky reuse returns before any of this, placement adds no locks (math/rand/v2 top-level generator), and the extra `Pick` in the sticky branch runs only for already-constrained sessions.

## Proof the picks actually change

Committed as a failing-tests-first commit (CI red → green):

- `TestPickSpreadsPlacementsAcrossHealthyCodexPool` — 200 placements against the live pool's exact headrooms: before, 200/200 on `aziz+8`; after, spread across all 7.
- `TestPickSpreadSurvivesRefreshWipedDebits` — reproduces the exact production loop (place → NoteRouted → refresh wipes debits → place): before, 120/120 on one account.
- `TestPickConcurrentPlacementsSpread` — 64 concurrent picks (mass-reroute shape), race-detector clean.
- `TestStampedeSimSpreadsSessionsAndBoundsMassMoves` — 24h weekly-window simulation with lagging integer snapshots and cap-hit mass reroutes: argmax averages 0.58 peak concentration and 11-session mass moves; the fix averages 0.32 and 1.7.
- `TestNewCodexSessionsSpreadAcrossHealthyPool`, `TestConstrainedPoolDoesNotPingPongStickySessions`, `TestStickySessionLeavesConstrainedAccountOnlyForHealthyTarget`, `TestStickySessionIgnoresMarginallyBetterTarget` — proxy-level, through `accountForSessionProviderWithOptions`.

`go test ./...` green (output in PR checks); `-count=30` on all statistical tests without a flake; `-race` clean on the new tests.

## Edge cases considered

- **Threshold boundary**: an account exactly at `MinNewSessionHeadroom` gets the 0.01 weight floor, so an all-at-threshold pool still routes instead of dividing by zero / starving.
- **Pool shrinks over time**: accounts dropping below 0.40 leave the spread pool (they sort out of the usable run); the last usable account degenerates to the old argmax; a fully unusable pool keeps the existing tier-2 optimistic-routing behaviour, and exhausted accounts stay unpickable while alternatives exist (`TestPickSpreadNeverSelectsUnusableAccount`).
- **Mixed pressure pools**: any usable account with pressure > 0 sorts first and disables spreading, preserving Claude's GTO drain ordering (`TestFablePickPrefersSoonerWeeklyReset`, `TestOpusPickIgnoresWeeklyDrainPressure` unchanged).
- **API-key accounts**: tier ordering is evaluated per candidate, so API-key accounts never enter the spread pool and OAuth-before-API-key is preserved.
- **Same-session concurrent first requests** can now pick different accounts; last `Sessions.Put` wins and stickiness converges on the next request (previously also possible whenever a refresh landed between the two picks).
- **Session-count damping uses the never-pruned store** (`CountByAccount` counts all assignments ever). It only damps weights; a skewed baseline shifts proportions but cannot re-create a herd, and `Put` increments the count immediately so bursts self-balance.
- **Move-gate hysteresis boundaries**: destination below the retention floor never takes a session (would bounce next request); a <10pp gain is not worth a prefix re-bill; an exhausted account is always escapable to any non-exhausted account, so cap-hit failover is unimpeded; pool recovery (one account resets/imports fresh) moves each constrained session exactly once.
- **Fallback-collapsed sessions** (`codex:fallback`, #216) remain one sticky key riding one account; spreading placements means the account it rides is no longer also the target of every other placement.

## Out of scope

The two Claude credential bugs from the same review (`refreshProfileCredential` lock release, missing non-terminal-error carve-out in `refreshSelectedAccount`) are untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789700336&installation_model_id=21920&pr_number=228&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F228&signature=b4b7079b219b0513d1a57060f1dc1a7c3fbafba6c148e93608c240cab20bf4b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Spreads Codex placements across usable OAuth accounts and stops constrained-pool ping‑pong to prevent session herding and mass reroutes. Previously `Pick` returned a deterministic argmax from a lagging snapshot and constrained stickies always moved; now Codex placements sample within the healthy run and stickies move only to materially better targets.

- `selectacct.Scheduler.Pick`: for Codex OAuth pools with no `ExpiryPressure`, sample from the leading usable run. Weight = max(headroom − `MinNewSessionHeadroom`, 0.01) / (1 + Sessions). Any pool with pressure keeps deterministic drain ordering; non‑Codex is unchanged. New `PickBest` preserves deterministic argmax; `cmd/subrouter` `sr_auto_switch` now uses `PickBest` to keep one stable CLI account.
- `internal/proxy`: add a move‑worthiness gate for constrained Codex stickies. Move only if the destination could retain the session (≥ `MinStickyRetentionHeadroom`) and is ≥ 10pp better by measured headroom, or if the current account is exhausted (then any non‑exhausted destination). Uses measured scores, not live‑debited, and carries the picked candidate into assignment.
- Scope and compatibility: steady‑state sticky reuse is unchanged; spreading applies only to Codex OAuth and is disabled in mixed‑pressure pools. API‑key accounts never enter the spread pool.
- Tests: added spread/anti‑ping‑pong unit tests and a 24h stampede simulation; the sim now also asserts account coverage. Websocket and lease tests updated for non‑deterministic placement; all pass with `-race`.

<sup>Written for commit 3dd70ee996e42c14ec000fecf82e78903764c859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - New Codex sessions are distributed more evenly across healthy accounts.
  - Account selection now considers available capacity and existing session load.
  - Sticky sessions remain stable unless a meaningfully healthier account is available.
  - Exhausted or low-capacity accounts are avoided when suitable alternatives exist.

- **Bug Fixes**
  - Reduced session concentration and large-scale rerouting during usage refreshes or capacity changes.
  - Prevented caller-provided routing overrides from bypassing scheduler decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->