### PR TITLE
Retry Bedrock when a Fable stream fails before the first event

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -169,64 +169,85 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 		endpoint = "invoke-with-response-stream"
 	}
 	path := "/model/" + bedrockFableModelID + "/" + endpoint
+	var resp *http.Response
+	var sourceName, region string
 	started := time.Now()
-	resp, sourceName, region, err := s.signAndForwardBedrock(ctx, http.MethodPost, path, newBody)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusTooManyRequests {
-		if s.Logger != nil {
-			s.Logger.Warn("bedrock throttled", "model", bedrockFableModelID, "path", path, "bedrock_source", sourceName, "region", region)
+	for attempt := 1; ; attempt++ {
+		started = time.Now()
+		resp, sourceName, region, err = s.signAndForwardBedrock(ctx, http.MethodPost, path, newBody)
+		if err != nil {
+			return nil, err
 		}
-		cfg.onThrottle(sourceName, region, bedrockFableModelID)
-	}
-
-	if stream && resp.StatusCode == http.StatusOK {
-		first, peeked, err := peekBedrockStream(resp.Body)
-		if err != nil || strings.EqualFold(first.messageType, "exception") {
+		if resp.StatusCode == http.StatusTooManyRequests {
 			if s.Logger != nil {
-				attrs := []any{"bedrock_source", sourceName, "region", region, "saw_message_stop", false}
-				if first.exceptionType != "" {
-					attrs = append(attrs, "exception_type", first.exceptionType, "message", bedrockLogPreview(first.payload))
-				}
-				if err != nil {
-					attrs = append(attrs, "read_err", err)
-				}
-				s.Logger.Warn("claude-fable bedrock stream failed before first event", attrs...)
+				s.Logger.Warn("bedrock throttled", "model", bedrockFableModelID, "path", path, "bedrock_source", sourceName, "region", region)
 			}
-			_ = resp.Body.Close()
-			body := first.payload
-			if len(body) == 0 {
-				body = []byte(`{"type":"error","error":{"type":"api_error","message":"Bedrock stream failed before first event"}}`)
-			}
-			s.recordClaudeFableBedrockCost(started, region, http.StatusServiceUnavailable, bedrockUsage{}, false)
+			cfg.onThrottle(sourceName, region, bedrockFableModelID)
+		}
+		if !stream || resp.StatusCode != http.StatusOK {
+			break
+		}
+		first, peeked, peekErr := peekBedrockStream(resp.Body)
+		failed, retryable := bedrockFirstFrameFailure(first, peekErr)
+		if !failed {
+			pr, pw := io.Pipe()
+			streamStarted := started
+			streamRegion := region
+			streamSource := sourceName
+			body := resp.Body
+			go func() {
+				result := transcodeBedrockToSSE(pw, io.MultiReader(bytes.NewReader(peeked), body), s.Logger, streamSource, streamRegion)
+				_ = body.Close()
+				_ = pw.Close()
+				s.recordClaudeFableBedrockCost(streamStarted, streamRegion, http.StatusOK, result.Usage, result.HaveUsage)
+			}()
 			return &http.Response{
-				Status:        "503 Service Unavailable",
-				StatusCode:    http.StatusServiceUnavailable,
+				Status:        "200 OK",
+				StatusCode:    http.StatusOK,
 				Proto:         "HTTP/1.1",
 				ProtoMajor:    1,
 				ProtoMinor:    1,
-				Header:        http.Header{"Content-Type": {"application/json"}},
-				Body:          io.NopCloser(bytes.NewReader(body)),
-				ContentLength: int64(len(body)),
+				Header:        http.Header{"Content-Type": {"text/event-stream"}, "Cache-Control": {"no-cache"}},
+				Body:          pr,
+				ContentLength: -1,
 			}, nil
 		}
-		pr, pw := io.Pipe()
-		go func() {
-			result := transcodeBedrockToSSE(pw, io.MultiReader(bytes.NewReader(peeked), resp.Body), s.Logger, sourceName, region)
-			_ = resp.Body.Close()
-			_ = pw.Close()
-			s.recordClaudeFableBedrockCost(started, region, http.StatusOK, result.Usage, result.HaveUsage)
-		}()
+		// Error bodies only (never message content): the first frame is an
+		// exception or an Anthropic error event, so logging it is safe.
+		if s.Logger != nil {
+			attrs := []any{"bedrock_source", sourceName, "region", region, "saw_message_stop", false, "attempt", attempt, "retryable", retryable}
+			if first.exceptionType != "" {
+				attrs = append(attrs, "exception_type", first.exceptionType)
+			}
+			if len(first.payload) > 0 {
+				attrs = append(attrs, "message", bedrockLogPreview(first.payload))
+			}
+			if peekErr != nil {
+				attrs = append(attrs, "read_err", peekErr)
+			}
+			s.Logger.Warn("claude-fable bedrock stream failed before first event", attrs...)
+		}
+		_ = resp.Body.Close()
+		s.recordClaudeFableBedrockCost(started, region, http.StatusServiceUnavailable, bedrockUsage{}, false)
+		if retryable && attempt < claudeFableBedrockStreamAttempts && ctx.Err() == nil {
+			// A fresh signAndForwardBedrock call starts from the next
+			// credential source/region rotation, so the retry prefers a
+			// different endpoint when more than one is configured.
+			continue
+		}
+		errBody := first.payload
+		if len(errBody) == 0 {
+			errBody = []byte(`{"type":"error","error":{"type":"api_error","message":"Bedrock stream failed before first event"}}`)
+		}
 		return &http.Response{
-			Status:        "200 OK",
-			StatusCode:    http.StatusOK,
+			Status:        "503 Service Unavailable",
+			StatusCode:    http.StatusServiceUnavailable,
 			Proto:         "HTTP/1.1",
 			ProtoMajor:    1,
 			ProtoMinor:    1,
-			Header:        http.Header{"Content-Type": {"text/event-stream"}, "Cache-Control": {"no-cache"}},
-			Body:          pr,
-			ContentLength: -1,
+			Header:        http.Header{"Content-Type": {"application/json"}},
+			Body:          io.NopCloser(bytes.NewReader(errBody)),
+			ContentLength: int64(len(errBody)),
 		}, nil
 	}
 	// Non-stream success or any error status: Bedrock answers Anthropic-format JSON.
@@ -448,6 +469,48 @@ type bedrockFrame struct {
 }
 
 var errBedrockStreamEmpty = errors.New("bedrock stream ended before first event")
+
+// claudeFableBedrockStreamAttempts bounds how many times a streaming Fable
+// request is re-sent to Bedrock when the stream fails before any event has
+// been forwarded to the client. Nothing was committed yet, so the request is
+// safely replayable.
+const claudeFableBedrockStreamAttempts = 3
+
+// bedrockFirstFrameFailure classifies the peeked first frame of a Bedrock
+// response stream. failed reports that the stream opens with an error instead
+// of a message event; since no bytes have reached the client, the caller may
+// retry or fall down the fallback chain instead of committing a 200 that dies
+// immediately. Anthropic in-band error events arrive as ordinary chunk frames,
+// so a plain exception check misses them. retryable reports that a fresh
+// attempt may succeed: transport errors, throttles, and capacity errors
+// qualify; validation and auth errors fail identically everywhere and do not.
+func bedrockFirstFrameFailure(first bedrockFrame, peekErr error) (failed, retryable bool) {
+	if peekErr != nil {
+		return true, true
+	}
+	if strings.EqualFold(first.messageType, "exception") {
+		t := strings.ToLower(first.exceptionType)
+		return true, strings.Contains(t, "throttl") ||
+			strings.Contains(t, "serviceunavailable") ||
+			strings.Contains(t, "internalserver") ||
+			strings.Contains(t, "modelnotready") ||
+			strings.Contains(t, "timeout")
+	}
+	var ev struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type string `json:"type"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(first.payload, &ev) == nil && ev.Type == "error" {
+		switch ev.Error.Type {
+		case "overloaded_error", "api_error", "rate_limit_error", "internal_server_error":
+			return true, true
+		}
+		return true, false
+	}
+	return false, false
+}
 
 // transcodeBedrockToSSE converts a Bedrock invoke-with-response-stream body (AWS
 // event-stream framing wrapping Anthropic event JSON) into Anthropic Messages

--- a/internal/proxy/claude_fable_test.go
+++ b/internal/proxy/claude_fable_test.go
@@ -591,3 +591,150 @@ func TestServeClaudeFableBedrockPrimaryFallsThroughOnNon2xx(t *testing.T) {
 		t.Fatalf("restored body = %q, want %q", string(restored), bodyStr)
 	}
 }
+
+func fableStreamTestServer(rt bedrockRoundTripFunc) Server {
+	return Server{Bedrock: &BedrockConfig{
+		Regions:   []string{"us-east-1"},
+		Sources:   []BedrockCredentialSource{{Name: "aw0", Credentials: staticBedrockCreds()}},
+		Transport: rt,
+	}}
+}
+
+var fableStreamTestBody = []byte(`{"model":"claude-fable-5","stream":true,"max_tokens":8,"messages":[]}`)
+
+// An in-band Anthropic error event as the first frame used to slip through the
+// exception-only peek, committing a 200 SSE that immediately carried the error.
+// It must instead be retried; the second attempt succeeds here.
+func TestClaudeFableBedrockRetriesOverloadedFirstFrame(t *testing.T) {
+	good := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		buildEventStreamFrame(t, `{"type":"message_stop"}`)...,
+	)
+	overloaded := buildEventStreamFrame(t, `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)
+	calls := 0
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		body := overloaded
+		if calls >= 2 {
+			body = good
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	resp, err := s.claudeFableBedrockResponse(req.Context(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after retry", resp.StatusCode)
+	}
+	sse, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(sse), "event: message_stop") {
+		t.Fatalf("retried stream missing message_stop: %q", sse)
+	}
+	if strings.Contains(string(sse), "overloaded_error") {
+		t.Fatalf("first attempt's error leaked into the retried stream: %q", sse)
+	}
+	if calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2", calls)
+	}
+}
+
+func TestClaudeFableBedrockOverloadedFirstFrameExhaustsRetries(t *testing.T) {
+	overloaded := buildEventStreamFrame(t, `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)
+	calls := 0
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(overloaded)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	resp, err := s.claudeFableBedrockResponse(req.Context(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 so the fallback chain can take over", resp.StatusCode)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(respBody), "overloaded_error") {
+		t.Fatalf("503 body should carry the upstream error, got %q", respBody)
+	}
+	if calls != claudeFableBedrockStreamAttempts {
+		t.Fatalf("upstream calls = %d, want %d", calls, claudeFableBedrockStreamAttempts)
+	}
+}
+
+func TestClaudeFableBedrockInvalidRequestFirstFrameDoesNotRetry(t *testing.T) {
+	invalid := buildEventStreamFrame(t, `{"type":"error","error":{"type":"invalid_request_error","message":"bad"}}`)
+	calls := 0
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(invalid)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	resp, err := s.claudeFableBedrockResponse(req.Context(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", resp.StatusCode)
+	}
+	if calls != 1 {
+		t.Fatalf("upstream calls = %d, want 1 (no retry for validation errors)", calls)
+	}
+}
+
+func TestClaudeFableBedrockRetriesExceptionFirstFrame(t *testing.T) {
+	good := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		buildEventStreamFrame(t, `{"type":"message_stop"}`)...,
+	)
+	throttle := buildBedrockExceptionFrame(t, "throttlingException", `{"message":"Too many requests"}`)
+	calls := 0
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		body := throttle
+		if calls >= 2 {
+			body = good
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	resp, err := s.claudeFableBedrockResponse(req.Context(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after retrying past the throttle exception", resp.StatusCode)
+	}
+	if calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2", calls)
+	}
+}


### PR DESCRIPTION
Fable requests on cmux-lawrence intermittently died with `overloaded_error` tonight (18:17, 18:52, 19:34-19:36 in `/var/log/subrouter.err.log`). The error arrives as an in-band Anthropic `error` event in the first stream frame. The peek in `claudeFableBedrockResponse` only failed on AWS `exception` frames, so the error chunk slipped through, the 200 SSE was committed, and the client got a stream that opened and immediately died. Claude Code then backed off for minutes ("Waiting for API response, will retry in 1m 55s").

Fix: classify the peeked first frame. Any error there (exception frame, read error, or Anthropic error event) means zero bytes reached the client, so the request is replayable. Retryable failures (throttle, overloaded, api_error, transport) get up to 3 attempts; each fresh `signAndForwardBedrock` call starts from the next source/region rotation, so retries prefer a different endpoint when one is configured. Validation/auth errors do not retry. Final failure keeps the synthesized 503 with the upstream error body so the chain's API-key stage can take over.

No behavior change for healthy streams: the happy path transcodes exactly as before. Mid-stream errors after the first frame are still passed through, because the response is already committed.

Tests: retry-then-success on in-band overloaded first frame, retry exhaustion returns 503 with the upstream body after exactly 3 attempts, invalid_request does not retry, throttle exception frame retries. `go test ./...` green locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789703211&installation_model_id=21920&pr_number=230&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F230&signature=87ab63d8a9131ec922b46dee925dbd60cf000402e8a314b46803403e7f4241da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry Bedrock when a Fable stream fails before the first event to prevent committing a 200 SSE that immediately dies and causes client backoff. Previously only AWS exception frames triggered a retry; now we classify the first frame and retry safe failures.

- Classify the peeked first frame via `bedrockFirstFrameFailure`: treat AWS exceptions, read errors, and Anthropic in-band `error` events as pre-commit failures.
- Retry policy: up to 3 attempts (`claudeFableBedrockStreamAttempts`) for throttling/overloaded/api/transport errors; each new `signAndForwardBedrock` call advances the source/region rotation to prefer a different endpoint. Validation/auth errors do not retry.
- Response behavior: healthy streams are unchanged; mid-stream errors still pass through; on final failure return a 503 JSON carrying the upstream error so the fallback chain (API-key stage) can take over.
- Logging and cost recording are maintained; SSE responses remain 200 with event-stream headers, error responses are 503 JSON.
- Tests cover retry-then-success, retry exhaustion with upstream body, non-retry for `invalid_request`, and retry for throttle exception.

<sup>Written for commit ee895f4d34ec80b099c1095c51b10150a6764fe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

