### PR TITLE
Anchor the Fable commit window at the first thinking delta

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -597,7 +597,13 @@ var claudeFableBedrockCommitWindow = 20 * time.Second
 // within the first seconds of thinking, and holding those frames back keeps
 // the request replayable. message_start, content_block_start/stop, and pings
 // prove nothing.
-func bedrockFrameDecision(frame bedrockFrame, elapsed time.Duration) (decisive, failure bool, reason string) {
+// sinceFirstThinking is how long thinking deltas have been flowing (zero
+// until the first one arrives): the commit window is anchored there, not at
+// stream start, because display delay only begins to cost once there is
+// something to display. Fable regularly thinks silently for 30s+ before its
+// first delta (seen live: first delta at 38.6s, shed 3s later), and a
+// stream-start anchor expires the window during that silence for no benefit.
+func bedrockFrameDecision(frame bedrockFrame, sinceFirstThinking time.Duration) (decisive, failure bool, reason string) {
 	if strings.EqualFold(frame.messageType, "exception") {
 		return true, true, "exception"
 	}
@@ -619,7 +625,7 @@ func bedrockFrameDecision(frame bedrockFrame, elapsed time.Duration) (decisive, 
 	case "content_block_delta":
 		switch ev.Delta.Type {
 		case "thinking_delta", "signature_delta":
-			if elapsed >= claudeFableBedrockCommitWindow {
+			if sinceFirstThinking >= claudeFableBedrockCommitWindow {
 				return true, false, "window_expired_" + ev.Delta.Type
 			}
 			return false, false, ""
@@ -649,6 +655,21 @@ func bedrockFrameDecision(frame bedrockFrame, elapsed time.Duration) (decisive, 
 // read error). Nothing is forwarded to the client while peeking, so a failed
 // stream can be retried without duplicating output. peeked carries every raw
 // byte read, for replay into the transcoder on commit.
+// bedrockFrameIsThinkingDelta reports whether a frame is a thinking or
+// signature delta, the frame class the commit window buffers.
+func bedrockFrameIsThinkingDelta(frame bedrockFrame) bool {
+	var ev struct {
+		Type  string `json:"type"`
+		Delta struct {
+			Type string `json:"type"`
+		} `json:"delta"`
+	}
+	if json.Unmarshal(frame.payload, &ev) != nil || ev.Type != "content_block_delta" {
+		return false
+	}
+	return ev.Delta.Type == "thinking_delta" || ev.Delta.Type == "signature_delta"
+}
+
 func peekBedrockStreamUntilCommit(src io.Reader) bedrockStreamPeek {
 	var scanner bedrockFrameScanner
 	var peeked bytes.Buffer
@@ -657,20 +678,27 @@ func peekBedrockStreamUntilCommit(src io.Reader) bedrockStreamPeek {
 	failed := false
 	commitReason := ""
 	var commitAt time.Duration
+	var firstThinkingAt time.Time
 	var errorFrame bedrockFrame
 	emit := func(frame bedrockFrame) {
 		if decided {
 			return
 		}
-		elapsed := time.Since(started)
-		decisive, failure, reason := bedrockFrameDecision(frame, elapsed)
+		if firstThinkingAt.IsZero() && bedrockFrameIsThinkingDelta(frame) {
+			firstThinkingAt = time.Now()
+		}
+		var sinceFirstThinking time.Duration
+		if !firstThinkingAt.IsZero() {
+			sinceFirstThinking = time.Since(firstThinkingAt)
+		}
+		decisive, failure, reason := bedrockFrameDecision(frame, sinceFirstThinking)
 		if !decisive {
 			return
 		}
 		decided = true
 		failed = failure
 		commitReason = reason
-		commitAt = elapsed
+		commitAt = time.Since(started)
 		if failure {
 			errorFrame = frame
 		}

--- a/internal/proxy/claude_fable_test.go
+++ b/internal/proxy/claude_fable_test.go
@@ -1142,3 +1142,51 @@ func TestClaudeFableBedrockCommitsOnNonEmptyToolDelta(t *testing.T) {
 		t.Fatalf("committed stream must pass tool block and error through: %q", sse)
 	}
 }
+
+// The commit window anchors at the FIRST thinking delta, so a stream that
+// thinks silently (no deltas yet) never expires the window, no matter how much
+// wall time passes: with the window forced to zero, an error arriving before
+// any thinking delta must still retry.
+func TestClaudeFableBedrockSilentThinkingNeverExpiresWindow(t *testing.T) {
+	saved := claudeFableBedrockCommitWindow
+	claudeFableBedrockCommitWindow = 0
+	defer func() { claudeFableBedrockCommitWindow = saved }()
+
+	bad := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		append(
+			buildEventStreamFrame(t, `{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`),
+			buildEventStreamFrame(t, `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)...,
+		)...,
+	)
+	good := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		append(
+			buildEventStreamFrame(t, `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`),
+			buildEventStreamFrame(t, `{"type":"message_stop"}`)...,
+		)...,
+	)
+	calls := 0
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		body := bad
+		if calls >= 2 {
+			body = good
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	resp, err := s.claudeFableBedrockResponse(req.Context(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || calls != 2 {
+		t.Fatalf("status=%d calls=%d, want retried 200 with 2 calls", resp.StatusCode, calls)
+	}
+}


### PR DESCRIPTION
First live `commit_reason` datapoint from #263: `commit_reason=window_expired_thinking_delta commit_at_ms=38585 elapsed_ms=41508`. The model thought silently for 38.6s, so the stream-start-anchored window was long expired when the first delta arrived; it committed instantly and the shed 3s later surfaced.

The window exists to bound how long ALREADY-FLOWING thinking is withheld from the viewer. During silent thought there is nothing to withhold, so expiring then buys nothing and costs replayability. Anchor the expiry clock at the first buffered thinking delta: silent-thought periods never expire the window, perceived thinking latency is unchanged (still at most 20s after deltas start), and sheds during or shortly after long silent thought become silent retries.

Test pins the core: with the window forced to zero, an error before any thinking delta still retries. `internal/proxy` suite green; the two `cmd/subrouter` deploy-script 5s-deadline tests fail locally on a load-21 machine (clean main fails them identically right now) — CI is the arbiter.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789811662&installation_model_id=21920&pr_number=264&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F264&signature=80fdb4d43e972f8451bddf651d203124f7b3e6d6ec0735387dcfcd62e9638ce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchors the Claude Fable Bedrock commit window to the first thinking delta instead of stream start. This prevents premature commits after long silent thinking, preserves replayability, and keeps perceived thinking latency unchanged (still capped at 20s once deltas begin).

- Old behavior: window measured from stream start; long silent thought could expire the window and surface sheds. New behavior: clock starts at the first thinking/signature delta; silent thought never expires the window.
- An error that arrives before any thinking delta now retries; new test verifies this behavior.

<sup>Written for commit 90c90538323adcacc540c671a43f3b9c28541a9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bedrock streaming reliability by starting the admission window when thinking content first arrives, rather than when the stream begins.
  * Prevented valid responses from being prematurely rejected during silent thinking periods.
  * Preserved existing retry and forwarding behavior for overloaded requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->