### PR TITLE
Buffer early thinking for up to 2s so sub-second sheds retry silently

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -570,24 +570,47 @@ type bedrockStreamPeek struct {
 // and pings prove nothing: Bedrock regularly opens a message (and even a
 // content block) and then delivers an overloaded_error, so the peek window has
 // to extend past them.
-func bedrockFrameDecision(frame bedrockFrame) (decisive, failure bool) {
+// claudeFableBedrockCommitWindow bounds how long the peek keeps buffering
+// early thinking deltas before committing anyway. Production depth telemetry
+// (2026-08-18) put three of four overload sheds at 310-1322ms into the stream,
+// all during thinking with zero visible tokens; a two-second window converts
+// those into silent retries. The cost is visible thinking starting up to this
+// much later. Any visible delta (text or tool input) commits immediately, so
+// answers without long thinking pay nothing. A var, not a const, so tests can
+// shrink it.
+var claudeFableBedrockCommitWindow = 2 * time.Second
+
+// bedrockFrameDecision reports whether a frame decides the stream's fate at
+// the given elapsed time since the stream opened. Errors and exceptions are
+// failures. A visible delta (text_delta, input_json_delta), a usage delta, or
+// message_stop proves the stream viable immediately. Thinking deltas prove it
+// only once the commit window has elapsed: Bedrock regularly sheds a stream
+// within the first seconds of thinking, and holding those frames back keeps
+// the request replayable. message_start, content_block_start/stop, and pings
+// prove nothing.
+func bedrockFrameDecision(frame bedrockFrame, elapsed time.Duration) (decisive, failure bool) {
 	if strings.EqualFold(frame.messageType, "exception") {
 		return true, true
 	}
 	var ev struct {
-		Type string `json:"type"`
+		Type  string `json:"type"`
+		Delta struct {
+			Type string `json:"type"`
+		} `json:"delta"`
 	}
 	_ = json.Unmarshal(frame.payload, &ev)
 	switch ev.Type {
 	case "error":
 		return true, true
-	case "content_block_delta", "message_delta", "message_stop":
+	case "message_delta", "message_stop":
+		return true, false
+	case "content_block_delta":
+		switch ev.Delta.Type {
+		case "thinking_delta", "signature_delta":
+			return elapsed >= claudeFableBedrockCommitWindow, false
+		}
 		return true, false
 	}
-	// content_block_start carries zero tokens and regularly precedes an
-	// overload shed by under a second (seen live: died 762ms after the block
-	// opened, before any delta). Keep buffering until the first delta so that
-	// window stays replayable; the delta normally follows within ~100ms.
 	return false, false
 }
 
@@ -599,6 +622,7 @@ func bedrockFrameDecision(frame bedrockFrame) (decisive, failure bool) {
 func peekBedrockStreamUntilCommit(src io.Reader) bedrockStreamPeek {
 	var scanner bedrockFrameScanner
 	var peeked bytes.Buffer
+	started := time.Now()
 	decided := false
 	failed := false
 	var errorFrame bedrockFrame
@@ -606,7 +630,7 @@ func peekBedrockStreamUntilCommit(src io.Reader) bedrockStreamPeek {
 		if decided {
 			return
 		}
-		decisive, failure := bedrockFrameDecision(frame)
+		decisive, failure := bedrockFrameDecision(frame, time.Since(started))
 		if !decisive {
 			return
 		}

--- a/internal/proxy/claude_fable_test.go
+++ b/internal/proxy/claude_fable_test.go
@@ -952,3 +952,103 @@ func TestClaudeFableBedrockRetriesErrorAfterBlockStartBeforeDelta(t *testing.T) 
 		t.Fatalf("upstream calls = %d, want 2", calls)
 	}
 }
+
+// A shed during early thinking (within the commit window) retries silently:
+// thinking deltas inside the window are buffered, so nothing reached the client.
+func TestClaudeFableBedrockRetriesShedDuringEarlyThinking(t *testing.T) {
+	bad := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		append(
+			buildEventStreamFrame(t, `{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`),
+			append(
+				buildEventStreamFrame(t, `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}}`),
+				append(
+					buildEventStreamFrame(t, `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm2"}}`),
+					buildEventStreamFrame(t, `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)...,
+				)...,
+			)...,
+		)...,
+	)
+	good := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		append(
+			buildEventStreamFrame(t, `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`),
+			buildEventStreamFrame(t, `{"type":"message_stop"}`)...,
+		)...,
+	)
+	calls := 0
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		body := bad
+		if calls >= 2 {
+			body = good
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	resp, err := s.claudeFableBedrockResponse(req.Context(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after retrying a shed during buffered thinking", resp.StatusCode)
+	}
+	sse, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(sse), "overloaded_error") || strings.Contains(string(sse), "hmm") {
+		t.Fatalf("failed attempt's thinking or error leaked: %q", sse)
+	}
+	if calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2", calls)
+	}
+}
+
+// Once the commit window has elapsed, a thinking delta commits the stream and
+// a later shed passes through instead of retrying.
+func TestClaudeFableBedrockCommitsThinkingAfterWindow(t *testing.T) {
+	saved := claudeFableBedrockCommitWindow
+	claudeFableBedrockCommitWindow = 0
+	defer func() { claudeFableBedrockCommitWindow = saved }()
+
+	stream := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		append(
+			buildEventStreamFrame(t, `{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`),
+			append(
+				buildEventStreamFrame(t, `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"deep"}}`),
+				buildEventStreamFrame(t, `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)...,
+			)...,
+		)...,
+	)
+	calls := 0
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(stream)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	resp, err := s.claudeFableBedrockResponse(req.Context(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want committed 200", resp.StatusCode)
+	}
+	sse, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(sse), "deep") || !strings.Contains(string(sse), "overloaded_error") {
+		t.Fatalf("committed stream must pass thinking and the error through: %q", sse)
+	}
+	if calls != 1 {
+		t.Fatalf("upstream calls = %d, want 1 (no retry after window commit)", calls)
+	}
+}


### PR DESCRIPTION
The #240 depth telemetry measured tonight's overload sheds at 310ms/7ev, 762ms/3ev, 1322ms/7ev, and 14209ms/19ev — three of four sub-1.4s, all during thinking, zero visible tokens. #244 moved the commit point to the first delta, but the first *thinking* delta arrives within ~100ms, so the sub-second majority still committed and surfaced as "Server error mid-response".

Make the commit point content-aware and time-bounded: thinking_delta/signature_delta frames stay buffered until `claudeFableBedrockCommitWindow` (2s) elapses; text_delta/input_json_delta, message_delta, and message_stop commit immediately. A shed inside the window is a silent server-side retry (the client received nothing). Cost: on thinking-heavy responses, visible thinking starts up to 2s later; answers reaching text quickly pay nothing. The window is a var so tests shrink it; the expiry test pins pass-through-after-commit behavior.

`go test ./...` exit 0 locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789711123&installation_model_id=21920&pr_number=245&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F245&signature=de451aab079b7cec4abf760862aa2e34d19a328bc8d47837208242056b488d4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Buffers early thinking/signature deltas for up to 2s before committing Bedrock streams so sub‑second overload sheds retry silently. Previously we committed on the first delta (often a thinking delta ~100ms in), which surfaced non‑replayable “Server error mid-response”.

- Introduces a 2s commit window (`claudeFableBedrockCommitWindow`) that buffers `thinking_delta` and `signature_delta`. Any visible delta (`text_delta`, `input_json_delta`), `message_delta`, or `message_stop` still commits immediately.
- Behavior: sheds within the window trigger a server-side retry (no client output yet). After the window, thinking commits and any later shed passes through.
- User impact: visible thinking may start up to 2s later on thinking-heavy responses; answers that reach text quickly are unaffected.
- Review notes: `bedrockFrameDecision` now takes elapsed time; the commit window is a var to let tests shrink it. New tests cover silent retry during early thinking and pass-through after the window.

<sup>Written for commit 86e5fbe9041d78100884c6c20492d4c3108230d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

