### PR TITLE
Carry the cache_creation TTL split through the stream path

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -863,6 +863,9 @@ func transcodeBedrockToSSESince(w io.Writer, src io.Reader, logger *slog.Logger,
 			result.Usage.InputTokens = ev.Message.Usage.InputTokens
 			result.Usage.CacheReadTokens = ev.Message.Usage.CacheReadTokens
 			result.Usage.CacheWriteTokens = ev.Message.Usage.CacheWriteTokens
+			// Without the per-TTL split the cost log prices every write at
+			// the 5m rate, understating 1h writes by 1.6x.
+			result.Usage.CacheCreation = ev.Message.Usage.CacheCreation
 			result.HaveUsage = true
 		case "message_delta":
 			if ev.Usage.OutputTokens > 0 {

--- a/internal/proxy/bedrock_stream_test.go
+++ b/internal/proxy/bedrock_stream_test.go
@@ -234,3 +234,18 @@ func TestServeClaudeFableBedrockPrimaryFallsThroughOnEmptyStream(t *testing.T) {
 		t.Fatalf("restored body = %q, want %q", string(restored), bodyStr)
 	}
 }
+
+// The stream path must carry the cache_creation TTL split into the cost
+// record; dropping it prices 1h writes at the 5m rate.
+func TestTranscodeCarriesCacheCreationDetail(t *testing.T) {
+	start := `{"type":"message_start","message":{"usage":{"input_tokens":5,"cache_creation_input_tokens":100,"cache_read_input_tokens":7,"cache_creation":{"ephemeral_5m_input_tokens":25,"ephemeral_1h_input_tokens":75}}}}`
+	stream := append(buildEventStreamFrame(t, start), buildEventStreamFrame(t, `{"type":"message_stop"}`)...)
+	var out bytes.Buffer
+	result := transcodeBedrockToSSE(&out, bytes.NewReader(stream), nil, "src", "region")
+	if result.Usage.CacheCreation.Ephemeral5m != 25 || result.Usage.CacheCreation.Ephemeral1h != 75 {
+		t.Fatalf("cache_creation detail lost: %+v", result.Usage.CacheCreation)
+	}
+	if result.Usage.CacheWriteTokens != 100 {
+		t.Fatalf("cache write total = %d, want 100", result.Usage.CacheWriteTokens)
+	}
+}


### PR DESCRIPTION
Post-#265 audit: the cost log showed post-upgrade streaming writes in the legacy (no-split) bucket because `transcodeBedrockToSSE` copies `message_start` usage field by field and drops `cache_creation`. A live probe confirmed the writes ARE 1h; only the accounting was wrong, underpricing them at the 5m rate (~$500-600/day understated). One-line copy plus a passthrough test. `go test ./...` exit 0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789889263&installation_model_id=21920&pr_number=266&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F266&signature=563d3b14b525e883b40274940f72b27c79795b716db440af90a4ba41b40f4761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cost accounting for streamed cache writes by preserving the `cache_creation` TTL split. Previously the stream path dropped `cache_creation`, pricing all writes at the 5m rate; now it carries 5m vs 1h correctly. External behavior is unchanged; cost logs for 1h writes will increase to the accurate rate.

- Copies `cache_creation` from Bedrock `message_start` into the SSE result in the transcoder.
- Adds a passthrough test to assert the 5m/1h split and total write tokens.
- Rollout: no config changes; monitor cost logs for a ~1.6x increase on 1h cache writes (previously understated by ~$500–$600/day).

<sup>Written for commit ebd9687741472662295d8909753c806e3ffa5bce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

