### PR TITLE
Describe API-key providers in one registry instead of 24 switches

### DIFF
--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 	"github.com/manaflow-ai/subrouter/internal/broker"
+	"github.com/manaflow-ai/subrouter/internal/proxy"
 	"github.com/manaflow-ai/subrouter/internal/tenant"
 	"github.com/manaflow-ai/subrouter/selectacct"
 	"golang.org/x/term"
@@ -937,7 +938,7 @@ func (r srRunner) addKeyToServer(ctx context.Context, server srServerConfig, arg
 	command := r.programOrSubrouter() + " add-key"
 	flags := flag.NewFlagSet(command, flag.ContinueOnError)
 	flags.SetOutput(r.errOut)
-	providerRaw := flags.String("provider", string(accounts.ProviderCodex), "API-key provider: codex, claude, kimi, or zai")
+	providerRaw := flags.String("provider", string(accounts.ProviderCodex), "API-key provider: "+proxy.APIKeyProviderList())
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -1003,12 +1004,11 @@ func parseAPIKeyProvider(value string) (accounts.Provider, error) {
 		return accounts.ProviderCodex, nil
 	case string(accounts.ProviderClaude), "anthropic":
 		return accounts.ProviderClaude, nil
-	case string(accounts.ProviderKimi), "kimi-for-coding":
-		return accounts.ProviderKimi, nil
-	case string(accounts.ProviderZAI), "glm", "glm-5.2":
-		return accounts.ProviderZAI, nil
 	default:
-		return "", fmt.Errorf("unsupported API-key provider %q, expected codex, claude, kimi, or zai", value)
+		if provider, ok := proxy.APIKeyProviderForName(strings.ToLower(strings.TrimSpace(value))); ok {
+			return provider, nil
+		}
+		return "", fmt.Errorf("unsupported API-key provider %q, expected %s", value, proxy.APIKeyProviderList())
 	}
 }
 

