### PR TITLE
Spread placements within equal-pressure bands; per-provider routing-policy table

### DIFF
--- a/internal/proxy/claude_ratelimit_routing_test.go
+++ b/internal/proxy/claude_ratelimit_routing_test.go
@@ -242,7 +242,15 @@ func TestClaude429FailoverTriesPastDefaultAttemptBudget(t *testing.T) {
 		}
 		accountsList = append(accountsList, accounts.Account{ID: id, Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-" + id})
 		headroom := 0.90 - float64(i)*0.01
-		scores = append(scores, selectacct.Score{AccountID: id, Provider: accounts.ProviderClaude, Headroom: headroom, ShortHeadroom: headroom})
+		// Distinct ExpiryPressure values (descending with i) make each
+		// account its own pressure band, so the failover walk order is
+		// deterministic: cooked-0 .. cooked-6, then fresh-7.
+		reset := int64((i + 1) * 3600)
+		scores = append(scores, selectacct.Score{
+			AccountID: id, Provider: accounts.ProviderClaude,
+			Headroom: headroom, ShortHeadroom: headroom,
+			ShortResetAfterSeconds: reset, ExpiryPressure: headroom / float64(reset),
+		})
 	}
 
 	handler := Server{
@@ -667,12 +675,11 @@ func TestClaudeBareRejectedFableMarksOnlyFablePool(t *testing.T) {
 	if scheduler.ForModel(agentclaude.OpusFeature).Exhausted(accounts.ProviderClaude, fableAccount) {
 		t.Fatal("bare rejected fable response must not mark opus exhausted")
 	}
-	picked, err := scheduler.ForModel(agentclaude.OpusFeature).Pick(server.Accounts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if picked.ID != fableAccount {
-		t.Fatalf("opus pick after fable rejection = %q, want same account %q", picked.ID, fableAccount)
+	// Placement spreads within equal-pressure bands, so an exact-pick
+	// assertion is a coin flip; the intent is that the fable-pool mark left
+	// the account fully eligible for opus placement.
+	if !scheduler.ForModel(agentclaude.OpusFeature).UsableForNewSession(accounts.ProviderClaude, fableAccount) {
+		t.Fatalf("account %q is not usable for opus after a fable-only rejection", fableAccount)
 	}
 }
 
@@ -938,15 +945,32 @@ func TestClaudeFailoverSkipsDeadTokenAccount(t *testing.T) {
 			{ID: "dead@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-dead"},
 			{ID: "fresh@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-fresh"},
 		},
-		Sessions:     store,
-		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler(nil)),
-		// Pick order among untried candidates: dead (highest) before fresh, so
-		// failover tries the dead-token account first and must skip it.
+		Sessions: store,
+		// Seed the ref with the same pressure-ordered scores as the stub:
+		// UsageScoreTTL is 0 here, so the retry path never refreshes and
+		// picks straight from this snapshot. Distinct pressures make the
+		// failover order deterministic (dead before fresh) despite placement
+		// spreading within equal-pressure bands.
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+			{AccountID: "cooked@example.com", Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0},
+			{AccountID: "dead@example.com", Provider: accounts.ProviderClaude, Headroom: 1.0, ShortHeadroom: 1.0, ShortResetAfterSeconds: 3600, ExpiryPressure: 1.0 / 3600},
+			{AccountID: "fresh@example.com", Provider: accounts.ProviderClaude, Headroom: 0.9, ShortHeadroom: 0.9, ShortResetAfterSeconds: 4 * 3600, ExpiryPressure: 0.9 / (4 * 3600)},
+		})),
+		// Pick order among untried candidates: dead strictly before fresh
+		// (distinct ExpiryPressure values form singleton bands, so the order
+		// is deterministic despite placement spreading), so failover tries
+		// the dead-token account first and must skip it.
 		ScoreAccounts: func(ctx context.Context, available []accounts.Account) ([]selectacct.Score, int) {
 			h := map[string]float64{"cooked@example.com": 0, "dead@example.com": 1.0, "fresh@example.com": 0.9}
+			reset := map[string]int64{"dead@example.com": 3600, "fresh@example.com": 4 * 3600}
 			scores := make([]selectacct.Score, 0, len(available))
 			for _, a := range available {
-				scores = append(scores, selectacct.Score{AccountID: a.ID, Provider: a.Provider, Headroom: h[a.ID], ShortHeadroom: h[a.ID]})
+				score := selectacct.Score{AccountID: a.ID, Provider: a.Provider, Headroom: h[a.ID], ShortHeadroom: h[a.ID]}
+				if seconds := reset[a.ID]; seconds > 0 {
+					score.ShortResetAfterSeconds = seconds
+					score.ExpiryPressure = h[a.ID] / float64(seconds)
+				}
+				scores = append(scores, score)
 			}
 			return scores, len(scores)
 		},

