### PR TITLE
Strip Bedrock-unsupported server tools from Fable requests

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -146,6 +146,11 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 	// ("context_management: Extra inputs are not permitted"), which used to
 	// push every context-editing Claude Code request straight to the API key.
 	body = stripClaudeUnsupportedFields(body)
+	var strippedTools int
+	body, strippedTools = stripBedrockUnsupportedTools(body)
+	if strippedTools > 0 && s.Logger != nil {
+		s.Logger.Warn("stripped bedrock-unsupported server tools from claude-fable request", "count", strippedTools)
+	}
 	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, err
@@ -276,6 +281,68 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 		Body:          io.NopCloser(bytes.NewReader(respBody)),
 		ContentLength: int64(len(respBody)),
 	}, nil
+}
+
+// bedrockUnsupportedToolPrefixes lists Anthropic server-side tool types that
+// Bedrock rejects with a 400 ("tool type 'web_search_20250305' is not
+// supported for this model"). The direct Anthropic API supports them, so this
+// filter runs only on the Bedrock path; stripping the definition just means
+// the model never calls the tool, which is a strict improvement over failing
+// the whole request. Client tools (input_schema, custom types) and the
+// Bedrock-supported computer/text_editor/bash types pass through untouched.
+var bedrockUnsupportedToolPrefixes = []string{"web_search", "web_fetch", "code_execution"}
+
+// stripBedrockUnsupportedTools removes server tools Bedrock rejects from the
+// request's tools array, returning the possibly rebuilt body and how many
+// entries were dropped.
+func stripBedrockUnsupportedTools(body []byte) ([]byte, int) {
+	var payload map[string]json.RawMessage
+	if json.Unmarshal(body, &payload) != nil {
+		return body, 0
+	}
+	rawTools, ok := payload["tools"]
+	if !ok {
+		return body, 0
+	}
+	var tools []json.RawMessage
+	if json.Unmarshal(rawTools, &tools) != nil {
+		return body, 0
+	}
+	kept := make([]json.RawMessage, 0, len(tools))
+	dropped := 0
+	for _, tool := range tools {
+		var meta struct {
+			Type string `json:"type"`
+		}
+		_ = json.Unmarshal(tool, &meta)
+		unsupported := false
+		for _, prefix := range bedrockUnsupportedToolPrefixes {
+			if strings.HasPrefix(meta.Type, prefix) {
+				unsupported = true
+				break
+			}
+		}
+		if unsupported {
+			dropped++
+			continue
+		}
+		kept = append(kept, tool)
+	}
+	if dropped == 0 {
+		return body, 0
+	}
+	if len(kept) == 0 {
+		delete(payload, "tools")
+	} else if rebuilt, err := json.Marshal(kept); err == nil {
+		payload["tools"] = rebuilt
+	} else {
+		return body, 0
+	}
+	rebuilt, err := json.Marshal(payload)
+	if err != nil {
+		return body, 0
+	}
+	return rebuilt, dropped
 }
 
 func (s Server) recordClaudeFableBedrockCost(started time.Time, region string, status int, usage bedrockUsage, haveUsage bool) {

--- a/internal/proxy/claude_fable_test.go
+++ b/internal/proxy/claude_fable_test.go
@@ -832,3 +832,67 @@ func TestClaudeFableBedrockDoesNotRetryErrorAfterContent(t *testing.T) {
 		t.Fatalf("upstream calls = %d, want 1 (no retry after commit)", calls)
 	}
 }
