### PR TITLE
Absorb Codex capacity failures into the Azure fallback; gate it by model

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,18 +440,24 @@ One Azure resource:
 export SUBROUTER_AZURE_CODEX_ENDPOINT="https://YOUR_RESOURCE.openai.azure.com/openai/v1"
 export SUBROUTER_AZURE_CODEX_API_KEY="<azure-key>"          # or SUBROUTER_AZURE_CODEX_API_KEY_FILE
 export SUBROUTER_AZURE_CODEX_DEPLOYMENTS="gpt-5.6-codex=my-codex-deployment"   # only if the deployment name differs from the model
+export SUBROUTER_AZURE_CODEX_MODELS="gpt-5.6*"   # optional allow list; empty serves every model
 ```
 
 Several resources go in a file named by `SUBROUTER_AZURE_CODEX_CONFIG_FILE`:
 
 ```json
-{"endpoints":[
+{"models":["gpt-5.6*"],
+ "endpoints":[
   {"name":"eastus2","base_url":"https://east.openai.azure.com/openai/v1","api_key":"..."},
-  {"name":"swedencentral","base_url":"https://sweden.openai.azure.com/openai/v1","api_key":"..."}
+  {"name":"openai","base_url":"https://api.openai.com/v1","api_key_file":"/var/lib/subrouter/openai-api-key"}
 ]}
 ```
 
-Set `SUBROUTER_AZURE_CODEX_DEFAULT_DEPLOYMENT` to catch models Azure has not shipped yet. Azure trails the ChatGPT model list, and the request that needs the fallback is the one the pool refused, so an unmapped model lands on that deployment instead of 404ing.
+An endpoint may be `https://api.openai.com/v1` with an OpenAI API key: it speaks the same Responses surface with real model names, so it backs the pool when Azure itself is out. `api_key_file` reads the key from a file instead of carrying it inline. `models` limits which requested models the fallback serves; an entry matches exactly or as a prefix when it ends with `*`. A model outside the list keeps the pool's own failure, because paying a metered provider to answer with a different model than the one requested is worse.
+
+Set `SUBROUTER_AZURE_CODEX_DEFAULT_DEPLOYMENT` to catch models Azure has not shipped yet. Azure trails the ChatGPT model list, and the request that needs the fallback is the one the pool refused, so an unmapped model lands on that deployment instead of 404ing. Prefer the `models` allow list plus same-named deployments when Azure does host the requested models, so the fallback never answers with a silently different model.
+
+The fallback also catches the ChatGPT backend's capacity failure, which arrives inside an otherwise-200 stream rather than as a status code. Codex treats `server_is_overloaded` as terminal and renders "Selected model is at capacity. Please try a different model.", so the proxy absorbs it on both transports: an SSE stream that opens with the failure is served from Azure before any byte reaches the client, and on the WebSocket transport the event pins the session to Azure, closes with 1012 so Codex reconnects, and the reconnect is refused with 426, the one status Codex answers by switching to the HTTP transport, where the pin serves the turn from Azure.
 
 Prove the route without waiting for an outage:
 

--- a/cmd/subrouter/azure_codex_config.go
+++ b/cmd/subrouter/azure_codex_config.go
@@ -18,12 +18,18 @@ import (
 // by azureCodexConfigFromEnvironment.
 type azureCodexFile struct {
 	Endpoints []azureCodexFileEndpoint `json:"endpoints"`
+	// Models limits which requested models the fallback serves ("gpt-5.6*",
+	// "gpt-5.6-sol"). Empty serves every model.
+	Models []string `json:"models"`
 }
 
 type azureCodexFileEndpoint struct {
-	Name              string            `json:"name"`
-	BaseURL           string            `json:"base_url"`
-	APIKey            string            `json:"api_key"`
+	Name    string `json:"name"`
+	BaseURL string `json:"base_url"`
+	APIKey  string `json:"api_key"`
+	// APIKeyFile reads the key from a file, so the config file itself can be
+	// checked or templated without carrying the secret inline.
+	APIKeyFile        string            `json:"api_key_file"`
 	Deployments       map[string]string `json:"deployments"`
 	DefaultDeployment string            `json:"default_deployment"`
 }
@@ -55,7 +61,21 @@ func azureCodexConfigFromEnvironment() (*proxy.AzureCodexConfig, error) {
 		APIKey:            apiKey,
 		Deployments:       deployments,
 		DefaultDeployment: strings.TrimSpace(os.Getenv("SUBROUTER_AZURE_CODEX_DEFAULT_DEPLOYMENT")),
-	}})
+	}}, parseAzureCodexModels(os.Getenv("SUBROUTER_AZURE_CODEX_MODELS")))
+}
+
+// parseAzureCodexModels reads the comma-separated model allow list. An entry
+// matches a model exactly, or as a prefix when it ends with "*".
+func parseAzureCodexModels(raw string) []string {
+	var models []string
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		models = append(models, entry)
+	}
+	return models
 }
 
 func azureCodexConfigFromFile(path string) (*proxy.AzureCodexConfig, error) {
@@ -67,20 +87,27 @@ func azureCodexConfigFromFile(path string) (*proxy.AzureCodexConfig, error) {
 	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return nil, fmt.Errorf("azure codex: parse config: %w", err)
 	}
-	return azureCodexConfig(parsed.Endpoints)
+	return azureCodexConfig(parsed.Endpoints, parsed.Models)
 }
 
