### PR TITLE
Stop failing over healthy Claude accounts on a transient refresh error

### DIFF
--- a/internal/proxy/claude_failover_test.go
+++ b/internal/proxy/claude_failover_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -461,4 +462,90 @@ func TestUsageLimitRetryTransportClaudeFailsOverOn403OrgDisabled(t *testing.T) {
 	if !ok || assignment.AccountID != "fresh@example.com" {
 		t.Fatalf("sticky assignment = %+v, want moved off the org-disabled account", assignment)
 	}
+}
+
+// refreshSelectedAccount must only fail over when the refresh error says the
+// credential is dead. A transient failure (cancelled context, timeout, upstream
+// 5xx) previously fell straight through to markAccountExhaustedRefreshFailure
+// for Claude, because the non-terminal carve-out was gated on Codex, so a blip
+// held a healthy Claude account out of selection.
+func TestRefreshSelectedAccountClaudeKeepsAccountOnTransientRefreshError(t *testing.T) {
+	transient := []struct {
+		name string
+		err  error
+	}{
+		{name: "context canceled", err: context.Canceled},
+		{name: "deadline exceeded", err: context.DeadlineExceeded},
+		{name: "upstream 5xx", err: errors.New("Claude OAuth refresh failed: 503 Service Unavailable")},
+	}
+	for _, tc := range transient {
+		t.Run(tc.name, func(t *testing.T) {
+			server, _ := claudeFailoverServer(t)
+			cooked := server.Accounts[0]
+			refreshed := make([]string, 0, 2)
+			server.RefreshAccountFn = func(_ context.Context, account accounts.Account) (accounts.Account, error) {
+				refreshed = append(refreshed, account.ID)
+				return account, tc.err
+			}
+
+			got, err := server.refreshSelectedAccount(context.Background(), accounts.ProviderClaude, "claude", "session-1", "", claudeRefreshRequest(t), cooked)
+			if err == nil {
+				t.Fatal("a transient refresh failure must still be reported to the caller")
+			}
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("expected the transient error back, got %v", err)
+			}
+			if got.ID != cooked.ID {
+				t.Fatalf("expected the originally selected account back, got %q", got.ID)
+			}
+			if len(refreshed) != 1 || refreshed[0] != cooked.ID {
+				t.Fatalf("expected exactly one refresh of the selected account, got %v", refreshed)
+			}
+			if server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, cooked.ID) {
+				t.Fatal("a transient refresh failure must not mark a healthy Claude account exhausted")
+			}
+		})
+	}
+}
+
+// The carve-out must not swallow a real logout: Claude's refresh error text
+// carries invalid_grant, which isTerminalCredentialError classifies as terminal,
+// so the account is still marked and failover still runs.
+func TestRefreshSelectedAccountClaudeFailsOverOnTerminalRefreshError(t *testing.T) {
+	server, _ := claudeFailoverServer(t)
+	cooked := server.Accounts[0]
+	fresh := server.Accounts[1]
+	refreshed := make([]string, 0, 2)
+	server.RefreshAccountFn = func(_ context.Context, account accounts.Account) (accounts.Account, error) {
+		refreshed = append(refreshed, account.ID)
+		if account.ID == cooked.ID {
+			return account, errors.New(`Claude OAuth refresh failed: 400 Bad Request: {"error": "invalid_grant", "error_description": "Refresh token not found or invalid"}`)
+		}
+		return account, nil
+	}
+
+	got, err := server.refreshSelectedAccount(context.Background(), accounts.ProviderClaude, "claude", "session-1", "", claudeRefreshRequest(t), cooked)
+	if err != nil {
+		t.Fatalf("failover to the healthy account should succeed: %v", err)
+	}
+	if got.ID != fresh.ID {
+		t.Fatalf("expected failover to %q, got %q", fresh.ID, got.ID)
+	}
+	if len(refreshed) != 2 || refreshed[0] != cooked.ID || refreshed[1] != fresh.ID {
+		t.Fatalf("expected a refresh of the dead account then the healthy one, got %v", refreshed)
+	}
+	if !server.SchedulerRef.Get().Exhausted(accounts.ProviderClaude, cooked.ID) {
+		t.Fatal("a terminal Claude credential error must still mark the account exhausted")
+	}
+}
+
+func claudeRefreshRequest(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, "https://subrouter.test/v1/messages", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Subrouter-Agent", "claude")
+	req.Header.Set("X-Subrouter-Session", "session-1")
+	return req
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4695,7 +4695,13 @@ func (s Server) refreshSelectedAccount(ctx context.Context, provider accounts.Pr
 	if session.ExtractAccountID(r) != "" || (provider != accounts.ProviderClaude && provider != accounts.ProviderCodex) {
 		return account, err
 	}
-	if provider == accounts.ProviderCodex && !isTerminalCredentialError(err) {
+	// A refresh that failed for a transient reason (cancelled context, timeout,
+	// upstream 5xx) says nothing about the credential, so failing over would mark
+	// a healthy account exhausted and hold it out for the credential TTL. Only a
+	// terminal credential error justifies that. isTerminalCredentialError is
+	// provider-agnostic, so a genuine Claude logout (invalid_grant) still fails
+	// over here.
+	if !isTerminalCredentialError(err) {
 		return account, err
 	}
 	if s.Logger != nil {
@@ -4716,7 +4722,7 @@ func (s Server) refreshSelectedAccount(ctx context.Context, provider accounts.Pr
 		if err == nil {
 			return refreshed, nil
 		}
-		if provider == accounts.ProviderCodex && !isTerminalCredentialError(err) {
+		if !isTerminalCredentialError(err) {
 			return next, err
 		}
 		lastErr = err


### PR DESCRIPTION
## Problem

`refreshSelectedAccount` short-circuits failover when a refresh error is **not** terminal, so a transient blip doesn't burn an account. Both guards were gated on `provider == accounts.ProviderCodex`:

```go
if provider == accounts.ProviderCodex && !isTerminalCredentialError(err) {
    return account, err
}
```

For **Claude**, a cancelled context, a timeout, or an upstream 5xx therefore fell through to `markAccountExhaustedRefreshFailure` and failed over — marking a perfectly healthy account exhausted and holding it out of selection for the credential TTL.

A production log across three days shows **84** Claude refreshes failing with `context canceled`. Each one marked a healthy account exhausted.

## Change

Drop the Codex-only gate from both guards. The enclosing block already returns early unless the provider is Claude or Codex:

```go
if session.ExtractAccountID(r) != "" || (provider != accounts.ProviderClaude && provider != accounts.ProviderCodex) {
    return account, err
}
```

so this does not reach any other provider.

## Why a real Claude logout still fails over

`isTerminalCredentialError` is provider-agnostic below its typed Codex checks:

- returns **false** for `context.Canceled` / `context.DeadlineExceeded`
- returns **true** for a message containing `invalid_grant`, `refresh_token_reused`, `reauth required`, …

Claude's logout surfaces as

```
Claude OAuth refresh failed: 400 Bad Request: {"error": "invalid_grant", "error_description": "Refresh token not found or invalid"}
```

which contains `invalid_grant` → classified terminal → still marked and still failed over. Only transient failures stop burning accounts.

## Tests

- `TestRefreshSelectedAccountClaudeKeepsAccountOnTransientRefreshError` — table over `context.Canceled`, `context.DeadlineExceeded`, and an upstream 5xx. Asserts the error still reaches the caller, the originally selected account comes back, **exactly one** refresh happens (no failover), and the account is not marked exhausted.
- `TestRefreshSelectedAccountClaudeFailsOverOnTerminalRefreshError` — an `invalid_grant` refresh error still marks the account exhausted and still fails over to the healthy account.

**Falsified**: reverting only `proxy.go` and keeping the tests fails with

```
claude_failover_test.go:502: expected exactly one refresh of the selected account,
    got [cooked@example.com fresh@example.com]
```

i.e. the pre-fix code does fail over on `context canceled`. The tests are not vacuous.

## Verification

- `go build ./...` — clean
- `gofmt -l internal/proxy/` — clean
- `go vet ./internal/proxy/...` — clean
- `go test ./internal/proxy/... -count=1` — **ok, 133s**

## One behaviour change worth calling out

A refresh error that is *persistent* but not string-matched as terminal — notably a credential that fails to decode (`invalid character 'b' after top-level value`, from a malformed keychain blob) — is now also treated as non-terminal, so it no longer fails over to a sibling account. Previously it did.

That classification is arguably wrong in both directions today, and it deserves its own change: a credential that cannot be parsed cannot be refreshed without re-auth, so it is genuinely terminal. I'd rather fix it as a typed `*json.SyntaxError` check in `isTerminalCredentialError` alongside proper diagnostics for the decode failure, rather than widen this PR. Happy to fold it in here instead if you'd prefer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789703644&installation_model_id=21920&pr_number=231&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F231&signature=6838314f43cf4de6d319223d058e8bbac0a34012697d24e8762473f3478d02a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop failing over healthy Claude accounts on transient refresh errors. Previously, Claude refresh cancellations/timeouts/5xx marked the account exhausted and failed over because the non-terminal guard only applied to Codex; now only terminal credential errors trigger exhaustion and failover.

- Change scope: in `internal/proxy/proxy.go`, remove the `ProviderCodex` gate from both non-terminal guards inside `refreshSelectedAccount`; the enclosing check still limits this path to `ProviderClaude` and `ProviderCodex`. `internal/proxy/claude_failover_test.go` adds tests for transient and terminal cases.
- Behavior: on a transient refresh error, return the original account and the error; do not mark exhausted or attempt failover. On terminal errors (e.g., `invalid_grant`), still mark exhausted and fail over.
- Verification: new tests prove no failover on `context.Canceled`/`context.DeadlineExceeded`/upstream 5xx and failover on `invalid_grant`; the pre-fix code fails these tests.
- Notable edge case: persistent errors not classified as terminal (e.g., malformed credential JSON) now no longer fail over; we will tighten `isTerminalCredentialError` in a follow-up.

<sup>Written for commit 0191ec8ca0768947cde08e84a3f6b358c1831837. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

