### PR TITLE
Default sr az test to gpt-5.6-sol

### DIFF
--- a/cmd/subrouter/sr_az.go
+++ b/cmd/subrouter/sr_az.go
@@ -35,7 +35,10 @@ for an outage.
 // azureForceHeader is the request header the daemon reads to skip the pool.
 const azureForceHeader = "X-Subrouter-Azure"
 
-const defaultAzureTestModel = "gpt-5.3-codex"
+// gpt-5.6-sol: the gpt-5.3-codex Azure deployment was deleted on 2026-08-20
+// (no gpt-5.3 usage is allowed via Azure), and the live fallback gate only
+// serves the gpt-5.6 family anyway.
+const defaultAzureTestModel = "gpt-5.6-sol"
 
 func (r srRunner) az(ctx context.Context, args []string) error {
 	if len(args) == 0 {


### PR DESCRIPTION
The gpt-5.3-codex Azure deployment was deleted on 2026-08-20 (decision: no gpt-5.3 usage via Azure at all), and the live fallback config gates to `gpt-5.6*`. With the old default, bare `sr az test` targets a model the fallback refuses and a deployment that no longer exists. Default it to gpt-5.6-sol, the deployment the fallback actually serves. `go test ./...` green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789803478&installation_model_id=21920&pr_number=261&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F261&signature=b2ee6058535ac04d8aa42c254fda42a5248e5f4653ea9d3636ce7104aff89017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default `sr az test` to `gpt-5.6-sol` to match the live Azure fallback and avoid failures. Previously it defaulted to `gpt-5.3-codex`, which is deleted and blocked by the fallback; running `sr az test` could fail out of the box.

- Change is limited to `defaultAzureTestModel` in `cmd/subrouter/sr_az.go`; no other behavior changes.
- No config changes required. If any scripts relied on the old default, pass `--model=<desired>` explicitly; `gpt-5.3*` via Azure is no longer available.

<sup>Written for commit b66e3b72c1fed97fb01df2d61a600b1ef4fd0d85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default Azure test model to `gpt-5.6-sol`.
  * Azure testing is now limited to the `gpt-5.6` model family.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->