### PR TITLE
Keep model quota exhaustion scoped to its model

### DIFF
--- a/cmd/subrouter/sr.go
+++ b/cmd/subrouter/sr.go
@@ -1405,7 +1405,7 @@ func tempCookedFromWindows(windows []accounts.UsageWindow) (bool, string) {
 		return false, ""
 	}
 	for _, window := range windows {
-		if !isShortQuotaWindow(window) || clampUsagePercent(window.UsedPercent) < 100 {
+		if isModelScopedWindow(window) || !isShortQuotaWindow(window) || clampUsagePercent(window.UsedPercent) < 100 {
 			continue
 		}
 		if window.ResetAfterSeconds > 0 {

--- a/cmd/subrouter/sr_test.go
+++ b/cmd/subrouter/sr_test.go
@@ -607,6 +607,30 @@ func TestSRDefaultShowsTemporarilyCookedAccountWhenShortWindowConsumed(t *testin
 	}
 }
 
+func TestModelScopedShortWindowDoesNotTemporarilyCookWholeAccount(t *testing.T) {
+	windows := []accounts.UsageWindow{
+		{Name: "primary", UsedPercent: 28, LimitWindowSeconds: int64((7 * 24 * time.Hour) / time.Second)},
+		{
+			Name:               "GPT-5.3-Codex-Spark/primary",
+			Feature:            "GPT-5.3-Codex-Spark",
+			UsedPercent:        100,
+			LimitWindowSeconds: int64((5 * time.Hour) / time.Second),
+			ResetAfterSeconds:  int64((4 * time.Hour) / time.Second),
+		},
+		{
+			Name:               "GPT-5.3-Codex-Spark/secondary",
+			Feature:            "GPT-5.3-Codex-Spark",
+			UsedPercent:        48,
+			LimitWindowSeconds: int64((7 * 24 * time.Hour) / time.Second),
+		},
+	}
+
+	tempCooked, reason := tempCookedFromWindows(windows)
+	if tempCooked {
+		t.Fatalf("account should remain switchable when only a model-scoped short window is exhausted (reason=%q)", reason)
+	}
+}
+
 func TestSRInteractiveRefusesTemporarilyCookedSelection(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/selectacct/saturation_test.go
+++ b/selectacct/saturation_test.go
@@ -150,6 +150,42 @@ func TestScoreExcludesFeatureWindowsFromBase(t *testing.T) {
 	}
 }
 
+func TestSparkShortAndWeeklyWindowsRemainIndependentFromBase(t *testing.T) {
+	tests := []struct {
+		name              string
+		shortUsed         float64
+		weeklyUsed        float64
+		wantShortHeadroom float64
+	}{
+		{name: "short exhausted", shortUsed: 100, weeklyUsed: 48, wantShortHeadroom: 0},
+		{name: "weekly exhausted", shortUsed: 0, weeklyUsed: 100, wantShortHeadroom: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score := ScoreFromLimitWindows("acct", 0, []LimitWindow{
+				{Name: "primary", UsedPercent: 28, LimitWindowSeconds: 7 * 24 * 60 * 60},
+				{Name: "GPT-5.3-Codex-Spark/primary", Feature: "GPT-5.3-Codex-Spark", UsedPercent: tt.shortUsed, LimitWindowSeconds: 5 * 60 * 60},
+				{Name: "GPT-5.3-Codex-Spark/secondary", Feature: "GPT-5.3-Codex-Spark", UsedPercent: tt.weeklyUsed, LimitWindowSeconds: 7 * 24 * 60 * 60},
+			})
+
+			if math.Abs(score.Headroom-0.72) > 0.0001 {
+				t.Fatalf("base headroom = %.2f, want 0.72", score.Headroom)
+			}
+			spark, ok := score.ModelScores[ModelKey("gpt-5.3-codex-spark")]
+			if !ok {
+				t.Fatal("expected a Spark model pool score")
+			}
+			if !spark.exhausted() {
+				t.Fatal("Spark pool should be exhausted when either its short or weekly window is exhausted")
+			}
+			if math.Abs(spark.ShortHeadroom-tt.wantShortHeadroom) > 0.0001 {
+				t.Fatalf("Spark short headroom = %.2f, want %.2f", spark.ShortHeadroom, tt.wantShortHeadroom)
+			}
+		})
+	}
+}
+
 func TestForModelZeroesAccountsLackingTheFeature(t *testing.T) {
 	// One account advertises the Spark pool, another does not. A Spark request
 	// must not land on the account that cannot serve it.


### PR DESCRIPTION
## What happened

`sr status` and `sr pick` treated a fully consumed short model-specific quota window as if the whole Codex account were temporarily cooked. An account with healthy general quota could therefore appear unavailable and be refused for switching solely because its Spark pool was empty.

## Fix

Ignore model-scoped windows when determining whether the whole account is temporarily cooked, matching the existing account-wide cooked classification. Model-specific windows remain part of their dedicated scheduler pool.

Regression coverage proves that:

- an exhausted Spark 5-hour window does not cook the ordinary Codex account;
- Spark 5-hour and weekly windows remain distinct;
- either exhausted Spark window makes the Spark pool unavailable;
- ordinary account headroom remains independent.

No personal account identifiers are included.

## Verification

Focused `cmd/subrouter` and `selectacct` tests pass with Go 1.24.13. The full suite passed every package except the existing macOS GCP deployment-script fixture `TestGCPStartupBuildsPreparedFrontTopologyFromPinnedReleaseMetadata`, which also fails alone because its prepared-marker fixture is absent.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789892078&installation_model_id=21920&pr_number=267&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F267&signature=556c1c3e1130f785d17d1c7085574e89c04b1a3cdddc7320137b4237702e0938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps model quota exhaustion scoped to its model so healthy accounts remain switchable. Previously, `sr status` and `sr pick` cooked the whole account when a model-scoped short window hit 100%; now only account-wide short windows cook the account, while model-scoped windows only disable that model's pool.

- `tempCookedFromWindows` ignores model-scoped windows when computing account temporary-cooked status; model windows still govern their pool's availability and headroom.
- Adds coverage in `cmd/subrouter` and `selectacct` verifying Spark short vs weekly windows stay distinct, the Spark pool is exhausted when either window is spent, and base headroom and account switching remain unaffected.

<sup>Written for commit 6f1d6fd8a54481c449466782f9e0ef145fd042f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