--- a/internal/proxy/keyed_provider.go
+++ b/internal/proxy/keyed_provider.go
@@ -1,0 +1,217 @@
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+// authStyle names how a provider expects its API key to be presented.
+type authStyle int
+
+const (
+	// authBearer sends Authorization: Bearer <key> and removes any client
+	// X-Api-Key, which is the OpenAI-compatible convention.
+	authBearer authStyle = iota
+	// authBearerAndAnthropicKey sends both Authorization and X-Api-Key, and
+	// defaults Anthropic-Version, for providers exposing an Anthropic-shaped API.
+	authBearerAndAnthropicKey
+)
+
+// leaseEnvStyle names which SDK environment variables a lease hands to the
+// sandbox so the client library points back at this proxy.
+type leaseEnvStyle int
+
+const (
+	leaseEnvOpenAI leaseEnvStyle = iota
+	leaseEnvAnthropic
+)
+
+// keyedProvider describes an API-key provider that the proxy routes by path
+// prefix. Everything the router needs about such a provider lives in one entry,
+// so adding a provider is a table row rather than an edit to a dozen switch
+// statements that are easy to leave half-updated.
+type keyedProvider struct {
+	Provider accounts.Provider
+	// PathPrefix is the first path segment that selects this provider, so
+	// /<PathPrefix>/... routes here and the segment is stripped upstream.
+	PathPrefix string
+	// Aliases are the additional names accepted wherever a provider is named by
+	// a human or an API caller. The canonical provider string is always accepted.
+	Aliases []string
+	// ModelPrefix infers this provider from a bare model id, e.g. "glm-" for ZAI.
+	// Empty means no inference.
+	ModelPrefix string
+	// PlanLabel is how an API-key account of this provider is described in
+	// account listings.
+	PlanLabel string
+	Auth      authStyle
+	// CollapseVersionSegment marks a provider whose upstream base URL may already
+	// end in /v1, so a client's own /v1 must not be forwarded twice.
+	CollapseVersionSegment bool
+	// VendorPrefixedModels marks a provider that addresses models as
+	// vendor/model, where the segment before the slash belongs to the model id
+	// rather than naming a provider.
+	VendorPrefixedModels bool
+	// LeaseAPI is the Pi adapter a lease advertises for this provider.
+	LeaseAPI string
+	// LeasePath is the single path a lease for this provider may call.
+	LeasePath string
+	LeaseEnv  leaseEnvStyle
+	// Upstream reads this provider's configured base URL off the server.
+	Upstream func(Server) *url.URL
+}
+
+// keyedProviders is the registry. Adding an API-key provider means adding an
+// entry here and a base-URL field on Server; the routing, auth, lease, import,
+// and CLI paths all read from this table.
+var keyedProviders = []keyedProvider{
+	{
+		Provider:               accounts.ProviderKimi,
+		PathPrefix:             "kimi",
+		Aliases:                []string{"kimi-for-coding"},
+		ModelPrefix:            "kimi-",
+		PlanLabel:              "kimi api key",
+		Auth:                   authBearerAndAnthropicKey,
+		CollapseVersionSegment: true,
+		LeaseAPI:               "anthropic-messages",
+		LeasePath:              "/kimi/v1/messages",
+		LeaseEnv:               leaseEnvAnthropic,
+		Upstream:               func(s Server) *url.URL { return s.KimiUpstream },
+	},
+	{
+		Provider:    accounts.ProviderZAI,
+		PathPrefix:  "zai",
+		Aliases:     []string{"glm", "glm-5.2"},
+		ModelPrefix: "glm-",
+		PlanLabel:   "zai api key",
+		Auth:        authBearer,
+		LeaseAPI:    "openai-completions",
+		LeasePath:   "/zai/chat/completions",
+		LeaseEnv:    leaseEnvOpenAI,
+		Upstream:    func(s Server) *url.URL { return s.ZAIUpstream },
+	},
+}
+
+// keyedProviderFor returns the registry entry for a provider.
+func keyedProviderFor(provider accounts.Provider) (keyedProvider, bool) {
+	for _, entry := range keyedProviders {
+		if entry.Provider == provider {
+			return entry, true
+		}
+	}
+	return keyedProvider{}, false
+}
+
+// keyedProviderForPathPrefix resolves the first path segment to a provider.
+func keyedProviderForPathPrefix(segment string) (keyedProvider, bool) {
+	for _, entry := range keyedProviders {
+		if entry.PathPrefix == segment {
+			return entry, true
+		}
+	}
+	return keyedProvider{}, false
+}
+
+// keyedProviderForName resolves a provider named by a human or an API caller,
+// accepting the canonical provider string and any registered alias.
+func keyedProviderForName(name string) (keyedProvider, bool) {
+	for _, entry := range keyedProviders {
+		if name == string(entry.Provider) {
+			return entry, true
+		}
+		for _, alias := range entry.Aliases {
+			if name == alias {
+				return entry, true
+			}
+		}
+	}
+	return keyedProvider{}, false
+}
+
+// keyedProviderForModelPrefix infers a provider from a bare model id.
+func keyedProviderForModelPrefix(lowerModel string) (keyedProvider, bool) {
+	for _, entry := range keyedProviders {
+		if entry.ModelPrefix != "" && len(lowerModel) >= len(entry.ModelPrefix) &&
+			lowerModel[:len(entry.ModelPrefix)] == entry.ModelPrefix {
+			return entry, true
+		}
+	}
+	return keyedProvider{}, false
+}
+
+// isKeyedProvider reports whether a provider is routed through the registry.
+func isKeyedProvider(provider accounts.Provider) bool {
+	_, ok := keyedProviderFor(provider)
+	return ok
+}
+
+// keyedProviderNames lists every canonical provider name in the registry, in
+// registry order, for advertising and for error messages.
+func keyedProviderNames() []string {
+	names := make([]string, 0, len(keyedProviders))
+	for _, entry := range keyedProviders {
+		names = append(names, string(entry.Provider))
+	}
+	return names
+}
+
+// applyKeyedProviderAuth presents the account's API key the way this provider
+// expects it. Authorization is already set to the bearer form by the caller.
+func applyKeyedProviderAuth(headers http.Header, account accounts.Account, entry keyedProvider) {
+	switch entry.Auth {
+	case authBearerAndAnthropicKey:
+		headers.Set("Authorization", account.AuthorizationHeader())
+		headers.Set("X-Api-Key", account.Token)
+		if headers.Get("Anthropic-Version") == "" {
+			headers.Set("Anthropic-Version", "2023-06-01")
+		}
+	default:
+		headers.Del("X-Api-Key")
+	}
+}
+
+// collapseDuplicateVersionSegment drops a leading /v1 from an already
+// prefix-stripped path when the upstream base URL ends in /v1, so a client that
+// sends /<provider>/v1/... does not reach /v1/v1/... upstream. The collapse is
+// conditional on the configured base, so an unversioned override still forwards
+// the client's own /v1.
+func collapseDuplicateVersionSegment(path string, upstream *url.URL) string {
+	upstreamPath := ""
+	if upstream != nil {
+		upstreamPath = strings.TrimRight(upstream.Path, "/")
+	}
+	if !strings.HasSuffix(upstreamPath, "/v1") {
+		return path
+	}
+	if path == "/v1" {
+		return "/"
+	}
+	if strings.HasPrefix(path, "/v1/") {
+		return strings.TrimPrefix(path, "/v1")
+	}
+	return path
+}
+
+// APIKeyProviderForName resolves a provider named on the CLI or in an API
+// payload, accepting the canonical name and any registered alias. Exported so
+// the CLI does not carry a second copy of the alias list.
+func APIKeyProviderForName(name string) (accounts.Provider, bool) {
+	entry, ok := keyedProviderForName(name)
+	if !ok {
+		return "", false
+	}
+	return entry.Provider, true
+}
+
+// APIKeyProviderList renders the providers a user may name, for flag help and
+// for the error returned when they name something else.
+func APIKeyProviderList() string {
+	names := append([]string{"codex", "claude"}, keyedProviderNames()...)
+	if len(names) == 1 {
+		return names[0]
+	}
+	return strings.Join(names[:len(names)-1], ", ") + ", or " + names[len(names)-1]
+}

--- a/internal/proxy/keyed_provider_test.go
+++ b/internal/proxy/keyed_provider_test.go
@@ -181,4 +181,8 @@ func TestSessionLeaseProviderHonoursVendorPrefixedModels(t *testing.T) {
 	if provider != accounts.Provider("vendorcase") || model != "anthropic/claude-opus-5" {
 		t.Fatalf("got (%q, %q), want the vendor prefix preserved", provider, model)
 	}
+	provider, model, err = sessionLeaseProvider("", "vendorcase/vendor-model")
+	if err != nil || provider != accounts.Provider("vendorcase") || model != "vendorcase/vendor-model" {
+		t.Fatalf("inferred provider got (%q, %q, %v), want the full vendor-prefixed model", provider, model, err)
+	}
 }

