### PR TITLE
Log how deep a Fable Bedrock stream was when it died

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -689,6 +689,9 @@ func transcodeBedrockToSSE(w io.Writer, src io.Reader, logger *slog.Logger, bedr
 	flusher, _ := w.(http.Flusher)
 	var scanner bedrockFrameScanner
 	var result bedrockStreamResult
+	started := time.Now()
+	eventsForwarded := 0
+	sawTextBlock := false
 	exceptionHandled := false
 	finalize := func() bedrockStreamResult {
 		result.HaveUsage = result.HaveUsage && !result.Usage.empty()
@@ -752,9 +755,22 @@ func transcodeBedrockToSSE(w io.Writer, src io.Reader, logger *slog.Logger, bedr
 			}
 		case "message_stop":
 			result.SawMessageStop = true
+		case "content_block_start":
+			var block struct {
+				ContentBlock struct {
+					Type string `json:"type"`
+				} `json:"content_block"`
+			}
+			if json.Unmarshal(inner, &block) == nil && block.ContentBlock.Type == "text" {
+				sawTextBlock = true
+			}
 		case "error":
 			if logger != nil {
-				logger.Warn("claude-fable bedrock in-band error", "exception_type", "", "message", bedrockLogPreview(inner), "bedrock_source", bedrockSource, "region", region, "saw_message_stop", result.SawMessageStop)
+				// Depth telemetry: how far into the committed stream the
+				// upstream died. events_forwarded and saw_text_block separate
+				// admission-time sheds (retryable pre-commit, handled by the
+				// peek) from mid-generation sheds (not replayable).
+				logger.Warn("claude-fable bedrock in-band error", "exception_type", "", "message", bedrockLogPreview(inner), "bedrock_source", bedrockSource, "region", region, "saw_message_stop", result.SawMessageStop, "events_forwarded", eventsForwarded, "saw_text_block", sawTextBlock, "output_tokens_so_far", result.Usage.OutputTokens, "elapsed_ms", time.Since(started).Milliseconds())
 			}
 		}
 		eventType := ev.Type
@@ -764,6 +780,7 @@ func transcodeBedrockToSSE(w io.Writer, src io.Reader, logger *slog.Logger, bedr
 		_, _ = w.Write([]byte("event: " + eventType + "\ndata: "))
 		_, _ = w.Write(inner)
 		_, _ = w.Write([]byte("\n\n"))
+		eventsForwarded++
 		if flusher != nil {
 			flusher.Flush()
 		}
@@ -781,7 +798,7 @@ func transcodeBedrockToSSE(w io.Writer, src io.Reader, logger *slog.Logger, bedr
 			if !result.SawMessageStop && !exceptionHandled {
 				result.ReadErr = readErr
 				if logger != nil {
-					logger.Error("claude-fable bedrock stream truncated", "bedrock_source", bedrockSource, "region", region, "read_err", readErr, "saw_message_stop", result.SawMessageStop, "exception_type", "", "message", "")
+					logger.Error("claude-fable bedrock stream truncated", "bedrock_source", bedrockSource, "region", region, "read_err", readErr, "saw_message_stop", result.SawMessageStop, "exception_type", "", "message", "", "events_forwarded", eventsForwarded, "saw_text_block", sawTextBlock, "output_tokens_so_far", result.Usage.OutputTokens, "elapsed_ms", time.Since(started).Milliseconds())
 				}
 				writeErrorEvent("api_error", "Bedrock stream interrupted")
 			} else if readErr != io.EOF {


### PR DESCRIPTION
Tonight's `overloaded_error` events on cmux-lawrence all log identically, so we inferred rather than knew that Bedrock sheds long-running Fable streams mid-generation (16 short probes succeeded while real long requests died). Add depth telemetry to `transcodeBedrockToSSE`: `events_forwarded`, `saw_text_block`, `output_tokens_so_far`, `elapsed_ms` on both the in-band error and truncation logs. Pure logging; no behavior change. `go test ./...` exit 0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789707877&installation_model_id=21920&pr_number=240&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F240&signature=c0425e47da10126b93962d8bb16a0a178eee4feff48340ac59cd188472ebd8a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds depth telemetry to Bedrock SSE transcoder logs so we can see how far a Fable stream progressed when it died. Previously, in-band errors and truncations logged identically; now logs include events_forwarded, saw_text_block, output_tokens_so_far, and elapsed_ms. No runtime or response behavior change.

- Instrumentation is in `transcodeBedrockToSSE`; both in-band error and truncation logs include the new fields.
- Use events_forwarded and saw_text_block to distinguish admission-time sheds (retryable) from mid-generation sheds (not replayable).
- No API or client changes; no config or migration required.

<sup>Written for commit f8774afe18e798df58450f78bf9b9adf07f003ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