+
+func TestStripBedrockUnsupportedTools(t *testing.T) {
+	body := []byte(`{"model":"claude-fable-5","tools":[` +
+		`{"type":"web_search_20250305","name":"web_search","max_uses":8},` +
+		`{"name":"Bash","description":"run a command","input_schema":{"type":"object"}},` +
+		`{"type":"text_editor_20250124","name":"str_replace_editor"}` +
+		`],"max_tokens":8,"messages":[]}`)
+	got, dropped := stripBedrockUnsupportedTools(body)
+	if dropped != 1 {
+		t.Fatalf("dropped = %d, want 1", dropped)
+	}
+	s := string(got)
+	if strings.Contains(s, "web_search") {
+		t.Fatalf("web_search survived the strip: %s", s)
+	}
+	if !strings.Contains(s, `"Bash"`) || !strings.Contains(s, "text_editor_20250124") {
+		t.Fatalf("client or bedrock-supported tools were dropped: %s", s)
+	}
+
+	// Only unsupported tools: the tools key disappears entirely.
+	got, dropped = stripBedrockUnsupportedTools([]byte(`{"tools":[{"type":"web_search_20250305","name":"web_search"}],"messages":[]}`))
+	if dropped != 1 || strings.Contains(string(got), "tools") {
+		t.Fatalf("expected tools key removed, got dropped=%d body=%s", dropped, got)
+	}
+
+	// No tools: untouched.
+	in := []byte(`{"model":"claude-fable-5","messages":[]}`)
+	got, dropped = stripBedrockUnsupportedTools(in)
+	if dropped != 0 || !bytes.Equal(got, in) {
+		t.Fatalf("no-tools body must pass through unchanged, dropped=%d", dropped)
+	}
+}
+
+// The Bedrock request body must not carry web_search after the strip, while
+// the same request forwarded to the Anthropic API key path keeps its tools.
+func TestClaudeFableBedrockRequestDropsWebSearchTool(t *testing.T) {
+	var upstreamBody string
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		b, _ := io.ReadAll(req.Body)
+		upstreamBody = string(b)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"type":"message","usage":{"output_tokens":3}}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	body := []byte(`{"model":"claude-fable-5","max_tokens":8,"tools":[{"type":"web_search_20250305","name":"web_search"},{"name":"Bash","input_schema":{"type":"object"}}],"messages":[]}`)
+	resp, err := s.claudeFableBedrockResponse(req.Context(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if strings.Contains(upstreamBody, "web_search") {
+		t.Fatalf("web_search reached Bedrock: %s", upstreamBody)
+	}
+	if !strings.Contains(upstreamBody, `"Bash"`) {
+		t.Fatalf("client tool was lost: %s", upstreamBody)
+	}
+}


### PR DESCRIPTION
Live log on cmux-lawrence at 21:33 tonight: `claude-fable bedrock error response status=400 body={\"message\":\"tool type 'web_search_20250305' is not supported for this model\"}`. Claude Code advertises the WebSearch server tool; Bedrock rejects the whole request, and with no API-key stage configured the 400 goes straight to the client.

Fix: drop `web_search`/`web_fetch`/`code_execution` typed tools from the `tools` array on the Bedrock path only (`claudeFableBedrockResponse`), logging a count. The direct Anthropic API path (`claudeFableAPIKeyResponse`) keeps them, since that endpoint supports them. A stripped tool just never gets called by the model; the request succeeds instead of failing. Client tools (`input_schema`) and Bedrock-supported `computer`/`text_editor`/`bash` types pass through.

Known gap, deliberate: a conversation history already containing `server_tool_use`/`web_search_tool_result` blocks (from a session that previously ran against the direct API) may still be rejected by Bedrock; not touching message content until the monitor shows it happening.

`go test ./...` exit 0 locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789706290&installation_model_id=21920&pr_number=237&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F237&signature=2a4a0c95a5c0d8f04920d5dfe9f540e89a7e381e048a4eecb0fb08c0b27c2b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip Bedrock-unsupported Anthropic server tools from Fable requests so Bedrock no longer returns 400 and requests succeed. Previously, Bedrock rejected requests with `web_search_*`, `web_fetch_*`, or `code_execution_*`; now we remove those tool definitions on the Bedrock path while the direct Anthropic API path keeps them.

- Filter prefixes in the `tools` array on the Bedrock path; log the number stripped; drop the `tools` key if all are removed.
- Preserve client tools (`input_schema`) and Bedrock-supported `computer`/`text_editor`/`bash`.
- Do not modify message history; conversations with prior `server_tool_use`/`web_search_tool_result` blocks may still be rejected.
- Add unit tests for the filter and Bedrock request body; no changes to non-Bedrock behavior.

<sup>Written for commit 2ead0d55e4236a9bad842b299bc33a2393cd7f0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

