### PR TITLE
Upgrade Fable cache_control to the 1-hour TTL on Bedrock; split write accounting

### DIFF
--- a/cmd/subrouter/main.go
+++ b/cmd/subrouter/main.go
@@ -639,9 +639,12 @@ func serve(args []string) error {
 		MaxBodyBytes:          *maxBodyBytes,
 		Bedrock:               bedrockConfig,
 		ClaudeFableAPIKey:     fableAPIKey,
-		AzureCodex:            azureCodexConfig,
-		FableBedrockPrimary:   fableBedrockEnabled,
-		Transcripts:           transcript.NewRecorder(*transcriptDir),
+		// SUBROUTER_FABLE_CACHE_1H_OFF=1 disables the ephemeral->1h
+		// cache_control TTL upgrade on the Bedrock path.
+		ClaudeFableCacheTTLUpgradeOff: envTrue("SUBROUTER_FABLE_CACHE_1H_OFF"),
+		AzureCodex:                    azureCodexConfig,
+		FableBedrockPrimary:           fableBedrockEnabled,
+		Transcripts:                   transcript.NewRecorder(*transcriptDir),
 	}
 	transcriptGCSSyncer := transcript.NewGCSSyncer(transcript.GCSSyncerConfig{
 		SourceDir:      *transcriptDir,

--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -151,6 +151,9 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 	if strippedTools > 0 && s.Logger != nil {
 		s.Logger.Warn("stripped bedrock-unsupported server tools from claude-fable request", "count", strippedTools)
 	}
+	if !s.ClaudeFableCacheTTLUpgradeOff {
+		body = upgradeEphemeralCacheTTL(body)
+	}
 	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, err
@@ -283,6 +286,21 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 		Body:          io.NopCloser(bytes.NewReader(respBody)),
 		ContentLength: int64(len(respBody)),
 	}, nil
+}
+
+// upgradeEphemeralCacheTTL rewrites every bare cache_control
+// {"type":"ephemeral"} to the 1-hour TTL on the Bedrock path. Cost-log data
+// (2026-08-20): 88% of daily cache-write spend came from 819 requests that
+// re-wrote their whole context after the 5-minute cache expired during a long
+// tool run, and 89% of rewrite-causing gaps were under an hour. 1h writes cost
+// 1.6x the 5m rate, so the upgrade pays whenever more than 43% of rewrites
+// fall inside the hour. An explicit client-set ttl is respected untouched.
+// The byte-literal match is safe: inside a JSON string value the quotes would
+// be escaped, so the pattern can only match real cache_control objects.
+func upgradeEphemeralCacheTTL(body []byte) []byte {
+	return bytes.ReplaceAll(body,
+		[]byte(`"cache_control":{"type":"ephemeral"}`),
+		[]byte(`"cache_control":{"type":"ephemeral","ttl":"1h"}`))
 }
 
 // bedrockUnsupportedToolPrefixes lists Anthropic server-side tool types that