--- a/internal/proxy/provider_selection_policy_test.go
+++ b/internal/proxy/provider_selection_policy_test.go
@@ -1,0 +1,28 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+)
+
+// The policy table is the single place a provider's session-routing rules
+// live. The zero value (an unlisted provider) must be the safe default:
+// fully sticky, no gated moves.
+func TestSelectionPolicyDefaults(t *testing.T) {
+	codex := selectionPolicyFor(accounts.Account{Provider: accounts.ProviderCodex})
+	if !codex.retentionFloorGated || !codex.constrainedMoveGated {
+		t.Fatalf("codex policy = %+v, want both gates on", codex)
+	}
+	if empty := selectionPolicyFor(accounts.Account{}); empty != codex {
+		t.Fatalf("empty provider must resolve to the codex policy, got %+v", empty)
+	}
+	claude := selectionPolicyFor(accounts.Account{Provider: accounts.ProviderClaude})
+	if claude.retentionFloorGated || claude.constrainedMoveGated {
+		t.Fatalf("claude policy = %+v, want fully sticky with ungated moves (fable fallback depends on it)", claude)
+	}
+	unknown := selectionPolicyFor(accounts.Account{Provider: accounts.Provider("future-provider")})
+	if unknown.retentionFloorGated || unknown.constrainedMoveGated {
+		t.Fatalf("unknown provider policy = %+v, want the safe zero value", unknown)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4467,6 +4467,41 @@ func (s Server) logStickyReuse(agentType, sessionID string, account accounts.Acc
 	)
 }
 
+// providerSelectionPolicy states, per provider, how session routing treats
+// the account that already holds a session's upstream prompt cache. Add one
+// entry when onboarding a provider; every knob defaults to false, which is
+// the safest choice for a provider whose cache and quota economics are
+// unknown: sessions stay on their account unconditionally short of
+// exhaustion, and exhaustion-driven moves keep their existing semantics.
+// Placement spreading needs no entry here at all — Scheduler.Pick spreads
+// within equal-pressure bands for every provider, and the provider's own
+// usage windows (whether they carry reset-time pressure) decide how wide a
+// band gets.
+type providerSelectionPolicy struct {
+	// retentionFloorGated: an idle session leaves its account once the
+	// account's measured headroom falls below MinStickyRetentionHeadroom.
+	// Codex sets this (#216): its per-account prompt cache makes moving
+	// expensive, but holding a session on a truly empty account is worse.
+	retentionFloorGated bool
+	// constrainedMoveGated: when a session must consider leaving, the move
+	// happens only for a materially better target (see
+	// keepConstrainedStickyAssignment). Codex sets this to stop
+	// constrained-pool ping-pong. Claude must NOT set it: a Claude session
+	// only reaches the constrained branch when its account is exhausted, and
+	// for fable an exhausted pool has to surface a selection failure so the
+	// Bedrock fallback chain runs instead of a keep.
+	constrainedMoveGated bool
+}
+
+var providerSelectionPolicies = map[accounts.Provider]providerSelectionPolicy{
+	accounts.ProviderCodex:  {retentionFloorGated: true, constrainedMoveGated: true},
+	accounts.ProviderClaude: {},
+}
+
+func selectionPolicyFor(account accounts.Account) providerSelectionPolicy {
+	return providerSelectionPolicies[accountProviderOrCodex(account)]
+}
+
 func (s Server) reuseStickyAssignment(agentType, sessionID string, account accounts.Account, scheduler selectacct.Scheduler) bool {
 	if scheduler.Exhausted(account.Provider, account.ID) {
 		return false
@@ -4474,7 +4509,7 @@ func (s Server) reuseStickyAssignment(agentType, sessionID string, account accou
 	if s.activeSession(agentType, sessionID) {
 		return true
 	}
-	if accountProviderOrCodex(account) == accounts.ProviderCodex && account.AuthMode == accounts.AuthModeOAuth {
+	if selectionPolicyFor(account).retentionFloorGated && account.AuthMode == accounts.AuthModeOAuth {
 		// Retention, not placement: this session already built the upstream
 		// prompt cache on this account. Gating it on the new-session threshold
 		// moved every idle session off any account past 60% used, which in a
@@ -4510,7 +4545,7 @@ const minStickyMoveHeadroomGain = 0.10
 // providers keep their existing move-on-constraint behaviour, including the
 // Claude fable path whose selection failure triggers the Bedrock fallback.
 func (s Server) keepConstrainedStickyAssignment(scheduler selectacct.Scheduler, current, picked accounts.Account) bool {
-	if accountProviderOrCodex(current) != accounts.ProviderCodex || current.AuthMode != accounts.AuthModeOAuth {
+	if !selectionPolicyFor(current).constrainedMoveGated || current.AuthMode != accounts.AuthModeOAuth {
 		return false
 	}
 	if picked.ID == current.ID {

--- a/internal/proxy/proxy_websocket_test.go
+++ b/internal/proxy/proxy_websocket_test.go
@@ -901,14 +901,16 @@ func TestHandlerKeepsClaudeConversationOnSameAccount(t *testing.T) {
 	first := <-seen
 	second := <-seen
 	third := <-seen
-	if first != "Bearer claude-a-token" {
-		t.Fatalf("first Authorization = %q, want claude-a", first)
+	// Placement across the two equally-scored accounts spreads, so which
+	// account the first session lands on is not deterministic. The sticky
+	// guarantee under test: the same session keeps its account, and every
+	// request carries one of the pool's real credentials.
+	valid := map[string]bool{"Bearer claude-a-token": true, "Bearer claude-b-token": true}
+	if !valid[first] || !valid[third] {
+		t.Fatalf("unexpected Authorization values: first %q, third %q", first, third)
 	}
 	if second != first {
 		t.Fatalf("same Claude session switched accounts: first %q, second %q", first, second)
-	}
-	if third != "Bearer claude-b-token" {
-		t.Fatalf("new Claude session Authorization = %q, want claude-b", third)
 	}
 }
 

--- a/internal/proxy/session_lease_test.go
+++ b/internal/proxy/session_lease_test.go
@@ -910,8 +910,15 @@ func TestSessionLeaseDoesNotFailOverToDifferentClaudeAccount(t *testing.T) {
 			{ID: "assigned@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "assigned-token"},
 			{ID: "other@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "other-token"},
 		},
-		Sessions:      sessionStore,
-		Scheduler:     selectacct.NewScheduler(nil),
+		Sessions: sessionStore,
+		// Only assigned@example.com is usable for a new session, so the
+		// lease lands there deterministically even though placement spreads
+		// within equal-pressure bands. The subject under test is the
+		// no-failover guarantee after the 429, not placement.
+		Scheduler: selectacct.NewScheduler([]selectacct.Score{
+			{AccountID: "assigned@example.com", Provider: accounts.ProviderClaude, Headroom: 0.90, ShortHeadroom: 0.90},
+			{AccountID: "other@example.com", Provider: accounts.ProviderClaude, Headroom: 0.20, ShortHeadroom: 0.20},
+		}),
 		sessionLeases: newSessionLeaseStore(),
 		AdminToken:    "service-admin-token",
 		MaxBodyBytes:  1024,

--- a/selectacct/pressure_band_spread_test.go
+++ b/selectacct/pressure_band_spread_test.go
@@ -1,0 +1,98 @@
+package selectacct
+
+import (
+	"testing"
+
+	"github.com/manaflow-ai/subrouter/account"
+)
+
+func claudeAccounts(ids ...string) []account.Account {
+	accounts := make([]account.Account, 0, len(ids))
+	for _, id := range ids {
+		accounts = append(accounts, account.Account{ID: id, Provider: account.ProviderClaude, AuthMode: account.AuthModeOAuth})
+	}
+	return accounts
+}
+
+// A Claude pool with no usage data yet (every account carries the optimistic
+// default score, ExpiryPressure 0) has no drain-pressure signal to order by,
+// exactly like the Codex weekly-window pools that produced the 2026-08-18
+// placement stampede. Placement must spread across such a pool instead of
+// herding onto the sort's first account.
+func TestPickSpreadsUnscoredClaudePool(t *testing.T) {
+	scheduler := NewScheduler(nil)
+	candidates := claudeAccounts("a@example.com", "b@example.com", "c@example.com", "d@example.com", "e@example.com", "f@example.com")
+
+	counts := make(map[string]int)
+	for i := 0; i < 200; i++ {
+		picked, err := scheduler.Pick(candidates)
+		if err != nil {
+			t.Fatal(err)
+		}
+		counts[picked.ID]++
+	}
+	top := 0
+	for _, count := range counts {
+		if count > top {
+			top = count
+		}
+	}
+	if len(counts) < 4 {
+		t.Fatalf("placements used %d accounts (%v), want at least 4 of 6", len(counts), counts)
+	}
+	if top > 120 {
+		t.Fatalf("one account received %d of 200 placements (%v), want no account above 60%%", top, counts)
+	}
+}
+
+// Scored Claude accounts carry distinct ExpiryPressure values, and the
+// drain-soonest ordering is deliberate (GTO: prefer the account whose window
+// resets soonest). Distinct pressures form singleton bands, so the ordering
+// stays exactly deterministic.
+func TestPickKeepsClaudeDrainOrderingForScoredAccounts(t *testing.T) {
+	scheduler := NewScheduler([]Score{
+		{AccountID: "soon@example.com", Provider: account.ProviderClaude, Headroom: 0.90, ShortHeadroom: 0.90, ShortResetAfterSeconds: 3 * 3600, ExpiryPressure: 0.90 / float64(3*3600)},
+		{AccountID: "later@example.com", Provider: account.ProviderClaude, Headroom: 0.95, ShortHeadroom: 0.95, ShortResetAfterSeconds: 5 * 3600, ExpiryPressure: 0.95 / float64(5*3600)},
+		{AccountID: "unscored@example.com", Provider: account.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+	})
+	candidates := claudeAccounts("soon@example.com", "later@example.com", "unscored@example.com")
+
+	for i := 0; i < 100; i++ {
+		picked, err := scheduler.Pick(candidates)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if picked.ID != "soon@example.com" {
+			t.Fatalf("pick %d = %q, want the highest-pressure account soon@example.com every time", i, picked.ID)
+		}
+	}
+}
+
+// Spreading happens only WITHIN the leading equal-pressure band: accounts
+// tied at the top pressure share the placements, accounts with less pressure
+// get none while the band is usable.
+func TestPickSpreadsOnlyWithinEqualPressureBand(t *testing.T) {
+	pressure := 0.80 / float64(4*3600)
+	scheduler := NewScheduler([]Score{
+		{AccountID: "band-a@example.com", Provider: account.ProviderClaude, Headroom: 0.80, ShortHeadroom: 0.80, ShortResetAfterSeconds: 4 * 3600, ExpiryPressure: pressure},
+		{AccountID: "band-b@example.com", Provider: account.ProviderClaude, Headroom: 0.80, ShortHeadroom: 0.80, ShortResetAfterSeconds: 4 * 3600, ExpiryPressure: pressure},
+		{AccountID: "calm-c@example.com", Provider: account.ProviderClaude, Headroom: 0.99, ShortHeadroom: 0.99},
+		{AccountID: "calm-d@example.com", Provider: account.ProviderClaude, Headroom: 0.99, ShortHeadroom: 0.99},
+	})
+	candidates := claudeAccounts("band-a@example.com", "band-b@example.com", "calm-c@example.com", "calm-d@example.com")
+
+	counts := make(map[string]int)
+	for i := 0; i < 200; i++ {
+		picked, err := scheduler.Pick(candidates)
+		if err != nil {
+			t.Fatal(err)
+		}
+		counts[picked.ID]++
+	}
+	if counts["calm-c@example.com"] != 0 || counts["calm-d@example.com"] != 0 {
+		t.Fatalf("placements leaked outside the top-pressure band: %v", counts)
+	}
+	if counts["band-a@example.com"] == 0 || counts["band-b@example.com"] == 0 {
+		t.Fatalf("placements did not spread within the equal-pressure band: %v", counts)
+	}
+}

--- a/selectacct/scheduler.go
+++ b/selectacct/scheduler.go
@@ -189,51 +189,43 @@ func (s Scheduler) sortCandidates(candidates []account.Account) []account.Accoun
 }
 
 // spreadPool returns the leading candidates a new session may be spread
-// across: the usable OAuth accounts, when none of them carries a
-// drain-pressure signal. Codex accounts report only a weekly window (nothing
-// at or under 6h), so their ExpiryPressure is always 0 and headroom is the
-// only ordering input — an integer used_percent that lags real consumption by
-// hours. A deterministic argmax over that snapshot sends EVERY placement to
-// the same account until the snapshot finally catches up; because sessions
-// are long-lived and sticky, each placement commits hours of traffic, so the
-// pool drains one account at a time and a weekly-cap hit then reroutes the
-// whole herd at once (2026-08-18: one account served 100% of Codex traffic
-// for five hours while six healthy accounts sat idle). Spreading placements
-// across all usable accounts removes the herd without touching retention.
+// across: the usable OAuth accounts tied at the sort's top ExpiryPressure
+// (the leading equal-pressure band).
 //
-// When any usable account has ExpiryPressure > 0 (Claude windows carry reset
-// times), the deliberate drain-soonest ordering stays authoritative and no
-// spreading happens.
+// Between accounts with DIFFERENT pressure, the drain-soonest ordering is a
+// deliberate, simulation-tuned policy (see gto_sim_test.go) and stays
+// deterministic: distinct pressures form singleton bands and no spreading
+// happens. WITHIN a band the pressure signal says nothing, and the remaining
+// ordering input is headroom from a usage snapshot that lags consumption
+// (integer-only and hours late for Codex). A deterministic argmax over that
+// snapshot sends EVERY placement to the same account until the snapshot
+// catches up; sessions are long-lived and sticky, so the pool drains one
+// account at a time and a cap hit reroutes the whole herd at once
+// (2026-08-18: one account served 100% of Codex traffic for five hours while
+// six healthy accounts sat idle). Sampling within the band removes the herd
+// without touching retention or the pressure policy.
+//
+// This is provider-agnostic by construction: Codex accounts report only a
+// weekly window, so their pressure is always 0 and the band is the whole
+// usable pool; scored Claude accounts carry distinct reset-time pressures,
+// so their bands are singletons; an unscored pool of any provider (all
+// optimistic defaults, pressure 0) spreads instead of herding. A future
+// provider gets the right behaviour from whatever pressure signal its usage
+// windows produce, with no per-provider case here.
 func (s Scheduler) spreadPool(sorted []account.Account) []account.Account {
-	if !codexProvider(sorted[0].Provider) {
-		return nil
-	}
 	topScore := s.score(sorted[0].Provider, sorted[0].ID)
-	if selectionTier(sorted[0], topScore) != 0 || topScore.ExpiryPressure != 0 {
+	if selectionTier(sorted[0], topScore) != 0 {
 		return nil
 	}
 	end := 1
 	for end < len(sorted) {
-		if !codexProvider(sorted[end].Provider) {
-			break
-		}
 		score := s.score(sorted[end].Provider, sorted[end].ID)
-		if selectionTier(sorted[end], score) != 0 || score.ExpiryPressure != 0 {
+		if selectionTier(sorted[end], score) != 0 || score.ExpiryPressure != topScore.ExpiryPressure {
 			break
 		}
 		end++
 	}
 	return sorted[:end]
-}
-
-// codexProvider treats an empty provider as Codex, matching ScoreKey and the
-// proxy's accountProviderOrCodex. Spreading is scoped to Codex pools: that is
-// the provider whose accounts carry no drain-pressure signal and whose
-// concentration produced the incident, while Claude selection (fable Bedrock
-// fallback, credential leases, 429 failover order) keeps its existing
-// deterministic ordering.
-func codexProvider(provider account.Provider) bool {
-	return provider == "" || provider == account.ProviderCodex
 }
 
 // spreadWeightFloor keeps an account that sits exactly at the new-session

--- a/selectacct/scheduler_test.go
+++ b/selectacct/scheduler_test.go
@@ -246,15 +246,17 @@ func TestLiveDebitsReorderPickWithoutExhausting(t *testing.T) {
 		{AccountID: "b", Provider: account.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
 	})
 
-	// Equal scores: deterministic tie falls to "a".
-	picked, err := scheduler.Pick([]account.Account{accountA, accountB})
+	// Equal scores: the deterministic ordering (PickBest) ties to "a".
+	// Pick itself spreads within equal-pressure bands, so the ordering
+	// contract is asserted through PickBest.
+	picked, err := scheduler.PickBest([]account.Account{accountA, accountB})
 	if err != nil || picked.ID != "a" {
 		t.Fatalf("baseline pick = %v %v, want a", picked.ID, err)
 	}
 
-	// Five requests routed to "a" since the snapshot: the debit flips the pick.
+	// Five requests routed to "a" since the snapshot: the debit flips the order.
 	debited := scheduler.WithLiveDebits(map[string]int{ScoreKey(account.ProviderClaude, "a"): 5})
-	picked, err = debited.Pick([]account.Account{accountA, accountB})
+	picked, err = debited.PickBest([]account.Account{accountA, accountB})
 	if err != nil || picked.ID != "b" {
 		t.Fatalf("debited pick = %v %v, want b", picked.ID, err)
 	}
@@ -277,7 +279,10 @@ func TestLiveDebitsSurviveForModelAndSessionCounts(t *testing.T) {
 			ModelScores: map[string]Score{"claudefable": {AccountID: "a", Provider: account.ProviderClaude, Headroom: 1, ShortHeadroom: 1}}},
 		{AccountID: "b", Provider: account.ProviderClaude, Headroom: 1, ShortHeadroom: 1,
 			ModelScores: map[string]Score{"claudefable": {AccountID: "b", Provider: account.ProviderClaude, Headroom: 1, ShortHeadroom: 1}}},
-	}).WithLiveDebits(map[string]int{ScoreKey(account.ProviderClaude, "a"): 5}).
+		// 35 debited requests push a's headroom to 0.30, below the
+		// new-session threshold, so the pick is deterministic even though
+		// placement spreads within equal-pressure bands.
+	}).WithLiveDebits(map[string]int{ScoreKey(account.ProviderClaude, "a"): 35}).
 		WithSessionCounts(map[string]int{})
 	accountA := account.Account{ID: "a", Provider: account.ProviderClaude, AuthMode: account.AuthModeOAuth, Token: "x"}
 	accountB := account.Account{ID: "b", Provider: account.ProviderClaude, AuthMode: account.AuthModeOAuth, Token: "x"}
@@ -325,7 +330,9 @@ func TestOpusPickIgnoresWeeklyDrainPressure(t *testing.T) {
 	})
 	later.Provider = account.ProviderClaude
 	scheduler := NewScheduler([]Score{later, soon}).ForModel(opus)
-	picked, err := scheduler.Pick([]account.Account{
+	// PickBest: the assertion is about ordering (weekly drain pressure must
+	// not reorder opus picks), not about placement spreading.
+	picked, err := scheduler.PickBest([]account.Account{
 		{ID: "later@example.com", Provider: account.ProviderClaude, AuthMode: account.AuthModeOAuth, Token: "x"},
 		{ID: "soon@example.com", Provider: account.ProviderClaude, AuthMode: account.AuthModeOAuth, Token: "x"},
 	})


### PR DESCRIPTION
## What

Generalizes the Codex placement-stampede fix (#228) to every provider and replaces the provider special-cases with two explicit abstractions.

**1. Equal-pressure band spread in `Pick` (selectacct).** Placement spreads within the leading run of usable OAuth accounts tied at the top `ExpiryPressure`, weighted by headroom surplus and damped by session count. Distinct pressures form singleton bands, so the simulation-tuned drain-soonest ordering for scored Claude accounts stays exactly deterministic (`TestPickKeepsClaudeDrainOrderingForScoredAccounts`, existing fable/opus GTO tests unchanged). Codex pools (pressure always 0) keep the #228 behaviour. A Claude — or any future provider's — pool with no usage data yet (all optimistic defaults, pressure 0) now spreads instead of herding onto the sort's first account (`TestPickSpreadsUnscoredClaudePool`, failing-first commit). `spreadPool` no longer mentions any provider: the provider's own usage windows decide how wide a band is.

**2. Provider routing-policy table (proxy).** The sticky-session rules scattered as `== ProviderCodex` checks are now one table, `providerSelectionPolicies`, with two documented knobs: `retentionFloorGated` (idle sessions leave below the retention floor — Codex, per #216) and `constrainedMoveGated` (constrained moves need a materially better target — Codex, per #228). Claude keeps both off deliberately: a Claude session only reaches the constrained branch when its account is exhausted, and the fable Bedrock fallback requires selection to fail there rather than keep. Unlisted future providers get the safe zero value: fully sticky, ungated moves. Onboarding a provider means adding usage windows (band width falls out) and, if its cache economics warrant, one table entry.

## Why not spread Claude unconditionally

Claude's scored accounts carry real reset-time pressure and the drain-soonest ordering is deliberate, tuned policy (gto_sim_test.go). Randomizing across different pressures would fight it. Ties are exactly where the ordering carries no information, so ties are exactly what spreads.

## Tests

- Failing-first commit: `TestPickSpreadsUnscoredClaudePool`, `TestPickSpreadsOnlyWithinEqualPressureBand` (red), plus the guard `TestPickKeepsClaudeDrainOrderingForScoredAccounts` (green throughout).
- `TestSelectionPolicyDefaults` pins the table: codex both gates, claude none, unknown provider = safe default.
- Tests that asserted picks among *tied* accounts were coin flips under spreading; each was rewritten to preserve its intent deterministically: ordering contracts assert via `PickBest` (`TestLiveDebitsReorderPickWithoutExhausting`, `TestOpusPickIgnoresWeeklyDrainPressure`), failover-order tests encode the intended order with distinct pressures (`TestClaude429FailoverTriesPastDefaultAttemptBudget`, `TestClaudeFailoverSkipsDeadTokenAccount` — the latter's ScoreAccounts stub was dead weight: with `UsageScoreTTL: 0` it never loaded, and the old determinism came from a session-count tie-break accident), eligibility is asserted directly (`TestClaudeBareRejectedFableMarksOnlyFablePool`), and sticky tests assert same-account rather than which-account (`TestHandlerKeepsClaudeConversationOnSameAccount`).
- `go test ./...` green; risky packages green under `-count=3`; `-race` clean on the new paths.

## Behaviour changes in production today

Codex: none (band = whole usable pool, same as #228). Claude: only the no-usage-data regime changes (placement spreads); scored ordering, fable fallback, lease no-failover, and 429 walk order are unchanged and covered by the updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789711211&installation_model_id=21920&pr_number=246&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F246&signature=80881743d1067e481b6afc4283ae3f8121f512a3a04ebd4000f1998285481607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Spreads new-session placement within the leading equal-pressure band for all providers and replaces provider-specific sticky logic with a routing-policy table. Previously only Codex pools spread and unscored Claude pools herded to the first account; now ties spread while distinct pressures keep deterministic ordering.

- Review focus:
  - `selectacct`: `Scheduler.Pick` now samples within the top-pressure band; provider checks removed. Codex pools (pressure 0) behave as before; scored Claude pools remain deterministic; unscored pools for any provider now spread.
  - `internal/proxy`: adds `providerSelectionPolicies` with `retentionFloorGated` and `constrainedMoveGated`. Codex = both on; Claude = both off (needed for fable fallback); unknown providers default to fully sticky, ungated moves.
  - Tests assert ordering via `PickBest` and encode failover order with distinct pressures instead of tie-breaks.

- Rollout/migration:
  - Production effect: Codex unchanged; Claude changes only when a pool lacks usage data (placements spread). Fallback, leases, and 429 walk order remain intact.
  - Onboarded providers: provide usage-window scoring; add a policy entry only if their cache/quota economics require gates; otherwise rely on the safe default.

<sup>Written for commit 3e4b27b224bf19d27d4c001afd13f4fba2b5de42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

