### PR TITLE
Say what a credential blob looked like when it fails to decode

### DIFF
--- a/internal/agents/claude/credential_payload.go
+++ b/internal/agents/claude/credential_payload.go
@@ -1,0 +1,104 @@
+package claude
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// unreadableCredentialPhrase appears in every credential-decode error. A
+// credential that will not parse cannot be refreshed without re-auth, so the
+// proxy classifies this phrase as a terminal credential error rather than a
+// transient one.
+const unreadableCredentialPhrase = "unreadable credential"
+
+// credentialPayloadPreviewLimit bounds how much of a payload the shape summary
+// inspects. The categories below only need the first few bytes of the trailing
+// region.
+const credentialPayloadPreviewLimit = 64
+
+// describeCredentialPayload summarizes a payload that failed to decode, in
+// terms that identify how it is malformed without revealing any of it. The
+// payload holds an access token and, when a write left an older value behind,
+// the trailing bytes can be the tail of a previous token — so the summary
+// reports lengths, the failing offset, and a category, never the bytes.
+func describeCredentialPayload(body []byte, err error) string {
+	fields := []string{fmt.Sprintf("bytes=%d", len(body))}
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		return strings.Join(append(fields, "trailing=unknown"), " ")
+	}
+	offset := int(syntaxErr.Offset)
+	if offset < 0 || offset > len(body) {
+		return strings.Join(append(fields, "trailing=unknown"), " ")
+	}
+	// json.SyntaxError.Offset is one past the byte that failed, so the trailing
+	// region starts one byte earlier.
+	start := offset - 1
+	if start < 0 {
+		start = 0
+	}
+	trailing := body[start:]
+	fields = append(fields,
+		fmt.Sprintf("offset=%d", offset),
+		fmt.Sprintf("trailing_bytes=%d", len(trailing)),
+		"trailing_kind="+classifyTrailingBytes(trailing),
+	)
+	return strings.Join(fields, " ")
+}
+
+// classifyTrailingBytes names the shape of the bytes that follow a complete
+// JSON value. The category is the diagnosis: a binary plist means the keychain
+// handed back a wrapper, a json fragment means a shorter value was written over
+// a longer one and left its tail behind, nul padding means a truncated write.
+func classifyTrailingBytes(trailing []byte) string {
+	preview := trailing
+	if len(preview) > credentialPayloadPreviewLimit {
+		preview = preview[:credentialPayloadPreviewLimit]
+	}
+	switch {
+	case len(preview) == 0:
+		return "empty"
+	case hasPrefixBytes(preview, "bplist00"):
+		return "binary-plist"
+	case allBytesEqual(preview, 0x00):
+		return "nul-padding"
+	case allBytesFunc(preview, func(b byte) bool { return unicode.IsSpace(rune(b)) }):
+		return "whitespace"
+	case looksLikeJSONFragment(preview):
+		return "json-fragment"
+	case allBytesFunc(preview, func(b byte) bool { return b >= 0x20 && b < 0x7f }):
+		return "text"
+	default:
+		return "binary"
+	}
+}
+
+func looksLikeJSONFragment(preview []byte) bool {
+	for _, b := range preview {
+		switch b {
+		case '"', '{', '}', '[', ']', ':', ',':
+			return true
+		}
+	}
+	return false
+}
+
+func hasPrefixBytes(b []byte, prefix string) bool {
+	return len(b) >= len(prefix) && string(b[:len(prefix)]) == prefix
+}
+
+func allBytesEqual(b []byte, want byte) bool {
+	return allBytesFunc(b, func(got byte) bool { return got == want })
+}
+
+func allBytesFunc(b []byte, ok func(byte) bool) bool {
+	for _, got := range b {
+		if !ok(got) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/agents/claude/credential_payload_test.go
+++ b/internal/agents/claude/credential_payload_test.go
@@ -1,0 +1,120 @@
+package claude
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+const validCredentialPayload = `{"claudeAiOauth":{"accessToken":"sk-ant-oat-secret","refreshToken":"sk-ant-ort-secret","expiresAt":1799999999999}}`
+
+func TestParseCredentialPayloadDecodesValidBlob(t *testing.T) {
+	credential, err := parseCredentialPayload([]byte(validCredentialPayload), "keychain")
+	if err != nil {
+		t.Fatalf("valid payload must decode: %v", err)
+	}
+	if credential == nil || credential.AccessToken != "sk-ant-oat-secret" {
+		t.Fatalf("decoded credential did not round-trip: %+v", credential)
+	}
+}
+
+// The production symptom was `invalid character 'b' after top-level value`,
+// repeated thousands of times with no indication of what the payload actually
+// was. The decode error must name the source and the shape.
+func TestParseCredentialPayloadReportsSourceAndShape(t *testing.T) {
+	body := []byte(validCredentialPayload + "bplist00\x00\x01")
+	_, err := parseCredentialPayload(body, "keychain")
+	if err == nil {
+		t.Fatal("a payload with trailing bytes must not decode")
+	}
+	message := err.Error()
+	for _, want := range []string{
+		unreadableCredentialPhrase,
+		"from keychain",
+		"trailing_kind=binary-plist",
+		"invalid character 'b' after top-level value",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("decode error %q is missing %q", message, want)
+		}
+	}
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		t.Fatal("the underlying json error must stay unwrappable")
+	}
+}
+
+// The payload holds an access token, and trailing bytes can be the tail of a
+// previous token, so no part of it may reach a log line.
+func TestParseCredentialPayloadNeverEchoesTheBlob(t *testing.T) {
+	secrets := []string{"sk-ant-oat-secret", "sk-ant-ort-secret"}
+	bodies := [][]byte{
+		[]byte(validCredentialPayload + `xToken":"sk-ant-ort-leftover"}}`),
+		[]byte(validCredentialPayload + "bplist00"),
+		[]byte(validCredentialPayload + "\x00\x00\x00"),
+		[]byte(validCredentialPayload + " trailing text"),
+		append([]byte(validCredentialPayload), 0xff, 0xfe),
+	}
+	for _, body := range bodies {
+		_, err := parseCredentialPayload(body, "keychain")
+		if err == nil {
+			t.Fatalf("payload %q should not decode", trimForName(body))
+		}
+		message := err.Error()
+		for _, secret := range secrets {
+			if strings.Contains(message, secret) {
+				t.Fatalf("decode error leaked a secret: %q", message)
+			}
+		}
+		if strings.Contains(message, "leftover") {
+			t.Fatalf("decode error leaked trailing payload bytes: %q", message)
+		}
+	}
+}
+
+func TestClassifyTrailingBytes(t *testing.T) {
+	cases := []struct {
+		name     string
+		trailing []byte
+		want     string
+	}{
+		{name: "empty", trailing: nil, want: "empty"},
+		{name: "binary plist", trailing: []byte("bplist00\x00\x08"), want: "binary-plist"},
+		{name: "nul padding", trailing: []byte{0, 0, 0, 0}, want: "nul-padding"},
+		{name: "whitespace", trailing: []byte("\n\t  "), want: "whitespace"},
+		{name: "json fragment", trailing: []byte(`Token":"abc"}}`), want: "json-fragment"},
+		{name: "text", trailing: []byte("truncated write"), want: "text"},
+		{name: "binary", trailing: []byte{0xff, 0xfe, 0x01}, want: "binary"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyTrailingBytes(tc.trailing); got != tc.want {
+				t.Fatalf("classifyTrailingBytes(%q) = %q, want %q", tc.trailing, got, tc.want)
+			}
+		})
+	}
+}
+
+// A non-syntax decode failure (well-formed JSON, wrong shape) still reports the
+// size but has no meaningful trailing region.
+func TestDescribeCredentialPayloadWithoutSyntaxError(t *testing.T) {
+	body := []byte(`{"claudeAiOauth":"not-an-object"}`)
+	_, err := parseCredentialPayload(body, "credentials file")
+	if err == nil {
+		t.Fatal("a type mismatch must not decode")
+	}
+	if !strings.Contains(err.Error(), "trailing=unknown") {
+		t.Fatalf("expected an unknown trailing region, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "from credentials file") {
+		t.Fatalf("expected the file source to be named, got %q", err.Error())
+	}
+}
+
+func trimForName(body []byte) string {
+	if len(body) > 32 {
+		return string(body[:32]) + "..."
+	}
+	return string(body)
+}

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -1099,7 +1099,7 @@ func (s Store) readCredential(ctx context.Context, instancePath string) (*Creden
 	if err != nil || len(strings.TrimSpace(string(body))) == 0 {
 		return nil, nil
 	}
-	return parseCredentialPayload(body)
+	return parseCredentialPayload(body, "keychain")
 }
 
 func (s Store) RefreshCredentialIfExpired(ctx context.Context, client *http.Client, profile Profile) (accounts.Account, bool, error) {
@@ -1330,16 +1330,20 @@ func readCredentialFile(instancePath string) (*CredentialInfo, bool) {
 	if err != nil {
 		return nil, false
 	}
-	credential, err := parseCredentialPayload(body)
+	credential, err := parseCredentialPayload(body, "credentials file")
 	return credential, err == nil && credential != nil
 }
 
-func parseCredentialPayload(body []byte) (*CredentialInfo, error) {
+// parseCredentialPayload decodes a stored credential blob. source names where
+// the blob came from, and appears in the decode error along with a redacted
+// summary of the payload's shape: a decode failure is otherwise indistinguishable
+// between a keychain wrapper, a partial write, and a corrupt file.
+func parseCredentialPayload(body []byte, source string) (*CredentialInfo, error) {
 	var raw struct {
 		ClaudeAIOAuth *CredentialInfo `json:"claudeAiOauth"`
 	}
 	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s from %s (%s): %w", unreadableCredentialPhrase, source, describeCredentialPayload(body, err), err)
 	}
 	return raw.ClaudeAIOAuth, nil
 }

--- a/internal/proxy/claude_failover_test.go
+++ b/internal/proxy/claude_failover_test.go
@@ -549,3 +549,20 @@ func claudeRefreshRequest(t *testing.T) *http.Request {
 	req.Header.Set("X-Subrouter-Session", "session-1")
 	return req
 }
+
+// A stored credential that will not decode cannot be refreshed, so it needs
+// re-auth exactly like a rejected refresh token does. Classifying it as
+// transient would retry the same unparseable blob forever instead of failing
+// over to an account that still works.
+func TestIsTerminalCredentialErrorClassifiesUnreadableCredential(t *testing.T) {
+	unreadable := errors.New(`unreadable credential from keychain (bytes=132 offset=125 trailing_bytes=8 trailing_kind=binary-plist): invalid character 'b' after top-level value`)
+	if !isTerminalCredentialError(unreadable) {
+		t.Fatal("an unreadable stored credential must be terminal so selection fails over")
+	}
+	if isTerminalCredentialError(errors.New("Claude OAuth refresh failed: 503 Service Unavailable")) {
+		t.Fatal("an upstream 5xx must stay transient")
+	}
+	if isTerminalCredentialError(context.Canceled) {
+		t.Fatal("a cancelled context must stay transient")
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -5400,6 +5400,11 @@ func isTerminalCredentialError(err error) bool {
 		"no refresh token",
 		"has no refresh token",
 		"no usable credential",
+		// A stored credential that will not decode cannot be refreshed, so it
+		// needs re-auth exactly like a rejected refresh token does. Treating it
+		// as transient would retry the same unparseable blob forever instead of
+		// failing over to an account that still works.
+		"unreadable credential",
 		"invalid_client",
 		"unauthorized_client",
 	} {


### PR DESCRIPTION
Rebase of #232 (author @danielraffel, commit authorship preserved) onto main after #231 landed; the two PRs appended tests to the same end of `claude_failover_test.go` and conflicted. Resolution keeps both test blocks; no code change beyond the rebase.

See #232 for the full rationale: decode failures now name the source (keychain vs credentials file) and a redacted shape summary, and `unreadable credential` is classified terminal so selection fails over instead of retrying the same unparseable blob forever.

`go test ./internal/proxy ./internal/agents/claude` green locally on top of current main.

Supersedes #232.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789705346&installation_model_id=21920&pr_number=235&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F235&signature=7585bcf24b0b2ec4f07cfec5964366a769aaf62eb43326e2fcbd50d5aea3b0df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve diagnostics for credential decode failures and treat unreadable stored credentials as terminal to enable failover instead of retry loops. Previously we logged only the bare JSON error; now errors include the source and a redacted shape summary without leaking secrets.

- Decode errors now include: source (keychain vs credentials file) and a redacted shape summary (bytes, offset, trailing_bytes, trailing_kind: binary-plist | json-fragment | nul-padding | whitespace | text | binary). The underlying `json.SyntaxError` remains unwrappable. No payload bytes or secrets reach logs.
- Unreadable stored credentials are classified as terminal by the proxy, so account selection fails over rather than retrying an unparseable blob. Upstream 5xx and canceled contexts remain transient.
- `parseCredentialPayload` now takes a `source` argument; call sites in `internal/agents/claude` are updated to pass "keychain" or "credentials file".
- Tests added in `internal/agents/claude` and `internal/proxy` cover valid decode, source/shape reporting, secret redaction, trailing-bytes classification, and terminal error classification.

<sup>Written for commit f95d61a80cc24ae821b4dfaa2f48aa7ec33987b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