--- a/internal/proxy/bedrock_cost.go
+++ b/internal/proxy/bedrock_cost.go
@@ -13,22 +13,32 @@ import (
 
 // bedrockUsage holds the token counts reported by a Bedrock/Anthropic response.
 type bedrockUsage struct {
-	InputTokens      int `json:"input_tokens"`
-	OutputTokens     int `json:"output_tokens"`
-	CacheReadTokens  int `json:"cache_read_input_tokens"`
-	CacheWriteTokens int `json:"cache_creation_input_tokens"`
+	InputTokens      int                  `json:"input_tokens"`
+	OutputTokens     int                  `json:"output_tokens"`
+	CacheReadTokens  int                  `json:"cache_read_input_tokens"`
+	CacheWriteTokens int                  `json:"cache_creation_input_tokens"`
+	CacheCreation    bedrockCacheCreation `json:"cache_creation"`
+}
+
+// bedrockCacheCreation splits cache writes by TTL, which price differently
+// (5m = 1.25x input, 1h = 2x input).
+type bedrockCacheCreation struct {
+	Ephemeral5m int `json:"ephemeral_5m_input_tokens"`
+	Ephemeral1h int `json:"ephemeral_1h_input_tokens"`
 }
 
 func (u bedrockUsage) empty() bool {
 	return u.InputTokens == 0 && u.OutputTokens == 0 && u.CacheReadTokens == 0 && u.CacheWriteTokens == 0
 }
 
-// bedrockPricing is USD per million tokens. Cache write is the 5-minute rate.
+// bedrockPricing is USD per million tokens. cacheWrite is the 5-minute rate
+// (1.25x input); cacheWrite1h is the 1-hour rate (2x input).
 type bedrockPricing struct {
-	input      float64
-	output     float64
-	cacheRead  float64
-	cacheWrite float64
+	input        float64
+	output       float64
+	cacheRead    float64
+	cacheWrite   float64
+	cacheWrite1h float64
 }
 
 // bedrockPriceFor returns pricing for a Bedrock model id / inference profile.
@@ -38,13 +48,13 @@ func bedrockPriceFor(model string) bedrockPricing {
 	m := strings.ToLower(model)
 	switch {
 	case strings.Contains(m, "fable"):
-		return bedrockPricing{input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5}
+		return bedrockPricing{input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5, cacheWrite1h: 20}
 	case strings.Contains(m, "opus"):
-		return bedrockPricing{input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25}
+		return bedrockPricing{input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25, cacheWrite1h: 10}
 	case strings.Contains(m, "sonnet"):
-		return bedrockPricing{input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75}
+		return bedrockPricing{input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75, cacheWrite1h: 6}
 	case strings.Contains(m, "haiku"):
-		return bedrockPricing{input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25}
+		return bedrockPricing{input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25, cacheWrite1h: 2}
 	default:
 		return bedrockPricing{}
 	}
@@ -52,10 +62,17 @@ func bedrockPriceFor(model string) bedrockPricing {
 
 func (u bedrockUsage) costUSD(model string) float64 {
 	p := bedrockPriceFor(model)
+	// When the response reports the per-TTL split, price each bucket at its
+	// own rate; otherwise everything wrote at the 5m rate.
+	writeCost := float64(u.CacheWriteTokens) * p.cacheWrite
+	if u.CacheCreation.Ephemeral5m+u.CacheCreation.Ephemeral1h > 0 {
+		writeCost = float64(u.CacheCreation.Ephemeral5m)*p.cacheWrite +
+			float64(u.CacheCreation.Ephemeral1h)*p.cacheWrite1h
+	}
 	return (float64(u.InputTokens)*p.input +
 		float64(u.OutputTokens)*p.output +
 		float64(u.CacheReadTokens)*p.cacheRead +
-		float64(u.CacheWriteTokens)*p.cacheWrite) / 1_000_000
+		writeCost) / 1_000_000
 }
 
 // bedrockCostRecord is one JSONL line in the Bedrock cost log.

--- a/internal/proxy/claude_fable_test.go
+++ b/internal/proxy/claude_fable_test.go
@@ -1190,3 +1190,72 @@ func TestClaudeFableBedrockSilentThinkingNeverExpiresWindow(t *testing.T) {
 		t.Fatalf("status=%d calls=%d, want retried 200 with 2 calls", resp.StatusCode, calls)
 	}
 }
+
+func TestUpgradeEphemeralCacheTTL(t *testing.T) {
+	body := []byte(`{"system":[{"type":"text","text":"s","cache_control":{"type":"ephemeral"}}],` +
+		`"tools":[{"name":"Bash","input_schema":{},"cache_control":{"type":"ephemeral"}}],` +
+		`"messages":[{"role":"user","content":[{"type":"text","text":"escaped literal: \"cache_control\":{\"type\":\"ephemeral\"}","cache_control":{"type":"ephemeral","ttl":"5m"}}]}]}`)
+	got := string(upgradeEphemeralCacheTTL(body))
+	if n := strings.Count(got, `"cache_control":{"type":"ephemeral","ttl":"1h"}`); n != 2 {
+		t.Fatalf("upgraded blocks = %d, want 2 (system and tools): %s", n, got)
+	}
+	if !strings.Contains(got, `"ttl":"5m"`) {
+		t.Fatalf("explicit 5m ttl must be respected: %s", got)
+	}
+	if !strings.Contains(got, `escaped literal: \"cache_control\"`) {
+		t.Fatalf("string content must be untouched: %s", got)
+	}
+}
+
+func TestClaudeFableBedrockRequestCarries1hCacheTTL(t *testing.T) {
+	var upstreamBody string
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		b, _ := io.ReadAll(req.Body)
+		upstreamBody = string(b)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"type":"message","usage":{"output_tokens":3}}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	body := []byte(`{"model":"claude-fable-5","max_tokens":8,"system":[{"type":"text","text":"s","cache_control":{"type":"ephemeral"}}],"messages":[]}`)
+	resp, err := s.claudeFableBedrockResponse(req.Context(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if !strings.Contains(upstreamBody, `"ttl":"1h"`) {
+		t.Fatalf("bedrock request missing 1h ttl upgrade: %s", upstreamBody)
+	}
+
+	// Kill switch: no rewrite.
+	s.ClaudeFableCacheTTLUpgradeOff = true
+	upstreamBody = ""
+	resp2, err := s.claudeFableBedrockResponse(req.Context(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	if strings.Contains(upstreamBody, `"ttl":"1h"`) {
+		t.Fatalf("kill switch must disable the upgrade: %s", upstreamBody)
+	}
+}
+
+func TestBedrockCostSplitsCacheWriteTTL(t *testing.T) {
+	u := bedrockUsage{
+		CacheWriteTokens: 1_000_000,
+		CacheCreation:    bedrockCacheCreation{Ephemeral5m: 400_000, Ephemeral1h: 600_000},
+	}
+	got := u.costUSD("us.anthropic.claude-fable-5")
+	want := 0.4*12.5 + 0.6*20
+	if got < want-0.001 || got > want+0.001 {
+		t.Fatalf("split cost = %f, want %f", got, want)
+	}
+	// Without the split, everything prices at the 5m rate.
+	u2 := bedrockUsage{CacheWriteTokens: 1_000_000}
+	if got2 := u2.costUSD("us.anthropic.claude-fable-5"); got2 != 12.5 {
+		t.Fatalf("legacy cost = %f, want 12.5", got2)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -108,6 +108,11 @@ type Server struct {
 	// ONLY to Fable; Opus/Sonnet/etc. continue to use the OAuth pool and never
 	// touch this key.
 	ClaudeFableAPIKey string
+
+	// ClaudeFableCacheTTLUpgradeOff disables the Bedrock-path rewrite of bare
+	// ephemeral cache_control blocks to the 1-hour TTL (see
+	// upgradeEphemeralCacheTTL). Default off = upgrade enabled.
+	ClaudeFableCacheTTLUpgradeOff bool
 	// AzureCodex, when set, serves Codex Responses requests from Azure OpenAI
 	// after the subscription pool has spent its retry budget and still failed,
 	// and pins the session to Azure afterwards so later turns keep hitting the


### PR DESCRIPTION
Audit numbers from `/_subrouter/bedrock-cost` and the cost JSONL on cmux-lawrence (last 24h, ~24.4k fable requests, ~$9.2k estimated):

- cache reads $5,362, cache writes $3,135, output $627, uncached input $68. Caching works; writes are the waste.
- $2,757 of the write cost (88%) came from just 819 requests whose write was >=50% of their read: the 5-minute cache expired during a long tool run and the whole ~270k-token context re-wrote at $12.5/M.
- Session transcripts: of gaps long enough to expire the 5m cache, 89% are under one hour. Break-even for 1h writes (1.6x price) is 43%.
- Probe confirmed Bedrock accepts `ttl:"1h"` for `us.anthropic.claude-fable-5` and reports `ephemeral_1h_input_tokens`.

Change: `upgradeEphemeralCacheTTL` rewrites bare `\"cache_control\":{\"type\":\"ephemeral\"}` to the 1h TTL on the Bedrock path only. Explicit client TTLs pass through untouched; the byte-literal match cannot hit string content (quotes would be escaped). `SUBROUTER_FABLE_CACHE_1H_OFF=1` disables. Estimated saving ~$1.5-2k/day at list rates. Cost accounting now prices the 5m/1h write buckets separately so the estimate tracks reality.

`go test ./...` exit 0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789818671&installation_model_id=21920&pr_number=265&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F265&signature=d9240070016f8ee755a437e7bfa5bef2f0ec20113b1886c8b129d5611e5205e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades Bedrock-side Fable caching: bare ephemeral cache blocks now write with a 1-hour TTL instead of the implicit 5-minute TTL, and cache-write costs are accounted per TTL. This cuts expensive rewrites during long tool runs and aligns our estimates with Bedrock billing.

- Old vs new behavior: On the Bedrock path only, `"cache_control":{"type":"ephemeral"}` becomes `"cache_control":{"type":"ephemeral","ttl":"1h"}`; explicit client TTLs pass through; non-Bedrock paths are unchanged.
- Implementation: `upgradeEphemeralCacheTTL` runs in `claudeFableBedrockResponse`; byte-literal replacement cannot match inside JSON strings. Tests cover the rewrite, kill switch, and cost split pricing.
- Config: `SUBROUTER_FABLE_CACHE_1H_OFF=1` disables the upgrade (`Server.ClaudeFableCacheTTLUpgradeOff`).
- Cost accounting: Reads Bedrock’s `cache_creation` split (`ephemeral_5m_input_tokens`, `ephemeral_1h_input_tokens`) and prices 5m and 1h writes separately; falls back to 5m rate when the split is absent.
- Rollout: Default on; no client changes required. Monitor `/_subrouter/bedrock-cost` and the JSONL cost log to verify reduced write churn and correct bucket splits.

<sup>Written for commit 4d83a3dc32843d0ec546d21f5c8eeb61c55a9b03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude Fable Bedrock requests now default to a one-hour cache TTL when no explicit duration is provided.
  * Administrators can disable the automatic cache TTL upgrade through configuration.
  * Cache usage costs now distinguish between five-minute and one-hour cache storage durations.

* **Bug Fixes**
  * Explicit cache durations are preserved, including five-minute settings and escaped content.
  * Legacy cost reporting remains supported when detailed TTL usage is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->