### PR TITLE
Stop recording the model-catalog session

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ subrouter serve --transcripts ~/.subrouter/transcripts
 
 Transcripts are JSONL files keyed by agent type and session id under `by-agent/<agent-type>/by-session/<agent-session-id>.jsonl`. They include Subrouter metadata, redacted headers, HTTP/SSE body chunks, HTTP/SSE body summaries, and WebSocket message payloads as base64 with byte counts and SHA-256 hashes. Each event includes `agent_type` and `agent_session_id`; Codex events also include `codex_session_id` for matching `~/.codex/sessions` JSONL files. This is intentionally storage-heavy and can contain sensitive request/response payloads. Authorization-style headers are redacted, but bodies are stored in full.
 
+The synthetic model-catalog session is never recorded. Every Codex client polls `/models` continuously, all of it lands under one session id, and each poll would write the request metadata plus the whole catalog body: on the team server that single file reached 30 GB in two days, dwarfed every real transcript, saturated the upload, and filled the disk. Its responses are still inspected for quota signals; they are just not written down.
+
 When transcript recording is enabled, `/_subrouter/dashboard` serves an internal HTML dashboard over the same Subrouter listener. It shows token usage over time, usage by user email, usage by selected account, session assignments, transcript summaries, and links to sanitized transcript event JSON under `/_subrouter/transcripts/<agent-type>/<session-id>`. Raw internal trajectory JSON with decoded body text is available under `/_subrouter/transcripts/<agent-type>/<session-id>/raw`.
 
 To mirror transcripts to GCS without blocking proxy requests, also pass a `gs://` destination:

--- a/internal/proxy/azure_codex_test.go
+++ b/internal/proxy/azure_codex_test.go
@@ -1493,3 +1493,18 @@ func TestAzureCodexResendsAfterAConnectionReset(t *testing.T) {
 		t.Fatalf("resent body = %q, want the rewritten request", sent)
 	}
 }