--- a/internal/proxy/keyed_provider_test.go
+++ b/internal/proxy/keyed_provider_test.go
@@ -1,0 +1,184 @@
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+// Every registry entry has to be complete: a half-filled row silently routes to
+// an empty upstream or advertises an empty lease path, which is exactly the
+// class of mistake the registry exists to prevent.
+func TestKeyedProviderRegistryEntriesAreComplete(t *testing.T) {
+	seenProvider := map[accounts.Provider]bool{}
+	seenPrefix := map[string]bool{}
+	seenName := map[string]bool{}
+
+	for _, entry := range keyedProviders {
+		name := string(entry.Provider)
+		if name == "" || entry.PathPrefix == "" || entry.PlanLabel == "" ||
+			entry.LeaseAPI == "" || entry.LeasePath == "" || entry.Upstream == nil {
+			t.Fatalf("incomplete registry entry: %+v", entry)
+		}
+		if !strings.HasPrefix(entry.LeasePath, "/"+entry.PathPrefix+"/") {
+			t.Fatalf("provider %s lease path %q is not under its own path prefix", name, entry.LeasePath)
+		}
+		if seenProvider[entry.Provider] {
+			t.Fatalf("provider %s is registered twice", name)
+		}
+		seenProvider[entry.Provider] = true
+		if seenPrefix[entry.PathPrefix] {
+			t.Fatalf("path prefix %q is claimed twice", entry.PathPrefix)
+		}
+		seenPrefix[entry.PathPrefix] = true
+		for _, candidate := range append([]string{name}, entry.Aliases...) {
+			if seenName[candidate] {
+				t.Fatalf("provider name %q is claimed twice", candidate)
+			}
+			seenName[candidate] = true
+		}
+	}
+}
+
+// Each lookup is a routing decision, so each must round-trip for every entry.
+func TestKeyedProviderLookupsRoundTrip(t *testing.T) {
+	for _, entry := range keyedProviders {
+		name := string(entry.Provider)
+
+		if got, ok := keyedProviderFor(entry.Provider); !ok || got.PathPrefix != entry.PathPrefix {
+			t.Fatalf("keyedProviderFor(%s) did not round-trip", name)
+		}
+		if got, ok := keyedProviderForPathPrefix(entry.PathPrefix); !ok || got.Provider != entry.Provider {
+			t.Fatalf("keyedProviderForPathPrefix(%q) did not resolve to %s", entry.PathPrefix, name)
+		}
+		for _, candidate := range append([]string{name}, entry.Aliases...) {
+			if got, ok := keyedProviderForName(candidate); !ok || got.Provider != entry.Provider {
+				t.Fatalf("keyedProviderForName(%q) did not resolve to %s", candidate, name)
+			}
+		}
+		if entry.ModelPrefix != "" {
+			if got, ok := keyedProviderForModelPrefix(entry.ModelPrefix + "test"); !ok || got.Provider != entry.Provider {
+				t.Fatalf("model prefix %q did not resolve to %s", entry.ModelPrefix, name)
+			}
+		}
+		if !isKeyedProvider(entry.Provider) {
+			t.Fatalf("%s should be a keyed provider", name)
+		}
+	}
+
+	if isKeyedProvider(accounts.ProviderCodex) || isKeyedProvider(accounts.ProviderClaude) {
+		t.Fatal("codex and claude are not path-prefixed API-key providers")
+	}
+	if _, ok := keyedProviderForPathPrefix("v1"); ok {
+		t.Fatal("a bare API path must not resolve to a provider")
+	}
+	if _, ok := keyedProviderForName("gemini"); ok {
+		t.Fatal("an unregistered provider name must not resolve")
+	}
+}
+
+func TestAPIKeyProviderListNamesEveryProvider(t *testing.T) {
+	list := APIKeyProviderList()
+	for _, want := range append([]string{"codex", "claude"}, keyedProviderNames()...) {
+		if !strings.Contains(list, want) {
+			t.Fatalf("provider list %q omits %q", list, want)
+		}
+	}
+	if !strings.Contains(list, ", or ") {
+		t.Fatalf("provider list %q should read as a sentence", list)
+	}
+}
+
+func TestApplyKeyedProviderAuthPresentsTheKeyPerStyle(t *testing.T) {
+	account := accounts.Account{Provider: accounts.ProviderZAI, AuthMode: accounts.AuthModeAPIKey, Token: "key"}
+
+	bearer := http.Header{}
+	bearer.Set("X-Api-Key", "client-supplied")
+	applyKeyedProviderAuth(bearer, account, keyedProvider{Auth: authBearer})
+	if bearer.Get("X-Api-Key") != "" {
+		t.Fatal("a bearer provider must not forward a client X-Api-Key")
+	}
+
+	anthropic := http.Header{}
+	applyKeyedProviderAuth(anthropic, account, keyedProvider{Auth: authBearerAndAnthropicKey})
+	if anthropic.Get("X-Api-Key") != "key" {
+		t.Fatalf("X-Api-Key = %q, want the account key", anthropic.Get("X-Api-Key"))
+	}
+	if anthropic.Get("Authorization") != "Bearer key" {
+		t.Fatalf("Authorization = %q, want the bearer form", anthropic.Get("Authorization"))
+	}
+	if anthropic.Get("Anthropic-Version") != "2023-06-01" {
+		t.Fatalf("Anthropic-Version = %q, want a default", anthropic.Get("Anthropic-Version"))
+	}
+
+	explicit := http.Header{}
+	explicit.Set("Anthropic-Version", "2024-01-01")
+	applyKeyedProviderAuth(explicit, account, keyedProvider{Auth: authBearerAndAnthropicKey})
+	if explicit.Get("Anthropic-Version") != "2024-01-01" {
+		t.Fatal("a client's Anthropic-Version must not be overwritten")
+	}
+}
+
+func TestCollapseDuplicateVersionSegment(t *testing.T) {
+	versioned := &url.URL{Scheme: "https", Host: "example.test", Path: "/api/v1"}
+	bare := &url.URL{Scheme: "https", Host: "example.test"}
+	cases := []struct {
+		name     string
+		path     string
+		upstream *url.URL
+		want     string
+	}{
+		{name: "collapses against a versioned base", path: "/v1/chat/completions", upstream: versioned, want: "/chat/completions"},
+		{name: "collapses a bare version path", path: "/v1", upstream: versioned, want: "/"},
+		{name: "keeps the version against a bare base", path: "/v1/chat/completions", upstream: bare, want: "/v1/chat/completions"},
+		{name: "leaves an unversioned path alone", path: "/chat/completions", upstream: versioned, want: "/chat/completions"},
+		{name: "tolerates a nil upstream", path: "/v1/chat/completions", upstream: nil, want: "/v1/chat/completions"},
+		{name: "does not collapse a lookalike segment", path: "/v10/chat", upstream: versioned, want: "/v10/chat"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := collapseDuplicateVersionSegment(tc.path, tc.upstream); got != tc.want {
+				t.Fatalf("collapseDuplicateVersionSegment(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// A provider that addresses models as vendor/model must keep the whole id,
+// while every other provider keeps reading the leading segment as a provider
+// selector. No registered provider sets this today; the behaviour is asserted
+// against a synthetic entry so the flag cannot rot before it is used.
+func TestSessionLeaseProviderHonoursVendorPrefixedModels(t *testing.T) {
+	provider, model, err := sessionLeaseProvider("claude", "anthropic/claude-opus-5")
+	if err != nil || provider != accounts.ProviderClaude || model != "claude-opus-5" {
+		t.Fatalf("got (%q, %q, %v), want (claude, claude-opus-5, nil)", provider, model, err)
+	}
+	if _, _, err := sessionLeaseProvider("claude", "openai/gpt-5"); err == nil {
+		t.Fatal("a mismatched model provider must still be rejected")
+	}
+
+	original := keyedProviders
+	t.Cleanup(func() { keyedProviders = original })
+	keyedProviders = append(append([]keyedProvider{}, original...), keyedProvider{
+		Provider:             accounts.Provider("vendorcase"),
+		PathPrefix:           "vendorcase",
+		PlanLabel:            "vendorcase api key",
+		Auth:                 authBearer,
+		VendorPrefixedModels: true,
+		LeaseAPI:             "openai-completions",
+		LeasePath:            "/vendorcase/chat/completions",
+		LeaseEnv:             leaseEnvOpenAI,
+		Upstream:             func(Server) *url.URL { return nil },
+	})
+
+	provider, model, err = sessionLeaseProvider("vendorcase", "anthropic/claude-opus-5")
+	if err != nil {
+		t.Fatalf("a vendor-prefixed model must be accepted: %v", err)
+	}
+	if provider != accounts.Provider("vendorcase") || model != "anthropic/claude-opus-5" {
+		t.Fatalf("got (%q, %q), want the vendor prefix preserved", provider, model)
+	}
+}

--- a/internal/proxy/provider_registry_regression_test.go
+++ b/internal/proxy/provider_registry_regression_test.go
@@ -1,0 +1,144 @@
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+// Codex and Claude are not registry providers, and the registry lookup sits
+// below their explicit branches on every path it touches. These assertions pin
+// that: a registry entry must never be able to capture a Codex or Claude
+// request, whatever gets added to the table later.
+func TestRegistryDoesNotCaptureCodexOrClaudeRouting(t *testing.T) {
+	server := Server{
+		CodexUpstream:  mustURL(t, "https://chatgpt.test/backend-api"),
+		APIUpstream:    mustURL(t, "https://api.openai.test"),
+		ClaudeUpstream: mustURL(t, "https://api.anthropic.test"),
+		KimiUpstream:   mustURL(t, "https://kimi.test/coding/v1"),
+		ZAIUpstream:    mustURL(t, "https://zai.test/api/coding/paas/v4"),
+	}
+
+	upstreams := []struct {
+		name    string
+		account accounts.Account
+		path    string
+		want    *url.URL
+	}{
+		{name: "claude oauth", account: accounts.Account{Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth}, path: "/v1/messages", want: server.ClaudeUpstream},
+		{name: "claude api key", account: accounts.Account{Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeAPIKey}, path: "/v1/messages", want: server.ClaudeUpstream},
+		{name: "codex api key", account: accounts.Account{Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeAPIKey}, path: "/v1/responses", want: server.APIUpstream},
+		{name: "codex oauth", account: accounts.Account{Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth}, path: "/v1/responses", want: server.CodexUpstream},
+		{name: "provider-less oauth", account: accounts.Account{AuthMode: accounts.AuthModeOAuth}, path: "/v1/responses", want: server.CodexUpstream},
+	}
+	for _, tc := range upstreams {
+		t.Run("upstream/"+tc.name, func(t *testing.T) {
+			if got := server.upstreamForRequest(tc.path, tc.account); got != tc.want {
+				t.Fatalf("upstreamForRequest = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// Claude paths pass through untouched; no prefix is stripped and no version
+	// segment is collapsed.
+	for _, path := range []string{"/v1/messages", "/v1/messages/count_tokens", "/"} {
+		if got := server.pathForUpstream(path, accounts.Account{Provider: accounts.ProviderClaude}); got != path {
+			t.Fatalf("pathForUpstream(%q) for claude = %q, want it unchanged", path, got)
+		}
+	}
+
+	// Session agent type and plan label fall through for the non-registry
+	// providers rather than being replaced by a provider name.
+	for _, provider := range []accounts.Provider{accounts.ProviderCodex, accounts.ProviderClaude, ""} {
+		if got := agentTypeForProviderSession("claude", provider); got != "claude" {
+			t.Fatalf("agentTypeForProviderSession(%q) = %q, want the caller's agent type", provider, got)
+		}
+		if got := apiKeyPlanType(provider); got != "api key" {
+			t.Fatalf("apiKeyPlanType(%q) = %q, want the generic label", provider, got)
+		}
+	}
+
+	// A provider-less legacy account still backs Codex and Claude selection, and
+	// is still withheld from registry providers.
+	legacy := []accounts.Account{{ID: "legacy", AuthMode: accounts.AuthModeOAuth}}
+	for _, provider := range []accounts.Provider{accounts.ProviderCodex, accounts.ProviderClaude} {
+		if got := filterAccountsForProvider(legacy, provider); len(got) != 1 {
+			t.Fatalf("filterAccountsForProvider(%q) dropped the legacy account", provider)
+		}
+	}
+	for _, entry := range keyedProviders {
+		if got := filterAccountsForProvider(legacy, entry.Provider); len(got) != 0 {
+			t.Fatalf("registry provider %q must not inherit provider-less legacy accounts", entry.Provider)
+		}
+	}
+
+	// No registry entry may claim a path prefix that a non-registry provider
+	// already routes on.
+	for _, reserved := range []string{"v1", "backend-api", "messages", "responses"} {
+		if _, ok := keyedProviderForPathPrefix(reserved); ok {
+			t.Fatalf("a registry entry claims the reserved path segment %q", reserved)
+		}
+	}
+	for _, reserved := range []string{"codex", "openai", "openai-codex", "claude", "anthropic"} {
+		if _, ok := keyedProviderForName(reserved); ok {
+			t.Fatalf("a registry entry claims the reserved provider name %q", reserved)
+		}
+	}
+}
+
+// The auth headers for Codex and Claude must be exactly what they were before
+// the registry existed, including the Claude API-key and OAuth split.
+func TestRegistryDoesNotChangeCodexOrClaudeAuthHeaders(t *testing.T) {
+	claudeOAuth := http.Header{}
+	claudeOAuth.Set("X-Api-Key", "client-supplied")
+	setAccountAuthHeaders(claudeOAuth, accounts.Account{Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "oauth-token"})
+	if claudeOAuth.Get("Authorization") != "Bearer oauth-token" {
+		t.Fatalf("claude oauth Authorization = %q", claudeOAuth.Get("Authorization"))
+	}
+	if claudeOAuth.Get("X-Api-Key") != "" {
+		t.Fatal("claude oauth must strip a client X-Api-Key")
+	}
+	if claudeOAuth.Get("Anthropic-Beta") != claudeOAuthBetaHeader {
+		t.Fatalf("claude oauth Anthropic-Beta = %q, want %q", claudeOAuth.Get("Anthropic-Beta"), claudeOAuthBetaHeader)
+	}
+
+	claudeKey := http.Header{}
+	claudeKey.Set("Anthropic-Beta", claudeOAuthBetaHeader)
+	setAccountAuthHeaders(claudeKey, accounts.Account{Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeAPIKey, Token: "sk-ant"})
+	if claudeKey.Get("Authorization") != "" {
+		t.Fatal("claude api-key auth must not send Authorization")
+	}
+	if claudeKey.Get("X-Api-Key") != "sk-ant" {
+		t.Fatalf("claude api-key X-Api-Key = %q", claudeKey.Get("X-Api-Key"))
+	}
+	if claudeKey.Get("Anthropic-Beta") == claudeOAuthBetaHeader {
+		t.Fatal("claude api-key auth must drop the OAuth beta header")
+	}
+
+	codex := http.Header{}
+	setAccountAuthHeaders(codex, accounts.Account{Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "codex-token", AccountID: "acct-1"})
+	if codex.Get("Authorization") != "Bearer codex-token" {
+		t.Fatalf("codex Authorization = %q", codex.Get("Authorization"))
+	}
+	if codex.Get("ChatGPT-Account-ID") != "acct-1" {
+		t.Fatalf("codex ChatGPT-Account-ID = %q, want the account id", codex.Get("ChatGPT-Account-ID"))
+	}
+
+	// A provider-less account is still treated as Codex.
+	legacy := http.Header{}
+	setAccountAuthHeaders(legacy, accounts.Account{AuthMode: accounts.AuthModeOAuth, Token: "legacy-token", AccountID: "acct-2"})
+	if legacy.Get("ChatGPT-Account-ID") != "acct-2" {
+		t.Fatalf("provider-less ChatGPT-Account-ID = %q, want the account id", legacy.Get("ChatGPT-Account-ID"))
+	}
+}
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -733,14 +733,10 @@ func authLikeUsageError(message string) bool {
 }
 
 func apiKeyPlanType(provider accounts.Provider) string {
-	switch provider {
-	case accounts.ProviderKimi:
-		return "kimi api key"
-	case accounts.ProviderZAI:
-		return "zai api key"
-	default:
-		return "api key"
+	if entry, ok := keyedProviderFor(provider); ok {
+		return entry.PlanLabel
 	}
+	return "api key"
 }
 
 func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus {
@@ -1428,7 +1424,7 @@ func (s Server) handleAccountImport(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		writeJSON(w, map[string]any{
 			"ok":        true,
-			"providers": []string{"codex", "claude", "kimi", "zai"},
+			"providers": append([]string{"codex", "claude"}, keyedProviderNames()...),
 		})
 		return
 	case http.MethodPost:
@@ -1540,8 +1536,8 @@ func (s Server) installImportedAccount(ctx context.Context, input accountImportR
 			}
 		}
 	}()
-	switch input.Provider {
-	case accounts.ProviderCodex, accounts.ProviderKimi, accounts.ProviderZAI:
+	switch {
+	case input.Provider == accounts.ProviderCodex || isKeyedProvider(input.Provider):
 		if input.Codex == nil || input.Claude != nil {
 			return "", invalidAccountImport("exactly one matching account payload is required")
 		}
@@ -1558,7 +1554,7 @@ func (s Server) installImportedAccount(ctx context.Context, input accountImportR
 			return "", err
 		}
 		accountID = account.Email
-	case accounts.ProviderClaude:
+	case input.Provider == accounts.ProviderClaude:
 		if input.Claude != nil && input.Codex == nil {
 			name, credential, err := validateClaudeAccountImport(*input.Claude)
 			if err != nil {
@@ -4325,6 +4321,10 @@ const claudeOAuthBetaHeader = "oauth-2025-04-20"
 func setAccountAuthHeaders(headers http.Header, account accounts.Account) {
 	headers.Set("Authorization", account.AuthorizationHeader())
 	headers.Del("ChatGPT-Account-ID")
+	if entry, ok := keyedProviderFor(account.Provider); ok {
+		applyKeyedProviderAuth(headers, account, entry)
+		return
+	}
 	switch account.Provider {
 	case accounts.ProviderClaude:
 		if account.AuthMode == accounts.AuthModeAPIKey {
@@ -4335,14 +4335,6 @@ func setAccountAuthHeaders(headers http.Header, account accounts.Account) {
 		}
 		headers.Del("X-Api-Key")
 		ensureCommaHeaderValue(headers, "Anthropic-Beta", claudeOAuthBetaHeader)
-	case accounts.ProviderKimi:
-		headers.Set("Authorization", account.AuthorizationHeader())
-		headers.Set("X-Api-Key", account.Token)
-		if headers.Get("Anthropic-Version") == "" {
-			headers.Set("Anthropic-Version", "2023-06-01")
-		}
-	case accounts.ProviderZAI:
-		headers.Del("X-Api-Key")
 	case accounts.ProviderCodex, "":
 		if account.AccountID != "" {
 			headers.Set("ChatGPT-Account-ID", account.AccountID)
@@ -4392,11 +4384,8 @@ func (s Server) upstreamForRequest(path string, account accounts.Account) *url.U
 	if account.Provider == accounts.ProviderClaude {
 		return s.ClaudeUpstream
 	}
-	if account.Provider == accounts.ProviderKimi {
-		return s.KimiUpstream
-	}
-	if account.Provider == accounts.ProviderZAI {
-		return s.ZAIUpstream
+	if entry, ok := keyedProviderFor(account.Provider); ok {
+		return entry.Upstream(s)
 	}
 	if account.AuthMode == accounts.AuthModeAPIKey {
 		return s.APIUpstream
@@ -4417,24 +4406,12 @@ func (s Server) pathForUpstream(path string, account accounts.Account) string {
 	if account.Provider == accounts.ProviderClaude {
 		return path
 	}
-	if account.Provider == accounts.ProviderKimi {
-		path = stripProviderPathPrefix(path, "kimi")
-		upstreamPath := ""
-		if s.KimiUpstream != nil {
-			upstreamPath = strings.TrimRight(s.KimiUpstream.Path, "/")
-		}
-		if strings.HasSuffix(upstreamPath, "/v1") {
-			if path == "/v1" {
-				return "/"
-			}
-			if strings.HasPrefix(path, "/v1/") {
-				return strings.TrimPrefix(path, "/v1")
-			}
+	if entry, ok := keyedProviderFor(account.Provider); ok {
+		path = stripProviderPathPrefix(path, entry.PathPrefix)
+		if entry.CollapseVersionSegment {
+			return collapseDuplicateVersionSegment(path, entry.Upstream(s))
 		}
 		return path
-	}
-	if account.Provider == accounts.ProviderZAI {
-		return stripProviderPathPrefix(path, "zai")
 	}
 	if account.AuthMode == accounts.AuthModeOAuth {
 		if stripped, ok := stripChatGPTBackendPath(path); ok {
@@ -4963,23 +4940,18 @@ func providerForRequest(agentType, path string) accounts.Provider {
 }
 
 func agentTypeForProviderSession(agentType string, provider accounts.Provider) string {
-	switch provider {
-	case accounts.ProviderKimi, accounts.ProviderZAI:
+	if isKeyedProvider(provider) {
 		return string(provider)
-	default:
-		return agentType
 	}
+	return agentType
 }
 
 func providerForPath(path string) (accounts.Provider, bool) {
-	switch firstPathSegment(path) {
-	case "kimi":
-		return accounts.ProviderKimi, true
-	case "zai":
-		return accounts.ProviderZAI, true
-	default:
+	entry, ok := keyedProviderForPathPrefix(firstPathSegment(path))
+	if !ok {
 		return "", false
 	}
+	return entry.Provider, true
 }
 
 func firstPathSegment(path string) string {
@@ -5020,7 +4992,9 @@ func filterAccountsForProvider(all []accounts.Account, provider accounts.Provide
 	if len(filtered) > 0 {
 		return filtered
 	}
-	if provider == accounts.ProviderKimi || provider == accounts.ProviderZAI {
+	// A keyed provider never inherits provider-less legacy accounts: those
+	// predate multi-provider support and are Codex credentials.
+	if isKeyedProvider(provider) {
 		return nil
 	}
 	return legacy

--- a/internal/proxy/session_lease.go
+++ b/internal/proxy/session_lease.go
@@ -843,6 +843,7 @@ func (request *sessionLeaseRequest) normalize() {
 func sessionLeaseProvider(providerValue, modelValue string) (accounts.Provider, string, error) {
 	providerName := strings.ToLower(strings.TrimSpace(providerValue))
 	model := strings.TrimSpace(modelValue)
+	originalModel := model
 	if providerName == "" {
 		modelProvider, modelID, hasProvider := strings.Cut(model, "/")
 		if hasProvider {
@@ -868,7 +869,7 @@ func sessionLeaseProvider(providerValue, modelValue string) (accounts.Provider, 
 	// A provider that addresses models as vendor/model owns the whole id: the
 	// segment before the slash belongs to the model, not to a provider name.
 	if entry, ok := keyedProviderFor(provider); ok && entry.VendorPrefixedModels {
-		return provider, model, nil
+		return provider, originalModel, nil
 	}
 	if modelProvider, modelID, hasProvider := strings.Cut(model, "/"); hasProvider {
 		if modelProviderValue, modelProviderErr := parseSessionLeaseProvider(strings.ToLower(strings.TrimSpace(modelProvider))); modelProviderErr == nil {

--- a/internal/proxy/session_lease.go
+++ b/internal/proxy/session_lease.go
@@ -541,11 +541,10 @@ func (lease sessionLease) allowsRequest(r *http.Request) bool {
 		return codexResponsePath(r.URL.Path)
 	case accounts.ProviderClaude:
 		return r.URL.Path == "/v1/messages"
-	case accounts.ProviderKimi:
-		return r.URL.Path == "/kimi/v1/messages"
-	case accounts.ProviderZAI:
-		return r.URL.Path == "/zai/chat/completions"
 	default:
+		if entry, ok := keyedProviderFor(lease.Provider); ok {
+			return r.URL.Path == entry.LeasePath
+		}
 		return false
 	}
 }
@@ -854,18 +853,22 @@ func sessionLeaseProvider(providerValue, modelValue string) (accounts.Provider, 
 			switch {
 			case strings.HasPrefix(lowerModel, "claude-"):
 				providerName = "claude"
-			case strings.HasPrefix(lowerModel, "kimi-"):
-				providerName = "kimi"
-			case strings.HasPrefix(lowerModel, "glm-"):
-				providerName = "zai"
 			default:
 				providerName = "codex"
+				if entry, ok := keyedProviderForModelPrefix(lowerModel); ok {
+					providerName = string(entry.Provider)
+				}
 			}
 		}
 	}
 	provider, err := parseSessionLeaseProvider(providerName)
 	if err != nil {
 		return "", "", err
+	}
+	// A provider that addresses models as vendor/model owns the whole id: the
+	// segment before the slash belongs to the model, not to a provider name.
+	if entry, ok := keyedProviderFor(provider); ok && entry.VendorPrefixedModels {
+		return provider, model, nil
 	}
 	if modelProvider, modelID, hasProvider := strings.Cut(model, "/"); hasProvider {
 		if modelProviderValue, modelProviderErr := parseSessionLeaseProvider(strings.ToLower(strings.TrimSpace(modelProvider))); modelProviderErr == nil {
@@ -884,11 +887,10 @@ func parseSessionLeaseProvider(providerName string) (accounts.Provider, error) {
 		return accounts.ProviderCodex, nil
 	case "claude", "anthropic":
 		return accounts.ProviderClaude, nil
-	case "kimi", "kimi-for-coding":
-		return accounts.ProviderKimi, nil
-	case "zai", "glm":
-		return accounts.ProviderZAI, nil
 	default:
+		if entry, ok := keyedProviderForName(providerName); ok {
+			return entry.Provider, nil
+		}
 		return "", fmt.Errorf("unsupported provider %q", providerName)
 	}
 }
@@ -948,19 +950,18 @@ func sessionLeaseResponseFor(lease sessionLease) sessionLeaseResponse {
 		piBaseURL += "/backend-api"
 	case accounts.ProviderClaude:
 		api = "anthropic-messages"
-	case accounts.ProviderKimi:
-		api = "anthropic-messages"
-		baseURL += "/kimi"
-		piBaseURL += "/kimi"
-	case accounts.ProviderZAI:
-		api = "openai-completions"
-		baseURL += "/zai"
-		piBaseURL += "/zai"
+	default:
+		if entry, ok := keyedProviderFor(lease.Provider); ok {
+			api = entry.LeaseAPI
+			baseURL += "/" + entry.PathPrefix
+			piBaseURL += "/" + entry.PathPrefix
+		}
 	}
 	environment := map[string]string{
 		"CLOUDMUX_SUBROUTER_LEASE_TOKEN": lease.Token,
 	}
-	if lease.Provider == accounts.ProviderCodex || lease.Provider == accounts.ProviderZAI {
+	entry, isKeyed := keyedProviderFor(lease.Provider)
+	if lease.Provider == accounts.ProviderCodex || (isKeyed && entry.LeaseEnv == leaseEnvOpenAI) {
 		environment["OPENAI_API_KEY"] = lease.Token
 		environment["OPENAI_BASE_URL"] = baseURL
 	} else {


### PR DESCRIPTION
## Why

Adding an API-key provider currently means finding and editing **24 separate** `switch provider` / `if provider ==` sites across `proxy.go`, `session_lease.go`, and `sr_server.go`. They are spread over routing, auth headers, path rewriting, lease adapters, lease env vars, account import, session stickiness, and CLI parsing. Nothing links them, so a provider added correctly in 22 places and missed in 2 compiles fine and misroutes at runtime.

Writing the OpenRouter provider (#234) meant touching every one of them.

## What

Introduces `internal/proxy/keyed_provider.go`: one registry entry per API-key provider, carrying everything the router needs.

```go
{
    Provider:               accounts.ProviderKimi,
    PathPrefix:             "kimi",
    Aliases:                []string{"kimi-for-coding"},
    ModelPrefix:            "kimi-",
    PlanLabel:              "kimi api key",
    Auth:                   authBearerAndAnthropicKey,
    CollapseVersionSegment: true,
    LeaseAPI:               "anthropic-messages",
    LeasePath:              "/kimi/v1/messages",
    LeaseEnv:               leaseEnvAnthropic,
    Upstream:               func(s Server) *url.URL { return s.KimiUpstream },
}
```

Every field corresponds to a site that previously had to be edited by hand. Kimi and ZAI move into the table; the 24 call sites become table lookups.

**Result: 24 → 0** provider-specific decision sites outside the registry, at **-30 net lines**.

`Server`'s named upstream fields are untouched (the registry reads them through an accessor), so nothing that constructs a `Server` or sets `server.KimiUpstream` in a test has to change.

## Why this is safe

**Every existing test in `internal/proxy` and `internal/accounts` passes unchanged.** No test was modified, added-to, or relaxed to make the refactor green — that is the behaviour-preservation argument, and it covers Kimi and ZAI routing, auth headers, path rewriting, leases, and account import.

New tests cover the registry itself:

- `TestKeyedProviderRegistryEntriesAreComplete` — every entry is fully populated, its lease path lives under its own path prefix, and no provider, path prefix, or alias is claimed twice. A half-filled row is the failure mode a registry can introduce, so it is asserted directly.
- `TestKeyedProviderLookupsRoundTrip` — each lookup resolves for every entry and every alias; Codex and Claude are correctly *not* keyed providers; `/v1` does not resolve to a provider.
- `TestApplyKeyedProviderAuthPresentsTheKeyPerStyle` — bearer strips a client `X-Api-Key`; the Anthropic style sets both headers and defaults `Anthropic-Version` without overwriting a client's.
- `TestCollapseDuplicateVersionSegment` — including that `/v10/chat` is not mistaken for a version segment.
- `TestAPIKeyProviderListNamesEveryProvider` — the CLI help and error text are generated from the registry, so they cannot drift.
- `TestSessionLeaseProviderHonoursVendorPrefixedModels` — `VendorPrefixedModels` is wired now even though no current entry sets it, asserted against a synthetic registry entry so the flag cannot rot before its first user. Claude still resolves `anthropic/claude-opus-5` and still rejects `openai/gpt-5`.

## One deliberate behaviour change

`parseSessionLeaseProvider` (lease API) previously accepted `glm` for ZAI but not `glm-5.2`, while the CLI's `parseAPIKeyProvider` accepted both. The registry has one alias list, so the lease API now also accepts `glm-5.2`. That is a widening, not a narrowing — no name that used to resolve stops resolving — but it is a real change and I would rather flag it than have it found in review.

## Impact on the providers that are not in the registry

The registry lookup sits **below** the explicit Codex and Claude branches on every path it touches — upstream selection, path rewriting, auth headers, session agent type, plan label, lease routing, and account import. Those providers are unaffected.

That is now asserted rather than argued, in `provider_registry_regression_test.go`:

- `TestRegistryDoesNotCaptureCodexOrClaudeRouting` — upstream selection for Claude OAuth and API key, Codex OAuth and API key, and a provider-less legacy account; Claude paths passing through unrewritten; session agent type and plan label falling through; legacy provider-less accounts still backing Codex and Claude selection while being withheld from registry providers.
- `TestRegistryDoesNotChangeCodexOrClaudeAuthHeaders` — the full Codex and Claude header shapes, including the Claude API-key vs OAuth split (`X-Api-Key` + no `Authorization` vs `Authorization` + `Anthropic-Beta`) and `ChatGPT-Account-ID` for Codex and for a provider-less account.

It also guards the **future**: no registry entry may claim a path segment (`v1`, `backend-api`, `messages`, `responses`) or a provider name (`codex`, `openai`, `openai-codex`, `claude`, `anthropic`) that a non-registry provider already routes on. Adding `"anthropic"` as an alias to any entry fails the test — verified by doing it.

Kimi and ZAI keep their existing behaviour, covered by their unchanged tests.

## What this makes cheap

Stacked on this, #234 (OpenRouter) collapses from ~11 edits to a single row:

```go
{
    Provider:               accounts.ProviderOpenRouter,
    PathPrefix:             "openrouter",
    Aliases:                []string{"open-router"},
    PlanLabel:              "openrouter api key",
    Auth:                   authBearer,
    CollapseVersionSegment: true,
    VendorPrefixedModels:   true,
    LeaseAPI:               "openai-completions",
    LeasePath:              "/openrouter/chat/completions",
    LeaseEnv:               leaseEnvOpenAI,
    Upstream:               func(s Server) *url.URL { return s.OpenRouterUpstream },
}
```

Same for Grok (`https://api.x.ai/v1`) and a Gemini API-key provider via Google's OpenAI-compatible endpoint. I'm happy to rebase #234 onto this and resubmit it as that one row — say the word and I'll do it, or drop this PR entirely if you'd rather keep the explicit switches.

## Where this architecture lands

This PR is the registry foundation for the complete provider stack. By #254, the same metadata-driven contract owns built-in and operator-declared OpenAI-compatible providers; provider-scoped account lifecycle and status; API-key and OAuth-mode upstream selection; sticky-session identity; quota-aware retry/failover; and the two-protocol Qwen Token Plan pool. The later work also preserves the explicit Codex/Claude fallback boundary with regression coverage, so extending keyed providers cannot silently capture those built-ins.

The full sequence is #236 -> #234 -> #238 -> #241 -> #242 -> #250 -> #251 -> #252 -> #253 -> #254. The culminating implementation and final capability boundaries are in https://github.com/manaflow-ai/subrouter/pull/254.

## Verification

- `go build ./...` — clean
- `gofmt -l ./account ./cmd ./internal` — clean
- `go vet ./...` — clean
- `go test ./internal/proxy/... ./internal/accounts/... -count=1` — ok, unchanged tests
- `go test ./cmd/subrouter/...` — one pre-existing failure, `TestGCPStartupBuildsPreparedFrontTopologyFromPinnedReleaseMetadata`, which also fails on `main` at `760054b`


## Review order

These are cross-fork stacked PRs, so review and merge bottom-up:

1. #236 - provider registry
2. #234 - OpenRouter
3. #238 - Grok API keys
4. #241 - Qwen Coding Plan
5. #242 - Qwen Token Plan and custom OpenAI-compatible providers
6. #250 - shared OAuth device flow
7. #251 - Antigravity credential source
8. #252 - Kimi OAuth subscriptions
9. #253 - Antigravity routing
10. #254 - Grok subscriptions and completed provider lifecycle, status, and failover stack

Each child collapses after its parent merges. If maintainers prefer a different landing shape, the stack can be re-split or re-targeted without changing this registry contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-neutral server configuration with fallback to the existing Codex-specific setting.
  * Expanded API-key provider support through a centralized provider registry.
  * Added dynamic provider discovery, validation, authentication, routing, and supported-provider listings.
  * Added support for vendor-prefixed models and improved request path handling.

* **Bug Fixes**
  * Prevented provider routing from incorrectly capturing Codex, Claude, or legacy provider-less requests.
  * Preserved correct upstream selection, authentication headers, account filtering, and session labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->