### PR TITLE
Route Grok as an API-key provider

### DIFF
--- a/account/types.go
+++ b/account/types.go
@@ -13,6 +13,10 @@ const (
 	// ProviderOpenRouter routes to OpenRouter's OpenAI-compatible API with a
 	// per-account API key.
 	ProviderOpenRouter Provider = "openrouter"
+
+	// ProviderGrok routes to xAI's OpenAI-compatible API with a per-account
+	// API key.
+	ProviderGrok Provider = "grok"
 )
 
 type AuthMode string

--- a/account/types.go
+++ b/account/types.go
@@ -9,6 +9,10 @@ const (
 	ProviderClaude Provider = "claude"
 	ProviderKimi   Provider = "kimi"
 	ProviderZAI    Provider = "zai"
+
+	// ProviderOpenRouter routes to OpenRouter's OpenAI-compatible API with a
+	// per-account API key.
+	ProviderOpenRouter Provider = "openrouter"
 )
 
 type AuthMode string

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -286,6 +286,7 @@ func serve(args []string) error {
 	claudeUpstreamRaw := flags.String("claude-upstream", "https://api.anthropic.com", "Claude subscription upstream base URL")
 	kimiUpstreamRaw := flags.String("kimi-upstream", "https://api.kimi.com/coding/v1", "Kimi For Coding upstream base URL")
 	zaiUpstreamRaw := flags.String("zai-upstream", "https://api.z.ai/api/coding/paas/v4", "Z.AI coding upstream base URL")
+	openRouterUpstreamRaw := flags.String("openrouter-upstream", "https://openrouter.ai/api/v1", "OpenRouter upstream base URL")
 	sessionPath := flags.String("sessions", session.DefaultStorePath(), "session assignment store")
 	transcriptDir := flags.String("transcripts", "", "directory for raw Subrouter transcript JSONL files")
 	transcriptGCSURI := flags.String("transcript-gcs-uri", "", "optional gs:// bucket/prefix for background transcript sync")
@@ -432,6 +433,10 @@ func serve(args []string) error {
 		return err
 	}
 	zaiUpstream, err := url.Parse(*zaiUpstreamRaw)
+	if err != nil {
+		return err
+	}
+	openRouterUpstream, err := url.Parse(*openRouterUpstreamRaw)
 	if err != nil {
 		return err
 	}
@@ -621,6 +626,7 @@ func serve(args []string) error {
 		ClaudeUpstream:        claudeUpstream,
 		KimiUpstream:          kimiUpstream,
 		ZAIUpstream:           zaiUpstream,
+		OpenRouterUpstream:    openRouterUpstream,
 		Accounts:              nil,
 		AccountRef:            accountRef,
 		CredentialBroker:      credentialBroker,
@@ -1434,7 +1440,7 @@ Usage:
   %[1]s spend              Show AWS Bedrock spend tracked by the server
   %[1]s gemini             Manage Gemini profiles
 
-  %[1]s serve [--addr 127.0.0.1:31415] [--fetch-usage=true] [--multi-tenant] [--codex-upstream URL] [--claude-upstream URL] [--kimi-upstream URL] [--zai-upstream URL] [--transcripts DIR] [--transcript-gcs-uri gs://bucket/prefix] [--transcript-gcs-sync-timeout 30m] [--transcript-local-retention 24h] [--transcript-max-local-bytes 2GiB]
+  %[1]s serve [--addr 127.0.0.1:31415] [--fetch-usage=true] [--multi-tenant] [--codex-upstream URL] [--claude-upstream URL] [--kimi-upstream URL] [--zai-upstream URL] [--openrouter-upstream URL] [--transcripts DIR] [--transcript-gcs-uri gs://bucket/prefix] [--transcript-gcs-sync-timeout 30m] [--transcript-local-retention 24h] [--transcript-max-local-bytes 2GiB]
   %[1]s supervise --worker-bin PATH [--addr 127.0.0.1:31415] [--control-socket /var/run/subrouter-supervisor.sock] [--expect-proxy-protocol] [--drain-timeout 10m] [--worker-stop-grace 30s] -- [serve flags]
   %[1]s front --backend-id ID --backend-address ADDRESS [--backend-network tcp|unix] [--addr 127.0.0.1:31415] [--control-socket /var/run/subrouter-front.sock] [--listener-transfer-socket /var/run/subrouter-front-listener.sock]
   %[1]s probe [--url http://127.0.0.1:31415]

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -287,6 +287,7 @@ func serve(args []string) error {
 	kimiUpstreamRaw := flags.String("kimi-upstream", "https://api.kimi.com/coding/v1", "Kimi For Coding upstream base URL")
 	zaiUpstreamRaw := flags.String("zai-upstream", "https://api.z.ai/api/coding/paas/v4", "Z.AI coding upstream base URL")
 	openRouterUpstreamRaw := flags.String("openrouter-upstream", "https://openrouter.ai/api/v1", "OpenRouter upstream base URL")
+	grokUpstreamRaw := flags.String("grok-upstream", "https://api.x.ai/v1", "xAI Grok upstream base URL")
 	sessionPath := flags.String("sessions", session.DefaultStorePath(), "session assignment store")
 	transcriptDir := flags.String("transcripts", "", "directory for raw Subrouter transcript JSONL files")
 	transcriptGCSURI := flags.String("transcript-gcs-uri", "", "optional gs:// bucket/prefix for background transcript sync")
@@ -437,6 +438,10 @@ func serve(args []string) error {
 		return err
 	}
 	openRouterUpstream, err := url.Parse(*openRouterUpstreamRaw)
+	if err != nil {
+		return err
+	}
+	grokUpstream, err := url.Parse(*grokUpstreamRaw)
 	if err != nil {
 		return err
 	}
@@ -627,6 +632,7 @@ func serve(args []string) error {
 		KimiUpstream:          kimiUpstream,
 		ZAIUpstream:           zaiUpstream,
 		OpenRouterUpstream:    openRouterUpstream,
+		GrokUpstream:          grokUpstream,
 		Accounts:              nil,
 		AccountRef:            accountRef,
 		CredentialBroker:      credentialBroker,
@@ -1443,7 +1449,7 @@ Usage:
   %[1]s spend              Show AWS Bedrock spend tracked by the server
   %[1]s gemini             Manage Gemini profiles
 
-  %[1]s serve [--addr 127.0.0.1:31415] [--fetch-usage=true] [--multi-tenant] [--codex-upstream URL] [--claude-upstream URL] [--kimi-upstream URL] [--zai-upstream URL] [--openrouter-upstream URL] [--transcripts DIR] [--transcript-gcs-uri gs://bucket/prefix] [--transcript-gcs-sync-timeout 30m] [--transcript-local-retention 24h] [--transcript-max-local-bytes 2GiB]
+  %[1]s serve [--addr 127.0.0.1:31415] [--fetch-usage=true] [--multi-tenant] [--codex-upstream URL] [--claude-upstream URL] [--kimi-upstream URL] [--zai-upstream URL] [--openrouter-upstream URL] [--grok-upstream URL] [--transcripts DIR] [--transcript-gcs-uri gs://bucket/prefix] [--transcript-gcs-sync-timeout 30m] [--transcript-local-retention 24h] [--transcript-max-local-bytes 2GiB]
   %[1]s supervise --worker-bin PATH [--addr 127.0.0.1:31415] [--control-socket /var/run/subrouter-supervisor.sock] [--expect-proxy-protocol] [--drain-timeout 10m] [--worker-stop-grace 30s] -- [serve flags]
   %[1]s front --backend-id ID --backend-address ADDRESS [--backend-network tcp|unix] [--addr 127.0.0.1:31415] [--control-socket /var/run/subrouter-front.sock] [--listener-transfer-socket /var/run/subrouter-front-listener.sock]
   %[1]s probe [--url http://127.0.0.1:31415]

--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -652,6 +652,9 @@ func serve(args []string) error {
 		FableBedrockPrimary:           fableBedrockEnabled,
 		Transcripts:                   transcript.NewRecorder(*transcriptDir),
 	}
+	if err := server.ValidateCredentialUpstreams(); err != nil {
+		return err
+	}
 	transcriptGCSSyncer := transcript.NewGCSSyncer(transcript.GCSSyncerConfig{
 		SourceDir:      *transcriptDir,
 		Destination:    *transcriptGCSURI,

--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -20,6 +20,7 @@ import (
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 	agentclaude "github.com/manaflow-ai/subrouter/internal/agents/claude"
 	"github.com/manaflow-ai/subrouter/internal/broker"
+	"github.com/manaflow-ai/subrouter/internal/proxy"
 	"github.com/manaflow-ai/subrouter/selectacct"
 	"golang.org/x/term"
 )
@@ -253,7 +254,7 @@ func (r srRunner) run(ctx context.Context, args []string) error {
 	case "storage":
 		return r.cloudStorage(args[1:])
 	case "add-key", "add-api-key":
-		return r.addKey()
+		return r.addKey(args[1:])
 	case "import":
 		return r.importActive()
 	case "list", "ls":
@@ -395,6 +396,13 @@ func (r srRunner) runTeamCredentialCommand(
 		}
 		return true, r.cloudAccountAdd(ctx, client, providerArgs)
 	case "add-key", "add-api-key":
+		provider, err := parseAddKeyProviderArgs(r.programOrSubrouter()+" add-key", r.errOut, args[1:])
+		if err != nil {
+			return true, err
+		}
+		if provider != accounts.ProviderCodex {
+			return true, fmt.Errorf("hosted credential storage does not support %s API keys; use 'sr storage local' or a self-hosted remote", provider)
+		}
 		_, _, client, err := loadCloudClient(true)
 		if err != nil {
 			return true, err
@@ -572,7 +580,11 @@ func (r srRunner) add(ctx context.Context) error {
 	return nil
 }
 
-func (r srRunner) addKey() error {
+func (r srRunner) addKey(args []string) error {
+	provider, err := parseAddKeyProviderArgs(r.programOrSubrouter()+" add-key", r.errOut, args)
+	if err != nil {
+		return err
+	}
 	if err := r.store.SyncActiveToStore(); err != nil {
 		return err
 	}
@@ -581,16 +593,20 @@ func (r srRunner) addKey() error {
 	if err != nil {
 		return err
 	}
+	keyPrompt := "API key"
+	if provider == accounts.ProviderCodex {
+		keyPrompt = "API key (sk-...)"
+	}
 	key, err := promptSecret(
 		r.out,
 		reader,
 		r.in,
-		"API key (sk-...): ",
+		keyPrompt+": ",
 	)
 	if err != nil {
 		return err
 	}
-	account, existed, err := r.store.AddAPIKey(label, key)
+	account, existed, err := r.store.AddProviderAPIKey(provider, label, key)
 	if err != nil {
 		return err
 	}
@@ -600,6 +616,23 @@ func (r srRunner) addKey() error {
 		fmt.Fprintf(r.out, "Added API key account: %s\n", account.APIKeyLabel())
 	}
 	return nil
+}
+
+func parseAddKeyProviderArgs(command string, errOut io.Writer, args []string) (accounts.Provider, error) {
+	flags := flag.NewFlagSet(command, flag.ContinueOnError)
+	flags.SetOutput(errOut)
+	providerRaw := flags.String("provider", string(accounts.ProviderCodex), "API-key provider: "+proxy.APIKeyProviderList())
+	if err := flags.Parse(args); err != nil {
+		return "", err
+	}
+	if flags.NArg() != 0 {
+		return "", fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	provider, err := parseAPIKeyProvider(*providerRaw)
+	if err != nil {
+		return "", err
+	}
+	return provider, nil
 }
 
 func (r srRunner) importActive() error {
@@ -959,7 +992,7 @@ func (r srRunner) fetchUsageRows(ctx context.Context) ([]srUsageRow, error) {
 	var wg sync.WaitGroup
 	for i, account := range all {
 		i, account := i, account
-		rows[i] = srUsageRow{email: account.Email, active: account.Email == active, provider: accounts.ProviderCodex}
+		rows[i] = srUsageRow{email: account.Email, active: account.Email == active, provider: account.ProviderOrDefault()}
 		if account.IsAPIKey() {
 			rows[i].authMode = accounts.AuthModeAPIKey
 			rows[i].score = selectacct.Score{AccountID: account.Email, Headroom: 0.01, ShortHeadroom: 0.01}
@@ -1331,7 +1364,7 @@ func (r srRunner) usage(ctx context.Context, days int) error {
 func accountFromStored(account accounts.StoredCodexAccount) accounts.Account {
 	out := accounts.Account{
 		ID:       account.Email,
-		Provider: accounts.ProviderCodex,
+		Provider: account.ProviderOrDefault(),
 		Label:    account.Email,
 		Email:    account.Email,
 		Source:   account.Email,
@@ -1535,7 +1568,7 @@ func hasSwitchableUsageRows(rows []srUsageRow) bool {
 
 func ensureUsageRowSwitchable(row srUsageRow) error {
 	if row.provider != "" && row.provider != accounts.ProviderCodex {
-		return fmt.Errorf("cannot switch to %s with sr; use sr claude switch %s", row.email, row.email)
+		return fmt.Errorf("cannot switch to %s with sr; %s credentials are selected by provider routing", row.email, row.provider)
 	}
 	if row.cooked {
 		return fmt.Errorf("cannot switch to %s: account is cooked (%s)", row.email, row.cookedReason)

--- a/cmd/subrouter/sr_cloud.go
+++ b/cmd/subrouter/sr_cloud.go
@@ -945,7 +945,7 @@ func (r srRunner) cloudAccountAdd(
 			return err
 		}
 	case "openai-key":
-		if err := r.addKey(); err != nil {
+		if err := r.addKey(nil); err != nil {
 			return err
 		}
 	default:

--- a/cmd/subrouter/sr_server.go
+++ b/cmd/subrouter/sr_server.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 	"github.com/manaflow-ai/subrouter/internal/broker"
+	"github.com/manaflow-ai/subrouter/internal/proxy"
 	"github.com/manaflow-ai/subrouter/internal/tenant"
 	"github.com/manaflow-ai/subrouter/selectacct"
 	"golang.org/x/term"
@@ -937,7 +938,7 @@ func (r srRunner) addKeyToServer(ctx context.Context, server srServerConfig, arg
 	command := r.programOrSubrouter() + " add-key"
 	flags := flag.NewFlagSet(command, flag.ContinueOnError)
 	flags.SetOutput(r.errOut)
-	providerRaw := flags.String("provider", string(accounts.ProviderCodex), "API-key provider: codex, claude, kimi, or zai")
+	providerRaw := flags.String("provider", string(accounts.ProviderCodex), "API-key provider: "+proxy.APIKeyProviderList())
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -1003,12 +1004,11 @@ func parseAPIKeyProvider(value string) (accounts.Provider, error) {
 		return accounts.ProviderCodex, nil
 	case string(accounts.ProviderClaude), "anthropic":
 		return accounts.ProviderClaude, nil
-	case string(accounts.ProviderKimi), "kimi-for-coding":
-		return accounts.ProviderKimi, nil
-	case string(accounts.ProviderZAI), "glm", "glm-5.2":
-		return accounts.ProviderZAI, nil
 	default:
-		return "", fmt.Errorf("unsupported API-key provider %q, expected codex, claude, kimi, or zai", value)
+		if provider, ok := proxy.APIKeyProviderForName(strings.ToLower(strings.TrimSpace(value))); ok {
+			return provider, nil
+		}
+		return "", fmt.Errorf("unsupported API-key provider %q, expected %s", value, proxy.APIKeyProviderList())
 	}
 }
 

--- a/cmd/subrouter/sr_server_test.go
+++ b/cmd/subrouter/sr_server_test.go
@@ -1894,3 +1894,34 @@ func TestParseAPIKeyProviderClaude(t *testing.T) {
 func jsonMarshalIndent(value any) ([]byte, error) {
 	return json.MarshalIndent(value, "", "  ")
 }
+
+func TestParseAPIKeyProviderCoversEveryProvider(t *testing.T) {
+	cases := map[string]accounts.Provider{
+		"":                accounts.ProviderCodex,
+		"codex":           accounts.ProviderCodex,
+		"openai":          accounts.ProviderCodex,
+		"claude":          accounts.ProviderClaude,
+		"anthropic":       accounts.ProviderClaude,
+		"kimi":            accounts.ProviderKimi,
+		"kimi-for-coding": accounts.ProviderKimi,
+		"zai":             accounts.ProviderZAI,
+		"glm":             accounts.ProviderZAI,
+		"openrouter":      accounts.ProviderOpenRouter,
+		"open-router":     accounts.ProviderOpenRouter,
+		"  OpenRouter  ":  accounts.ProviderOpenRouter,
+	}
+	for value, want := range cases {
+		got, err := parseAPIKeyProvider(value)
+		if err != nil {
+			t.Fatalf("parseAPIKeyProvider(%q) failed: %v", value, err)
+		}
+		if got != want {
+			t.Fatalf("parseAPIKeyProvider(%q) = %q, want %q", value, got, want)
+		}
+	}
+	if _, err := parseAPIKeyProvider("gemini"); err == nil {
+		t.Fatal("an unsupported provider must be rejected")
+	} else if !strings.Contains(err.Error(), "openrouter") {
+		t.Fatalf("the error should list openrouter as supported, got %v", err)
+	}
+}

--- a/cmd/subrouter/sr_test.go
+++ b/cmd/subrouter/sr_test.go
@@ -61,6 +61,92 @@ func TestSRListReadsNativeCodexStore(t *testing.T) {
 	}
 }
 
+func TestSRAddKeyStoresRegistryProviderInLocalStorage(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	store := accounts.DefaultCodexStore()
+	var out bytes.Buffer
+	runner := srRunner{
+		store:  store,
+		in:     strings.NewReader("work\nsk-or-v1-test\n"),
+		out:    &out,
+		errOut: &out,
+	}
+
+	if err := runner.run(context.Background(), []string{"add-key", "--provider", "open-router"}); err != nil {
+		t.Fatal(err)
+	}
+	stored, ok, err := store.FindStored("openrouter:work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("missing provider-scoped OpenRouter account")
+	}
+	if stored.Provider != accounts.ProviderOpenRouter || stored.Auth.AuthMode != "apikey" || stored.Auth.OpenAIAPIKey != "sk-or-v1-test" {
+		t.Fatalf("stored account provider=%q auth_mode=%q key_matches=%t, want OpenRouter API-key account", stored.Provider, stored.Auth.AuthMode, stored.Auth.OpenAIAPIKey == "sk-or-v1-test")
+	}
+	if _, codex, err := store.FindStored("apikey:work"); err != nil {
+		t.Fatal(err)
+	} else if codex {
+		t.Fatal("OpenRouter key was also stored in the Codex API-key pool")
+	}
+}
+
+func TestSRAddKeyRejectsUnknownLocalProviderBeforePrompting(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	store := accounts.DefaultCodexStore()
+	var out bytes.Buffer
+	runner := srRunner{store: store, in: strings.NewReader(""), out: &out, errOut: &out}
+
+	err := runner.run(context.Background(), []string{"add-key", "--provider", "not-a-provider"})
+	if err == nil || !strings.Contains(err.Error(), "unsupported API-key provider") {
+		t.Fatalf("error = %v, want unsupported provider", err)
+	}
+	stored, listErr := store.ListStored()
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	if len(stored) != 0 {
+		t.Fatalf("invalid provider stored accounts: %+v", stored)
+	}
+}
+
+func TestHostedAddKeyRejectsRegistryProviderInsteadOfReclassifyingIt(t *testing.T) {
+	var out bytes.Buffer
+	runner := srRunner{in: strings.NewReader(""), out: &out, errOut: &out}
+
+	handled, err := runner.runTeamCredentialCommand(context.Background(), []string{"add-key", "--provider", "openrouter"})
+	if !handled {
+		t.Fatal("hosted add-key command was not handled")
+	}
+	if err == nil || !strings.Contains(err.Error(), "hosted credential storage does not support openrouter API keys") {
+		t.Fatalf("error = %v, want explicit hosted OpenRouter rejection", err)
+	}
+}
+
+func TestUsageRowsKeepProviderAPIKeysOutOfCodexSwitching(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	store := accounts.DefaultCodexStore()
+	if _, _, err := store.AddProviderAPIKey(accounts.ProviderOpenRouter, "work", "sk-or-v1-test"); err != nil {
+		t.Fatal(err)
+	}
+	runner := srRunner{store: store, client: http.DefaultClient}
+
+	rows, err := runner.fetchUsageRows(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].provider != accounts.ProviderOpenRouter {
+		t.Fatalf("usage rows = %+v, want one OpenRouter row", rows)
+	}
+	if err := ensureUsageRowSwitchable(rows[0]); err == nil {
+		t.Fatal("OpenRouter API key was switchable as an active Codex credential")
+	}
+}
+
 func TestSRTraceShowsOAuthBreadcrumbs(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/docs/design.md
+++ b/docs/design.md
@@ -44,9 +44,9 @@ through to normal account routing.
 Codex Pi leases select only OAuth subscription accounts because Pi's
 `openai-codex-responses` adapter and `/backend-api` route are ChatGPT-specific.
 If no Codex OAuth account is available, lease creation returns `503` without
-creating a lease or sticky session assignment. Claude, Kimi, ZAI, and
-OpenRouter leases may use API-key accounts supported by their returned Pi
-adapter configuration.
+creating a lease or sticky session assignment. Claude, Kimi, ZAI,
+OpenRouter, and Grok leases may use API-key accounts supported by their returned
+Pi adapter configuration.
 
 A model-bound lease requires a top-level `model` string in the forwarded JSON
 body. Every body occurrence and any forwarded `model` query value must match

--- a/docs/design.md
+++ b/docs/design.md
@@ -44,8 +44,9 @@ through to normal account routing.
 Codex Pi leases select only OAuth subscription accounts because Pi's
 `openai-codex-responses` adapter and `/backend-api` route are ChatGPT-specific.
 If no Codex OAuth account is available, lease creation returns `503` without
-creating a lease or sticky session assignment. Claude, Kimi, and ZAI leases may
-use API-key accounts supported by their returned Pi adapter configuration.
+creating a lease or sticky session assignment. Claude, Kimi, ZAI, and
+OpenRouter leases may use API-key accounts supported by their returned Pi
+adapter configuration.
 
 A model-bound lease requires a top-level `model` string in the forwarded JSON
 body. Every body occurrence and any forwarded `model` query value must match

--- a/internal/accounts/codex_auth.go
+++ b/internal/accounts/codex_auth.go
@@ -163,15 +163,32 @@ func (s CodexStore) ImportActive() (StoredCodexAccount, bool, error) {
 }
 
 func (s CodexStore) AddAPIKey(label, key string) (StoredCodexAccount, bool, error) {
+	return s.AddProviderAPIKey(ProviderCodex, label, key)
+}
+
+// AddProviderAPIKey stores an API key under the provider-scoped identifier
+// used by proxy routing. ProviderCodex retains the legacy apikey: prefix and
+// sk- validation; registry-backed providers may use their own key formats.
+func (s CodexStore) AddProviderAPIKey(provider Provider, label, key string) (StoredCodexAccount, bool, error) {
+	if provider == "" {
+		provider = ProviderCodex
+	}
 	label = strings.TrimSpace(label)
 	key = strings.TrimSpace(key)
 	if label == "" {
 		return StoredCodexAccount{}, false, fmt.Errorf("label is required")
 	}
-	if !strings.HasPrefix(key, "sk-") {
+	if key == "" {
+		return StoredCodexAccount{}, false, fmt.Errorf("API key is required")
+	}
+	if provider == ProviderCodex && !strings.HasPrefix(key, "sk-") {
 		return StoredCodexAccount{}, false, fmt.Errorf("invalid API key format, expected sk-...")
 	}
-	email := "apikey:" + label
+	emailPrefix := "apikey:"
+	if provider != ProviderCodex {
+		emailPrefix = string(provider) + ":"
+	}
+	email := emailPrefix + label
 	account, existed, err := s.FindStored(email)
 	if err != nil {
 		return StoredCodexAccount{}, false, err
@@ -181,6 +198,11 @@ func (s CodexStore) AddAPIKey(label, key string) (StoredCodexAccount, bool, erro
 			Email:   email,
 			AddedAt: time.Now().UTC().Format(time.RFC3339),
 		}
+	}
+	if provider == ProviderCodex {
+		account.Provider = ""
+	} else {
+		account.Provider = provider
 	}
 	account.Auth = CodexAuthFile{
 		AuthMode:     "apikey",

--- a/internal/accounts/types.go
+++ b/internal/accounts/types.go
@@ -24,6 +24,8 @@ const (
 	ProviderKimi   = account.ProviderKimi
 	ProviderZAI    = account.ProviderZAI
 
+	ProviderOpenRouter = account.ProviderOpenRouter
+
 	AuthModeOAuth  = account.AuthModeOAuth
 	AuthModeAPIKey = account.AuthModeAPIKey
 )

--- a/internal/accounts/types.go
+++ b/internal/accounts/types.go
@@ -26,6 +26,8 @@ const (
 
 	ProviderOpenRouter = account.ProviderOpenRouter
 
+	ProviderGrok = account.ProviderGrok
+
 	AuthModeOAuth  = account.AuthModeOAuth
 	AuthModeAPIKey = account.AuthModeAPIKey
 )

--- a/internal/proxy/account_import_test.go
+++ b/internal/proxy/account_import_test.go
@@ -446,7 +446,7 @@ func TestAccountImportSupportsEveryAPIKeyProvider(t *testing.T) {
 	ref.claudeStore = agentclaude.Store{Dir: t.TempDir()}
 	handler := Server{AccountRef: ref, AdminToken: "secret"}.Handler()
 
-	for _, tc := range []struct {
+	providers := []struct {
 		provider accounts.Provider
 		email    string
 		key      string
@@ -455,7 +455,10 @@ func TestAccountImportSupportsEveryAPIKeyProvider(t *testing.T) {
 		{provider: accounts.ProviderClaude, email: "claude:anthropic", key: "anthropic-test"},
 		{provider: accounts.ProviderKimi, email: "kimi:kimi", key: "kimi-test"},
 		{provider: accounts.ProviderZAI, email: "zai:zai", key: "zai-test"},
-	} {
+		{provider: accounts.ProviderOpenRouter, email: "openrouter:openrouter", key: "sk-or-v1-test"},
+	}
+
+	for _, tc := range providers {
 		account := accounts.StoredCodexAccount{
 			Email:    tc.email,
 			Provider: tc.provider,
@@ -478,8 +481,8 @@ func TestAccountImportSupportsEveryAPIKeyProvider(t *testing.T) {
 	}
 
 	loaded := ref.All()
-	if len(loaded) != 4 {
-		t.Fatalf("loaded accounts = %d, want 4: %+v", len(loaded), loaded)
+	if len(loaded) != len(providers) {
+		t.Fatalf("loaded accounts = %d, want %d: %+v", len(loaded), len(providers), loaded)
 	}
 	for _, account := range loaded {
 		if account.AuthMode != accounts.AuthModeAPIKey || account.Token == "" {

--- a/internal/proxy/keyed_provider.go
+++ b/internal/proxy/keyed_provider.go
@@ -1,0 +1,217 @@
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+// authStyle names how a provider expects its API key to be presented.
+type authStyle int
+
+const (
+	// authBearer sends Authorization: Bearer <key> and removes any client
+	// X-Api-Key, which is the OpenAI-compatible convention.
+	authBearer authStyle = iota
+	// authBearerAndAnthropicKey sends both Authorization and X-Api-Key, and
+	// defaults Anthropic-Version, for providers exposing an Anthropic-shaped API.
+	authBearerAndAnthropicKey
+)
+
+// leaseEnvStyle names which SDK environment variables a lease hands to the
+// sandbox so the client library points back at this proxy.
+type leaseEnvStyle int
+
+const (
+	leaseEnvOpenAI leaseEnvStyle = iota
+	leaseEnvAnthropic
+)
+
+// keyedProvider describes an API-key provider that the proxy routes by path
+// prefix. Everything the router needs about such a provider lives in one entry,
+// so adding a provider is a table row rather than an edit to a dozen switch
+// statements that are easy to leave half-updated.
+type keyedProvider struct {
+	Provider accounts.Provider
+	// PathPrefix is the first path segment that selects this provider, so
+	// /<PathPrefix>/... routes here and the segment is stripped upstream.
+	PathPrefix string
+	// Aliases are the additional names accepted wherever a provider is named by
+	// a human or an API caller. The canonical provider string is always accepted.
+	Aliases []string
+	// ModelPrefix infers this provider from a bare model id, e.g. "glm-" for ZAI.
+	// Empty means no inference.
+	ModelPrefix string
+	// PlanLabel is how an API-key account of this provider is described in
+	// account listings.
+	PlanLabel string
+	Auth      authStyle
+	// CollapseVersionSegment marks a provider whose upstream base URL may already
+	// end in /v1, so a client's own /v1 must not be forwarded twice.
+	CollapseVersionSegment bool
+	// VendorPrefixedModels marks a provider that addresses models as
+	// vendor/model, where the segment before the slash belongs to the model id
+	// rather than naming a provider.
+	VendorPrefixedModels bool
+	// LeaseAPI is the Pi adapter a lease advertises for this provider.
+	LeaseAPI string
+	// LeasePath is the single path a lease for this provider may call.
+	LeasePath string
+	LeaseEnv  leaseEnvStyle
+	// Upstream reads this provider's configured base URL off the server.
+	Upstream func(Server) *url.URL
+}
+
+// keyedProviders is the registry. Adding an API-key provider means adding an
+// entry here and a base-URL field on Server; the routing, auth, lease, import,
+// and CLI paths all read from this table.
+var keyedProviders = []keyedProvider{
+	{
+		Provider:               accounts.ProviderKimi,
+		PathPrefix:             "kimi",
+		Aliases:                []string{"kimi-for-coding"},
+		ModelPrefix:            "kimi-",
+		PlanLabel:              "kimi api key",
+		Auth:                   authBearerAndAnthropicKey,
+		CollapseVersionSegment: true,
+		LeaseAPI:               "anthropic-messages",
+		LeasePath:              "/kimi/v1/messages",
+		LeaseEnv:               leaseEnvAnthropic,
+		Upstream:               func(s Server) *url.URL { return s.KimiUpstream },
+	},
+	{
+		Provider:    accounts.ProviderZAI,
+		PathPrefix:  "zai",
+		Aliases:     []string{"glm", "glm-5.2"},
+		ModelPrefix: "glm-",
+		PlanLabel:   "zai api key",
+		Auth:        authBearer,
+		LeaseAPI:    "openai-completions",
+		LeasePath:   "/zai/chat/completions",
+		LeaseEnv:    leaseEnvOpenAI,
+		Upstream:    func(s Server) *url.URL { return s.ZAIUpstream },
+	},
+}
+
+// keyedProviderFor returns the registry entry for a provider.
+func keyedProviderFor(provider accounts.Provider) (keyedProvider, bool) {
+	for _, entry := range keyedProviders {
+		if entry.Provider == provider {
+			return entry, true
+		}
+	}
+	return keyedProvider{}, false
+}
+
+// keyedProviderForPathPrefix resolves the first path segment to a provider.
+func keyedProviderForPathPrefix(segment string) (keyedProvider, bool) {
+	for _, entry := range keyedProviders {
+		if entry.PathPrefix == segment {
+			return entry, true
+		}
+	}
+	return keyedProvider{}, false
+}
+
+// keyedProviderForName resolves a provider named by a human or an API caller,
+// accepting the canonical provider string and any registered alias.
+func keyedProviderForName(name string) (keyedProvider, bool) {
+	for _, entry := range keyedProviders {
+		if name == string(entry.Provider) {
+			return entry, true
+		}
+		for _, alias := range entry.Aliases {
+			if name == alias {
+				return entry, true
+			}
+		}
+	}
+	return keyedProvider{}, false
+}
+
+// keyedProviderForModelPrefix infers a provider from a bare model id.
+func keyedProviderForModelPrefix(lowerModel string) (keyedProvider, bool) {
+	for _, entry := range keyedProviders {
+		if entry.ModelPrefix != "" && len(lowerModel) >= len(entry.ModelPrefix) &&
+			lowerModel[:len(entry.ModelPrefix)] == entry.ModelPrefix {
+			return entry, true
+		}
+	}
+	return keyedProvider{}, false
+}
+
+// isKeyedProvider reports whether a provider is routed through the registry.
+func isKeyedProvider(provider accounts.Provider) bool {
+	_, ok := keyedProviderFor(provider)
+	return ok
+}
+
+// keyedProviderNames lists every canonical provider name in the registry, in
+// registry order, for advertising and for error messages.
+func keyedProviderNames() []string {
+	names := make([]string, 0, len(keyedProviders))
+	for _, entry := range keyedProviders {
+		names = append(names, string(entry.Provider))
+	}
+	return names
+}
+
+// applyKeyedProviderAuth presents the account's API key the way this provider
+// expects it. Authorization is already set to the bearer form by the caller.
+func applyKeyedProviderAuth(headers http.Header, account accounts.Account, entry keyedProvider) {
+	switch entry.Auth {
+	case authBearerAndAnthropicKey:
+		headers.Set("Authorization", account.AuthorizationHeader())
+		headers.Set("X-Api-Key", account.Token)
+		if headers.Get("Anthropic-Version") == "" {
+			headers.Set("Anthropic-Version", "2023-06-01")
+		}
+	default:
+		headers.Del("X-Api-Key")
+	}
+}
+
+// collapseDuplicateVersionSegment drops a leading /v1 from an already
+// prefix-stripped path when the upstream base URL ends in /v1, so a client that
+// sends /<provider>/v1/... does not reach /v1/v1/... upstream. The collapse is
+// conditional on the configured base, so an unversioned override still forwards
+// the client's own /v1.
+func collapseDuplicateVersionSegment(path string, upstream *url.URL) string {
+	upstreamPath := ""
+	if upstream != nil {
+		upstreamPath = strings.TrimRight(upstream.Path, "/")
+	}
+	if !strings.HasSuffix(upstreamPath, "/v1") {
+		return path
+	}
+	if path == "/v1" {
+		return "/"
+	}
+	if strings.HasPrefix(path, "/v1/") {
+		return strings.TrimPrefix(path, "/v1")
+	}
+	return path
+}
+
+// APIKeyProviderForName resolves a provider named on the CLI or in an API
+// payload, accepting the canonical name and any registered alias. Exported so
+// the CLI does not carry a second copy of the alias list.
+func APIKeyProviderForName(name string) (accounts.Provider, bool) {
+	entry, ok := keyedProviderForName(name)
+	if !ok {
+		return "", false
+	}
+	return entry.Provider, true
+}
+
+// APIKeyProviderList renders the providers a user may name, for flag help and
+// for the error returned when they name something else.
+func APIKeyProviderList() string {
+	names := append([]string{"codex", "claude"}, keyedProviderNames()...)
+	if len(names) == 1 {
+		return names[0]
+	}
+	return strings.Join(names[:len(names)-1], ", ") + ", or " + names[len(names)-1]
+}

--- a/internal/proxy/keyed_provider.go
+++ b/internal/proxy/keyed_provider.go
@@ -151,6 +151,21 @@ var keyedProviders = []keyedProvider{
 		LeaseEnv:               leaseEnvOpenAI,
 		Upstream:               func(s Server) *url.URL { return s.OpenRouterUpstream },
 	},
+	{
+		Provider:    accounts.ProviderGrok,
+		PathPrefix:  "grok",
+		Aliases:     []string{"xai", "x-ai"},
+		ModelPrefix: "grok-",
+		PlanLabel:   "grok api key",
+		Auth:        authBearer,
+		// api.x.ai/v1 already ends in /v1. xAI model ids are bare (grok-4), so
+		// the vendor/model provider-selector rule still applies.
+		CollapseVersionSegment: true,
+		LeaseAPI:               "openai-completions",
+		LeasePath:              "/grok/chat/completions",
+		LeaseEnv:               leaseEnvOpenAI,
+		Upstream:               func(s Server) *url.URL { return s.GrokUpstream },
+	},
 }
 
 // keyedProviderFor returns the registry entry for a provider.

--- a/internal/proxy/keyed_provider.go
+++ b/internal/proxy/keyed_provider.go
@@ -93,6 +93,21 @@ var keyedProviders = []keyedProvider{
 		LeaseEnv:    leaseEnvOpenAI,
 		Upstream:    func(s Server) *url.URL { return s.ZAIUpstream },
 	},
+	{
+		Provider:   accounts.ProviderOpenRouter,
+		PathPrefix: "openrouter",
+		Aliases:    []string{"open-router"},
+		PlanLabel:  "openrouter api key",
+		Auth:       authBearer,
+		// OpenRouter's base already ends in /v1 and it addresses every model as
+		// vendor/model, e.g. anthropic/claude-opus-5.
+		CollapseVersionSegment: true,
+		VendorPrefixedModels:   true,
+		LeaseAPI:               "openai-completions",
+		LeasePath:              "/openrouter/chat/completions",
+		LeaseEnv:               leaseEnvOpenAI,
+		Upstream:               func(s Server) *url.URL { return s.OpenRouterUpstream },
+	},
 }
 
 // keyedProviderFor returns the registry entry for a provider.

--- a/internal/proxy/keyed_provider.go
+++ b/internal/proxy/keyed_provider.go
@@ -1,12 +1,55 @@
 package proxy
 
 import (
+	"fmt"
+	"net"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 
 	"github.com/manaflow-ai/subrouter/internal/accounts"
 )
+
+// ValidateCredentialUpstreams rejects configurations that could send a
+// selected account credential over cleartext. HTTP remains available on
+// loopback for local development and tests; every remote upstream must use
+// HTTPS. Every URL field on Server is an upstream, so walking those fields
+// keeps the startup gate complete when a provider adds another upstream.
+func (s Server) ValidateCredentialUpstreams() error {
+	value := reflect.ValueOf(s)
+	typeOfURL := reflect.TypeOf((*url.URL)(nil))
+	for i := 0; i < value.NumField(); i++ {
+		field := value.Type().Field(i)
+		if field.Type != typeOfURL || !strings.HasSuffix(field.Name, "Upstream") {
+			continue
+		}
+		upstream, _ := value.Field(i).Interface().(*url.URL)
+		if err := validateCredentialUpstream(field.Name, upstream); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateCredentialUpstream(name string, upstream *url.URL) error {
+	if upstream == nil {
+		return nil
+	}
+	host := strings.TrimSpace(upstream.Hostname())
+	if host == "" {
+		return fmt.Errorf("credential-bearing upstream %s must include a host", name)
+	}
+	if strings.EqualFold(upstream.Scheme, "https") {
+		return nil
+	}
+	ip := net.ParseIP(host)
+	loopback := strings.EqualFold(host, "localhost") || (ip != nil && ip.IsLoopback())
+	if strings.EqualFold(upstream.Scheme, "http") && loopback {
+		return nil
+	}
+	return fmt.Errorf("credential-bearing upstream %s must use HTTPS, except HTTP on loopback", name)
+}
 
 // authStyle names how a provider expects its API key to be presented.
 type authStyle int

--- a/internal/proxy/keyed_provider_test.go
+++ b/internal/proxy/keyed_provider_test.go
@@ -181,4 +181,8 @@ func TestSessionLeaseProviderHonoursVendorPrefixedModels(t *testing.T) {
 	if provider != accounts.Provider("vendorcase") || model != "anthropic/claude-opus-5" {
 		t.Fatalf("got (%q, %q), want the vendor prefix preserved", provider, model)
 	}
+	provider, model, err = sessionLeaseProvider("", "vendorcase/vendor-model")
+	if err != nil || provider != accounts.Provider("vendorcase") || model != "vendorcase/vendor-model" {
+		t.Fatalf("inferred provider got (%q, %q, %v), want the full vendor-prefixed model", provider, model, err)
+	}
 }

--- a/internal/proxy/keyed_provider_test.go
+++ b/internal/proxy/keyed_provider_test.go
@@ -80,6 +80,44 @@ func TestKeyedProviderLookupsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestValidateCredentialUpstreamsRejectsNonLoopbackCleartext(t *testing.T) {
+	t.Parallel()
+
+	server := Server{
+		OpenRouterUpstream: mustParseURL(t, "http://openrouter.example/v1"),
+	}
+	if err := server.ValidateCredentialUpstreams(); err == nil || !strings.Contains(err.Error(), "OpenRouter") || !strings.Contains(err.Error(), "HTTPS") {
+		t.Fatalf("ValidateCredentialUpstreams() error = %v, want OpenRouter HTTPS error", err)
+	}
+}
+
+func TestValidateCredentialUpstreamsAllowsHTTPSAndLoopbackHTTP(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		"https://openrouter.example/v1",
+		"http://127.0.0.1:8080/v1",
+		"http://[::1]:8080/v1",
+		"http://localhost:8080/v1",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			server := Server{OpenRouterUpstream: mustParseURL(t, raw)}
+			if err := server.ValidateCredentialUpstreams(); err != nil {
+				t.Fatalf("ValidateCredentialUpstreams() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateCredentialUpstreamsRejectsMissingHost(t *testing.T) {
+	t.Parallel()
+
+	server := Server{OpenRouterUpstream: mustParseURL(t, "https:///v1")}
+	if err := server.ValidateCredentialUpstreams(); err == nil || !strings.Contains(err.Error(), "host") {
+		t.Fatalf("ValidateCredentialUpstreams() error = %v, want missing-host error", err)
+	}
+}
+
 func TestAPIKeyProviderListNamesEveryProvider(t *testing.T) {
 	list := APIKeyProviderList()
 	for _, want := range append([]string{"codex", "claude"}, keyedProviderNames()...) {

--- a/internal/proxy/keyed_provider_test.go
+++ b/internal/proxy/keyed_provider_test.go
@@ -1,0 +1,184 @@
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+// Every registry entry has to be complete: a half-filled row silently routes to
+// an empty upstream or advertises an empty lease path, which is exactly the
+// class of mistake the registry exists to prevent.
+func TestKeyedProviderRegistryEntriesAreComplete(t *testing.T) {
+	seenProvider := map[accounts.Provider]bool{}
+	seenPrefix := map[string]bool{}
+	seenName := map[string]bool{}
+
+	for _, entry := range keyedProviders {
+		name := string(entry.Provider)
+		if name == "" || entry.PathPrefix == "" || entry.PlanLabel == "" ||
+			entry.LeaseAPI == "" || entry.LeasePath == "" || entry.Upstream == nil {
+			t.Fatalf("incomplete registry entry: %+v", entry)
+		}
+		if !strings.HasPrefix(entry.LeasePath, "/"+entry.PathPrefix+"/") {
+			t.Fatalf("provider %s lease path %q is not under its own path prefix", name, entry.LeasePath)
+		}
+		if seenProvider[entry.Provider] {
+			t.Fatalf("provider %s is registered twice", name)
+		}
+		seenProvider[entry.Provider] = true
+		if seenPrefix[entry.PathPrefix] {
+			t.Fatalf("path prefix %q is claimed twice", entry.PathPrefix)
+		}
+		seenPrefix[entry.PathPrefix] = true
+		for _, candidate := range append([]string{name}, entry.Aliases...) {
+			if seenName[candidate] {
+				t.Fatalf("provider name %q is claimed twice", candidate)
+			}
+			seenName[candidate] = true
+		}
+	}
+}
+
+// Each lookup is a routing decision, so each must round-trip for every entry.
+func TestKeyedProviderLookupsRoundTrip(t *testing.T) {
+	for _, entry := range keyedProviders {
+		name := string(entry.Provider)
+
+		if got, ok := keyedProviderFor(entry.Provider); !ok || got.PathPrefix != entry.PathPrefix {
+			t.Fatalf("keyedProviderFor(%s) did not round-trip", name)
+		}
+		if got, ok := keyedProviderForPathPrefix(entry.PathPrefix); !ok || got.Provider != entry.Provider {
+			t.Fatalf("keyedProviderForPathPrefix(%q) did not resolve to %s", entry.PathPrefix, name)
+		}
+		for _, candidate := range append([]string{name}, entry.Aliases...) {
+			if got, ok := keyedProviderForName(candidate); !ok || got.Provider != entry.Provider {
+				t.Fatalf("keyedProviderForName(%q) did not resolve to %s", candidate, name)
+			}
+		}
+		if entry.ModelPrefix != "" {
+			if got, ok := keyedProviderForModelPrefix(entry.ModelPrefix + "test"); !ok || got.Provider != entry.Provider {
+				t.Fatalf("model prefix %q did not resolve to %s", entry.ModelPrefix, name)
+			}
+		}
+		if !isKeyedProvider(entry.Provider) {
+			t.Fatalf("%s should be a keyed provider", name)
+		}
+	}
+
+	if isKeyedProvider(accounts.ProviderCodex) || isKeyedProvider(accounts.ProviderClaude) {
+		t.Fatal("codex and claude are not path-prefixed API-key providers")
+	}
+	if _, ok := keyedProviderForPathPrefix("v1"); ok {
+		t.Fatal("a bare API path must not resolve to a provider")
+	}
+	if _, ok := keyedProviderForName("gemini"); ok {
+		t.Fatal("an unregistered provider name must not resolve")
+	}
+}
+
+func TestAPIKeyProviderListNamesEveryProvider(t *testing.T) {
+	list := APIKeyProviderList()
+	for _, want := range append([]string{"codex", "claude"}, keyedProviderNames()...) {
+		if !strings.Contains(list, want) {
+			t.Fatalf("provider list %q omits %q", list, want)
+		}
+	}
+	if !strings.Contains(list, ", or ") {
+		t.Fatalf("provider list %q should read as a sentence", list)
+	}
+}
+
+func TestApplyKeyedProviderAuthPresentsTheKeyPerStyle(t *testing.T) {
+	account := accounts.Account{Provider: accounts.ProviderZAI, AuthMode: accounts.AuthModeAPIKey, Token: "key"}
+
+	bearer := http.Header{}
+	bearer.Set("X-Api-Key", "client-supplied")
+	applyKeyedProviderAuth(bearer, account, keyedProvider{Auth: authBearer})
+	if bearer.Get("X-Api-Key") != "" {
+		t.Fatal("a bearer provider must not forward a client X-Api-Key")
+	}
+
+	anthropic := http.Header{}
+	applyKeyedProviderAuth(anthropic, account, keyedProvider{Auth: authBearerAndAnthropicKey})
+	if anthropic.Get("X-Api-Key") != "key" {
+		t.Fatalf("X-Api-Key = %q, want the account key", anthropic.Get("X-Api-Key"))
+	}
+	if anthropic.Get("Authorization") != "Bearer key" {
+		t.Fatalf("Authorization = %q, want the bearer form", anthropic.Get("Authorization"))
+	}
+	if anthropic.Get("Anthropic-Version") != "2023-06-01" {
+		t.Fatalf("Anthropic-Version = %q, want a default", anthropic.Get("Anthropic-Version"))
+	}
+
+	explicit := http.Header{}
+	explicit.Set("Anthropic-Version", "2024-01-01")
+	applyKeyedProviderAuth(explicit, account, keyedProvider{Auth: authBearerAndAnthropicKey})
+	if explicit.Get("Anthropic-Version") != "2024-01-01" {
+		t.Fatal("a client's Anthropic-Version must not be overwritten")
+	}
+}
+
+func TestCollapseDuplicateVersionSegment(t *testing.T) {
+	versioned := &url.URL{Scheme: "https", Host: "example.test", Path: "/api/v1"}
+	bare := &url.URL{Scheme: "https", Host: "example.test"}
+	cases := []struct {
+		name     string
+		path     string
+		upstream *url.URL
+		want     string
+	}{
+		{name: "collapses against a versioned base", path: "/v1/chat/completions", upstream: versioned, want: "/chat/completions"},
+		{name: "collapses a bare version path", path: "/v1", upstream: versioned, want: "/"},
+		{name: "keeps the version against a bare base", path: "/v1/chat/completions", upstream: bare, want: "/v1/chat/completions"},
+		{name: "leaves an unversioned path alone", path: "/chat/completions", upstream: versioned, want: "/chat/completions"},
+		{name: "tolerates a nil upstream", path: "/v1/chat/completions", upstream: nil, want: "/v1/chat/completions"},
+		{name: "does not collapse a lookalike segment", path: "/v10/chat", upstream: versioned, want: "/v10/chat"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := collapseDuplicateVersionSegment(tc.path, tc.upstream); got != tc.want {
+				t.Fatalf("collapseDuplicateVersionSegment(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// A provider that addresses models as vendor/model must keep the whole id,
+// while every other provider keeps reading the leading segment as a provider
+// selector. No registered provider sets this today; the behaviour is asserted
+// against a synthetic entry so the flag cannot rot before it is used.
+func TestSessionLeaseProviderHonoursVendorPrefixedModels(t *testing.T) {
+	provider, model, err := sessionLeaseProvider("claude", "anthropic/claude-opus-5")
+	if err != nil || provider != accounts.ProviderClaude || model != "claude-opus-5" {
+		t.Fatalf("got (%q, %q, %v), want (claude, claude-opus-5, nil)", provider, model, err)
+	}
+	if _, _, err := sessionLeaseProvider("claude", "openai/gpt-5"); err == nil {
+		t.Fatal("a mismatched model provider must still be rejected")
+	}
+
+	original := keyedProviders
+	t.Cleanup(func() { keyedProviders = original })
+	keyedProviders = append(append([]keyedProvider{}, original...), keyedProvider{
+		Provider:             accounts.Provider("vendorcase"),
+		PathPrefix:           "vendorcase",
+		PlanLabel:            "vendorcase api key",
+		Auth:                 authBearer,
+		VendorPrefixedModels: true,
+		LeaseAPI:             "openai-completions",
+		LeasePath:            "/vendorcase/chat/completions",
+		LeaseEnv:             leaseEnvOpenAI,
+		Upstream:             func(Server) *url.URL { return nil },
+	})
+
+	provider, model, err = sessionLeaseProvider("vendorcase", "anthropic/claude-opus-5")
+	if err != nil {
+		t.Fatalf("a vendor-prefixed model must be accepted: %v", err)
+	}
+	if provider != accounts.Provider("vendorcase") || model != "anthropic/claude-opus-5" {
+		t.Fatalf("got (%q, %q), want the vendor prefix preserved", provider, model)
+	}
+}

--- a/internal/proxy/opencode_provider_test.go
+++ b/internal/proxy/opencode_provider_test.go
@@ -115,15 +115,27 @@ func opencodeProviderTestServer(t *testing.T, account accounts.Account, provider
 		Sessions:     store,
 		MaxBodyBytes: 1024,
 	}
-	switch provider {
+	// Resolve through the registry so a newly registered provider is testable
+	// without editing this helper, and so an entry whose Upstream accessor reads
+	// the wrong field fails loudly instead of silently routing nowhere.
+	entry, ok := keyedProviderFor(provider)
+	if !ok {
+		t.Fatalf("unsupported provider %s", provider)
+	}
+	switch entry.Provider {
 	case accounts.ProviderKimi:
 		server.KimiUpstream = upstream
 	case accounts.ProviderZAI:
 		server.ZAIUpstream = upstream
 	case accounts.ProviderOpenRouter:
 		server.OpenRouterUpstream = upstream
+	case accounts.ProviderGrok:
+		server.GrokUpstream = upstream
 	default:
-		t.Fatalf("unsupported provider %s", provider)
+		t.Fatalf("no upstream field wired for provider %s", provider)
+	}
+	if entry.Upstream(server) != upstream {
+		t.Fatalf("provider %s upstream accessor does not read the field this helper set", provider)
 	}
 	return server
 }
@@ -223,5 +235,84 @@ func TestProviderForPathOpenRouter(t *testing.T) {
 	}
 	if plan := apiKeyPlanType(accounts.ProviderOpenRouter); plan != "openrouter api key" {
 		t.Fatalf("apiKeyPlanType = %q, want openrouter api key", plan)
+	}
+}
+
+func TestHandlerRoutesGrokProviderPrefixToGrokUpstream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("upstream path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer xai-token" {
+			t.Fatalf("Authorization = %q, want the xai bearer", got)
+		}
+		if got := r.Header.Get("X-Api-Key"); got != "" {
+			t.Fatalf("X-Api-Key = %q, want stripped", got)
+		}
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"ok"}}]}`)
+	}))
+	defer upstream.Close()
+
+	handler := opencodeProviderTestServer(t, accounts.Account{
+		ID:       "grok:main",
+		Provider: accounts.ProviderGrok,
+		AuthMode: accounts.AuthModeAPIKey,
+		Token:    "xai-token",
+	}, accounts.ProviderGrok, upstream.URL+"/v1").Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/grok/chat/completions", strings.NewReader(`{"model":"grok-4"}`))
+	req.Header.Set("X-Api-Key", "client-key")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+// api.x.ai/v1 already ends in /v1 and OpenAI-compatible clients send
+// /v1/chat/completions, so the version segment must collapse.
+func TestHandlerCollapsesDuplicateV1ForGrokUpstream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("upstream path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	handler := opencodeProviderTestServer(t, accounts.Account{
+		ID:       "grok:main",
+		Provider: accounts.ProviderGrok,
+		AuthMode: accounts.AuthModeAPIKey,
+		Token:    "xai-token",
+	}, accounts.ProviderGrok, upstream.URL+"/v1").Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/grok/v1/chat/completions", strings.NewReader(`{"model":"grok-4"}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+// A bare grok- model id resolves to Grok without the caller naming a provider,
+// the same way glm- resolves to ZAI. Unlike OpenRouter, xAI model ids carry no
+// vendor prefix, so the provider-selector rule still applies to Grok.
+func TestSessionLeaseInfersGrokFromModelPrefix(t *testing.T) {
+	provider, model, err := sessionLeaseProvider("", "grok-4")
+	if err != nil {
+		t.Fatalf("a bare grok model should resolve: %v", err)
+	}
+	if provider != accounts.ProviderGrok || model != "grok-4" {
+		t.Fatalf("got (%q, %q), want (grok, grok-4)", provider, model)
+	}
+	for _, alias := range []string{"grok", "xai", "x-ai"} {
+		got, _, err := sessionLeaseProvider(alias, "grok-4")
+		if err != nil || got != accounts.ProviderGrok {
+			t.Fatalf("alias %q resolved to (%q, %v), want grok", alias, got, err)
+		}
+	}
+	if _, _, err := sessionLeaseProvider("grok", "openai/gpt-5"); err == nil {
+		t.Fatal("grok must keep the vendor/model selector rule and reject a mismatch")
 	}
 }

--- a/internal/proxy/opencode_provider_test.go
+++ b/internal/proxy/opencode_provider_test.go
@@ -120,8 +120,108 @@ func opencodeProviderTestServer(t *testing.T, account accounts.Account, provider
 		server.KimiUpstream = upstream
 	case accounts.ProviderZAI:
 		server.ZAIUpstream = upstream
+	case accounts.ProviderOpenRouter:
+		server.OpenRouterUpstream = upstream
 	default:
 		t.Fatalf("unsupported provider %s", provider)
 	}
 	return server
+}
+
+func TestHandlerRoutesOpenRouterProviderPrefixToOpenRouterUpstream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/chat/completions" {
+			t.Fatalf("upstream path = %q, want /api/v1/chat/completions", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-or-v1-token" {
+			t.Fatalf("Authorization = %q, want openrouter bearer", got)
+		}
+		if got := r.Header.Get("X-Api-Key"); got != "" {
+			t.Fatalf("X-Api-Key = %q, want stripped", got)
+		}
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"ok"}}]}`)
+	}))
+	defer upstream.Close()
+
+	handler := opencodeProviderTestServer(t, accounts.Account{
+		ID:       "openrouter:main",
+		Provider: accounts.ProviderOpenRouter,
+		AuthMode: accounts.AuthModeAPIKey,
+		Token:    "sk-or-v1-token",
+	}, accounts.ProviderOpenRouter, upstream.URL+"/api/v1").Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/openrouter/chat/completions", strings.NewReader(`{"model":"anthropic/claude-opus-5"}`))
+	req.Header.Set("X-Api-Key", "client-key")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+// OpenRouter's base URL already ends in /v1 and OpenAI-compatible clients send
+// /v1/chat/completions, so the version segment must collapse rather than reach
+// upstream as /api/v1/v1/chat/completions.
+func TestHandlerCollapsesDuplicateV1ForOpenRouterUpstream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/chat/completions" {
+			t.Fatalf("upstream path = %q, want /api/v1/chat/completions", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	handler := opencodeProviderTestServer(t, accounts.Account{
+		ID:       "openrouter:main",
+		Provider: accounts.ProviderOpenRouter,
+		AuthMode: accounts.AuthModeAPIKey,
+		Token:    "sk-or-v1-token",
+	}, accounts.ProviderOpenRouter, upstream.URL+"/api/v1").Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/openrouter/v1/chat/completions", strings.NewReader(`{"model":"anthropic/claude-opus-5"}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+// An unversioned override base must keep the client's /v1, the same way the
+// Kimi lane does — the collapse is conditional on the upstream base, not on the
+// provider.
+func TestHandlerPreservesV1ForOpenRouterUpstreamWithoutVersionedBase(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("upstream path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	handler := opencodeProviderTestServer(t, accounts.Account{
+		ID:       "openrouter:custom",
+		Provider: accounts.ProviderOpenRouter,
+		AuthMode: accounts.AuthModeAPIKey,
+		Token:    "sk-or-v1-token",
+	}, accounts.ProviderOpenRouter, upstream.URL).Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/openrouter/v1/chat/completions", strings.NewReader(`{"model":"anthropic/claude-opus-5"}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProviderForPathOpenRouter(t *testing.T) {
+	provider, ok := providerForPath("/openrouter/chat/completions")
+	if !ok || provider != accounts.ProviderOpenRouter {
+		t.Fatalf("providerForPath = (%q, %v), want openrouter", provider, ok)
+	}
+	if agent := agentTypeForProviderSession("codex", accounts.ProviderOpenRouter); agent != "openrouter" {
+		t.Fatalf("agentTypeForProviderSession = %q, want openrouter", agent)
+	}
+	if plan := apiKeyPlanType(accounts.ProviderOpenRouter); plan != "openrouter api key" {
+		t.Fatalf("apiKeyPlanType = %q, want openrouter api key", plan)
+	}
 }

--- a/internal/proxy/provider_registry_regression_test.go
+++ b/internal/proxy/provider_registry_regression_test.go
@@ -1,0 +1,144 @@
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+// Codex and Claude are not registry providers, and the registry lookup sits
+// below their explicit branches on every path it touches. These assertions pin
+// that: a registry entry must never be able to capture a Codex or Claude
+// request, whatever gets added to the table later.
+func TestRegistryDoesNotCaptureCodexOrClaudeRouting(t *testing.T) {
+	server := Server{
+		CodexUpstream:  mustURL(t, "https://chatgpt.test/backend-api"),
+		APIUpstream:    mustURL(t, "https://api.openai.test"),
+		ClaudeUpstream: mustURL(t, "https://api.anthropic.test"),
+		KimiUpstream:   mustURL(t, "https://kimi.test/coding/v1"),
+		ZAIUpstream:    mustURL(t, "https://zai.test/api/coding/paas/v4"),
+	}
+
+	upstreams := []struct {
+		name    string
+		account accounts.Account
+		path    string
+		want    *url.URL
+	}{
+		{name: "claude oauth", account: accounts.Account{Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth}, path: "/v1/messages", want: server.ClaudeUpstream},
+		{name: "claude api key", account: accounts.Account{Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeAPIKey}, path: "/v1/messages", want: server.ClaudeUpstream},
+		{name: "codex api key", account: accounts.Account{Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeAPIKey}, path: "/v1/responses", want: server.APIUpstream},
+		{name: "codex oauth", account: accounts.Account{Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth}, path: "/v1/responses", want: server.CodexUpstream},
+		{name: "provider-less oauth", account: accounts.Account{AuthMode: accounts.AuthModeOAuth}, path: "/v1/responses", want: server.CodexUpstream},
+	}
+	for _, tc := range upstreams {
+		t.Run("upstream/"+tc.name, func(t *testing.T) {
+			if got := server.upstreamForRequest(tc.path, tc.account); got != tc.want {
+				t.Fatalf("upstreamForRequest = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// Claude paths pass through untouched; no prefix is stripped and no version
+	// segment is collapsed.
+	for _, path := range []string{"/v1/messages", "/v1/messages/count_tokens", "/"} {
+		if got := server.pathForUpstream(path, accounts.Account{Provider: accounts.ProviderClaude}); got != path {
+			t.Fatalf("pathForUpstream(%q) for claude = %q, want it unchanged", path, got)
+		}
+	}
+
+	// Session agent type and plan label fall through for the non-registry
+	// providers rather than being replaced by a provider name.
+	for _, provider := range []accounts.Provider{accounts.ProviderCodex, accounts.ProviderClaude, ""} {
+		if got := agentTypeForProviderSession("claude", provider); got != "claude" {
+			t.Fatalf("agentTypeForProviderSession(%q) = %q, want the caller's agent type", provider, got)
+		}
+		if got := apiKeyPlanType(provider); got != "api key" {
+			t.Fatalf("apiKeyPlanType(%q) = %q, want the generic label", provider, got)
+		}
+	}
+
+	// A provider-less legacy account still backs Codex and Claude selection, and
+	// is still withheld from registry providers.
+	legacy := []accounts.Account{{ID: "legacy", AuthMode: accounts.AuthModeOAuth}}
+	for _, provider := range []accounts.Provider{accounts.ProviderCodex, accounts.ProviderClaude} {
+		if got := filterAccountsForProvider(legacy, provider); len(got) != 1 {
+			t.Fatalf("filterAccountsForProvider(%q) dropped the legacy account", provider)
+		}
+	}
+	for _, entry := range keyedProviders {
+		if got := filterAccountsForProvider(legacy, entry.Provider); len(got) != 0 {
+			t.Fatalf("registry provider %q must not inherit provider-less legacy accounts", entry.Provider)
+		}
+	}
+
+	// No registry entry may claim a path prefix that a non-registry provider
+	// already routes on.
+	for _, reserved := range []string{"v1", "backend-api", "messages", "responses"} {
+		if _, ok := keyedProviderForPathPrefix(reserved); ok {
+			t.Fatalf("a registry entry claims the reserved path segment %q", reserved)
+		}
+	}
+	for _, reserved := range []string{"codex", "openai", "openai-codex", "claude", "anthropic"} {
+		if _, ok := keyedProviderForName(reserved); ok {
+			t.Fatalf("a registry entry claims the reserved provider name %q", reserved)
+		}
+	}
+}
+
+// The auth headers for Codex and Claude must be exactly what they were before
+// the registry existed, including the Claude API-key and OAuth split.
+func TestRegistryDoesNotChangeCodexOrClaudeAuthHeaders(t *testing.T) {
+	claudeOAuth := http.Header{}
+	claudeOAuth.Set("X-Api-Key", "client-supplied")
+	setAccountAuthHeaders(claudeOAuth, accounts.Account{Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "oauth-token"})
+	if claudeOAuth.Get("Authorization") != "Bearer oauth-token" {
+		t.Fatalf("claude oauth Authorization = %q", claudeOAuth.Get("Authorization"))
+	}
+	if claudeOAuth.Get("X-Api-Key") != "" {
+		t.Fatal("claude oauth must strip a client X-Api-Key")
+	}
+	if claudeOAuth.Get("Anthropic-Beta") != claudeOAuthBetaHeader {
+		t.Fatalf("claude oauth Anthropic-Beta = %q, want %q", claudeOAuth.Get("Anthropic-Beta"), claudeOAuthBetaHeader)
+	}
+
+	claudeKey := http.Header{}
+	claudeKey.Set("Anthropic-Beta", claudeOAuthBetaHeader)
+	setAccountAuthHeaders(claudeKey, accounts.Account{Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeAPIKey, Token: "sk-ant"})
+	if claudeKey.Get("Authorization") != "" {
+		t.Fatal("claude api-key auth must not send Authorization")
+	}
+	if claudeKey.Get("X-Api-Key") != "sk-ant" {
+		t.Fatalf("claude api-key X-Api-Key = %q", claudeKey.Get("X-Api-Key"))
+	}
+	if claudeKey.Get("Anthropic-Beta") == claudeOAuthBetaHeader {
+		t.Fatal("claude api-key auth must drop the OAuth beta header")
+	}
+
+	codex := http.Header{}
+	setAccountAuthHeaders(codex, accounts.Account{Provider: accounts.ProviderCodex, AuthMode: accounts.AuthModeOAuth, Token: "codex-token", AccountID: "acct-1"})
+	if codex.Get("Authorization") != "Bearer codex-token" {
+		t.Fatalf("codex Authorization = %q", codex.Get("Authorization"))
+	}
+	if codex.Get("ChatGPT-Account-ID") != "acct-1" {
+		t.Fatalf("codex ChatGPT-Account-ID = %q, want the account id", codex.Get("ChatGPT-Account-ID"))
+	}
+
+	// A provider-less account is still treated as Codex.
+	legacy := http.Header{}
+	setAccountAuthHeaders(legacy, accounts.Account{AuthMode: accounts.AuthModeOAuth, Token: "legacy-token", AccountID: "acct-2"})
+	if legacy.Get("ChatGPT-Account-ID") != "acct-2" {
+		t.Fatalf("provider-less ChatGPT-Account-ID = %q, want the account id", legacy.Get("ChatGPT-Account-ID"))
+	}
+}
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -733,14 +733,10 @@ func authLikeUsageError(message string) bool {
 }
 
 func apiKeyPlanType(provider accounts.Provider) string {
-	switch provider {
-	case accounts.ProviderKimi:
-		return "kimi api key"
-	case accounts.ProviderZAI:
-		return "zai api key"
-	default:
-		return "api key"
+	if entry, ok := keyedProviderFor(provider); ok {
+		return entry.PlanLabel
 	}
+	return "api key"
 }
 
 func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus {
@@ -1428,7 +1424,7 @@ func (s Server) handleAccountImport(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		writeJSON(w, map[string]any{
 			"ok":        true,
-			"providers": []string{"codex", "claude", "kimi", "zai"},
+			"providers": append([]string{"codex", "claude"}, keyedProviderNames()...),
 		})
 		return
 	case http.MethodPost:
@@ -1540,8 +1536,8 @@ func (s Server) installImportedAccount(ctx context.Context, input accountImportR
 			}
 		}
 	}()
-	switch input.Provider {
-	case accounts.ProviderCodex, accounts.ProviderKimi, accounts.ProviderZAI:
+	switch {
+	case input.Provider == accounts.ProviderCodex || isKeyedProvider(input.Provider):
 		if input.Codex == nil || input.Claude != nil {
 			return "", invalidAccountImport("exactly one matching account payload is required")
 		}
@@ -1558,7 +1554,7 @@ func (s Server) installImportedAccount(ctx context.Context, input accountImportR
 			return "", err
 		}
 		accountID = account.Email
-	case accounts.ProviderClaude:
+	case input.Provider == accounts.ProviderClaude:
 		if input.Claude != nil && input.Codex == nil {
 			name, credential, err := validateClaudeAccountImport(*input.Claude)
 			if err != nil {
@@ -4325,6 +4321,10 @@ const claudeOAuthBetaHeader = "oauth-2025-04-20"
 func setAccountAuthHeaders(headers http.Header, account accounts.Account) {
 	headers.Set("Authorization", account.AuthorizationHeader())
 	headers.Del("ChatGPT-Account-ID")
+	if entry, ok := keyedProviderFor(account.Provider); ok {
+		applyKeyedProviderAuth(headers, account, entry)
+		return
+	}
 	switch account.Provider {
 	case accounts.ProviderClaude:
 		if account.AuthMode == accounts.AuthModeAPIKey {
@@ -4335,14 +4335,6 @@ func setAccountAuthHeaders(headers http.Header, account accounts.Account) {
 		}
 		headers.Del("X-Api-Key")
 		ensureCommaHeaderValue(headers, "Anthropic-Beta", claudeOAuthBetaHeader)
-	case accounts.ProviderKimi:
-		headers.Set("Authorization", account.AuthorizationHeader())
-		headers.Set("X-Api-Key", account.Token)
-		if headers.Get("Anthropic-Version") == "" {
-			headers.Set("Anthropic-Version", "2023-06-01")
-		}
-	case accounts.ProviderZAI:
-		headers.Del("X-Api-Key")
 	case accounts.ProviderCodex, "":
 		if account.AccountID != "" {
 			headers.Set("ChatGPT-Account-ID", account.AccountID)
@@ -4392,11 +4384,8 @@ func (s Server) upstreamForRequest(path string, account accounts.Account) *url.U
 	if account.Provider == accounts.ProviderClaude {
 		return s.ClaudeUpstream
 	}
-	if account.Provider == accounts.ProviderKimi {
-		return s.KimiUpstream
-	}
-	if account.Provider == accounts.ProviderZAI {
-		return s.ZAIUpstream
+	if entry, ok := keyedProviderFor(account.Provider); ok {
+		return entry.Upstream(s)
 	}
 	if account.AuthMode == accounts.AuthModeAPIKey {
 		return s.APIUpstream
@@ -4417,24 +4406,12 @@ func (s Server) pathForUpstream(path string, account accounts.Account) string {
 	if account.Provider == accounts.ProviderClaude {
 		return path
 	}
-	if account.Provider == accounts.ProviderKimi {
-		path = stripProviderPathPrefix(path, "kimi")
-		upstreamPath := ""
-		if s.KimiUpstream != nil {
-			upstreamPath = strings.TrimRight(s.KimiUpstream.Path, "/")
-		}
-		if strings.HasSuffix(upstreamPath, "/v1") {
-			if path == "/v1" {
-				return "/"
-			}
-			if strings.HasPrefix(path, "/v1/") {
-				return strings.TrimPrefix(path, "/v1")
-			}
+	if entry, ok := keyedProviderFor(account.Provider); ok {
+		path = stripProviderPathPrefix(path, entry.PathPrefix)
+		if entry.CollapseVersionSegment {
+			return collapseDuplicateVersionSegment(path, entry.Upstream(s))
 		}
 		return path
-	}
-	if account.Provider == accounts.ProviderZAI {
-		return stripProviderPathPrefix(path, "zai")
 	}
 	if account.AuthMode == accounts.AuthModeOAuth {
 		if stripped, ok := stripChatGPTBackendPath(path); ok {
@@ -4963,23 +4940,18 @@ func providerForRequest(agentType, path string) accounts.Provider {
 }
 
 func agentTypeForProviderSession(agentType string, provider accounts.Provider) string {
-	switch provider {
-	case accounts.ProviderKimi, accounts.ProviderZAI:
+	if isKeyedProvider(provider) {
 		return string(provider)
-	default:
-		return agentType
 	}
+	return agentType
 }
 
 func providerForPath(path string) (accounts.Provider, bool) {
-	switch firstPathSegment(path) {
-	case "kimi":
-		return accounts.ProviderKimi, true
-	case "zai":
-		return accounts.ProviderZAI, true
-	default:
+	entry, ok := keyedProviderForPathPrefix(firstPathSegment(path))
+	if !ok {
 		return "", false
 	}
+	return entry.Provider, true
 }
 
 func firstPathSegment(path string) string {
@@ -5020,7 +4992,9 @@ func filterAccountsForProvider(all []accounts.Account, provider accounts.Provide
 	if len(filtered) > 0 {
 		return filtered
 	}
-	if provider == accounts.ProviderKimi || provider == accounts.ProviderZAI {
+	// A keyed provider never inherits provider-less legacy accounts: those
+	// predate multi-provider support and are Codex credentials.
+	if isKeyedProvider(provider) {
 		return nil
 	}
 	return legacy

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -48,19 +48,20 @@ type CredentialBroker interface {
 }
 
 type Server struct {
-	Upstream       *url.URL
-	CodexUpstream  *url.URL
-	APIUpstream    *url.URL
-	ClaudeUpstream *url.URL
-	KimiUpstream   *url.URL
-	ZAIUpstream    *url.URL
-	Accounts       []accounts.Account
-	AccountRef     *AccountRef
-	Sessions       *session.Store
-	Scheduler      selectacct.Scheduler
-	SchedulerRef   *selectacct.SchedulerRef
-	UsageScoreTTL  time.Duration
-	ScoreAccounts  func(context.Context, []accounts.Account) ([]selectacct.Score, int)
+	Upstream           *url.URL
+	CodexUpstream      *url.URL
+	APIUpstream        *url.URL
+	ClaudeUpstream     *url.URL
+	KimiUpstream       *url.URL
+	ZAIUpstream        *url.URL
+	OpenRouterUpstream *url.URL
+	Accounts           []accounts.Account
+	AccountRef         *AccountRef
+	Sessions           *session.Store
+	Scheduler          selectacct.Scheduler
+	SchedulerRef       *selectacct.SchedulerRef
+	UsageScoreTTL      time.Duration
+	ScoreAccounts      func(context.Context, []accounts.Account) ([]selectacct.Score, int)
 	// RefreshAccountFn, when set, replaces the default OAuth refresh path. Test
 	// seam for simulating dead/expired refresh tokens; nil in production.
 	RefreshAccountFn func(context.Context, accounts.Account) (accounts.Account, error)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -55,6 +55,7 @@ type Server struct {
 	KimiUpstream       *url.URL
 	ZAIUpstream        *url.URL
 	OpenRouterUpstream *url.URL
+	GrokUpstream       *url.URL
 	Accounts           []accounts.Account
 	AccountRef         *AccountRef
 	Sessions           *session.Store

--- a/internal/proxy/session_lease.go
+++ b/internal/proxy/session_lease.go
@@ -843,6 +843,7 @@ func (request *sessionLeaseRequest) normalize() {
 func sessionLeaseProvider(providerValue, modelValue string) (accounts.Provider, string, error) {
 	providerName := strings.ToLower(strings.TrimSpace(providerValue))
 	model := strings.TrimSpace(modelValue)
+	originalModel := model
 	if providerName == "" {
 		modelProvider, modelID, hasProvider := strings.Cut(model, "/")
 		if hasProvider {
@@ -868,7 +869,7 @@ func sessionLeaseProvider(providerValue, modelValue string) (accounts.Provider, 
 	// A provider that addresses models as vendor/model owns the whole id: the
 	// segment before the slash belongs to the model, not to a provider name.
 	if entry, ok := keyedProviderFor(provider); ok && entry.VendorPrefixedModels {
-		return provider, model, nil
+		return provider, originalModel, nil
 	}
 	if modelProvider, modelID, hasProvider := strings.Cut(model, "/"); hasProvider {
 		if modelProviderValue, modelProviderErr := parseSessionLeaseProvider(strings.ToLower(strings.TrimSpace(modelProvider))); modelProviderErr == nil {

--- a/internal/proxy/session_lease.go
+++ b/internal/proxy/session_lease.go
@@ -541,11 +541,10 @@ func (lease sessionLease) allowsRequest(r *http.Request) bool {
 		return codexResponsePath(r.URL.Path)
 	case accounts.ProviderClaude:
 		return r.URL.Path == "/v1/messages"
-	case accounts.ProviderKimi:
-		return r.URL.Path == "/kimi/v1/messages"
-	case accounts.ProviderZAI:
-		return r.URL.Path == "/zai/chat/completions"
 	default:
+		if entry, ok := keyedProviderFor(lease.Provider); ok {
+			return r.URL.Path == entry.LeasePath
+		}
 		return false
 	}
 }
@@ -854,18 +853,22 @@ func sessionLeaseProvider(providerValue, modelValue string) (accounts.Provider, 
 			switch {
 			case strings.HasPrefix(lowerModel, "claude-"):
 				providerName = "claude"
-			case strings.HasPrefix(lowerModel, "kimi-"):
-				providerName = "kimi"
-			case strings.HasPrefix(lowerModel, "glm-"):
-				providerName = "zai"
 			default:
 				providerName = "codex"
+				if entry, ok := keyedProviderForModelPrefix(lowerModel); ok {
+					providerName = string(entry.Provider)
+				}
 			}
 		}
 	}
 	provider, err := parseSessionLeaseProvider(providerName)
 	if err != nil {
 		return "", "", err
+	}
+	// A provider that addresses models as vendor/model owns the whole id: the
+	// segment before the slash belongs to the model, not to a provider name.
+	if entry, ok := keyedProviderFor(provider); ok && entry.VendorPrefixedModels {
+		return provider, model, nil
 	}
 	if modelProvider, modelID, hasProvider := strings.Cut(model, "/"); hasProvider {
 		if modelProviderValue, modelProviderErr := parseSessionLeaseProvider(strings.ToLower(strings.TrimSpace(modelProvider))); modelProviderErr == nil {
@@ -884,11 +887,10 @@ func parseSessionLeaseProvider(providerName string) (accounts.Provider, error) {
 		return accounts.ProviderCodex, nil
 	case "claude", "anthropic":
 		return accounts.ProviderClaude, nil
-	case "kimi", "kimi-for-coding":
-		return accounts.ProviderKimi, nil
-	case "zai", "glm":
-		return accounts.ProviderZAI, nil
 	default:
+		if entry, ok := keyedProviderForName(providerName); ok {
+			return entry.Provider, nil
+		}
 		return "", fmt.Errorf("unsupported provider %q", providerName)
 	}
 }
@@ -948,19 +950,18 @@ func sessionLeaseResponseFor(lease sessionLease) sessionLeaseResponse {
 		piBaseURL += "/backend-api"
 	case accounts.ProviderClaude:
 		api = "anthropic-messages"
-	case accounts.ProviderKimi:
-		api = "anthropic-messages"
-		baseURL += "/kimi"
-		piBaseURL += "/kimi"
-	case accounts.ProviderZAI:
-		api = "openai-completions"
-		baseURL += "/zai"
-		piBaseURL += "/zai"
+	default:
+		if entry, ok := keyedProviderFor(lease.Provider); ok {
+			api = entry.LeaseAPI
+			baseURL += "/" + entry.PathPrefix
+			piBaseURL += "/" + entry.PathPrefix
+		}
 	}
 	environment := map[string]string{
 		"CLOUDMUX_SUBROUTER_LEASE_TOKEN": lease.Token,
 	}
-	if lease.Provider == accounts.ProviderCodex || lease.Provider == accounts.ProviderZAI {
+	entry, isKeyed := keyedProviderFor(lease.Provider)
+	if lease.Provider == accounts.ProviderCodex || (isKeyed && entry.LeaseEnv == leaseEnvOpenAI) {
 		environment["OPENAI_API_KEY"] = lease.Token
 		environment["OPENAI_BASE_URL"] = baseURL
 	} else {

--- a/internal/proxy/session_lease_test.go
+++ b/internal/proxy/session_lease_test.go
@@ -444,13 +444,14 @@ func TestRequiredSessionLeaseAlsoClosesBedrockGateway(t *testing.T) {
 	}
 }
 
-func TestKimiAndZAILeasePiRoutesMatchProviderUpstreams(t *testing.T) {
+func TestAPIKeyProviderLeasePiRoutesMatchProviderUpstreams(t *testing.T) {
 	tests := []struct {
 		name          string
 		provider      string
 		model         string
 		account       accounts.Account
 		configure     func(*Server, *url.URL)
+		upstreamPath  string
 		wantAPI       string
 		adapterSuffix string
 		wantPath      string
@@ -467,6 +468,7 @@ func TestKimiAndZAILeasePiRoutesMatchProviderUpstreams(t *testing.T) {
 			configure: func(server *Server, upstream *url.URL) {
 				server.KimiUpstream = upstream
 			},
+			upstreamPath:  "/coding/v1",
 			wantAPI:       "anthropic-messages",
 			adapterSuffix: "/v1/messages",
 			wantPath:      "/coding/v1/messages",
@@ -483,9 +485,26 @@ func TestKimiAndZAILeasePiRoutesMatchProviderUpstreams(t *testing.T) {
 			configure: func(server *Server, upstream *url.URL) {
 				server.ZAIUpstream = upstream
 			},
+			upstreamPath:  "/api/coding/paas/v4",
 			wantAPI:       "openai-completions",
 			adapterSuffix: "/chat/completions",
 			wantPath:      "/api/coding/paas/v4/chat/completions",
+		},
+		{
+			name:     "openrouter OpenAI completions",
+			provider: "openrouter",
+			model:    "anthropic/claude-opus-5",
+			account: accounts.Account{
+				ID: "openrouter:main", Provider: accounts.ProviderOpenRouter,
+				AuthMode: accounts.AuthModeAPIKey, Token: "sk-or-v1-secret",
+			},
+			configure: func(server *Server, upstream *url.URL) {
+				server.OpenRouterUpstream = upstream
+			},
+			upstreamPath:  "/api/v1",
+			wantAPI:       "openai-completions",
+			adapterSuffix: "/chat/completions",
+			wantPath:      "/api/v1/chat/completions",
 		},
 	}
 
@@ -499,11 +518,7 @@ func TestKimiAndZAILeasePiRoutesMatchProviderUpstreams(t *testing.T) {
 			}))
 			defer upstream.Close()
 			upstreamURL := mustParseURL(t, upstream.URL)
-			if test.provider == "kimi" {
-				upstreamURL.Path = "/coding/v1"
-			} else {
-				upstreamURL.Path = "/api/coding/paas/v4"
-			}
+			upstreamURL.Path = test.upstreamPath
 			server := Server{
 				Accounts:      []accounts.Account{test.account},
 				Sessions:      newSessionStore(t),
@@ -1441,4 +1456,40 @@ func decodeSessionLeaseToken(t *testing.T, token string) (sessionLeaseTokenHeade
 		t.Fatal(err)
 	}
 	return header, payload, parts
+}
+
+// OpenRouter addresses every model as vendor/model, so a lease must forward the
+// whole id. Every other provider keeps treating the segment before the slash as
+// a provider selector.
+func TestSessionLeaseProviderKeepsVendorPrefixedModelForOpenRouter(t *testing.T) {
+	provider, model, err := sessionLeaseProvider("openrouter", "anthropic/claude-opus-5")
+	if err != nil {
+		t.Fatalf("an OpenRouter vendor-prefixed model must be accepted: %v", err)
+	}
+	if provider != accounts.ProviderOpenRouter {
+		t.Fatalf("provider = %q, want openrouter", provider)
+	}
+	if model != "anthropic/claude-opus-5" {
+		t.Fatalf("model = %q, want the vendor prefix preserved", model)
+	}
+
+	provider, model, err = sessionLeaseProvider("openrouter", "x-ai/grok-4")
+	if err != nil {
+		t.Fatalf("an unknown vendor prefix must still be accepted: %v", err)
+	}
+	if provider != accounts.ProviderOpenRouter || model != "x-ai/grok-4" {
+		t.Fatalf("got (%q, %q), want (openrouter, x-ai/grok-4)", provider, model)
+	}
+
+	// Unchanged for the providers that do use the prefix as a selector.
+	provider, model, err = sessionLeaseProvider("claude", "anthropic/claude-opus-5")
+	if err != nil {
+		t.Fatalf("claude vendor prefix should still resolve: %v", err)
+	}
+	if provider != accounts.ProviderClaude || model != "claude-opus-5" {
+		t.Fatalf("got (%q, %q), want (claude, claude-opus-5)", provider, model)
+	}
+	if _, _, err = sessionLeaseProvider("claude", "openai/gpt-5"); err == nil {
+		t.Fatal("a mismatched model provider must still be rejected")
+	}
 }


### PR DESCRIPTION
## What

Adds **Grok** (xAI) as an API-key provider. `/grok/...` routes to xAI's OpenAI-compatible API with the selected account's key.

```bash
sr server add-key --provider grok ...        # aliases: xai, x-ai
sr serve --grok-upstream https://api.x.ai/v1  # default
```

## Stacked on #236

This is built on the provider registry from #236, and it is the argument for that PR: Grok is **one table row**.

```go
{
    Provider:               accounts.ProviderGrok,
    PathPrefix:             "grok",
    Aliases:                []string{"xai", "x-ai"},
    ModelPrefix:            "grok-",
    PlanLabel:              "grok api key",
    Auth:                   authBearer,
    CollapseVersionSegment: true,
    LeaseAPI:               "openai-completions",
    LeasePath:              "/grok/chat/completions",
    LeaseEnv:               leaseEnvOpenAI,
    Upstream:               func(s Server) *url.URL { return s.GrokUpstream },
}
```

Everything else follows from it with no further code: path routing, bearer auth with `X-Api-Key` stripped, `/v1` de-duplication (xAI's base already ends in `/v1`), session stickiness, lease adapter and env vars, account import, the CLI `--provider` parser and its aliases, and the plan label. The only additions outside the row are the provider constant, the `Server.GrokUpstream` field, and the `--grok-upstream` flag.

For comparison, adding OpenRouter the pre-registry way (#234) touched ~11 sites and churned 82 lines of `proxy.go`. This touches one line of `proxy.go`.

**Please review #236 first** — without it this PR is much larger and repeats the same 24-site edit.

## Verification of the base URL

`https://api.x.ai/v1` is xAI's OpenAI-compatible endpoint. Cross-checked against an independent implementation (`router-for-me/CLIProxyAPI`, MIT — `internal/auth/xai/types.go`, `DefaultAPIBaseURL`). No code was taken from it; it was used to confirm the endpoint and that no provider-specific headers are required beyond bearer auth.

Unlike OpenRouter, xAI model ids are bare (`grok-4`, `grok-code-fast-1`), so `VendorPrefixedModels` stays false and the normal `vendor/model` provider-selector behaviour applies.

## Tests

- `TestHandlerRoutesGrokProviderPrefixToGrokUpstream` — path, bearer auth, `X-Api-Key` stripped.
- `TestHandlerCollapsesDuplicateV1ForGrokUpstream` — `/grok/v1/chat/completions` reaches `/v1/chat/completions`, not `/v1/v1/...`.
- `TestSessionLeaseInfersGrokFromModelPrefix` — a bare `grok-4` resolves to Grok without naming a provider, and every alias resolves.
- The registry invariant tests from #236 (`TestKeyedProviderRegistryEntriesAreComplete`, `TestKeyedProviderLookupsRoundTrip`, `TestAPIKeyProviderListNamesEveryProvider`) pick the new row up automatically — completeness, prefix and alias uniqueness, every lookup, and the CLI help text all get asserted for Grok with no new test code. That is the registry earning its keep.

`opencodeProviderTestServer` now resolves the upstream through the registry and asserts that the accessor reads the field the helper set, so a row whose `Upstream` accessor points at the wrong field fails loudly instead of silently routing nowhere.

## Verification

- `go build ./...` — clean
- `gofmt -l ./account ./cmd ./internal` — clean
- `go vet ./...` — clean
- `go test ./internal/proxy/... ./internal/accounts/... -count=1`
- `go test ./cmd/subrouter/...` — one pre-existing failure, `TestGCPStartupBuildsPreparedFrontTopologyFromPinnedReleaseMetadata`, which also fails on `main` at `760054b`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789706731&installation_model_id=21920&pr_number=238&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F238&signature=e6ea33733e2706cdfe15d97fbbe9768ac3e17954365ceebefd2c4860b49d7477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes API-key provider handling in one registry and routes OpenRouter and Grok as keyed providers, while keeping Codex and Claude behavior unchanged. Adds `--openrouter-upstream` and `--grok-upstream` (defaulting to the official endpoints) and startup validation that rejects cleartext upstreams except on loopback; existing setups need no migration.

- `/openrouter/...` and `/grok/...` use the selected account key with bearer auth and strip client-supplied `X-Api-Key`.
- Both collapse duplicate `/v1` segments when the upstream includes `/v1`; OpenRouter preserves vendor-prefixed model IDs.
- Grok infers from bare `grok-` model IDs and accepts `grok`, `xai`, and `x-ai`; OpenRouter accepts `openrouter` and `open-router`.
- Provider-scoped keys are stored under `provider:` labels; hosted credential storage rejects non-Codex providers.
- `sr server add-key --provider`, account import, session leases, plan labels, and supported-provider help now derive from the registry.

<sup>Written for commit 7db892041a24d5eed118270ffe62923a7b9dd95c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for OpenRouter and Grok API-key accounts.
  - Added provider selection when adding API keys, including aliases and provider-specific routing.
  - Added configurable OpenRouter and Grok upstreams for the server.
  - Added provider-aware model, session, authentication, and lease routing.

- **Bug Fixes**
  - Improved credential validation, requiring secure upstream connections except for loopback addresses.
  - Prevented provider API keys from being treated as Codex accounts during account switching.

- **Documentation**
  - Updated design documentation to include OpenRouter and Grok API-key support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->