### PR TITLE
Resend an Azure request whose connection died

### DIFF
--- a/internal/proxy/azure_codex.go
+++ b/internal/proxy/azure_codex.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -627,7 +628,7 @@ func (s Server) azureCodexEndpointResponse(
 		outReq.Host = target.Host
 		outReq.ContentLength = int64(len(encoded))
 
-		response, err := transport.RoundTrip(outReq)
+		response, err := s.azureCodexRoundTrip(req.Context(), transport, outReq, encoded, endpoint.Name)
 		if err != nil || response.StatusCode != http.StatusBadRequest || attempt >= azureCodexUnknownParamRetries {
 			return response, err
 		}
@@ -668,6 +669,56 @@ func (s Server) azureCodexEndpointResponse(
 // with: every later turn of a mixed-provider conversation carries the same
 // unreadable blobs, and rediscovering that per turn costs a full upload.
 const azureCodexSealedReasoningMemoryField = "reasoning.encrypted_content()"
+
+// azureCodexTransportRetries bounds how many times one Azure request is resent
+// after the connection dies. A reset mid-handshake is ordinary on a long-lived
+// TLS path, and by this point the pool has already refused the request, so
+// giving up on the first reset turns a recoverable blip into a failed turn.
+const azureCodexTransportRetries = 2
+
+// azureCodexTransportRetryDelay is the pause between those attempts. Short: the
+// client is waiting, and the retry budget upstream is already spent.
+const azureCodexTransportRetryDelay = 250 * time.Millisecond
+
+// azureCodexRoundTrip sends one attempt, resending it when the connection
+// fails. The body is already buffered, so a resend costs nothing but the
+// round trip. A request the server answered, with any status, is returned as
+// is: only a dead connection is retried here.
+func (s Server) azureCodexRoundTrip(
+	ctx context.Context,
+	transport http.RoundTripper,
+	req *http.Request,
+	body []byte,
+	endpointName string,
+) (*http.Response, error) {
+	var lastErr error
+	for attempt := 0; attempt <= azureCodexTransportRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(azureCodexTransportRetryDelay):
+			}
+			retryReq := req.Clone(ctx)
+			retryReq.Body = io.NopCloser(bytes.NewReader(body))
+			retryReq.ContentLength = int64(len(body))
+			req = retryReq
+		}
+		response, err := transport.RoundTrip(req)
+		if err == nil {
+			return response, nil
+		}
+		if ctx.Err() != nil {
+			return nil, err
+		}
+		lastErr = err
+		if s.Logger != nil {
+			s.Logger.Warn("azure codex connection failed; resending",
+				"endpoint", endpointName, "attempt", attempt+1, "error", err)
+		}
+	}
+	return nil, lastErr
+}
 
 // azureCodexUnknownParamRetries bounds how many unknown fields are stripped
 // before the rejection is returned as-is. Small: a body that needs more than a

--- a/internal/proxy/azure_codex_test.go
+++ b/internal/proxy/azure_codex_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1436,5 +1437,59 @@ func TestAzureCodexStripsSealedContentFromAnyItemType(t *testing.T) {
 	}
 	if items[1]["type"] != "reasoning" {
 		t.Fatalf("the readable reasoning summary was dropped: %v", items[1])
+	}
+}
+
+// A reset connection to Azure used to lose the fallback outright, and by then
+// the pool had already refused the request, so the client saw the failure.
+func TestAzureCodexResendsAfterAConnectionReset(t *testing.T) {
+	var attempts atomic.Int32
+	var received atomic.Value
+	_, azureURL := azureCodexTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		received.Store(string(body))
+		if attempts.Add(1) == 1 {
+			// Drop the connection the way a reset does, before any response.
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				t.Error("test server does not support hijacking")
+				return
+			}
+			conn, _, err := hijacker.Hijack()
+			if err != nil {
+				t.Errorf("hijack: %v", err)
+				return
+			}
+			if tcp, ok := conn.(*net.TCPConn); ok {
+				_ = tcp.SetLinger(0)
+			}
+			_ = conn.Close()
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_azure"}`)
+	})
+	poolURL, err := url.Parse("https://chatgpt.com/backend-api/codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy := httptest.NewServer(azureCodexFallbackServer(t, azureURL, poolURL, 0).Handler())
+	defer proxy.Close()
+
+	response, err := http.Post(proxy.URL+"/responses", "application/json",
+		strings.NewReader(`{"model":"gpt-5.6-codex","session_id":"reset-1","input":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), "resp_azure") {
+		t.Fatalf("status = %d, body = %s, want the resend to succeed", response.StatusCode, body)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("azure attempts = %d, want the request resent once", attempts.Load())
+	}
+	if sent, _ := received.Load().(string); !strings.Contains(sent, "codex-deployment") {
+		t.Fatalf("resent body = %q, want the rewritten request", sent)
 	}
 }


### PR DESCRIPTION
The live server logged `connection reset by peer` against Azure and lost the fallback for that turn. A reset mid-handshake is ordinary on a long-lived TLS path, and by that point the pool had already refused the request, so one blip became a failed turn for the client.

The request is resent up to twice, 250ms apart. The body is already buffered, so a resend costs only the round trip. A request the server answered is returned untouched whatever its status: only a dead connection is retried here, and a cancelled client context stops it immediately.

Test hijacks and drops the first connection the way a reset does, then asserts the turn was served by the resend and that the resent body was the rewritten one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789771614&installation_model_id=21920&pr_number=255&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F255&signature=9bff0c93fb721e375828f86fb8b4288117a9e25adae4c3d73480191738042c33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries Azure Codex requests when the connection dies so a transient reset no longer fails the client’s turn. Previously a mid-handshake reset resulted in a failed turn; now we resend up to twice, 250 ms apart, using the buffered body and honoring context cancellation.

- Introduces `azureCodexRoundTrip(ctx, transport, req, body, endpointName)` and uses it in `azureCodexEndpointResponse` to retry only on transport errors; any HTTP response is returned as-is.
- Rebuilds the request on resend (body + `ContentLength`), adds a warn log with endpoint and attempt, and stops immediately on context cancel.
- Adds `TestAzureCodexResendsAfterAConnectionReset` that hijacks and drops the first connection, then asserts the resend succeeds and the rewritten body is sent.
- No config, API, or migration changes.

<sup>Written for commit 2c1f807eecf3717071d0f7ab6e57c0f8226b89bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for Azure requests by retrying transient connection failures automatically.
  * Preserved request details when retrying, including Azure deployment routing.
  * Stopped retrying promptly when requests are canceled.
  * Server responses are returned without unnecessary retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->