### PR TITLE
Commit the Fable stream on the first delta, not on content_block_start

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -565,10 +565,11 @@ type bedrockStreamPeek struct {
 }
 
 // bedrockFrameDecision reports whether a frame decides the stream's fate.
-// Errors and exceptions are failures. The first content block (thinking or
-// text), a usage delta, or message_stop proves the stream viable. message_start
-// and pings prove nothing: Bedrock regularly opens a message and then delivers
-// an overloaded_error, so the peek window has to extend past them.
+// Errors and exceptions are failures. The first content delta, a usage delta,
+// or message_stop proves the stream viable. message_start, content_block_start,
+// and pings prove nothing: Bedrock regularly opens a message (and even a
+// content block) and then delivers an overloaded_error, so the peek window has
+// to extend past them.
 func bedrockFrameDecision(frame bedrockFrame) (decisive, failure bool) {
 	if strings.EqualFold(frame.messageType, "exception") {
 		return true, true
@@ -580,9 +581,13 @@ func bedrockFrameDecision(frame bedrockFrame) (decisive, failure bool) {
 	switch ev.Type {
 	case "error":
 		return true, true
-	case "content_block_start", "content_block_delta", "message_delta", "message_stop":
+	case "content_block_delta", "message_delta", "message_stop":
 		return true, false
 	}
+	// content_block_start carries zero tokens and regularly precedes an
+	// overload shed by under a second (seen live: died 762ms after the block
+	// opened, before any delta). Keep buffering until the first delta so that
+	// window stays replayable; the delta normally follows within ~100ms.
 	return false, false
 }
 

--- a/internal/proxy/claude_fable_test.go
+++ b/internal/proxy/claude_fable_test.go
@@ -799,7 +799,10 @@ func TestClaudeFableBedrockDoesNotRetryErrorAfterContent(t *testing.T) {
 		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
 		append(
 			buildEventStreamFrame(t, `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`),
-			buildEventStreamFrame(t, `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)...,
+			append(
+				buildEventStreamFrame(t, `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`),
+				buildEventStreamFrame(t, `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)...,
+			)...,
 		)...,
 	)
 	calls := 0
@@ -894,5 +897,58 @@ func TestClaudeFableBedrockRequestDropsWebSearchTool(t *testing.T) {
 	}
 	if !strings.Contains(upstreamBody, `"Bash"`) {
 		t.Fatalf("client tool was lost: %s", upstreamBody)
+	}
+}
+
+// A shed between content_block_start and the first delta (seen live: 762ms in,
+// zero tokens) must retry: the block-open frame carries nothing the client
+// needs, so the stream is still replayable.
+func TestClaudeFableBedrockRetriesErrorAfterBlockStartBeforeDelta(t *testing.T) {
+	bad := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		append(
+			buildEventStreamFrame(t, `{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`),
+			buildEventStreamFrame(t, `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)...,
+		)...,
+	)
+	good := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		append(
+			buildEventStreamFrame(t, `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`),
+			append(
+				buildEventStreamFrame(t, `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`),
+				buildEventStreamFrame(t, `{"type":"message_stop"}`)...,
+			)...,
+		)...,
+	)
+	calls := 0
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		body := bad
+		if calls >= 2 {
+			body = good
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	resp, err := s.claudeFableBedrockResponse(req.Context(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after retrying past a pre-delta shed", resp.StatusCode)
+	}
+	sse, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(sse), "event: message_stop") || strings.Contains(string(sse), "overloaded_error") {
+		t.Fatalf("retried stream wrong: %q", sse)
+	}
+	if calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2", calls)
 	}
 }


### PR DESCRIPTION
The depth telemetry from #240 caught this live within minutes of deploying: `events_forwarded=3 saw_text_block=false output_tokens_so_far=0 elapsed_ms=762` — the shed hit after `content_block_start` but before the first delta, and the peek from #233 had already committed because it treated block-open as proof of viability. A block-open frame carries zero tokens, so nothing of value had reached the client, yet the request was no longer replayable.

Change `bedrockFrameDecision`: `content_block_start` no longer commits; the window extends to the first `content_block_delta`/`message_delta`/`message_stop`. The first delta typically follows block-open within ~100ms, so streaming latency is unaffected, and every open-to-first-token shed becomes a silent server-side retry.

Tests: the after-content pass-through test now includes a real delta before the error (matching the new meaning of committed), and a new test covers retry on a shed between block-open and first delta. `go test ./...` exit 0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789709327&installation_model_id=21920&pr_number=244&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F244&signature=44b60202d89deb8f9762f239201fd456a3398a7c1a009dadb457b7ff44e85736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Commit Fable streams on the first delta instead of on content_block_start so the pre-token window remains replayable. Previously we committed at block-open; overloads before the first delta produced unretryable streams with zero tokens.

- Update `bedrockFrameDecision`: treat `content_block_start` as non-decisive; commit on `content_block_delta`, `message_delta`, or `message_stop`.
- Tests: adjust after-content no-retry to include a real delta; add a retry test for sheds between block-open and first delta.
- Impact: negligible added latency (~100ms to first delta); open-to-first-token sheds now retry transparently; no client changes.

<sup>Written for commit ecece9aea5e7e621bda679e81b19cb32c5638c5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