-func azureCodexConfig(endpoints []azureCodexFileEndpoint) (*proxy.AzureCodexConfig, error) {
+func azureCodexConfig(endpoints []azureCodexFileEndpoint, models []string) (*proxy.AzureCodexConfig, error) {
 	if len(endpoints) == 0 {
 		return nil, errors.New("azure codex: no endpoints configured")
 	}
-	config := &proxy.AzureCodexConfig{}
+	config := &proxy.AzureCodexConfig{Models: models}
 	for index, endpoint := range endpoints {
 		base, err := azureCodexBaseURL(endpoint.BaseURL)
 		if err != nil {
 			return nil, err
 		}
 		apiKey := strings.TrimSpace(endpoint.APIKey)
+		if apiKey == "" && strings.TrimSpace(endpoint.APIKeyFile) != "" {
+			keyBytes, err := os.ReadFile(strings.TrimSpace(endpoint.APIKeyFile))
+			if err != nil {
+				return nil, fmt.Errorf("azure codex: endpoint %d read api key file: %w", index, err)
+			}
+			apiKey = strings.TrimSpace(string(keyBytes))
+		}
 		if apiKey == "" {
 			return nil, fmt.Errorf("azure codex: endpoint %d has no api key", index)
 		}
@@ -135,8 +162,13 @@ func azureCodexBaseURL(raw string) (*url.URL, error) {
 	case strings.HasSuffix(path, "/openai/v1"):
 	case strings.HasSuffix(path, "/openai"):
 		path += "/v1"
+	case path == "/v1" && !strings.HasSuffix(strings.ToLower(parsed.Hostname()), ".azure.com"):
+		// api.openai.com/v1 speaks the same Responses surface with real model
+		// names, so an OpenAI API key can back the pool as a further fallback
+		// endpoint next to Azure. On an Azure host a bare /v1 is still a
+		// wrong base that would 404 every fallback, so it stays rejected.
 	default:
-		return nil, fmt.Errorf("azure codex: endpoint %q must end in /openai/v1", trimmed)
+		return nil, fmt.Errorf("azure codex: endpoint %q must end in /openai/v1 or /v1", trimmed)
 	}
 	parsed.Path = path
 	parsed.RawQuery = ""

--- a/cmd/subrouter/azure_codex_config_test.go
+++ b/cmd/subrouter/azure_codex_config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -165,5 +166,70 @@ func TestAzResponseSummaryReadsJSONAndSSE(t *testing.T) {
 	sse := azResponseSummary([]byte("event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"object\":\"response\",\"model\":\"gpt-5.3-codex\",\"usage\":{\"input_tokens\":10,\"output_tokens\":2}}}\n\n"))
 	if sse.Model != "gpt-5.3-codex" || sse.InputTokens != 10 {
 		t.Fatalf("sse summary = %+v", sse)
+	}
+}
+
+func TestAzureCodexModelsFromEnvironment(t *testing.T) {
+	t.Setenv("SUBROUTER_AZURE_CODEX_CONFIG_FILE", "")
+	t.Setenv("SUBROUTER_AZURE_CODEX_ENDPOINT", "https://res.openai.azure.com")
+	t.Setenv("SUBROUTER_AZURE_CODEX_API_KEY", "azure-key")
+	t.Setenv("SUBROUTER_AZURE_CODEX_API_KEY_FILE", "")
+	t.Setenv("SUBROUTER_AZURE_CODEX_DEPLOYMENTS", "")
+	t.Setenv("SUBROUTER_AZURE_CODEX_DEFAULT_DEPLOYMENT", "")
+	t.Setenv("SUBROUTER_AZURE_CODEX_MODELS", "gpt-5.6*, gpt-5.3-codex ,")
+	config, err := azureCodexConfigFromEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(config.Models) != 2 || config.Models[0] != "gpt-5.6*" || config.Models[1] != "gpt-5.3-codex" {
+		t.Fatalf("models = %v, want the trimmed allow list", config.Models)
+	}
+}
+
+func TestAzureCodexOpenAIEndpointAndKeyFile(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), "openai-key")
+	if err := os.WriteFile(keyPath, []byte("sk-test-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(t.TempDir(), "azure-codex.json")
+	contents := fmt.Sprintf(`{
+		"models": ["gpt-5.6*"],
+		"endpoints": [
+			{"name": "azure", "base_url": "https://res.openai.azure.com", "api_key": "azure-key"},
+			{"name": "openai", "base_url": "https://api.openai.com/v1", "api_key_file": %q}
+		]
+	}`, keyPath)
+	if err := os.WriteFile(configPath, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SUBROUTER_AZURE_CODEX_CONFIG_FILE", configPath)
+	config, err := azureCodexConfigFromEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(config.Endpoints) != 2 {
+		t.Fatalf("endpoints = %d, want 2", len(config.Endpoints))
+	}
+	if got := config.Endpoints[1].BaseURL.String(); got != "https://api.openai.com/v1" {
+		t.Fatalf("openai base url = %q", got)
+	}
+	if config.Endpoints[1].APIKey != "sk-test-key" {
+		t.Fatalf("openai api key = %q, want the trimmed file contents", config.Endpoints[1].APIKey)
+	}
+	if len(config.Models) != 1 || config.Models[0] != "gpt-5.6*" {
+		t.Fatalf("models = %v", config.Models)
+	}
+}
+
+func TestAzureCodexBaseURLRejectsBareV1OnAzureHosts(t *testing.T) {
+	if _, err := azureCodexBaseURL("https://res.openai.azure.com/v1"); err == nil {
+		t.Fatal("/v1 on an Azure host must stay rejected; it 404s every fallback")
+	}
+	got, err := azureCodexBaseURL("https://api.openai.com/v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.String() != "https://api.openai.com/v1" {
+		t.Fatalf("openai base = %q", got)
 	}
 }

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -116,7 +116,7 @@ OPENAI_API_KEY=dummy codex exec \
 
 ## Azure fallback
 
-`SUBROUTER_AZURE_CODEX_ENDPOINT` plus `SUBROUTER_AZURE_CODEX_API_KEY` (or `SUBROUTER_AZURE_CODEX_CONFIG_FILE` for several Azure resources) lets Subrouter finish a Codex `/responses` request on Azure OpenAI after the pool has spent five retries or has no usable account. The session then stays on that Azure endpoint for 30 minutes of activity so its prompt cache keeps hitting.
+`SUBROUTER_AZURE_CODEX_ENDPOINT` plus `SUBROUTER_AZURE_CODEX_API_KEY` (or `SUBROUTER_AZURE_CODEX_CONFIG_FILE` for several Azure resources) lets Subrouter finish a Codex `/responses` request on Azure OpenAI after the pool has spent five retries or has no usable account. It also absorbs the ChatGPT backend's in-stream `server_is_overloaded` failure ("Selected model is at capacity") on both the SSE and WebSocket transports, and `SUBROUTER_AZURE_CODEX_MODELS` limits which requested models it serves. The session then stays on that Azure endpoint for 30 minutes of activity so its prompt cache keeps hitting.
 
 Force the route to test it:
 

--- a/internal/proxy/azure_codex.go
+++ b/internal/proxy/azure_codex.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bufio"
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
@@ -43,6 +44,13 @@ type AzureCodexEndpoint struct {
 // prompt cache instead of flapping between two providers.
 type AzureCodexConfig struct {
 	Endpoints []AzureCodexEndpoint
+	// Models limits which requested models the fallback serves. Empty serves
+	// every model. An entry matches the model exactly (case-insensitive), or
+	// as a prefix when it ends with "*" ("gpt-5.6*"). The gate exists because
+	// the fallback is metered and Azure trails the ChatGPT catalog: without
+	// it, a default deployment quietly answers a request for one model with a
+	// different one.
+	Models []string
 	// Transport is the outbound RoundTripper. Nil uses the server transport.
 	Transport http.RoundTripper
 	// CostLogPath is the JSONL file each served request is priced into. Empty
@@ -58,6 +66,29 @@ func (c *AzureCodexConfig) configured() bool {
 	}
 	for _, endpoint := range c.Endpoints {
 		if endpoint.BaseURL != nil && endpoint.APIKey != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// modelAllowed reports whether the fallback serves a requested model. An
+// empty allow list keeps the historical behaviour of serving everything.
+func (c *AzureCodexConfig) modelAllowed(model string) bool {
+	if c == nil {
+		return false
+	}
+	if len(c.Models) == 0 {
+		return true
+	}
+	for _, allowed := range c.Models {
+		if prefix, wildcard := strings.CutSuffix(allowed, "*"); wildcard {
+			if len(model) >= len(prefix) && strings.EqualFold(model[:len(prefix)], prefix) {
+				return true
+			}
+			continue
+		}
+		if strings.EqualFold(model, allowed) {
 			return true
 		}
 	}
@@ -492,6 +523,12 @@ func (s Server) azureCodexResponse(
 	if model == "" {
 		return nil, 0, false
 	}
+	if !s.AzureCodex.modelAllowed(model) {
+		if s.Logger != nil {
+			s.Logger.Info("azure codex fallback does not serve this model", "model", model, "reason", reason)
+		}
+		return nil, 0, false
+	}
 	if preferred < 0 || preferred >= len(endpoints) {
 		preferred = azureCodexEndpointIndex(sessionKey, len(endpoints))
 	}
@@ -730,6 +767,32 @@ type azureCodexFallbackTransport struct {
 	replayBody func() ([]byte, bool)
 }
 
+// azureCodexWebSocketDivert pins a Codex websocket session to Azure when an
+// upstream capacity error would otherwise end the turn. The websocket relay
+// cannot splice a second provider into a live socket, so the pin plus a 1012
+// close hands the session back to the client, whose reconnect is refused with
+// 426 and lands on the HTTP transport, where the sticky lookup serves it from
+// Azure. Returns false when the fallback is not configured or does not serve
+// the session's model, in which case the event is forwarded unchanged.
+func (s Server) azureCodexWebSocketDivert(agentType, sessionID, model string) bool {
+	if !s.AzureCodex.configured() {
+		return false
+	}
+	if model == "" || !s.AzureCodex.modelAllowed(model) {
+		return false
+	}
+	key := azureCodexSessionKeyFor(agentType, sessionID)
+	if key == "" {
+		return false
+	}
+	s.azureCodexSessions.pin(key, azureCodexEndpointIndex(key, len(s.AzureCodex.Endpoints)))
+	if s.Logger != nil {
+		s.Logger.Warn("codex websocket turn hit a capacity error; pinning session to the azure fallback",
+			"agent", agentType, "session", sessionID, "model", model)
+	}
+	return true
+}
+
 func (t azureCodexFallbackTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	base := t.base
 	if base == nil {
@@ -742,9 +805,15 @@ func (t azureCodexFallbackTransport) RoundTrip(req *http.Request) (*http.Respons
 	reason := "transport_error"
 	if err == nil {
 		if !azureCodexPoolFailed(response.StatusCode) {
-			return response, nil
+			overloaded, replaced := azureCodexStreamOverloaded(response)
+			response = replaced
+			if !overloaded {
+				return response, nil
+			}
+			reason = "pool_stream_overloaded"
+		} else {
+			reason = fmt.Sprintf("pool_status_%d", response.StatusCode)
 		}
-		reason = fmt.Sprintf("pool_status_%d", response.StatusCode)
 	}
 	body, ok := t.replayBody()
 	if !ok {
@@ -770,6 +839,107 @@ func (t azureCodexFallbackTransport) RoundTrip(req *http.Request) (*http.Respons
 		_ = response.Body.Close()
 	}
 	return fallback, nil
+}
+
+// azureCodexOverloadSniffBytes bounds how much of a pool SSE stream the
+// overload sniff may buffer. The capacity failure arrives at the head of the
+// stream, so the cap only guards against an upstream that streams something
+// unexpected before its first blank line.
+const azureCodexOverloadSniffBytes = 128 * 1024
+
+// azureCodexStreamOverloaded peeks at a 2xx pool response before any byte
+// reaches the client. Codex treats a response.failed event carrying
+// server_is_overloaded or slow_down as terminal ("Selected model is at
+// capacity. Please try a different model."), so a stream that opens with one
+// is a pool failure the status code never shows. Only the first two events
+// are inspected (the failure is the first event, or follows response.created)
+// so a healthy stream is delayed by at most its own preamble, never by model
+// thinking time. The returned response carries the peeked bytes stitched back
+// in front of the unread remainder, whichever way the decision goes, so the
+// stream stays intact for whoever receives it.
+func azureCodexStreamOverloaded(response *http.Response) (bool, *http.Response) {
+	if response == nil || response.Body == nil {
+		return false, response
+	}
+	if !strings.HasPrefix(response.Header.Get("Content-Type"), "text/event-stream") {
+		return false, response
+	}
+	reader := bufioReaderForSniff(response.Body)
+	var peeked bytes.Buffer
+	var event bytes.Buffer
+	events := 0
+	for peeked.Len() < azureCodexOverloadSniffBytes && events < 2 {
+		line, err := reader.ReadBytes('\n')
+		peeked.Write(line)
+		if err != nil {
+			// The stream ended (or stalled into an error) inside the sniff
+			// window: decide on whatever is buffered.
+			overloaded := codexOverloadedJSON(sseEventData(event.Bytes()))
+			return overloaded, azureCodexRestitchedResponse(response, peeked.Bytes(), reader)
+		}
+		if len(bytes.TrimSpace(line)) > 0 {
+			event.Write(line)
+			continue
+		}
+		payload := sseEventData(event.Bytes())
+		event.Reset()
+		if len(payload) == 0 {
+			continue
+		}
+		events++
+		if codexOverloadedJSON(payload) {
+			return true, azureCodexRestitchedResponse(response, peeked.Bytes(), reader)
+		}
+		if !sseEventHasType(payload, "response.created") {
+			break
+		}
+	}
+	return false, azureCodexRestitchedResponse(response, peeked.Bytes(), reader)
+}
+
+func bufioReaderForSniff(body io.Reader) *bufio.Reader {
+	return bufio.NewReader(body)
+}
+
+// azureCodexRestitchedResponse puts the sniffed bytes back in front of the
+// unread remainder, including whatever the bufio reader holds.
+func azureCodexRestitchedResponse(response *http.Response, peeked []byte, reader *bufio.Reader) *http.Response {
+	rest := response.Body
+	response.Body = readCloser{
+		Reader: io.MultiReader(bytes.NewReader(peeked), reader, rest),
+		Closer: rest,
+	}
+	return response
+}
+
+type readCloser struct {
+	io.Reader
+	io.Closer
+}
+
+// sseEventData concatenates the data lines of one SSE event block.
+func sseEventData(event []byte) []byte {
+	var data []byte
+	for _, line := range bytes.Split(event, []byte("\n")) {
+		line = bytes.TrimRight(line, "\r")
+		value, ok := bytes.CutPrefix(line, []byte("data:"))
+		if !ok {
+			continue
+		}
+		data = append(data, bytes.TrimSpace(value)...)
+	}
+	return data
+}
+
+// sseEventHasType reports whether an SSE data payload is the named event.
+func sseEventHasType(payload []byte, eventType string) bool {
+	var event struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(payload, &event) != nil {
+		return false
+	}
+	return event.Type == eventType
 }
 
 // azureCodexPoolFailed reports whether a pool response is a failure worth

--- a/internal/proxy/azure_codex_test.go
+++ b/internal/proxy/azure_codex_test.go
@@ -985,3 +985,208 @@ func TestAzureCodexDropsAnUnknownKeyInsideAnInputItem(t *testing.T) {
 		t.Fatal("a non-object element reported success")
 	}
 }
+
+func TestAzureCodexModelAllowed(t *testing.T) {
+	unrestricted := &AzureCodexConfig{}
+	if !unrestricted.modelAllowed("gpt-5.3-codex") {
+		t.Fatal("empty allow list must serve every model")
+	}
+	var nilConfig *AzureCodexConfig
+	if nilConfig.modelAllowed("gpt-5.6-sol") {
+		t.Fatal("nil config must not serve anything")
+	}
+	gated := &AzureCodexConfig{Models: []string{"gpt-5.6*", "gpt-5.3-codex"}}
+	for model, want := range map[string]bool{
+		"gpt-5.6-sol":   true,
+		"gpt-5.6-luna":  true,
+		"GPT-5.6-TERRA": true,
+		"gpt-5.3-codex": true,
+		"gpt-5.2-codex": false,
+		"gpt-5":         false,
+		"":              false,
+	} {
+		if got := gated.modelAllowed(model); got != want {
+			t.Fatalf("modelAllowed(%q) = %v, want %v", model, got, want)
+		}
+	}
+}
+
+// A model outside the allow list stays on the pool: paying a metered provider
+// to answer with a different model than the one requested is worse than
+// surfacing the pool's own failure.
+func TestAzureCodexFallbackSkipsDisallowedModel(t *testing.T) {
+	pool := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"type":"usage_limit_reached"}}`)
+	}))
+	defer pool.Close()
+	poolURL, err := url.Parse(pool.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var azureCalls atomic.Int32
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		azureCalls.Add(1)
+		_, _ = io.WriteString(w, `{"id":"resp_azure"}`)
+	})
+	server := azureCodexFallbackServer(t, azureURL, poolURL, 1)
+	server.AzureCodex.Models = []string{"gpt-5.6*"}
+	proxy := httptest.NewServer(server.Handler())
+	defer proxy.Close()
+
+	response, err := http.Post(proxy.URL+"/responses", "application/json",
+		strings.NewReader(`{"model":"gpt-5.2-codex","session_id":"session-gate","input":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want the pool's own 429 back", response.StatusCode)
+	}
+	if azureCalls.Load() != 0 {
+		t.Fatalf("azure calls = %d, want 0 for a disallowed model", azureCalls.Load())
+	}
+
+	allowed, err := http.Post(proxy.URL+"/responses", "application/json",
+		strings.NewReader(`{"model":"gpt-5.6-sol","session_id":"session-gate-2","input":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer allowed.Body.Close()
+	if allowed.StatusCode != http.StatusOK {
+		t.Fatalf("allowed model status = %d, want 200 from Azure", allowed.StatusCode)
+	}
+	if azureCalls.Load() != 1 {
+		t.Fatalf("azure calls = %d, want 1 for the allowed model", azureCalls.Load())
+	}
+}
+
+// Codex treats an in-stream server_is_overloaded as terminal ("Selected model
+// is at capacity. Please try a different model."), so a 200 SSE stream that
+// opens with one is a pool failure the status code never shows.
+func TestAzureCodexStreamOverloadedDivertsToAzure(t *testing.T) {
+	pool := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\"}}\n\n")
+		_, _ = io.WriteString(w, "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"error\":{\"code\":\"server_is_overloaded\",\"message\":\"capacity\"}}}\n\n")
+	}))
+	defer pool.Close()
+	poolURL, err := url.Parse(pool.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var azureCalls atomic.Int32
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		azureCalls.Add(1)
+		_, _ = io.WriteString(w, `{"id":"resp_azure"}`)
+	})
+	proxy := httptest.NewServer(azureCodexFallbackServer(t, azureURL, poolURL, 1).Handler())
+	defer proxy.Close()
+
+	response, err := http.Post(proxy.URL+"/responses", "application/json",
+		strings.NewReader(`{"model":"gpt-5.6-codex","session_id":"session-overload","stream":true,"input":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 from Azure; body: %s", response.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "resp_azure") {
+		t.Fatalf("body = %s, want the Azure response, not the overloaded pool stream", body)
+	}
+	if azureCalls.Load() != 1 {
+		t.Fatalf("azure calls = %d, want 1", azureCalls.Load())
+	}
+}
+
+// A healthy stream must reach the client byte-for-byte: the sniff may peek,
+// never consume.
+func TestAzureCodexStreamPassthroughKeepsBytes(t *testing.T) {
+	stream := "event: response.created\ndata: {\"type\":\"response.created\"}\n\n" +
+		"event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{}}\n\n" +
+		"event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n"
+	pool := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, stream)
+	}))
+	defer pool.Close()
+	poolURL, err := url.Parse(pool.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var azureCalls atomic.Int32
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		azureCalls.Add(1)
+	})
+	proxy := httptest.NewServer(azureCodexFallbackServer(t, azureURL, poolURL, 1).Handler())
+	defer proxy.Close()
+
+	response, err := http.Post(proxy.URL+"/responses", "application/json",
+		strings.NewReader(`{"model":"gpt-5.6-codex","session_id":"session-healthy","stream":true,"input":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	if string(body) != stream {
+		t.Fatalf("stream mutated by the sniff:\ngot:  %q\nwant: %q", body, stream)
+	}
+	if azureCalls.Load() != 0 {
+		t.Fatalf("azure calls = %d, want 0 for a healthy stream", azureCalls.Load())
+	}
+}
+
+func TestAzureCodexStreamOverloadedDetection(t *testing.T) {
+	cases := map[string]struct {
+		contentType string
+		body        string
+		want        bool
+	}{
+		"failed first event": {
+			contentType: "text/event-stream",
+			body:        "data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"code\":\"server_is_overloaded\"}}}\n\n",
+			want:        true,
+		},
+		"slow_down after created": {
+			contentType: "text/event-stream",
+			body: "data: {\"type\":\"response.created\"}\n\n" +
+				"data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"code\":\"slow_down\"}}}\n\n",
+			want: true,
+		},
+		"healthy stream": {
+			contentType: "text/event-stream",
+			body:        "data: {\"type\":\"response.created\"}\n\ndata: {\"type\":\"response.in_progress\"}\n\n",
+			want:        false,
+		},
+		"not sse": {
+			contentType: "application/json",
+			body:        `{"error":{"code":"server_is_overloaded"}}`,
+			want:        false,
+		},
+		"truncated failed event without trailing blank line": {
+			contentType: "text/event-stream",
+			body:        "data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"code\":\"server_is_overloaded\"}}}\n",
+			want:        true,
+		},
+	}
+	for name, test := range cases {
+		response := &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{test.contentType}},
+			Body:       io.NopCloser(strings.NewReader(test.body)),
+		}
+		overloaded, replaced := azureCodexStreamOverloaded(response)
+		if overloaded != test.want {
+			t.Fatalf("%s: overloaded = %v, want %v", name, overloaded, test.want)
+		}
+		rest, err := io.ReadAll(replaced.Body)
+		if err != nil {
+			t.Fatalf("%s: read restitched body: %v", name, err)
+		}
+		if string(rest) != test.body {
+			t.Fatalf("%s: restitched body = %q, want the original %q", name, rest, test.body)
+		}
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2432,6 +2432,10 @@ func (s Server) proxyHandler() http.Handler {
 			if azureCodexConfigured && s.serveAzureCodex(w, r, azureCodexSessionKey, -1, "no_usable_account", true) {
 				return
 			}
+			if azureCodexUpgradeShouldFallBack(s, boundLease, requestProvider, r) {
+				http.Error(w, "codex pool has no usable account; retry over https", http.StatusUpgradeRequired)
+				return
+			}
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 			return
 		}
@@ -2452,6 +2456,10 @@ func (s Server) proxyHandler() http.Handler {
 			if azureCodexConfigured && s.serveAzureCodex(w, r, azureCodexSessionKey, -1, "no_usable_credential", true) {
 				return
 			}
+			if azureCodexUpgradeShouldFallBack(s, boundLease, requestProvider, r) {
+				http.Error(w, "codex pool has no usable credential; retry over https", http.StatusUpgradeRequired)
+				return
+			}
 			http.Error(w, "selected account has no usable credential", http.StatusServiceUnavailable)
 			return
 		}
@@ -2470,7 +2478,22 @@ func (s Server) proxyHandler() http.Handler {
 			return
 		}
 		if websocket.IsWebSocketUpgrade(r) {
-			s.proxyWebSocket(w, r, account, credentialLease, sessionAgentType, sessionID, userEmail, requestPoolModel, retryPoolModel, upstream)
+			var azureDivert func(model string) bool
+			if boundLease == nil && s.CredentialBroker == nil &&
+				requestProvider == accounts.ProviderCodex && s.AzureCodex.configured() {
+				key := azureCodexSessionKeyFor(sessionAgentType, sessionID)
+				if _, pinned := s.azureCodexSessions.lookup(key); pinned {
+					// 426 is the one refusal Codex answers by switching the
+					// session to the HTTP transport, where the sticky pin
+					// serves it from Azure. Any other status ends the turn.
+					http.Error(w, "codex session is pinned to the azure fallback; retry over https", http.StatusUpgradeRequired)
+					return
+				}
+				azureDivert = func(model string) bool {
+					return s.azureCodexWebSocketDivert(sessionAgentType, sessionID, model)
+				}
+			}
+			s.proxyWebSocket(w, r, account, credentialLease, sessionAgentType, sessionID, userEmail, requestPoolModel, retryPoolModel, upstream, azureDivert)
 			return
 		}
 		proxyRequest := r.Clone(r.Context())
@@ -2702,6 +2725,16 @@ func (s Server) proxyHandler() http.Handler {
 	})
 }
 
+// azureCodexUpgradeShouldFallBack reports whether a Codex websocket upgrade
+// that the pool cannot start should be refused with 426 instead of 503. Codex
+// switches the session to the HTTP transport only on 426, and only the HTTP
+// path can serve the turn from Azure; a 503 ends the turn with nothing tried.
+func azureCodexUpgradeShouldFallBack(s Server, boundLease *sessionLease, provider accounts.Provider, r *http.Request) bool {
+	return boundLease == nil && s.CredentialBroker == nil &&
+		provider == accounts.ProviderCodex && s.AzureCodex.configured() &&
+		websocket.IsWebSocketUpgrade(r)
+}
+
 func (s Server) localProxyAuthorized(r *http.Request) bool {
 	token := strings.TrimSpace(s.LocalProxyToken)
 	if token == "" {
@@ -2853,7 +2886,7 @@ func (s Server) reportCredentialLease(
 	}()
 }
 
-func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account accounts.Account, credentialLease *broker.Lease, agentType, sessionID, userEmail, poolModel, compatibilityModel string, upstream *url.URL) {
+func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account accounts.Account, credentialLease *broker.Lease, agentType, sessionID, userEmail, poolModel, compatibilityModel string, upstream *url.URL, azureDivert func(model string) bool) {
 	if !webSocketOriginAllowed(r) {
 		http.Error(w, "websocket origin not allowed", http.StatusForbidden)
 		return
@@ -2952,12 +2985,12 @@ func (s Server) proxyWebSocket(w http.ResponseWriter, r *http.Request, account a
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		s.copyWebSocketMessages(r.Context(), agentType, sessionID, userEmail, account.ID, poolModel, modelState, "client_to_upstream", clientConn, upstreamConn, nil)
+		s.copyWebSocketMessages(r.Context(), agentType, sessionID, userEmail, account.ID, poolModel, modelState, "client_to_upstream", clientConn, upstreamConn, nil, nil)
 		_ = upstreamConn.Close()
 	}()
 	go func() {
 		defer wg.Done()
-		s.copyWebSocketMessages(r.Context(), agentType, sessionID, userEmail, account.ID, poolModel, modelState, "upstream_to_client", upstreamConn, clientConn, reportLeaseFailure)
+		s.copyWebSocketMessages(r.Context(), agentType, sessionID, userEmail, account.ID, poolModel, modelState, "upstream_to_client", upstreamConn, clientConn, reportLeaseFailure, azureDivert)
 		_ = clientConn.Close()
 	}()
 	wg.Wait()
@@ -3090,9 +3123,9 @@ func codexWebSocketResponseFinished(body []byte) bool {
 	}
 }
 
-func (s Server) copyWebSocketMessages(ctx context.Context, agentType, sessionID, userEmail, accountID, poolModel string, modelState *webSocketModelState, direction string, src, dst *websocket.Conn, reportLeaseFailure func(int)) {
+func (s Server) copyWebSocketMessages(ctx context.Context, agentType, sessionID, userEmail, accountID, poolModel string, modelState *webSocketModelState, direction string, src, dst *websocket.Conn, reportLeaseFailure func(int), azureDivert func(model string) bool) {
 	provider := providerForRequest(agentType, "")
-	observeMessage := func(messageType int, body []byte) {
+	observeMessage := func(messageType int, body []byte) error {
 		if messageType == websocket.TextMessage && direction == "client_to_upstream" && provider == accounts.ProviderCodex {
 			modelState.observe(body)
 		}
@@ -3111,22 +3144,35 @@ func (s Server) copyWebSocketMessages(ctx context.Context, agentType, sessionID,
 				if model := modelState.current(); model != "" {
 					_, _ = s.rerouteModelIncompatibility(ctx, provider, agentType, sessionID, userEmail, accountID, model, nil)
 				}
+			case provider == accounts.ProviderCodex && azureDivert != nil && codexOverloadedJSON(body):
+				model := modelState.current()
+				if model == "" {
+					model = poolModel
+				}
+				if azureDivert(model) {
+					return errAzureCodexWebSocketDivert
+				}
 			}
 			if provider == accounts.ProviderCodex && codexWebSocketResponseFinished(body) {
 				modelState.complete()
 			}
 		}
+		return nil
 	}
 	for {
 		err := s.forwardWebSocketMessage(ctx, agentType, sessionID, direction, src, dst, observeMessage)
 		if err != nil {
+			if errors.Is(err, errAzureCodexWebSocketDivert) {
+				closeWebSocketForAzureDivert(dst)
+				return
+			}
 			forwardWebSocketClose(dst, err)
 			return
 		}
 	}
 }
 
-func (s Server) forwardWebSocketMessage(ctx context.Context, agentType, sessionID, direction string, src, dst *websocket.Conn, observe func(int, []byte)) error {
+func (s Server) forwardWebSocketMessage(ctx context.Context, agentType, sessionID, direction string, src, dst *websocket.Conn, observe func(int, []byte) error) error {
 	messageType, reader, err := src.NextReader()
 	if err != nil {
 		return err
@@ -3134,8 +3180,8 @@ func (s Server) forwardWebSocketMessage(ctx context.Context, agentType, sessionI
 	observer := newWebSocketMessageObserver(s.Transcripts, agentType, sessionID, direction, messageType)
 	_, release, err := streamWebSocketMessage(ctx, reader, func() (io.WriteCloser, error) {
 		return dst.NextWriter(messageType)
-	}, observer, webSocketForwardBuffers, func(body []byte) {
-		observe(messageType, body)
+	}, observer, webSocketForwardBuffers, func(body []byte) error {
+		return observe(messageType, body)
 	})
 	if release != nil {
 		release()
@@ -3149,7 +3195,7 @@ func streamWebSocketMessage(
 	openWriter func() (io.WriteCloser, error),
 	observer *webSocketMessageObserver,
 	buffers *webSocketCopyBufferPool,
-	beforeClose func([]byte),
+	beforeClose func([]byte) error,
 ) ([]byte, func(), error) {
 	buffer, releaseBuffer, err := buffers.acquire(ctx)
 	if err != nil {
@@ -3200,7 +3246,13 @@ func streamWebSocketMessage(
 	}
 	body, release := observer.finish()
 	if beforeClose != nil {
-		beforeClose(body)
+		if err := beforeClose(body); err != nil {
+			// The message must not be delivered: mark the writer closed
+			// without closing it, so the final frame is never flushed, and
+			// surface the veto to the copy loop.
+			writerOpen = false
+			return body, release, err
+		}
 	}
 	if err := closeWriter(); err != nil {
 		return body, release, err
@@ -3400,6 +3452,24 @@ func (o *webSocketMessageObserver) abort() {
 // TCP close makes the other peer report abnormal closure 1006 even when the
 // first peer sent a valid WebSocket close frame. Unexpected transport loss is
 // translated to 1011 so the proxy still terminates with a valid close frame.
+// errAzureCodexWebSocketDivert says an upstream Codex websocket message was a
+// capacity failure the Azure fallback will absorb: the message must not reach
+// the client (Codex treats it as terminal), the session is already pinned,
+// and both connections close so the client reconnects — its next upgrade is
+// refused with 426, which is the one status Codex answers by switching to the
+// HTTP transport, where the sticky pin serves the turn from Azure.
+var errAzureCodexWebSocketDivert = errors.New("codex websocket turn diverted to the azure fallback")
+
+// closeWebSocketForAzureDivert ends the client connection with 1012 (service
+// restart), which Codex handles by reconnecting with a full response.create.
+func closeWebSocketForAzureDivert(dst *websocket.Conn) {
+	_ = dst.WriteControl(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseServiceRestart, "codex pool is at capacity; reconnect"),
+		time.Now().Add(webSocketCloseWriteTimeout),
+	)
+}
+
 func forwardWebSocketClose(dst *websocket.Conn, readErr error) {
 	code := websocket.CloseInternalServerErr
 	reason := "peer connection closed unexpectedly"
@@ -3505,6 +3575,31 @@ func claudeExhaustionExpiry(header http.Header, now time.Time) time.Time {
 		return max
 	}
 	return until
+}
+
+// codexOverloadedJSON reports whether a Codex event carries the ChatGPT
+// backend's capacity failure. Codex renders it as "Selected model is at
+// capacity. Please try a different model." and treats it as terminal, so the
+// proxy has to absorb it before the client sees it.
+func codexOverloadedJSON(body []byte) bool {
+	var event map[string]any
+	if err := json.Unmarshal(body, &event); err != nil {
+		return false
+	}
+	return codexOverloadedMap(event)
+}
+
+func codexOverloadedMap(event map[string]any) bool {
+	switch strings.ToLower(strings.TrimSpace(stringField(event, "code"))) {
+	case "server_is_overloaded", "slow_down":
+		return true
+	}
+	for _, key := range []string{"error", "response"} {
+		if nested, ok := event[key].(map[string]any); ok && codexOverloadedMap(nested) {
+			return true
+		}
+	}
+	return false
 }
 
 func usageLimitJSON(body []byte) bool {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -4488,3 +4488,206 @@ func TestHandlerBalancesEquivalentNewSessionsByStoredCounts(t *testing.T) {
 		t.Fatalf("auths = %#v, want %d sessions balanced across both accounts", auths, sessions)
 	}
 }
+
+// An in-stream server_is_overloaded is terminal for Codex ("Selected model is
+// at capacity. Please try a different model."), so the relay must absorb the
+// event, pin the session to the Azure fallback, close with 1012 so the client
+// reconnects, refuse the reconnect's upgrade with 426 so the client switches
+// to the HTTP transport, and then serve the HTTP turn from Azure.
+func TestHandlerDivertsOverloadedCodexWebSocketToAzure(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upstream upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Errorf("upstream read: %v", err)
+			return
+		}
+		failed := `{"type":"response.failed","response":{"error":{"code":"server_is_overloaded","message":"capacity"}}}`
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(failed)); err != nil {
+			t.Errorf("upstream write: %v", err)
+		}
+		// Hold the socket open so the proxy, not this handler, decides how the
+		// client connection ends.
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer upstream.Close()
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var azureCalls atomic.Int32
+	azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		azureCalls.Add(1)
+		if r.URL.Path != "/openai/v1/responses" {
+			t.Errorf("azure path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"id":"resp_azure_ws"}`)
+	}))
+	defer azureServer.Close()
+	azureURL, err := url.Parse(azureServer.URL + "/openai/v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := Server{
+		CodexUpstream: upstreamURL,
+		Accounts: []accounts.Account{{
+			ID:       "codex-account",
+			AuthMode: accounts.AuthModeOAuth,
+			Token:    "oauth-token",
+		}},
+		Sessions:     store,
+		Scheduler:    selectacct.NewScheduler(nil),
+		MaxBodyBytes: 1 << 20,
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		AzureCodex: &AzureCodexConfig{
+			Models: []string{"gpt-5.6*"},
+			Endpoints: []AzureCodexEndpoint{{
+				Name:    "test-azure",
+				BaseURL: azureURL,
+				APIKey:  "azure-key",
+			}},
+		},
+	}
+	proxy := httptest.NewServer(server.Handler())
+	defer proxy.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(proxy.URL, "http") + "/backend-api/codex/responses"
+	header := http.Header{"Session-Id": []string{"ws-overload-session"}}
+	conn, response, err := websocket.DefaultDialer.Dial(wsURL, header)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer response.Body.Close()
+	defer conn.Close()
+
+	create := `{"type":"response.create","response":{"model":"gpt-5.6-sol"}}`
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(create)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, body, err := conn.ReadMessage()
+	if err == nil {
+		t.Fatalf("client received %q, want the overloaded event absorbed and the socket closed", body)
+	}
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) || closeErr.Code != websocket.CloseServiceRestart {
+		t.Fatalf("close = %v, want 1012 so the client reconnects", err)
+	}
+
+	// The reconnect must be refused with 426: it is the one status Codex
+	// answers by switching the session to the HTTP transport.
+	_, retryResponse, err := websocket.DefaultDialer.Dial(wsURL, header)
+	if err == nil {
+		t.Fatal("second upgrade succeeded, want 426")
+	}
+	if retryResponse == nil || retryResponse.StatusCode != http.StatusUpgradeRequired {
+		status := 0
+		if retryResponse != nil {
+			status = retryResponse.StatusCode
+		}
+		t.Fatalf("second upgrade status = %d, want 426", status)
+	}
+
+	// The HTTP turn for the pinned session is served from Azure.
+	request, err := http.NewRequest(http.MethodPost, proxy.URL+"/backend-api/codex/responses",
+		strings.NewReader(`{"model":"gpt-5.6-sol","input":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Session-Id", "ws-overload-session")
+	httpResponse, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer httpResponse.Body.Close()
+	responseBody, _ := io.ReadAll(httpResponse.Body)
+	if httpResponse.StatusCode != http.StatusOK || !strings.Contains(string(responseBody), "resp_azure_ws") {
+		t.Fatalf("http turn = %d %s, want the Azure response", httpResponse.StatusCode, responseBody)
+	}
+	if azureCalls.Load() != 1 {
+		t.Fatalf("azure calls = %d, want 1", azureCalls.Load())
+	}
+}
+
+// An overloaded event for a model the fallback does not serve is forwarded
+// unchanged: absorbing it without an alternative would strand the turn.
+func TestHandlerForwardsOverloadedEventWhenModelNotServed(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
+	failed := `{"type":"response.failed","response":{"error":{"code":"server_is_overloaded"}}}`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, _, _ = conn.ReadMessage()
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(failed))
+	}))
+	defer upstream.Close()
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	azureURL, err := url.Parse("https://unused.example.com/openai/v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := Server{
+		CodexUpstream: upstreamURL,
+		Accounts: []accounts.Account{{
+			ID:       "codex-account",
+			AuthMode: accounts.AuthModeOAuth,
+			Token:    "oauth-token",
+		}},
+		Sessions:     store,
+		Scheduler:    selectacct.NewScheduler(nil),
+		MaxBodyBytes: 1 << 20,
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		AzureCodex: &AzureCodexConfig{
+			Models: []string{"gpt-5.6*"},
+			Endpoints: []AzureCodexEndpoint{{
+				Name:    "test-azure",
+				BaseURL: azureURL,
+				APIKey:  "azure-key",
+			}},
+		},
+	}
+	proxy := httptest.NewServer(server.Handler())
+	defer proxy.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(proxy.URL, "http") + "/backend-api/codex/responses"
+	conn, response, err := websocket.DefaultDialer.Dial(wsURL, http.Header{"Session-Id": []string{"ws-old-model"}})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer response.Body.Close()
+	defer conn.Close()
+	create := `{"type":"response.create","response":{"model":"gpt-5.2-codex"}}`
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(create)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, body, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v, want the event forwarded unchanged", err)
+	}
+	if string(body) != failed {
+		t.Fatalf("body = %q, want the upstream event verbatim", body)
+	}
+}


### PR DESCRIPTION
Fixes the one error the Azure fallback existed for but never caught: the ChatGPT backend's capacity failure arrives inside an otherwise-200 stream, and Codex treats `server_is_overloaded` as terminal, rendering "Selected model is at capacity. Please try a different model." The status-based fallback (429/5xx) never fired for it.

- HTTP SSE: sniff the first two events before any byte reaches the client; a stream opening with `server_is_overloaded`/`slow_down` is served from Azure. Healthy streams pass through byte-for-byte, delayed by at most their own preamble.
- WebSocket: the relay cannot splice a second provider into a live socket, so the event pins the session to Azure, closes with 1012 so Codex reconnects, and the reconnect is refused with 426, the one status Codex answers by switching to the HTTP transport, where the pin serves the turn. A pool that cannot start a Codex upgrade at all also answers 426.
- `SUBROUTER_AZURE_CODEX_MODELS` / `models` allow list: the default-deployment catch-all was quietly answering gpt-5.6-sol/luna requests with gpt-5.3-codex. Production will gate to `gpt-5.6*` with same-named deployments.
- An endpoint may now be `https://api.openai.com/v1` with an OpenAI API key (`api_key_file` reads it from disk) as a further fallback; a bare `/v1` on an Azure host stays rejected.

Tests: `go test ./...` PASS, `go test -race ./internal/proxy` PASS, `go vet ./...` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789707706&installation_model_id=21920&pr_number=239&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F239&signature=5252d7c1dde3c8fb96df84e6d68408d58e24f342d64c11f6a30b1eb1865a38ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Absorbs Codex “capacity” failures into the Azure fallback and gates fallback by model. Previously only 429/5xx triggered fallback; now in-stream `server_is_overloaded`/`slow_down` errors are diverted (SSE is retried on Azure; WebSocket pins to Azure, closes with 1012, then the reconnect is refused with 426 to switch to HTTP).

- SSE: sniff only the first two events (≤128 KiB), restitch bytes so healthy streams pass through unchanged with at most preamble delay.
- WebSocket: detect overloaded events, pin the session to Azure, close with 1012; subsequent upgrade returns 426 so Codex moves to HTTP where the pin serves the turn.
- When the pool cannot start a Codex upgrade (no usable account/credential), return 426 instead of 503 for the same HTTP diversion behavior.
- Add `models` allow list (exact or prefix with `*`, case-insensitive) to prevent serving a different model than requested; model outside the list keeps pool errors.
- Allow an endpoint at `https://api.openai.com/v1` with an OpenAI API key (supports `api_key_file`); reject bare `/v1` on Azure hosts.

- Rollout
  - Set `SUBROUTER_AZURE_CODEX_MODELS` (or `"models"` in the config) to the models you intend to serve, e.g. `gpt-5.6*`, and ensure same-named Azure deployments exist; stop relying on a broad default deployment.
  - Optionally add an `https://api.openai.com/v1` endpoint with `api_key` or `api_key_file` to backstop Azure during outages.
  - Expect Codex WebSocket clients to see 1012 on overload and a 426 on immediate reconnect; they will retry over HTTP automatically.

<sup>Written for commit cf0387128f6fd29be3da07fe30ee377d1f31083b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