+
+// Every Codex client polls /models continuously, and all of it lands under one
+// synthetic session id. Recording it produced a single 30 GB transcript on the
+// team server that dwarfed every real conversation, saturated the upload, and
+// filled the disk.
+func TestModelCatalogTrafficIsNotRecorded(t *testing.T) {
+	if transcriptWorthRecording(codexModelCatalogSessionID) {
+		t.Fatal("the synthetic catalog session is still recorded")
+	}
+	for _, session := range []string{"01a01631-d346-72f2-bad8-c41e46d4e136", "", "internal-looking-but-real"} {
+		if !transcriptWorthRecording(session) {
+			t.Fatalf("a real session %q was excluded from transcripts", session)
+		}
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3825,8 +3825,21 @@ func websocketMessageType(messageType int) string {
 	}
 }
 
+// transcriptWorthRecording reports whether a session's traffic belongs in a
+// transcript.
+//
+// The synthetic catalog session is not a conversation: every Codex client polls
+// /models continuously, all of it lands under one session id, and each poll
+// records the request meta plus the whole catalog body. On the team server that
+// single file reached 30 GB in two days, dwarfed every real transcript,
+// saturated the upload, and filled the disk. Nothing about it is useful for
+// debugging an agent.
+func transcriptWorthRecording(sessionID string) bool {
+	return sessionID != codexModelCatalogSessionID
+}
+
 func (s Server) recordHTTPMeta(r *http.Request, agentType, sessionID, userEmail string, account accounts.Account, upstream *url.URL) {
-	if s.Transcripts == nil {
+	if s.Transcripts == nil || !transcriptWorthRecording(sessionID) {
 		return
 	}
 	s.Transcripts.RecordMeta(agentType, sessionID, map[string]any{
@@ -3841,7 +3854,7 @@ func (s Server) recordHTTPMeta(r *http.Request, agentType, sessionID, userEmail 
 }
 
 func (s Server) recordWebSocketMeta(r *http.Request, upstreamURL *url.URL, headers http.Header, agentType, sessionID, userEmail string, account accounts.Account, upstream *url.URL) {
-	if s.Transcripts == nil {
+	if s.Transcripts == nil || !transcriptWorthRecording(sessionID) {
 		return
 	}
 	s.Transcripts.RecordMeta(agentType, sessionID, map[string]any{
@@ -3857,7 +3870,7 @@ func (s Server) recordWebSocketMeta(r *http.Request, upstreamURL *url.URL, heade
 }
 
 func (s Server) captureRequestBody(r *http.Request, agentType, sessionID string) {
-	if s.Transcripts == nil || r.Body == nil {
+	if s.Transcripts == nil || r.Body == nil || !transcriptWorthRecording(sessionID) {
 		return
 	}
 	r.Body = newStreamingTranscriptReadCloser(streamingTranscriptConfig{
@@ -3872,7 +3885,7 @@ func (s Server) captureRequestBody(r *http.Request, agentType, sessionID string)
 }
 
 func (s Server) recordReplayableRequestBody(r *http.Request, agentType, sessionID string) {
-	if s.Transcripts == nil || r.GetBody == nil || !s.Transcripts.Enabled() {
+	if s.Transcripts == nil || r.GetBody == nil || !s.Transcripts.Enabled() || !transcriptWorthRecording(sessionID) {
 		return
 	}
 	body, err := r.GetBody()
@@ -4017,9 +4030,15 @@ func (s Server) captureResponseBody(response *http.Response, clientCtx context.C
 		}
 	}
 	streamStarted := time.Now()
+	// The catalog session still needs its body inspected for quota signals, so
+	// it reaches here; it just must not be written down.
+	bodyRecorder := s.Transcripts
+	if !transcriptWorthRecording(sessionID) {
+		bodyRecorder = nil
+	}
 	response.Body = newStreamingTranscriptReadCloser(streamingTranscriptConfig{
 		ReadCloser: response.Body,
-		Recorder:   s.Transcripts,
+		Recorder:   bodyRecorder,
 		AgentType:  agentType,
 		SessionID:  sessionID,
 		EventType:  "http_body",


### PR DESCRIPTION
One transcript file on the team server reached **30 GB in two days** and was 88% of the spool. It was not a conversation: every Codex client polls `/models` continuously, all of it lands under the synthetic `internal:codex-model-catalog` session, and each poll wrote the request metadata plus the entire catalog body.

That one file explained the whole transcript problem I have been chasing: it saturated the upload, kept the spool above its 4 GiB cap (retention will not retire a file whose blob has not caught up), and took the host disk to 88% full.

The catalog session is no longer recorded. Its responses are still inspected for quota signals, because that is what the pool scheduler reads; only the writing stops. Real sessions, including any whose id merely looks internal, are unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789778633&installation_model_id=21920&pr_number=256&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F256&signature=ca54a0ba01f3062143e9ef59f6afe4626a538000642db2f51ba93c4cce02cec0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop recording the synthetic Codex model-catalog session to prevent runaway transcript files and disk/spool saturation. Previously every `/models` poll was recorded under one session with full bodies; now those events are not written, while responses are still inspected for quota signals used by the scheduler. All real sessions remain recorded.

**Reviewer notes**
- Recording is gated by `transcriptWorthRecording(sessionID)`; only the `internal:codex-model-catalog` session is excluded.
- Response bodies for the catalog session still pass through inspection, but the recorder is set to nil to avoid writes.
- Tests: `TestModelCatalogTrafficIsNotRecorded` covers exclusion and ensures real-looking sessions still record.
- Docs: README notes the catalog session exclusion.

<sup>Written for commit cc1186825f35832784eb183df923f85c644e939f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Synthetic model-catalog sessions are no longer included in recorded transcripts.
  * Model-catalog responses remain available for quota and model-signal inspection.
* **Documentation**
  * Updated documentation to describe model-catalog transcript handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->