### PR TITLE
Widen the Fable commit window to 6s; make death telemetry stream-relative

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -201,7 +201,7 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 			body := resp.Body
 			peeked := peek.peeked
 			go func() {
-				result := transcodeBedrockToSSE(pw, io.MultiReader(bytes.NewReader(peeked), body), s.Logger, streamSource, streamRegion)
+				result := transcodeBedrockToSSESince(pw, io.MultiReader(bytes.NewReader(peeked), body), s.Logger, streamSource, streamRegion, streamStarted)
 				_ = body.Close()
 				_ = pw.Close()
 				s.recordClaudeFableBedrockCost(streamStarted, streamRegion, http.StatusOK, result.Usage, result.HaveUsage)
@@ -572,13 +572,16 @@ type bedrockStreamPeek struct {
 // to extend past them.
 // claudeFableBedrockCommitWindow bounds how long the peek keeps buffering
 // early thinking deltas before committing anyway. Production depth telemetry
-// (2026-08-18) put three of four overload sheds at 310-1322ms into the stream,
-// all during thinking with zero visible tokens; a two-second window converts
-// those into silent retries. The cost is visible thinking starting up to this
-// much later. Any visible delta (text or tool input) commits immediately, so
+// (2026-08-18) put most overload sheds within the first seconds of the stream,
+// all during thinking with zero visible tokens. Fable adaptive thinking often
+// delivers its FIRST thinking_delta only after seconds of server-side thought,
+// so a short window expires before that delta arrives and commits on it (seen
+// live: committed on a late first delta, shed 743ms later). Six seconds covers
+// first-delta latency plus the early shed period. The cost is visible thinking
+// starting up to this much later on thinking-heavy responses. Any visible delta (text or tool input) commits immediately, so
 // answers without long thinking pay nothing. A var, not a const, so tests can
 // shrink it.
-var claudeFableBedrockCommitWindow = 2 * time.Second
+var claudeFableBedrockCommitWindow = 6 * time.Second
 
 // bedrockFrameDecision reports whether a frame decides the stream's fate at
 // the given elapsed time since the stream opened. Errors and exceptions are
@@ -715,10 +718,16 @@ func bedrockRetryBackoff(ctx context.Context, attempt int) bool {
 // http.ResponseWriter (flushed per event) or a plain writer like an io.Pipe
 // (each Write hands the event to the reader directly).
 func transcodeBedrockToSSE(w io.Writer, src io.Reader, logger *slog.Logger, bedrockSource, region string) bedrockStreamResult {
+	return transcodeBedrockToSSESince(w, src, logger, bedrockSource, region, time.Now())
+}
+
+// transcodeBedrockToSSESince is transcodeBedrockToSSE with an explicit stream
+// start time, so elapsed_ms in the death logs is stream-relative (including
+// time spent in the pre-commit peek) rather than transcode-relative.
+func transcodeBedrockToSSESince(w io.Writer, src io.Reader, logger *slog.Logger, bedrockSource, region string, started time.Time) bedrockStreamResult {
 	flusher, _ := w.(http.Flusher)
 	var scanner bedrockFrameScanner
 	var result bedrockStreamResult
-	started := time.Now()
 	eventsForwarded := 0
 	sawTextBlock := false
 	exceptionHandled := false


### PR DESCRIPTION
Live counterexample to #245's 2s window within minutes of deploying it: `in-band error ... events_forwarded=3 saw_text_block=false elapsed_ms=743`. Fable adaptive thinking often delivers its FIRST `thinking_delta` only after seconds of server-side thought, so the 2s window had already expired when that delta arrived; it committed and the shed 743ms later surfaced to the client. Six seconds covers observed first-delta latency plus the early shed period.

Second fix in the same vein: `elapsed_ms` in the death logs was transcode-relative, which is what hid this (the peek time vanished). `transcodeBedrockToSSESince` takes the stream start so depth telemetry is stream-relative.

`go test ./...` exit 0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789711608&installation_model_id=21920&pr_number=247&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F247&signature=b7d472f12f4cd6f8293783191e175d444e8c32139cebd1bc8e896ef514af684b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the Fable Bedrock commit window from 2s to 6s and makes death-log elapsed_ms stream-relative to include peek time. This avoids committing on a late first thinking_delta and makes early sheds visible in telemetry.

- Old behavior: 2s commit window; New: 6s. Side effect: visible thinking may start up to 6s later on thinking-heavy responses; answers with early visible tokens unchanged (commit still happens immediately on text/tool-input deltas).
- Telemetry: pass stream start into `transcodeBedrockToSSESince(...)`; `transcodeBedrockToSSE` now delegates with `time.Now()`. Death-log `elapsed_ms` now includes pre-commit peek time.
- Tests: `go test ./...` passes.

<sup>Written for commit 259b658bcb03925a98816305b75619ea9a5618e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

