### PR TITLE
Never commit the Fable stream on an empty priming delta

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -598,7 +598,10 @@ func bedrockFrameDecision(frame bedrockFrame, elapsed time.Duration) (decisive, 
 	var ev struct {
 		Type  string `json:"type"`
 		Delta struct {
-			Type string `json:"type"`
+			Type        string `json:"type"`
+			Text        string `json:"text"`
+			PartialJSON string `json:"partial_json"`
+			Thinking    string `json:"thinking"`
 		} `json:"delta"`
 	}
 	_ = json.Unmarshal(frame.payload, &ev)
@@ -611,6 +614,15 @@ func bedrockFrameDecision(frame bedrockFrame, elapsed time.Duration) (decisive, 
 		switch ev.Delta.Type {
 		case "thinking_delta", "signature_delta":
 			return elapsed >= claudeFableBedrockCommitWindow, false
+		case "text_delta":
+			// Bedrock primes every block with an EMPTY first delta (seen in
+			// transcripts: text_delta{text:""}, input_json_delta
+			// {partial_json:""}). An empty delta carries nothing the client
+			// needs, so it proves nothing; committing on it made a shed one
+			// frame later non-replayable. Only a delta with payload commits.
+			return ev.Delta.Text != "", false
+		case "input_json_delta":
+			return ev.Delta.PartialJSON != "", false
 		}
 		return true, false
 	}

--- a/internal/proxy/claude_fable_test.go
+++ b/internal/proxy/claude_fable_test.go
@@ -1052,3 +1052,93 @@ func TestClaudeFableBedrockCommitsThinkingAfterWindow(t *testing.T) {
 		t.Fatalf("upstream calls = %d, want 1 (no retry after window commit)", calls)
 	}
 }
+
+// Bedrock primes each block with an empty first delta (transcript-verified:
+// input_json_delta{partial_json:""}). A shed right after that priming frame
+// must retry: the client received zero payload.
+func TestClaudeFableBedrockRetriesShedAfterEmptyPrimingDelta(t *testing.T) {
+	bad := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		append(
+			buildEventStreamFrame(t, `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_x","name":"Bash","input":{}}}`),
+			append(
+				buildEventStreamFrame(t, `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`),
+				buildEventStreamFrame(t, `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)...,
+			)...,
+		)...,
+	)
+	good := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		append(
+			buildEventStreamFrame(t, `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`),
+			buildEventStreamFrame(t, `{"type":"message_stop"}`)...,
+		)...,
+	)
+	calls := 0
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		body := bad
+		if calls >= 2 {
+			body = good
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	resp, err := s.claudeFableBedrockResponse(req.Context(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after retrying past an empty priming delta", resp.StatusCode)
+	}
+	sse, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(sse), "overloaded_error") || strings.Contains(string(sse), "toolu_x") {
+		t.Fatalf("failed attempt leaked into retried stream: %q", sse)
+	}
+	if calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2", calls)
+	}
+}
+
+// A delta with real tool-input payload still commits immediately.
+func TestClaudeFableBedrockCommitsOnNonEmptyToolDelta(t *testing.T) {
+	stream := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		append(
+			buildEventStreamFrame(t, `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_y","name":"Bash","input":{}}}`),
+			append(
+				buildEventStreamFrame(t, `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"comm"}}`),
+				buildEventStreamFrame(t, `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)...,
+			)...,
+		)...,
+	)
+	calls := 0
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(stream)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	resp, err := s.claudeFableBedrockResponse(req.Context(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || calls != 1 {
+		t.Fatalf("status=%d calls=%d, want committed 200 with 1 call", resp.StatusCode, calls)
+	}
+	sse, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(sse), "toolu_y") || !strings.Contains(string(sse), "overloaded_error") {
+		t.Fatalf("committed stream must pass tool block and error through: %q", sse)
+	}
+}


### PR DESCRIPTION
The recurring `events_forwarded=3 saw_text_block=false` deaths (2.6-5s, several per hour) finally got decoded from transcripts. The exact client-visible sequence was:

```
message_start
content_block_start  {type: tool_use, name: Bash}
content_block_delta  {type: input_json_delta, partial_json: ""}   <- committed here
error                {type: overloaded_error}
```

Bedrock primes every block with an empty first delta (same for `text_delta{text:""}` and the first `thinking_delta`). That frame carries zero payload, so committing on it converts a replayable request into a surfaced "Server error mid-response" for nothing. `bedrockFrameDecision` now commits on `text_delta`/`input_json_delta` only when they carry payload; empty ones keep the peek buffering. Deltas with real payload commit exactly as before (test pins that).

`go test ./...` exit 0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789794503&installation_model_id=21920&pr_number=258&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F258&signature=3429a73d61b0e885522197a1857240e4914e4f15aad0fe15b00bf0909988c149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming behavior for tool-use responses.
  * Empty initialization data no longer prematurely commits a response, allowing temporary overloads to be retried.
  * Non-empty tool input now correctly commits the stream, preventing unnecessary retries after meaningful output begins.
  * Streaming text, partial JSON, and thinking updates are handled more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->