### PR TITLE
Strip a sealed blob from any item, not only reasoning items

### DIFF
--- a/internal/proxy/azure_codex.go
+++ b/internal/proxy/azure_codex.go
@@ -1129,11 +1129,12 @@ func azureCodexEncryptedContentRejected(body []byte) bool {
 	return strings.Contains(strings.ToLower(payload.Error.Message), "encrypted content")
 }
 
-// azureCodexStripEncryptedReasoning removes sealed reasoning from the request.
-// The turn loses the model's own earlier reasoning trace, which costs some
-// continuity, and keeps the user's messages and tool results, which is what the
-// answer actually depends on. Returns false when there was nothing to strip, so
-// the caller does not retry an identical request.
+// azureCodexStripEncryptedReasoning removes every sealed blob from the request,
+// whatever item carries it. The turn loses the model's own earlier reasoning
+// and any compacted history, which costs some continuity, and keeps the user's
+// messages and tool results, which is what the answer actually depends on.
+// Returns false when there was nothing to strip, so the caller does not retry
+// an identical request.
 func azureCodexStripEncryptedReasoning(payload map[string]json.RawMessage) bool {
 	raw, ok := payload["input"]
 	if !ok {
@@ -1151,19 +1152,19 @@ func azureCodexStripEncryptedReasoning(payload map[string]json.RawMessage) bool 
 			kept = append(kept, item)
 			continue
 		}
-		if azureCodexStringField(fields, "type") != "reasoning" {
-			kept = append(kept, item)
-			continue
-		}
+		// Any item type may carry a sealed blob, not only reasoning: Codex also
+		// replays compaction items ("cmp_..."), and a provider that cannot read
+		// one cannot read the other. Keying this on the item type left those
+		// behind and the retry resent an identical body.
 		if _, sealed := fields["encrypted_content"]; !sealed {
 			kept = append(kept, item)
 			continue
 		}
 		changed = true
-		// A reasoning item whose only payload was the sealed blob has nothing
-		// left to send; keeping an empty shell invites a different rejection.
+		// An item whose only payload was the sealed blob has nothing left to
+		// send; keeping an empty shell invites a different rejection.
 		delete(fields, "encrypted_content")
-		if azureCodexReasoningItemIsEmpty(fields) {
+		if azureCodexSealedItemIsEmpty(fields) {
 			continue
 		}
 		rebuilt, err := json.Marshal(fields)
@@ -1196,10 +1197,10 @@ func azureCodexSplitIndex(name string) (string, int, bool) {
 	return name[:open], index, true
 }
 
-// azureCodexReasoningItemIsEmpty reports whether a reasoning item carries no
-// visible content once its sealed blob is gone.
-func azureCodexReasoningItemIsEmpty(fields map[string]json.RawMessage) bool {
-	for _, field := range []string{"summary", "content"} {
+// azureCodexSealedItemIsEmpty reports whether an item carries no visible
+// content once its sealed blob is gone.
+func azureCodexSealedItemIsEmpty(fields map[string]json.RawMessage) bool {
+	for _, field := range []string{"summary", "content", "text", "output"} {
 		raw, ok := fields[field]
 		if !ok {
 			continue

--- a/internal/proxy/azure_codex_test.go
+++ b/internal/proxy/azure_codex_test.go
@@ -1403,3 +1403,38 @@ func TestAzureCodexStreamClientFailurePassesThrough(t *testing.T) {
 		t.Fatalf("azure calls = %d, want 0 for a client-caused failure", azureCalls.Load())
 	}
 }
+
+// Codex replays compaction items as well as reasoning items, and both carry a
+// blob sealed by the provider that made them. Keying the strip on the item type
+// left compaction items behind, so the retry resent an identical body and the
+// turn failed.
+func TestAzureCodexStripsSealedContentFromAnyItemType(t *testing.T) {
+	payload := map[string]json.RawMessage{
+		"input": json.RawMessage(`[` +
+			`{"type":"message","role":"user","content":[{"type":"input_text","text":"go on"}]},` +
+			`{"type":"compaction","id":"cmp_1","encrypted_content":"sealed"},` +
+			`{"type":"reasoning","id":"rs_1","encrypted_content":"sealed","summary":[{"type":"summary_text","text":"kept"}]}` +
+			`]`),
+	}
+	if !azureCodexStripEncryptedReasoning(payload) {
+		t.Fatal("nothing was stripped")
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(payload["input"], &items); err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want the empty compaction item dropped and the rest kept: %v", len(items), items)
+	}
+	for _, item := range items {
+		if _, sealed := item["encrypted_content"]; sealed {
+			t.Fatalf("a sealed blob survived: %v", item)
+		}
+	}
+	if items[0]["role"] != "user" {
+		t.Fatalf("the user turn was disturbed: %v", items[0])
+	}
+	if items[1]["type"] != "reasoning" {
+		t.Fatalf("the readable reasoning summary was dropped: %v", items[1])
+	}
+}


### PR DESCRIPTION
The live server failed a turn on `The encrypted content for item cmp_... could not be verified`. Codex replays compaction items as well as reasoning items, and both carry a blob sealed by the provider that produced them. The strip keyed on `type == "reasoning"`, so compaction items stayed in the body, the retry resent an identical request, and the turn failed on the route whose whole job is to survive that.

Every item carrying a sealed blob now loses it, and an item left with nothing visible is dropped rather than sent as an empty shell. The emptiness check also looks at `text` and `output`, not only `summary` and `content`.

Test replays a body with a user turn, a compaction item whose only payload is sealed, and a reasoning item with a readable summary: the sealed blobs go, the empty compaction item is dropped, and the user turn and the summary survive.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789729070&installation_model_id=21920&pr_number=249&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F249&signature=7be93bc63476ceb74ab39aae03c981ed9ea109ac8e1cbf0b45ea4e71d68ac3e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips provider-sealed blobs from all Codex input items to prevent Azure retries from failing with “encrypted content” errors. Old behavior: only `type: "reasoning"` items were cleaned; new behavior: any item with `encrypted_content` is cleaned, and items with no visible payload are dropped.

- Emptiness detection now checks `summary`, `content`, `text`, and `output`.
- This may remove compacted history and prior reasoning, reducing continuity slightly; user messages and tool results remain intact.
- Adds a test that preserves the user turn and readable reasoning summary while dropping an empty compaction item.

<sup>Written for commit d917a0632919038fea9fc32704a8cfd85d906a1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Azure fallback handling for encrypted input content across all supported item types.
  - Removes empty items after encrypted content is stripped while preserving readable messages, summaries, text, and outputs.
  - Prevents loss of valid reasoning summaries and user messages during fallback processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->