### PR TITLE
Stop refusing the fallback for bodies past the session-id peek limit

### DIFF
--- a/internal/proxy/azure_codex.go
+++ b/internal/proxy/azure_codex.go
@@ -679,13 +679,21 @@ func azureCodexReplayedResponse(response *http.Response, body []byte) *http.Resp
 	return response
 }
 
-// azureCodexMaxBodyBytes bounds a decoded request body, falling back to the
-// replay buffer size when the server sets no explicit limit.
+// azureCodexMaxBodyBytes bounds a decoded request body.
+//
+// It is deliberately NOT MaxBodyBytes, which defaults to 1 MiB and exists to
+// bound how much of a body is *peeked at* for a session id. The fallback has to
+// send the whole request, and the bytes are already buffered under the replay
+// limit, so that is the honest bound. Using the peek limit here silently
+// refused the fallback for any compressed Codex request past a megabyte, which
+// is every session long enough to exhaust a quota: the requests that need the
+// fallback most were the ones it declined.
 func (s Server) azureCodexMaxBodyBytes() int64 {
-	if s.MaxBodyBytes > 0 {
-		return s.MaxBodyBytes
+	limit := int64(replayablePostMaxBodyBytes)
+	if s.MaxBodyBytes > limit {
+		limit = s.MaxBodyBytes
 	}
-	return replayablePostMaxBodyBytes
+	return limit
 }
 
 // azureCodexErrorSummary reads a bounded prefix of an Azure error body for one

--- a/internal/proxy/azure_codex_test.go
+++ b/internal/proxy/azure_codex_test.go
@@ -1190,3 +1190,62 @@ func TestAzureCodexStreamOverloadedDetection(t *testing.T) {
 		}
 	}
 }
+
+// Codex compresses large bodies, and a session long enough to exhaust a quota
+// is far past a megabyte. Bounding the decode by the session-id peek limit
+// refused the fallback for exactly those requests.
+func TestAzureCodexFallbackServesABodyLargerThanThePeekLimit(t *testing.T) {
+	pool := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"type":"usage_limit_reached"}}`)
+	}))
+	defer pool.Close()
+	poolURL, err := url.Parse(pool.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var received atomic.Int64
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		received.Store(int64(len(body)))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_azure"}`)
+	})
+
+	server := azureCodexFallbackServer(t, azureURL, poolURL, 1)
+	// The default peek limit, which this request is far larger than.
+	server.MaxBodyBytes = 1 << 20
+	proxy := httptest.NewServer(server.Handler())
+	defer proxy.Close()
+
+	filler := strings.Repeat("a conversation turn that has to survive the fallback. ", 60000)
+	payload := `{"model":"gpt-5.6-codex","session_id":"large","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"` + filler + `"}]}]}`
+	if len(payload) <= (1 << 20) {
+		t.Fatalf("payload is %d bytes, want more than the peek limit", len(payload))
+	}
+	encoder, err := zstd.NewWriter(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compressed := encoder.EncodeAll([]byte(payload), nil)
+	_ = encoder.Close()
+
+	req, err := http.NewRequest(http.MethodPost, proxy.URL+"/responses", bytes.NewReader(compressed))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "zstd")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), "resp_azure") {
+		t.Fatalf("status = %d, body = %s, want the large request served by Azure", response.StatusCode, body)
+	}
+	if received.Load() < int64(len(payload)/2) {
+		t.Fatalf("azure received %d bytes, want the whole conversation", received.Load())
+	}
+}


### PR DESCRIPTION
The live server logged `decoded request body is too large to validate`. The Azure fallback bounded its decode by `MaxBodyBytes`, which defaults to 1 MiB and exists to bound how much of a body is *peeked at* for a session id. The fallback has to send the whole request, so any compressed Codex body past a megabyte was declined, and a session long enough to exhaust a quota is far past one: the requests that needed the fallback most were exactly the ones it refused.

The bound is now the replay buffer limit, which is the memory already committed to holding that body.

Test sends a zstd-compressed conversation several megabytes past the peek limit through a pool that 429s, and asserts Azure served it and received the whole thing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789709271&installation_model_id=21920&pr_number=243&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F243&signature=2bb38ce204c44854cea43b3ac2e4c56b420f5bffa47f6d0806b49a9ef1d0e039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops declining Azure Codex fallback for compressed request bodies over 1 MiB by bounding decode with the replay buffer instead of the session-id peek limit. Previously the fallback used `MaxBodyBytes` (default 1 MiB) and rejected the exact large requests that needed fallback; now it forwards the full body up to max(replay buffer, `MaxBodyBytes`) without logging “decoded request body is too large to validate”.

- The bound in `azureCodexMaxBodyBytes` is now the replay buffer limit, or higher if `MaxBodyBytes` is larger; this does not increase memory use because the body is already buffered.
- Adds a test that zstd-compresses a multi-megabyte Codex request, forces a pool 429, and asserts Azure receives the entire body. No config or client changes required.

<sup>Written for commit 1131d772ffdf0697e7fd9405f1598b0450b3ddeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure fallback handling for compressed requests with large payloads.
  * Preserves complete conversation data when requests exceed the body preview limit.
  * Continues honoring larger configured server body limits.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->