### PR TITLE
Hold the Fable stream uncommitted until first content so late pre-content errors retry

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -187,14 +187,14 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 		if !stream || resp.StatusCode != http.StatusOK {
 			break
 		}
-		first, peeked, peekErr := peekBedrockStream(resp.Body)
-		failed, retryable := bedrockFirstFrameFailure(first, peekErr)
-		if !failed {
+		peek := peekBedrockStreamUntilCommit(resp.Body)
+		if peek.outcome == bedrockPeekCommit {
 			pr, pw := io.Pipe()
 			streamStarted := started
 			streamRegion := region
 			streamSource := sourceName
 			body := resp.Body
+			peeked := peek.peeked
 			go func() {
 				result := transcodeBedrockToSSE(pw, io.MultiReader(bytes.NewReader(peeked), body), s.Logger, streamSource, streamRegion)
 				_ = body.Close()
@@ -212,32 +212,33 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 				ContentLength: -1,
 			}, nil
 		}
-		// Error bodies only (never message content): the first frame is an
+		retryable := bedrockPeekFailureRetryable(peek)
+		// Error bodies only (never message content): the failing frame is an
 		// exception or an Anthropic error event, so logging it is safe.
 		if s.Logger != nil {
 			attrs := []any{"bedrock_source", sourceName, "region", region, "saw_message_stop", false, "attempt", attempt, "retryable", retryable}
-			if first.exceptionType != "" {
-				attrs = append(attrs, "exception_type", first.exceptionType)
+			if peek.errorFrame.exceptionType != "" {
+				attrs = append(attrs, "exception_type", peek.errorFrame.exceptionType)
 			}
-			if len(first.payload) > 0 {
-				attrs = append(attrs, "message", bedrockLogPreview(first.payload))
+			if len(peek.errorFrame.payload) > 0 {
+				attrs = append(attrs, "message", bedrockLogPreview(peek.errorFrame.payload))
 			}
-			if peekErr != nil {
-				attrs = append(attrs, "read_err", peekErr)
+			if peek.readErr != nil {
+				attrs = append(attrs, "read_err", peek.readErr)
 			}
-			s.Logger.Warn("claude-fable bedrock stream failed before first event", attrs...)
+			s.Logger.Warn("claude-fable bedrock stream failed before content", attrs...)
 		}
 		_ = resp.Body.Close()
 		s.recordClaudeFableBedrockCost(started, region, http.StatusServiceUnavailable, bedrockUsage{}, false)
-		if retryable && attempt < claudeFableBedrockStreamAttempts && ctx.Err() == nil {
+		if retryable && attempt < claudeFableBedrockStreamAttempts && bedrockRetryBackoff(ctx, attempt) {
 			// A fresh signAndForwardBedrock call starts from the next
 			// credential source/region rotation, so the retry prefers a
 			// different endpoint when more than one is configured.
 			continue
 		}
-		errBody := first.payload
+		errBody := peek.errorFrame.payload
 		if len(errBody) == 0 {
-			errBody = []byte(`{"type":"error","error":{"type":"api_error","message":"Bedrock stream failed before first event"}}`)
+			errBody = []byte(`{"type":"error","error":{"type":"api_error","message":"Bedrock stream failed before content"}}`)
 		}
 		return &http.Response{
 			Status:        "503 Service Unavailable",
@@ -471,26 +472,112 @@ type bedrockFrame struct {
 var errBedrockStreamEmpty = errors.New("bedrock stream ended before first event")
 
 // claudeFableBedrockStreamAttempts bounds how many times a streaming Fable
-// request is re-sent to Bedrock when the stream fails before any event has
+// request is re-sent to Bedrock when the stream fails before any content has
 // been forwarded to the client. Nothing was committed yet, so the request is
 // safely replayable.
 const claudeFableBedrockStreamAttempts = 3
 
-// bedrockFirstFrameFailure classifies the peeked first frame of a Bedrock
-// response stream. failed reports that the stream opens with an error instead
-// of a message event; since no bytes have reached the client, the caller may
-// retry or fall down the fallback chain instead of committing a 200 that dies
-// immediately. Anthropic in-band error events arrive as ordinary chunk frames,
-// so a plain exception check misses them. retryable reports that a fresh
-// attempt may succeed: transport errors, throttles, and capacity errors
-// qualify; validation and auth errors fail identically everywhere and do not.
-func bedrockFirstFrameFailure(first bedrockFrame, peekErr error) (failed, retryable bool) {
-	if peekErr != nil {
+type bedrockPeekOutcome int
+
+const (
+	// bedrockPeekCommit: the stream produced its first content block (or
+	// finished), so it is viable and must be forwarded as-is from here on.
+	bedrockPeekCommit bedrockPeekOutcome = iota
+	// bedrockPeekError: an exception frame or in-band Anthropic error event
+	// arrived before any content. The response is still fully replayable.
+	bedrockPeekError
+	// bedrockPeekReadErr: the connection died before the stream proved viable.
+	bedrockPeekReadErr
+)
+
+type bedrockStreamPeek struct {
+	outcome    bedrockPeekOutcome
+	errorFrame bedrockFrame
+	readErr    error
+	peeked     []byte
+}
+
+// bedrockFrameDecision reports whether a frame decides the stream's fate.
+// Errors and exceptions are failures. The first content block (thinking or
+// text), a usage delta, or message_stop proves the stream viable. message_start
+// and pings prove nothing: Bedrock regularly opens a message and then delivers
+// an overloaded_error, so the peek window has to extend past them.
+func bedrockFrameDecision(frame bedrockFrame) (decisive, failure bool) {
+	if strings.EqualFold(frame.messageType, "exception") {
 		return true, true
 	}
-	if strings.EqualFold(first.messageType, "exception") {
-		t := strings.ToLower(first.exceptionType)
-		return true, strings.Contains(t, "throttl") ||
+	var ev struct {
+		Type string `json:"type"`
+	}
+	_ = json.Unmarshal(frame.payload, &ev)
+	switch ev.Type {
+	case "error":
+		return true, true
+	case "content_block_start", "content_block_delta", "message_delta", "message_stop":
+		return true, false
+	}
+	return false, false
+}
+
+// peekBedrockStreamUntilCommit buffers a Bedrock response stream until it
+// either proves viable (first content block) or fails (error, exception, or
+// read error). Nothing is forwarded to the client while peeking, so a failed
+// stream can be retried without duplicating output. peeked carries every raw
+// byte read, for replay into the transcoder on commit.
+func peekBedrockStreamUntilCommit(src io.Reader) bedrockStreamPeek {
+	var scanner bedrockFrameScanner
+	var peeked bytes.Buffer
+	decided := false
+	failed := false
+	var errorFrame bedrockFrame
+	emit := func(frame bedrockFrame) {
+		if decided {
+			return
+		}
+		decisive, failure := bedrockFrameDecision(frame)
+		if !decisive {
+			return
+		}
+		decided = true
+		failed = failure
+		if failure {
+			errorFrame = frame
+		}
+	}
+	buf := make([]byte, 32*1024)
+	for !decided {
+		n, readErr := src.Read(buf)
+		if n > 0 {
+			peeked.Write(buf[:n])
+			scanner.feed(buf[:n], emit)
+		}
+		if decided {
+			break
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				readErr = errBedrockStreamEmpty
+			}
+			return bedrockStreamPeek{outcome: bedrockPeekReadErr, readErr: readErr, peeked: peeked.Bytes()}
+		}
+	}
+	if failed {
+		return bedrockStreamPeek{outcome: bedrockPeekError, errorFrame: errorFrame, peeked: peeked.Bytes()}
+	}
+	return bedrockStreamPeek{outcome: bedrockPeekCommit, peeked: peeked.Bytes()}
+}
+
+// bedrockPeekFailureRetryable reports whether a fresh attempt may succeed:
+// transport errors, throttles, and capacity errors qualify; validation and
+// auth errors fail identically everywhere and do not.
+func bedrockPeekFailureRetryable(peek bedrockStreamPeek) bool {
+	if peek.outcome == bedrockPeekReadErr {
+		return true
+	}
+	frame := peek.errorFrame
+	if strings.EqualFold(frame.messageType, "exception") {
+		t := strings.ToLower(frame.exceptionType)
+		return strings.Contains(t, "throttl") ||
 			strings.Contains(t, "serviceunavailable") ||
 			strings.Contains(t, "internalserver") ||
 			strings.Contains(t, "modelnotready") ||
@@ -502,14 +589,27 @@ func bedrockFirstFrameFailure(first bedrockFrame, peekErr error) (failed, retrya
 			Type string `json:"type"`
 		} `json:"error"`
 	}
-	if json.Unmarshal(first.payload, &ev) == nil && ev.Type == "error" {
+	if json.Unmarshal(frame.payload, &ev) == nil && ev.Type == "error" {
 		switch ev.Error.Type {
 		case "overloaded_error", "api_error", "rate_limit_error", "internal_server_error":
-			return true, true
+			return true
 		}
-		return true, false
 	}
-	return false, false
+	return false
+}
+
+// bedrockRetryBackoff spaces retries (200ms, then 400ms) so a momentary
+// capacity burst is not hit three times within the same millisecond. Returns
+// false when the caller's context is done, in which case retrying is moot.
+func bedrockRetryBackoff(ctx context.Context, attempt int) bool {
+	timer := time.NewTimer(time.Duration(attempt) * 200 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 // transcodeBedrockToSSE converts a Bedrock invoke-with-response-stream body (AWS
@@ -742,37 +842,6 @@ func parseBedrockEventHeaders(headers []byte) (map[string]string, bool) {
 		}
 	}
 	return out, true
-}
-
-func peekBedrockStream(src io.Reader) (bedrockFrame, []byte, error) {
-	var scanner bedrockFrameScanner
-	var first bedrockFrame
-	var got bool
-	var peeked bytes.Buffer
-	emit := func(frame bedrockFrame) {
-		if !got {
-			first = frame
-			got = true
-		}
-	}
-	buf := make([]byte, 32*1024)
-	for !got {
-		n, readErr := src.Read(buf)
-		if n > 0 {
-			peeked.Write(buf[:n])
-			scanner.feed(buf[:n], emit)
-		}
-		if got {
-			break
-		}
-		if readErr != nil {
-			if readErr == io.EOF {
-				return bedrockFrame{}, peeked.Bytes(), errBedrockStreamEmpty
-			}
-			return bedrockFrame{}, peeked.Bytes(), readErr
-		}
-	}
-	return first, peeked.Bytes(), nil
 }
 
 func bedrockLogPreview(payload []byte) string {

--- a/internal/proxy/bedrock_stream_test.go
+++ b/internal/proxy/bedrock_stream_test.go
@@ -199,7 +199,7 @@ func TestServeClaudeFableBedrockPrimaryFallsThroughOnExceptionFirstStream(t *tes
 	if string(restored) != bodyStr {
 		t.Fatalf("restored body = %q, want %q", string(restored), bodyStr)
 	}
-	if logs := logBuf.String(); !strings.Contains(logs, "claude-fable bedrock stream failed before first event") || !strings.Contains(logs, "exception_type=modelStreamErrorException") {
+	if logs := logBuf.String(); !strings.Contains(logs, "claude-fable bedrock stream failed before content") || !strings.Contains(logs, "exception_type=modelStreamErrorException") {
 		t.Fatalf("missing first-event failure log:\n%s", logs)
 	}
 }

--- a/internal/proxy/claude_fable_test.go
+++ b/internal/proxy/claude_fable_test.go
@@ -738,3 +738,97 @@ func TestClaudeFableBedrockRetriesExceptionFirstFrame(t *testing.T) {
 		t.Fatalf("upstream calls = %d, want 2", calls)
 	}
 }
+
+// Overload frequently arrives after message_start: the stream opens, then dies
+// before any content. That window must retry exactly like a first-frame error.
+func TestClaudeFableBedrockRetriesErrorAfterMessageStart(t *testing.T) {
+	bad := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		buildEventStreamFrame(t, `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)...,
+	)
+	good := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		append(
+			buildEventStreamFrame(t, `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`),
+			buildEventStreamFrame(t, `{"type":"message_stop"}`)...,
+		)...,
+	)
+	calls := 0
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		body := bad
+		if calls >= 2 {
+			body = good
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	resp, err := s.claudeFableBedrockResponse(req.Context(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after retrying past a post-message_start error", resp.StatusCode)
+	}
+	sse, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(sse), "event: message_stop") {
+		t.Fatalf("retried stream missing message_stop: %q", sse)
+	}
+	if strings.Contains(string(sse), "overloaded_error") {
+		t.Fatalf("failed attempt's frames leaked into the retried stream: %q", sse)
+	}
+	if calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2", calls)
+	}
+}
+
+// Once content has streamed, the response is committed and a later error must
+// pass through unchanged; retrying would duplicate output the client already
+// rendered.
+func TestClaudeFableBedrockDoesNotRetryErrorAfterContent(t *testing.T) {
+	stream := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		append(
+			buildEventStreamFrame(t, `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`),
+			buildEventStreamFrame(t, `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)...,
+		)...,
+	)
+	calls := 0
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(stream)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	resp, err := s.claudeFableBedrockResponse(req.Context(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want committed 200", resp.StatusCode)
+	}
+	sse, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(sse), "content_block_start") || !strings.Contains(string(sse), "overloaded_error") {
+		t.Fatalf("committed stream must pass content and the error through: %q", sse)
+	}
+	if calls != 1 {
+		t.Fatalf("upstream calls = %d, want 1 (no retry after commit)", calls)
+	}
+}


### PR DESCRIPTION
Follow-up to #230, which retried only when the error was the very first stream frame. Tonight's live traffic showed the other shape: Bedrock opens `message_start`, then delivers `overloaded_error` before any content. That still committed a 200 that died immediately, surfacing in Claude Code as "API Error: Server error mid-response".

Change `peekBedrockStream` (first frame only) into `peekBedrockStreamUntilCommit`: buffer frames until the stream proves viable (first `content_block_start`/`content_block_delta`/`message_delta`/`message_stop`) or fails (exception frame, in-band `error` event, read error). Nothing is forwarded to the client while peeking, so every pre-content failure is replayable through the existing retry loop and, on exhaustion, the synthesized 503 for the fallback chain. `message_start` and pings prove nothing and keep the window open.

Also space the retries (200ms, then 400ms, context-cancellable) so a momentary capacity burst is not hit three times within the same millisecond.

Errors after content has streamed are untouched: the response is committed and replaying would duplicate output the client already rendered.

Tests: retry after `message_start`+error, no retry after content (pass-through preserved), plus the #230 suite unchanged except the log-text rename ("before first event" → "before content"). `go test ./...` exit 0 locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789704956&installation_model_id=21920&pr_number=233&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F233&signature=17177f639ab400f5634719fe2d4ef49f89227a37f463613caf3523471dea8d7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Buffers the Bedrock Fable stream until first content before committing, so pre-content errors retry instead of returning a 200 that fails mid-response. Previously we retried only when the very first frame was an error; now we also retry on exceptions, in-band error events, or read errors that happen before any content. Errors after content still pass through unchanged.

- Replaces `peekBedrockStream` with `peekBedrockStreamUntilCommit`, which buffers frames until first content or failure, then replays buffered bytes on commit.
- Adds `bedrockPeekFailureRetryable` and `bedrockRetryBackoff` (200ms, then 400ms; context-cancellable). On exhaustion, synthesizes 503 to trigger the fallback chain; retries continue to rotate source/region as before.
- Log message changes to "failed before content". Tests cover retry after `message_start` + error and no retry after content.

<sup>Written for commit 349ebee0db4ec26b95594bc75f84a2bbcfb219af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability by safely retrying failures that occur before content is delivered.
  * Prevented duplicate or partial output from failed streaming attempts.
  * Preserved already-started responses and avoided retries when failures occur after content begins.
  * Enhanced handling of transport failures, exceptions, and provider-reported streaming errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->