### PR TITLE
Stop reporting a paced sync pass as a failed one

### DIFF
--- a/internal/transcript/azure_blob_sync.go
+++ b/internal/transcript/azure_blob_sync.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -244,6 +245,16 @@ func (s *AzureBlobSyncer) SyncOnce(ctx context.Context) error {
 		}
 		if err := s.syncFile(syncCtx, file); err != nil {
 			if syncCtx.Err() != nil {
+				// The pass ran out of its window, which is the normal shape of
+				// a pass with a backlog: uploads are paced, append blobs resume
+				// from their own offset, and the next pass continues where this
+				// one stopped. Reporting it as a failure every few minutes
+				// would bury the failures that matter.
+				if errors.Is(syncCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+					s.logger.Info("transcript azure sync pass reached its deadline; resuming next interval",
+						"destination", s.Destination(), "stopped_at", file.relPath)
+					return firstErr
+				}
 				return err
 			}
 			if firstErr == nil {
@@ -252,7 +263,7 @@ func (s *AzureBlobSyncer) SyncOnce(ctx context.Context) error {
 			s.logger.Warn("transcript azure upload failed", "file", file.relPath, "error", err)
 		}
 	}
-	if err := s.pruneLocal(syncCtx, s.now()); err != nil && firstErr == nil {
+	if err := s.pruneLocal(syncCtx, s.now()); err != nil && firstErr == nil && syncCtx.Err() == nil {
 		firstErr = err
 	}
 	return firstErr

--- a/internal/transcript/azure_blob_sync_test.go
+++ b/internal/transcript/azure_blob_sync_test.go
@@ -517,3 +517,28 @@ func TestUploadPacerSpreadsBytesOverTime(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// With a backlog, uploads are paced and a pass routinely ends at its deadline
+// having made progress. Reporting that as a failure every few minutes buries
+// the failures that matter.
+func TestAzureBlobSyncerTreatsItsOwnDeadlineAsANormalPassEnd(t *testing.T) {
+	fake := newAzureBlobFake(t)
+	spool := t.TempDir()
+	writeSpoolFile(t, spool, "codex/session-a.jsonl", strings.Repeat("{\"a\":1}\n", 1000))
+	writeSpoolFile(t, spool, "codex/session-b.jsonl", strings.Repeat("{\"b\":1}\n", 1000))
+
+	syncer := azureTestSyncer(t, fake, spool, AzureBlobSyncerConfig{
+		// Small enough that the pass cannot finish both files.
+		Timeout: time.Millisecond,
+	})
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("a pass that hit its own deadline reported failure: %v", err)
+	}
+
+	// A cancelled caller is different: that is a shutdown, and it propagates.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := syncer.SyncOnce(ctx); err == nil {
+		t.Fatal("a cancelled sync reported success")
+	}
+}


### PR DESCRIPTION
With a backlog, a pass routinely ends at its own deadline: uploads are paced at 2 MiB/s and append blobs resume from their own offset next interval. The server logged `transcript azure sync failed: context deadline exceeded` every few minutes for work that was proceeding normally, which is exactly how a real failure gets missed.

A pass that runs out of its window now logs where it stopped, at info, and returns whatever genuine errors it collected along the way. A cancelled caller still propagates as an error, because that is a shutdown rather than a full window.

Test runs a pass with a 1ms window over two files and asserts it is not a failure, then asserts a cancelled context still is.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789783170&installation_model_id=21920&pr_number=257&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F257&signature=67a93c0bd02000166542692f547f4aaca8a56d9bbf96597034661232e30c5bf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop treating a paced Azure transcript sync pass that hits its own deadline as a failure. Before: the pass returned context deadline exceeded and logged a failure; now: it logs where it stopped at info and only returns real errors. Caller cancellation still fails.

- Reviewer notes:
  - If the per-pass context hits DeadlineExceeded while the outer context is alive, log “pass reached its deadline; resuming next interval” with destination and stopped_at, then return any collected errors.
  - Caller-cancelled contexts still propagate as errors.
  - Do not record prune errors when the pass window expired.
  - Adds a test that a deadline end reports success, while a cancelled context reports failure.

<sup>Written for commit 1c0465a1ea6f39e6faebd1046ede186e8449fdc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript synchronization when an upload pass reaches its configured time limit.
  * Partial progress is preserved without reporting a misleading failure.
  * Local cleanup is skipped when synchronization is interrupted, preventing premature file removal.
  * Genuine cancellation or shutdown signals continue to be reported as errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->