### PR TITLE
Serialize Claude credential refresh so a single-use token is redeemed once

### DIFF
--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -1110,72 +1110,63 @@ func (s Store) ForceRefreshCredential(ctx context.Context, client *http.Client, 
 	return s.refreshProfileCredential(ctx, client, profile, true)
 }
 
+// refreshProfileCredential serializes concurrent refreshes of the same
+// profile using lockProfileRefresh, a lock distinct from
+// lockProfileCredential. Claude refresh tokens are single-use, so two
+// concurrent callers racing to refresh the same profile must still be
+// serialized across the network call itself — a caller that blocks here will
+// observe the winner's already-refreshed, still-fresh credential on its own
+// subsequent read and skip the network call entirely (see the shouldRefresh
+// check below). Unlike lockProfileCredential, lockProfileRefresh is only ever
+// held here, so holding it across the OAuth round-trip never blocks an
+// unrelated ImportProfileCredential call for the same profile; each
+// individual disk read/write still takes the short-lived
+// lockProfileCredential via ReadCredential / writeRefreshedCredentialIfUnchanged.
 func (s Store) refreshProfileCredential(ctx context.Context, client *http.Client, profile Profile, force bool) (account accounts.Account, didRefresh bool, err error) {
 	configDir := s.ClaudeConfigDir(profile.Name)
-	lock, err := lockProfileCredential(ctx, configDir)
+	refreshLock, err := lockProfileRefresh(ctx, configDir)
 	if err != nil {
 		return accounts.Account{}, false, err
 	}
+	defer func() {
+		if closeErr := refreshLock.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
 	current, ok := s.FindProfile(profile.Name)
 	if !ok || profileInstancePathKey(s.ClaudeConfigDir(current.Name)) != profileInstancePathKey(configDir) {
-		return accounts.Account{}, false, errors.Join(
-			fmt.Errorf("Claude profile %q is no longer current", profile.Name),
-			lock.Close(),
-		)
+		return accounts.Account{}, false, fmt.Errorf("Claude profile %q is no longer current", profile.Name)
 	}
 	profile = current
-	credential, err := s.readCredential(ctx, configDir)
+	credential, err := s.ReadCredential(ctx, configDir)
 	if err != nil {
-		return accounts.Account{}, false, errors.Join(err, lock.Close())
+		return accounts.Account{}, false, err
 	}
 	if credential == nil || credential.AccessToken == "" {
-		return accounts.Account{}, false, errors.Join(
-			fmt.Errorf("Claude profile %q has no access token", profile.Name),
-			lock.Close(),
-		)
+		return accounts.Account{}, false, fmt.Errorf("Claude profile %q has no access token", profile.Name)
 	}
 	if force && credential.RefreshToken == "" {
-		return accounts.Account{}, false, errors.Join(
-			fmt.Errorf("Claude profile %q has no refresh token", profile.Name),
-			lock.Close(),
-		)
+		return accounts.Account{}, false, fmt.Errorf("Claude profile %q has no refresh token", profile.Name)
 	}
 	shouldRefresh := credential.RefreshToken != "" &&
 		(force || credentialExpired(credential, 60*time.Second))
 	if !shouldRefresh {
 		account, ok = profileAccount(profile, configDir, credential)
 		if !ok {
-			return accounts.Account{}, false, errors.Join(
-				fmt.Errorf("Claude profile %q has no usable credential", profile.Name),
-				lock.Close(),
-			)
-		}
-		if err := lock.Close(); err != nil {
-			return accounts.Account{}, false, err
+			return accounts.Account{}, false, fmt.Errorf("Claude profile %q has no usable credential", profile.Name)
 		}
 		return account, false, nil
 	}
 
 	credentialBeforeRefresh := *credential
 	profileBeforeRefresh := profile
-	if err := lock.Close(); err != nil {
-		return accounts.Account{}, false, err
-	}
 	refreshed, err := RefreshCredential(ctx, client, credentialBeforeRefresh)
 	if err != nil {
 		return accounts.Account{}, false, err
 	}
 	didRefresh = true
 
-	lock, err = lockProfileCredential(ctx, configDir)
-	if err != nil {
-		return accounts.Account{}, false, err
-	}
-	defer func() {
-		if closeErr := lock.Close(); err == nil {
-			err = closeErr
-		}
-	}()
 	current, ok = s.FindProfile(profile.Name)
 	if !ok ||
 		current.CreatedAt != profileBeforeRefresh.CreatedAt ||
@@ -1183,24 +1174,51 @@ func (s Store) refreshProfileCredential(ctx context.Context, client *http.Client
 		return accounts.Account{}, false, fmt.Errorf("Claude profile %q is no longer current", profile.Name)
 	}
 	profile = current
-	credential, err = s.readCredential(ctx, configDir)
+	credential, err = s.writeRefreshedCredentialIfUnchanged(ctx, configDir, credentialBeforeRefresh, refreshed)
 	if err != nil {
 		return accounts.Account{}, false, err
 	}
 	if credential == nil || credential.AccessToken == "" {
 		return accounts.Account{}, false, fmt.Errorf("Claude profile %q has no access token", profile.Name)
 	}
-	if *credential == credentialBeforeRefresh {
-		credential = &refreshed
-		if err := s.writeCredential(ctx, configDir, *credential); err != nil {
-			return accounts.Account{}, false, err
-		}
-	}
 	account, ok = profileAccount(profile, configDir, credential)
 	if !ok {
 		return accounts.Account{}, false, fmt.Errorf("Claude profile %q has no usable credential", profile.Name)
 	}
 	return account, didRefresh, nil
+}
+
+// writeRefreshedCredentialIfUnchanged briefly holds lockProfileCredential to
+// re-read the on-disk credential and compare it against the value read before
+// the network refresh. If nothing else wrote to the profile in the meantime,
+// the refreshed credential is persisted and returned. Otherwise the newer
+// on-disk credential wins and the refreshed value is discarded, so a
+// concurrent ImportProfileCredential is never clobbered by a stale refresh.
+func (s Store) writeRefreshedCredentialIfUnchanged(ctx context.Context, instancePath string, before, refreshed CredentialInfo) (credential *CredentialInfo, err error) {
+	lock, err := lockProfileCredential(ctx, instancePath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := lock.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	current, err := s.readCredential(ctx, instancePath)
+	if err != nil {
+		return nil, err
+	}
+	if current == nil || current.AccessToken == "" {
+		return current, nil
+	}
+	if *current != before {
+		return current, nil
+	}
+	if err := s.writeCredential(ctx, instancePath, refreshed); err != nil {
+		return nil, err
+	}
+	return &refreshed, nil
 }
 
 func (s Store) RefreshAccountIfExpired(ctx context.Context, client *http.Client, account accounts.Account) (accounts.Account, bool, error) {

--- a/internal/agents/claude/store_lock_unix.go
+++ b/internal/agents/claude/store_lock_unix.go
@@ -105,3 +105,63 @@ func (l *profileCredentialLock) Close() error {
 	}
 	return closeErr
 }
+
+type profileRefreshLock struct {
+	file           *os.File
+	releaseProcess func()
+}
+
+// lockProfileRefresh serializes one profile's OAuth refresh network
+// round-trip across goroutines and overlapping supervisor worker
+// generations. It is distinct from lockProfileCredential so that a
+// long-running refresh never blocks an unrelated ImportProfileCredential
+// call on the same profile.
+func lockProfileRefresh(ctx context.Context, instancePath string) (*profileRefreshLock, error) {
+	if resolved, err := filepath.EvalSymlinks(instancePath); err == nil {
+		instancePath = resolved
+	}
+	path := filepath.Clean(instancePath) + ".refresh.lock"
+	releaseProcess, err := lockProfileCredentialProcess(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		releaseProcess()
+		return nil, err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		releaseProcess()
+		return nil, err
+	}
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return &profileRefreshLock{file: file, releaseProcess: releaseProcess}, nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			_ = file.Close()
+			releaseProcess()
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			_ = file.Close()
+			releaseProcess()
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (l *profileRefreshLock) Close() error {
+	unlockErr := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	closeErr := l.file.Close()
+	l.releaseProcess()
+	if unlockErr != nil {
+		return unlockErr
+	}
+	return closeErr
+}

--- a/internal/agents/claude/store_lock_windows.go
+++ b/internal/agents/claude/store_lock_windows.go
@@ -145,3 +145,78 @@ func (l *profileCredentialLock) Close() error {
 	}
 	return closeErr
 }
+
+type profileRefreshLock struct {
+	file           *os.File
+	overlapped     syscall.Overlapped
+	releaseProcess func()
+}
+
+// lockProfileRefresh serializes one profile's OAuth refresh network
+// round-trip across goroutines and overlapping supervisor worker
+// generations. It is distinct from lockProfileCredential so that a
+// long-running refresh never blocks an unrelated ImportProfileCredential
+// call on the same profile.
+func lockProfileRefresh(ctx context.Context, instancePath string) (*profileRefreshLock, error) {
+	if resolved, err := filepath.EvalSymlinks(instancePath); err == nil {
+		instancePath = resolved
+	}
+	path := filepath.Clean(instancePath) + ".refresh.lock"
+	releaseProcess, err := lockProfileCredentialProcess(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		releaseProcess()
+		return nil, err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		releaseProcess()
+		return nil, err
+	}
+	lock := &profileRefreshLock{file: file, releaseProcess: releaseProcess}
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		result, _, callErr := profileRegistryLockFile.Call(
+			file.Fd(),
+			profileRegistryExclusiveLock|profileRegistryFailImmediately,
+			0,
+			uintptr(^uint32(0)),
+			uintptr(^uint32(0)),
+			uintptr(unsafe.Pointer(&lock.overlapped)),
+		)
+		if result != 0 {
+			return lock, nil
+		}
+		if !errors.Is(callErr, profileLockViolation) {
+			_ = file.Close()
+			releaseProcess()
+			return nil, fmt.Errorf("lock Claude profile refresh: %w", callErr)
+		}
+		select {
+		case <-ctx.Done():
+			_ = file.Close()
+			releaseProcess()
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (l *profileRefreshLock) Close() error {
+	result, _, callErr := profileRegistryUnlock.Call(
+		l.file.Fd(),
+		0,
+		uintptr(^uint32(0)),
+		uintptr(^uint32(0)),
+		uintptr(unsafe.Pointer(&l.overlapped)),
+	)
+	closeErr := l.file.Close()
+	l.releaseProcess()
+	if result == 0 {
+		return fmt.Errorf("unlock Claude profile refresh: %w", callErr)
+	}
+	return closeErr
+}

--- a/internal/agents/claude/store_test.go
+++ b/internal/agents/claude/store_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -792,6 +793,108 @@ func TestRefreshCredentialPostsClaudeOAuthRefresh(t *testing.T) {
 	}
 	if got.ExpiresAt <= time.Now().UnixMilli() {
 		t.Fatalf("ExpiresAt = %d, want future", got.ExpiresAt)
+	}
+}
+
+// Claude refresh tokens are single-use. Concurrent callers that each read the
+// same stored refresh token and race to redeem it get one winner and one
+// invalidated credential, which logs the profile out. Concurrent refreshes of
+// one profile must therefore serialize across the network round-trip, so that
+// every caller after the first observes the winner's fresh credential and
+// skips the network call entirely.
+func TestRefreshCredentialIfExpiredRedeemsRefreshTokenOnce(t *testing.T) {
+	originalURL := oauthTokenURL
+	defer func() { oauthTokenURL = originalURL }()
+
+	var mu sync.Mutex
+	redeemed := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		token := payload["refresh_token"]
+
+		mu.Lock()
+		redeemed[token]++
+		reuse := redeemed[token] > 1
+		mu.Unlock()
+
+		// Model the upstream's single-use semantics: a token that has already
+		// been redeemed is dead, and redeeming it again is an error.
+		if reuse {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, `{"error":"invalid_grant"}`)
+			return
+		}
+		// Slow enough that unserialized callers would overlap inside the
+		// network call rather than lining up behind each other by accident.
+		time.Sleep(50 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"fresh-access","refresh_token":"fresh-refresh","expires_in":3600}`)
+	}))
+	defer server.Close()
+	oauthTokenURL = server.URL
+
+	store := Store{Dir: t.TempDir()}
+	if err := store.ImportProfileCredential("race@example.com", CredentialInfo{
+		AccessToken:  "stale-access",
+		RefreshToken: "stale-refresh",
+		ExpiresAt:    time.Now().Add(-time.Hour).UnixMilli(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	profile, ok := store.FindProfile("race@example.com")
+	if !ok {
+		t.Fatal("profile not found")
+	}
+
+	const callers = 8
+	type result struct {
+		account    accounts.Account
+		didRefresh bool
+		err        error
+	}
+	results := make([]result, callers)
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	start.Add(1)
+	for i := range results {
+		done.Add(1)
+		go func(i int) {
+			defer done.Done()
+			start.Wait()
+			account, didRefresh, err := store.RefreshCredentialIfExpired(context.Background(), server.Client(), profile)
+			results[i] = result{account: account, didRefresh: didRefresh, err: err}
+		}(i)
+	}
+	start.Done()
+	done.Wait()
+
+	refreshes := 0
+	for i, got := range results {
+		if got.err != nil {
+			t.Fatalf("caller %d failed: %v", i, got.err)
+		}
+		if got.account.Token != "fresh-access" {
+			t.Fatalf("caller %d token = %q, want fresh-access", i, got.account.Token)
+		}
+		if got.didRefresh {
+			refreshes++
+		}
+	}
+	if refreshes != 1 {
+		t.Fatalf("network refreshes reported = %d, want exactly 1", refreshes)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(redeemed) != 1 {
+		t.Fatalf("distinct refresh tokens redeemed = %d (%v), want 1", len(redeemed), redeemed)
+	}
+	if got := redeemed["stale-refresh"]; got != 1 {
+		t.Fatalf("stale-refresh redeemed %d times, want exactly 1", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

Claude OAuth refresh tokens are **single-use**. `refreshProfileCredential` read the stored credential, **released** the profile's credential lock, and only then made the network round-trip to Anthropic's token endpoint.

Two concurrent callers for the same profile therefore both read the same refresh token and both tried to redeem it. The first won; the second got `401 {"error":"invalid_grant"}`, and the profile was left holding an invalidated credential — i.e. a silent, unexplained logout.

This matches a report of several Claude accounts spontaneously logging out with a "weird JSON error".

## Why the obvious fix is wrong

Simply holding the existing `lockProfileCredential` across the network call does fix the double redemption, but that same lock is taken by `ImportProfileCredential`. An in-flight refresh would then block an unrelated import for the entire OAuth round-trip, which blows the 2s budget in `TestRefreshCredentialDoesNotOverwriteNewerImportAcrossProcesses`.

## This change

- Adds `lockProfileRefresh`, a **separate** per-profile lock using a distinct lock-file suffix `.refresh.lock` (vs `.credentials.lock`), implemented for both platforms in `store_lock_unix.go` / `store_lock_windows.go`. It reuses the existing generic, path-keyed `lockProfileCredentialProcess` in-process semaphore, so there is no new in-process locking logic.
- `refreshProfileCredential` holds `lockProfileRefresh` for the whole function, network call included. Refreshes serialize against each other (race fixed); imports are untouched because they take a different lock. A caller that blocks observes the winner's fresh credential and skips the network call entirely.
- The initial read moves from unlocked `readCredential` to locked `ReadCredential`, since the function no longer holds the credential lock throughout.
- New helper `writeRefreshedCredentialIfUnchanged` briefly re-takes `lockProfileCredential`, re-reads the on-disk credential, and writes the refreshed value **only if it still matches the pre-refresh value**; otherwise the newer on-disk credential wins and the refresh result is discarded. This is behaviourally identical to the previous inline compare-and-write, so a concurrent import is still never clobbered by a stale refresh.

## Test

`TestRefreshCredentialIfExpiredRedeemsRefreshTokenOnce` runs 8 concurrent `RefreshCredentialIfExpired` callers against one expired profile, with a fake OAuth server that models single-use semantics (a token redeemed twice returns `401 invalid_grant`) and sleeps 50ms so unserialized callers genuinely overlap. It asserts exactly one network refresh, one distinct token redeemed exactly once, and that every caller returns the fresh token.

**Falsified**: stashing only `store.go` and re-running the test against the pre-fix implementation fails with

```
caller 1 failed: Claude OAuth refresh failed: 401 Unauthorized: {"error":"invalid_grant"}
```

— the exact production symptom. The test is not vacuous.

## Verification

- `go build ./...` — clean
- `gofmt -l internal/agents/claude/` — clean
- `go vet ./internal/agents/claude/...` — clean
- `go test ./internal/agents/claude/... -count=1 -race` — ok
- `TestRefreshCredentialDoesNotOverwriteNewerImportAcrossProcesses` passes in 0.08s (it was blowing its 2s budget under the naive single-lock fix)
- `go test ./internal/transcript/... -count=1` — ok

One failure in `cmd/subrouter` (`TestGCPStartupBuildsPreparedFrontTopologyFromPinnedReleaseMetadata`) is **pre-existing on `main`** — verified by running that same test at `81daf6f` with the identical `read prepared marker: ... no such file or directory` failure. It is unrelated to this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789702558&installation_model_id=21920&pr_number=229&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F229&signature=26a42092dc5bd664e05e3e97e94ecba8abb42b3272aebdee94167d66ce5138cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents double redemption of Claude’s single‑use OAuth refresh tokens by serializing refreshes per profile. Previously, concurrent refreshes released the credential lock before the network call; one caller succeeded, the other got 401 invalid_grant and the profile kept an invalidated credential. Now, only one refresh proceeds; others reuse the winner’s refreshed credential.

- Introduces `lockProfileRefresh` (per-profile `.refresh.lock`) held across the network call; separate from `lockProfileCredential` so `ImportProfileCredential` is never blocked. Implemented in `store_lock_unix.go` and `store_lock_windows.go`, reusing the in-process `lockProfileCredentialProcess`.
- Updates `refreshProfileCredential` to acquire `lockProfileRefresh`, use `ReadCredential` for the initial locked read, and skip the network call if another caller already refreshed.
- Adds `writeRefreshedCredentialIfUnchanged`: compare-and-swap under `lockProfileCredential` so a concurrent `ImportProfileCredential` is never clobbered.
- Adds `TestRefreshCredentialIfExpiredRedeemsRefreshTokenOnce` to assert exactly one refresh, one token redemption, and fresh credentials returned to all callers. No config or migration changes.

<sup>Written for commit e982826ef03a16981c600544d53aea0e4f1eab0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential refresh reliability when multiple sessions refresh simultaneously.
  * Prevented stale refresh results from overwriting newer credential updates.
  * Reduced failures caused by single-use refresh tokens during concurrent requests.

* **Tests**
  * Added coverage confirming concurrent refresh attempts produce one successful token refresh while sharing the updated credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->