### PR TITLE
Fix the Anthropic-path hang cluster

### DIFF
--- a/internal/proxy/anthropic_hang_fixes_test.go
+++ b/internal/proxy/anthropic_hang_fixes_test.go
@@ -164,10 +164,12 @@ func TestBedrockPeekWatchdogAbortsSilentStream(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("silent Bedrock stream still hangs the request")
 	}
+	if resp != nil && resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
 	if respErr != nil {
 		t.Fatal(respErr)
 	}
-	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want 503 after aborting silent streams", resp.StatusCode)
 	}

--- a/internal/proxy/anthropic_hang_fixes_test.go
+++ b/internal/proxy/anthropic_hang_fixes_test.go
@@ -1,0 +1,247 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/selectacct"
+	"github.com/manaflow-ai/subrouter/session"
+)
+
+// The outbound transport streams responses, so it must not have an overall
+// deadline — but the wait for response headers has to be bounded, or an
+// upstream that accepts a request and goes silent holds the client request,
+// its goroutine, and its upload-limiter slot forever.
+func TestOutboundTransportBoundsResponseHeaderWait(t *testing.T) {
+	transport := NewOutboundTransport()
+	if transport.ResponseHeaderTimeout <= 0 {
+		t.Fatal("outbound transport has no ResponseHeaderTimeout; a header blackhole hangs requests forever")
+	}
+}
+
+// Ordinary-sized POSTs must not contend for the upload limiter: a slot spans
+// the whole nested retry chain (failover, backoff sleeps, the Bedrock
+// commit-window peek, header wait), so gating every POST serialized all
+// message traffic proxy-wide behind 4 slots.
+func TestSmallPostsBypassUploadLimiter(t *testing.T) {
+	limiter := make(chan struct{}, 1)
+	limiter <- struct{}{} // limiter fully occupied
+
+	served := false
+	transport := replayablePostRetryTransport{
+		base: bedrockRoundTripFunc(func(*http.Request) (*http.Response, error) {
+			served = true
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+		}),
+		maxAttempts: 1,
+		limiter:     limiter,
+	}
+
+	small, err := http.NewRequest(http.MethodPost, "https://example.invalid/v1/messages", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	small.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader(`{}`)), nil }
+	response, err := transport.RoundTrip(small)
+	if err != nil {
+		t.Fatalf("small POST should bypass a full limiter, got %v", err)
+	}
+	response.Body.Close()
+	if !served {
+		t.Fatal("small POST never reached the base transport")
+	}
+
+	bigBody := strings.Repeat("x", replayablePostLimiterMinBytes)
+	big, err := http.NewRequest(http.MethodPost, "https://example.invalid/v1/messages", strings.NewReader(bigBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	big.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader(bigBody)), nil }
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if _, err := transport.RoundTrip(big.WithContext(ctx)); err == nil {
+		t.Fatal("large POST should wait on the full limiter and fail on context timeout")
+	}
+}
+
+// A stream that stays alive but never produces a decisive frame (pings,
+// unparseable frames) must not buffer forever while the client has received
+// no response headers at all.
+func TestBedrockPeekForcesCommitOnDeadline(t *testing.T) {
+	saved := claudeFableBedrockPeekForceCommitAfter
+	claudeFableBedrockPeekForceCommitAfter = 30 * time.Millisecond
+	defer func() { claudeFableBedrockPeekForceCommitAfter = saved }()
+
+	ping := buildEventStreamFrame(t, `{"type":"ping"}`)
+	pr, pw := io.Pipe()
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				pw.Close()
+				return
+			case <-time.After(5 * time.Millisecond):
+				if _, err := pw.Write(ping); err != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	peek := peekBedrockStreamUntilCommit(pr)
+	if peek.outcome != bedrockPeekCommit {
+		t.Fatalf("outcome = %v, want commit forced by deadline", peek.outcome)
+	}
+	if peek.commitReason != "forced_deadline" {
+		t.Fatalf("commitReason = %q, want forced_deadline", peek.commitReason)
+	}
+}
+
+func TestBedrockPeekForcesCommitOnBufferCap(t *testing.T) {
+	saved := claudeFableBedrockPeekMaxBytes
+	claudeFableBedrockPeekMaxBytes = 256
+	defer func() { claudeFableBedrockPeekMaxBytes = saved }()
+
+	ping := buildEventStreamFrame(t, `{"type":"ping"}`)
+	var stream []byte
+	for len(stream) < 4096 {
+		stream = append(stream, ping...)
+	}
+	peek := peekBedrockStreamUntilCommit(bytes.NewReader(stream))
+	if peek.outcome != bedrockPeekCommit {
+		t.Fatalf("outcome = %v, want commit forced by buffer cap", peek.outcome)
+	}
+	if peek.commitReason != "forced_buffer_cap" {
+		t.Fatalf("commitReason = %q, want forced_buffer_cap", peek.commitReason)
+	}
+}
+
+// Unknown (future) delta types are invisible like thinking deltas and must be
+// gated by the commit window, not commit the stream instantly — an instant
+// commit reintroduces the unreplayable post-commit shed the window absorbs.
+func TestBedrockFrameDecisionGatesUnknownDeltaTypes(t *testing.T) {
+	frame := bedrockFrame{payload: []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"redacted_thinking_delta"}}`)}
+	if decisive, _, _ := bedrockFrameDecision(frame, 0); decisive {
+		t.Fatal("unknown delta type committed inside the window")
+	}
+	decisive, failure, reason := bedrockFrameDecision(frame, claudeFableBedrockCommitWindow)
+	if !decisive || failure {
+		t.Fatalf("unknown delta type after window: decisive=%v failure=%v", decisive, failure)
+	}
+	if !strings.Contains(reason, "window_expired") {
+		t.Fatalf("reason = %q, want window_expired_*", reason)
+	}
+	if !bedrockFrameIsThinkingDelta(frame) {
+		t.Fatal("unknown invisible delta must anchor the commit window")
+	}
+}
+
+// The gateway streaming usage writer must carry the cache_creation TTL split;
+// without it 1h cache writes are priced at the 5m rate.
+func TestBedrockStreamUsageWriterCarriesCacheCreationSplit(t *testing.T) {
+	start := buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":10,"cache_creation_input_tokens":100,"cache_creation":{"ephemeral_5m_input_tokens":25,"ephemeral_1h_input_tokens":75}}}}`)
+	stop := buildEventStreamFrame(t, `{"type":"message_delta","usage":{"output_tokens":5}}`)
+
+	p := newBedrockStreamUsageWriter()
+	p.Write(append(append([]byte{}, start...), stop...))
+	usage, ok := p.Usage()
+	if !ok {
+		t.Fatal("expected usage extracted")
+	}
+	if usage.CacheCreation.Ephemeral5m != 25 || usage.CacheCreation.Ephemeral1h != 75 {
+		t.Fatalf("cache creation split = %+v, want 25/75", usage.CacheCreation)
+	}
+}
+
+// A panic inside the score refresh must release the refresh claim; before,
+// the swallowed panic left refreshing=true forever and usage scores froze
+// for the life of the process.
+func TestUsageRefreshReleasesClaimOnPanic(t *testing.T) {
+	accountStore := accounts.CodexStore{Dir: t.TempDir()}
+	if err := accountStore.SaveStored(proxyStoredOAuthAccount("acct@example.com", "acct", time.Now().Add(time.Hour))); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := accountStore.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler(nil))
+	schedulerRef.SetUpdatedAt(time.Time{})
+	server := Server{
+		AccountRef:    NewAccountRef(accountStore, loaded, nil),
+		SchedulerRef:  schedulerRef,
+		UsageScoreTTL: time.Nanosecond,
+		ScoreAccounts: func(context.Context, []accounts.Account) ([]selectacct.Score, int) {
+			panic("boom")
+		},
+	}
+	func() {
+		defer func() { _ = recover() }()
+		server.refreshUsageScoresIfStale(context.Background())
+	}()
+
+	refreshed := false
+	server.ScoreAccounts = func(context.Context, []accounts.Account) ([]selectacct.Score, int) {
+		refreshed = true
+		return []selectacct.Score{{AccountID: "acct@example.com", Headroom: 0.5, ShortHeadroom: 0.5}}, 1
+	}
+	schedulerRef.SetUpdatedAt(time.Time{})
+	server.refreshUsageScoresIfStale(context.Background())
+	if !refreshed {
+		t.Fatal("refresh claim was never released after a panic; usage scores are frozen")
+	}
+}
+
+// With the whole Claude OAuth pool exhausted, a sticky session must fail
+// selection directly (routing to the fallback chain) instead of logging a
+// "rerouting" to another exhausted account that is never persisted — that
+// false log repeated once per request for as long as the pool stayed cooked.
+func TestClaudeExhaustedPoolStickyFailsWithoutRerouteLog(t *testing.T) {
+	store, err := session.NewStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put("claude", "session-1", "a@example.com", ""); err != nil {
+		t.Fatal(err)
+	}
+	var logBuf bytes.Buffer
+	server := Server{
+		Accounts: []accounts.Account{
+			{ID: "a@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-a"},
+			{ID: "b@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok-b"},
+		},
+		Sessions: store,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+			{AccountID: "a@example.com", Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0},
+			{AccountID: "b@example.com", Provider: accounts.ProviderClaude, Headroom: 0, ShortHeadroom: 0},
+		})),
+		Logger:       slog.New(slog.NewTextHandler(&logBuf, nil)),
+		MaxBodyBytes: 1024,
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://subrouter.test/v1/messages", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Subrouter-Agent", "claude")
+	req.Header.Set("X-Subrouter-Session", "session-1")
+	if _, _, _, err := server.accountForSessionProvider(accounts.ProviderClaude, "claude", "session-1", req); err == nil {
+		t.Fatal("expected selection to fail with the whole pool exhausted")
+	}
+	if strings.Contains(logBuf.String(), "rerouting cold sticky session") {
+		t.Fatalf("logged a reroute that never happens:\n%s", logBuf.String())
+	}
+	assignment, ok := store.Get("claude", "session-1")
+	if !ok || assignment.AccountID != "a@example.com" {
+		t.Fatalf("sticky assignment = %+v, want unchanged a@example.com", assignment)
+	}
+}

--- a/internal/proxy/anthropic_hang_fixes_test.go
+++ b/internal/proxy/anthropic_hang_fixes_test.go
@@ -45,7 +45,7 @@ func TestSmallPostsBypassUploadLimiter(t *testing.T) {
 		limiter:     limiter,
 	}
 
-	small, err := http.NewRequest(http.MethodPost, "https://example.invalid/v1/messages", strings.NewReader(`{}`))
+	small, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://example.invalid/v1/messages", strings.NewReader(`{}`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,20 +54,24 @@ func TestSmallPostsBypassUploadLimiter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("small POST should bypass a full limiter, got %v", err)
 	}
-	response.Body.Close()
+	if err := response.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
 	if !served {
 		t.Fatal("small POST never reached the base transport")
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
 	bigBody := strings.Repeat("x", replayablePostLimiterMinBytes)
-	big, err := http.NewRequest(http.MethodPost, "https://example.invalid/v1/messages", strings.NewReader(bigBody))
+	big, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://example.invalid/v1/messages", strings.NewReader(bigBody))
 	if err != nil {
 		t.Fatal(err)
 	}
 	big.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader(bigBody)), nil }
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-	if _, err := transport.RoundTrip(big.WithContext(ctx)); err == nil {
+	bigResponse, err := transport.RoundTrip(big)
+	if err == nil {
+		_ = bigResponse.Body.Close()
 		t.Fatal("large POST should wait on the full limiter and fail on context timeout")
 	}
 }
@@ -88,7 +92,7 @@ func TestBedrockPeekForcesCommitOnDeadline(t *testing.T) {
 		for {
 			select {
 			case <-stop:
-				pw.Close()
+				_ = pw.Close()
 				return
 			case <-time.After(5 * time.Millisecond):
 				if _, err := pw.Write(ping); err != nil {
@@ -126,6 +130,49 @@ func TestBedrockPeekForcesCommitOnBufferCap(t *testing.T) {
 	}
 }
 
+// A stream that goes completely silent blocks inside Read, where the peek's
+// between-read deadline can never fire; the watchdog must close the body so
+// the attempt fails retryably instead of withholding response headers forever.
+func TestBedrockPeekWatchdogAbortsSilentStream(t *testing.T) {
+	savedAfter := claudeFableBedrockPeekForceCommitAfter
+	savedGrace := claudeFableBedrockPeekSilenceGrace
+	claudeFableBedrockPeekForceCommitAfter = 10 * time.Millisecond
+	claudeFableBedrockPeekSilenceGrace = 10 * time.Millisecond
+	defer func() {
+		claudeFableBedrockPeekForceCommitAfter = savedAfter
+		claudeFableBedrockPeekSilenceGrace = savedGrace
+	}()
+
+	rt := bedrockRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		pr, _ := io.Pipe() // never written: Read blocks until the watchdog closes it
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       pr,
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	done := make(chan struct{})
+	var resp *http.Response
+	var respErr error
+	go func() {
+		defer close(done)
+		resp, respErr = s.claudeFableBedrockResponse(context.Background(), fableStreamTestBody)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("silent Bedrock stream still hangs the request")
+	}
+	if respErr != nil {
+		t.Fatal(respErr)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 after aborting silent streams", resp.StatusCode)
+	}
+}
+
 // Unknown (future) delta types are invisible like thinking deltas and must be
 // gated by the commit window, not commit the stream instantly — an instant
 // commit reintroduces the unreplayable post-commit shed the window absorbs.
@@ -153,7 +200,9 @@ func TestBedrockStreamUsageWriterCarriesCacheCreationSplit(t *testing.T) {
 	stop := buildEventStreamFrame(t, `{"type":"message_delta","usage":{"output_tokens":5}}`)
 
 	p := newBedrockStreamUsageWriter()
-	p.Write(append(append([]byte{}, start...), stop...))
+	if _, err := p.Write(append(append([]byte{}, start...), stop...)); err != nil {
+		t.Fatal(err)
+	}
 	usage, ok := p.Usage()
 	if !ok {
 		t.Fatal("expected usage extracted")
@@ -228,7 +277,7 @@ func TestClaudeExhaustedPoolStickyFailsWithoutRerouteLog(t *testing.T) {
 		Logger:       slog.New(slog.NewTextHandler(&logBuf, nil)),
 		MaxBodyBytes: 1024,
 	}
-	req, err := http.NewRequest(http.MethodPost, "https://subrouter.test/v1/messages", strings.NewReader(`{}`))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://subrouter.test/v1/messages", strings.NewReader(`{}`))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -607,6 +607,17 @@ type bedrockStreamPeek struct {
 // shrink it.
 var claudeFableBedrockCommitWindow = 20 * time.Second
 
+// The peek loop otherwise runs until a decisive frame arrives, and nothing
+// guarantees one ever does: a stream of pings, unparseable frames, or endless
+// thinking whose window anchor never trips buffers raw bytes without bound
+// while the client has received no response headers at all — silence
+// indistinguishable from a hang, for as long as the client waits. Past either
+// bound the stream has proved it is alive, just not classifiable, so commit
+// and let any later shed surface as an in-band error event instead of
+// buffering forever. Vars, not consts, so tests can shrink them.
+var claudeFableBedrockPeekMaxBytes = 8 << 20
+var claudeFableBedrockPeekForceCommitAfter = 120 * time.Second
+
 // bedrockFrameDecision reports whether a frame decides the stream's fate at
 // the given elapsed time since the stream opened. Errors and exceptions are
 // failures. A visible delta (text_delta, input_json_delta), a usage delta, or
@@ -663,7 +674,15 @@ func bedrockFrameDecision(frame bedrockFrame, sinceFirstThinking time.Duration) 
 			}
 			return false, false, ""
 		}
-		return true, false, "delta_" + ev.Delta.Type
+		// Unknown delta types arrive with new betas and are usually invisible
+		// (redacted_thinking-shaped). Committing on one instantly reintroduces
+		// the unreplayable post-commit shed the window exists to absorb, so
+		// gate them like thinking deltas; the peek's forced deadline backstops
+		// a stream made only of them.
+		if sinceFirstThinking >= claudeFableBedrockCommitWindow {
+			return true, false, "window_expired_delta_" + ev.Delta.Type
+		}
+		return false, false, ""
 	}
 	return false, false, ""
 }
@@ -685,7 +704,13 @@ func bedrockFrameIsThinkingDelta(frame bedrockFrame) bool {
 	if json.Unmarshal(frame.payload, &ev) != nil || ev.Type != "content_block_delta" {
 		return false
 	}
-	return ev.Delta.Type == "thinking_delta" || ev.Delta.Type == "signature_delta"
+	switch ev.Delta.Type {
+	case "text_delta", "input_json_delta":
+		return false
+	}
+	// thinking_delta, signature_delta, and any future invisible delta type:
+	// all are buffered by the commit window, so all anchor it.
+	return true
 }
 
 func peekBedrockStreamUntilCommit(src io.Reader) bedrockStreamPeek {
@@ -736,6 +761,18 @@ func peekBedrockStreamUntilCommit(src io.Reader) bedrockStreamPeek {
 				readErr = errBedrockStreamEmpty
 			}
 			return bedrockStreamPeek{outcome: bedrockPeekReadErr, readErr: readErr, peeked: peeked.Bytes()}
+		}
+		if peeked.Len() >= claudeFableBedrockPeekMaxBytes {
+			decided = true
+			commitReason = "forced_buffer_cap"
+			commitAt = time.Since(started)
+			break
+		}
+		if time.Since(started) >= claudeFableBedrockPeekForceCommitAfter {
+			decided = true
+			commitReason = "forced_deadline"
+			commitAt = time.Since(started)
+			break
 		}
 	}
 	if failed {

--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -195,7 +195,18 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 		if !stream || resp.StatusCode != http.StatusOK {
 			break
 		}
+		// The peek's forced deadline only fires between reads. A stream that
+		// goes completely silent blocks inside Read where no check can run, so
+		// a watchdog closes the body after the deadline plus a grace period
+		// (giving a frame-carrying stream time to force-commit first). The
+		// close errors the blocked Read and the attempt fails retryably. If
+		// the watchdog raced a commit, the body is already unusable: downgrade
+		// to the same retryable failure instead of streaming a closed body.
+		peekWatchdog := time.AfterFunc(claudeFableBedrockPeekForceCommitAfter+claudeFableBedrockPeekSilenceGrace, func() { _ = resp.Body.Close() })
 		peek := peekBedrockStreamUntilCommit(resp.Body)
+		if !peekWatchdog.Stop() && peek.outcome == bedrockPeekCommit {
+			peek = bedrockStreamPeek{outcome: bedrockPeekReadErr, readErr: errBedrockPeekWatchdog, peeked: peek.peeked}
+		}
 		if peek.outcome == bedrockPeekCommit {
 			pr, pw := io.Pipe()
 			streamStarted := started
@@ -557,6 +568,16 @@ type bedrockFrame struct {
 }
 
 var errBedrockStreamEmpty = errors.New("bedrock stream ended before first event")
+
+// errBedrockPeekWatchdog marks an attempt whose stream went silent long
+// enough that the peek watchdog closed the body out from under it.
+var errBedrockPeekWatchdog = errors.New("bedrock stream silent past the peek deadline")
+
+// claudeFableBedrockPeekSilenceGrace is added to the forced-commit deadline
+// before the watchdog closes a silent stream's body, so a stream that is
+// delivering frames always force-commits between reads first and only a
+// stream blocked inside Read is aborted.
+var claudeFableBedrockPeekSilenceGrace = 15 * time.Second
 
 // claudeFableBedrockStreamAttempts bounds how many times a streaming Fable
 // request is re-sent to Bedrock when the stream fails before any content has

--- a/internal/proxy/bedrock_cost.go
+++ b/internal/proxy/bedrock_cost.go
@@ -190,6 +190,9 @@ func (p *bedrockStreamUsageWriter) parsePayload(payload []byte) {
 		p.usage.InputTokens = event.Message.Usage.InputTokens
 		p.usage.CacheReadTokens = event.Message.Usage.CacheReadTokens
 		p.usage.CacheWriteTokens = event.Message.Usage.CacheWriteTokens
+		// Without the TTL split, costUSD falls back to pricing every cache
+		// write at the 5m rate and understates 1h writes by ~1.6x.
+		p.usage.CacheCreation = event.Message.Usage.CacheCreation
 		p.got = true
 	case "message_delta":
 		if event.Usage.OutputTokens > 0 {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2128,6 +2128,13 @@ func usageWindowMergeKey(window accounts.UsageWindow) string {
 
 const defaultUsageFetchTimeout = 10 * time.Second
 
+// usageScoreRefreshTimeout bounds one whole score-refresh sweep (every OAuth
+// account's token refresh plus usage fetch, serially). The sweep runs detached
+// from the triggering request's context, so this deadline is the only thing
+// keeping a wedged upstream from holding that request's account selection
+// open indefinitely.
+const usageScoreRefreshTimeout = 60 * time.Second
+
 func setZeroScore(scores []selectacct.Score, scoreByID map[string]int, provider accounts.Provider, accountID string) {
 	if idx, ok := scoreByID[selectacct.ScoreKey(provider, accountID)]; ok {
 		scores[idx] = selectacct.Score{AccountID: accountID, Provider: provider, Headroom: 0, ShortHeadroom: 0}
@@ -4491,6 +4498,17 @@ func (s Server) accountForSessionProviderWithOptions(provider accounts.Provider,
 				}
 				return account, sessionID, userEmail, nil
 			}
+			if candidate.AuthMode == accounts.AuthModeOAuth && provider == accounts.ProviderClaude && scheduler.Exhausted(candidate.Provider, candidate.ID) {
+				// The whole pool is exhausted: Pick ranks exhausted accounts
+				// last but still returns one, and the post-selection check
+				// below rejects it before the assignment is ever persisted.
+				// Reaching that check through this branch used to log a
+				// "rerouting" to an unusable account that never happened,
+				// once per request for as long as the pool stayed exhausted.
+				// Fail the selection here so the handler goes straight to the
+				// fallback chain.
+				return accounts.Account{}, sessionID, userEmail, fmt.Errorf("no non-exhausted %s accounts available", provider)
+			}
 			if s.Logger != nil {
 				s.Logger.Info("rerouting cold sticky session from constrained account",
 					"agent", agentType,
@@ -4739,14 +4757,36 @@ func (s Server) refreshUsageScoresIfStale(ctx context.Context) {
 	if !s.SchedulerRef.BeginRefreshIfStaleForAccountGeneration(s.UsageScoreTTL, accountGeneration) {
 		return
 	}
+	// The Begin claim set refreshing=true, and nothing else can clear it: a
+	// panic anywhere below (swallowed by net/http's per-request recover)
+	// would leave every future BeginRefresh returning false, freezing usage
+	// scores for the life of the process. Release the claim on the way out
+	// if no Finish call has.
+	finished := false
+	defer func() {
+		if !finished {
+			s.SchedulerRef.FinishRefreshForAccountGeneration(selectacct.Scheduler{}, false, accountGeneration)
+		}
+	}()
 	availableAccounts := oauthAccounts(allAccounts)
 	scoreAccounts := s.ScoreAccounts
 	if scoreAccounts == nil {
 		scoreAccounts = s.scoreAccounts
 	}
-	scores, scored := scoreAccounts(ctx, availableAccounts)
+	// The refresh runs on whichever request happened to find the scores stale.
+	// Its context must not be that request's: a client that disconnects or
+	// times out mid-refresh cancels every remaining per-account refresh and
+	// usage fetch with "context canceled", and FinishRefresh still stamps the
+	// TTL window, so one impatient client starves the whole pool of fresh
+	// scores for another full TTL — repeatedly, under load, which pinned
+	// exhausted accounts as exhausted long after their windows reset. Detach
+	// from the caller's cancellation and bound the refresh on its own clock.
+	scoreCtx, cancelScore := context.WithTimeout(context.WithoutCancel(ctx), usageScoreRefreshTimeout)
+	defer cancelScore()
+	scores, scored := scoreAccounts(scoreCtx, availableAccounts)
 	if scored == 0 {
 		s.SchedulerRef.FinishRefreshForAccountGeneration(selectacct.Scheduler{}, false, accountGeneration)
+		finished = true
 		if s.Logger != nil {
 			s.Logger.Warn("usage score refresh skipped", "reason", "no fresh OAuth usage scores")
 		}
@@ -4756,6 +4796,7 @@ func (s Server) refreshUsageScoresIfStale(ctx context.Context) {
 	if s.Sessions != nil {
 		scheduler = scheduler.WithSessionCounts(s.Sessions.CountByAccount())
 	}
+	finished = true
 	if !s.SchedulerRef.FinishRefreshForAccountGeneration(scheduler, true, accountGeneration) {
 		if s.Logger != nil {
 			s.Logger.Debug("usage score refresh discarded after account reload")
@@ -5034,6 +5075,19 @@ func (s Server) usageLimitRetryMaxAttempts(ctx context.Context, provider account
 }
 
 const replayablePostMaxConcurrentUploads = 4
+
+// replayablePostLimiterMinBytes exempts ordinary requests from the upload
+// limiter. The limiter exists to keep a few concurrent huge uploads from
+// saturating the uplink; the body is already buffered in memory before the
+// transport runs, so the limiter bounds bandwidth, not memory. Holding a slot
+// is expensive: one slot spans the entire nested retry chain — account
+// failover, overload backoff sleeps, the Fable fallback including Bedrock's
+// commit-window peek, and the wait for response headers — so gating every
+// POST serialized all message traffic proxy-wide behind 4 slots. Under a
+// long-thinking model that looked like the proxy hanging: at most 4 requests
+// made progress and everything else queued in the limiter until the client
+// gave up. Requests below this size skip the limiter entirely.
+const replayablePostLimiterMinBytes = 8 << 20
 
 var replayablePostUploadLimiter = make(chan struct{}, replayablePostMaxConcurrentUploads)
 
@@ -6046,6 +6100,11 @@ func (t replayablePostRetryTransport) roundTrip(req *http.Request) (*http.Respon
 	if t.limiter == nil {
 		return t.base.RoundTrip(req)
 	}
+	// Only genuinely large uploads contend for a slot; an unknown length
+	// (ContentLength < 0) is treated as large.
+	if req.ContentLength >= 0 && req.ContentLength < replayablePostLimiterMinBytes {
+		return t.base.RoundTrip(req)
+	}
 	select {
 	case t.limiter <- struct{}{}:
 		defer func() { <-t.limiter }()
@@ -6108,6 +6167,7 @@ func NewOutboundTransport() *http.Transport {
 	transport.MaxIdleConnsPerHost = outboundMaxIdleConnsPerHost
 	transport.MaxIdleConns = outboundMaxIdleConns
 	transport.IdleConnTimeout = outboundIdleConnTimeout
+	transport.ResponseHeaderTimeout = outboundResponseHeaderTimeout
 	return transport
 }
 
@@ -6131,6 +6191,15 @@ const (
 	// dropped by us before the peer drops it. Still long enough to absorb the
 	// bursts of concurrent requests that pooling exists to serve.
 	outboundIdleConnTimeout = 10 * time.Second
+	// The transport deliberately has no overall deadline (responses stream),
+	// and dial and TLS are individually bounded — but the wait for response
+	// headers was not: an upstream that accepted the request and then went
+	// silent held the client request, its goroutine, and its upload-limiter
+	// slot forever. Ten minutes is far above any observed legitimate
+	// time-to-first-byte, including non-streaming Bedrock invokes of
+	// long-thinking models, while turning a blackholed connection from a
+	// permanent wedge into a retryable 502.
+	outboundResponseHeaderTimeout = 10 * time.Minute
 )
 
 func (s Server) scheduler() selectacct.Scheduler {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -6100,9 +6100,12 @@ func (t replayablePostRetryTransport) roundTrip(req *http.Request) (*http.Respon
 	if t.limiter == nil {
 		return t.base.RoundTrip(req)
 	}
-	// Only genuinely large uploads contend for a slot; an unknown length
-	// (ContentLength < 0) is treated as large.
-	if req.ContentLength >= 0 && req.ContentLength < replayablePostLimiterMinBytes {
+	// Only genuinely large uploads contend for a slot. Zero means unknown as
+	// well as empty (the client convention for a chunked body), so bypass
+	// only on a known positive below-threshold length or a definitely-empty
+	// body; unknown lengths are treated as large.
+	if (req.ContentLength > 0 && req.ContentLength < replayablePostLimiterMinBytes) ||
+		(req.ContentLength == 0 && (req.Body == nil || req.Body == http.NoBody)) {
 		return t.base.RoundTrip(req)
 	}
 	select {

--- a/internal/proxy/usage_refresh_context_test.go
+++ b/internal/proxy/usage_refresh_context_test.go
@@ -1,0 +1,60 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/manaflow-ai/subrouter/internal/accounts"
+	"github.com/manaflow-ai/subrouter/selectacct"
+)
+
+// A usage-score refresh is triggered by whichever request found the scores
+// stale, but must not die with that request: a client disconnect mid-refresh
+// used to cancel every remaining per-account refresh ("context canceled" for
+// the whole pool) while still stamping the TTL window, starving the scheduler
+// of fresh scores for another full TTL per impatient client.
+func TestUsageRefreshSurvivesTriggeringRequestCancellation(t *testing.T) {
+	accountStore := accounts.CodexStore{Dir: t.TempDir()}
+	stored := proxyStoredOAuthAccount("acct@example.com", "acct", time.Now().Add(time.Hour))
+	if err := accountStore.SaveStored(stored); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := accountStore.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := NewAccountRef(accountStore, loaded, nil)
+	schedulerRef := selectacct.NewSchedulerRef(selectacct.NewScheduler(nil))
+	schedulerRef.SetUpdatedAt(time.Time{})
+
+	var scoreCtxErr error
+	var scoreCtxHasDeadline bool
+	server := Server{
+		AccountRef:    ref,
+		SchedulerRef:  schedulerRef,
+		UsageScoreTTL: time.Nanosecond,
+		ScoreAccounts: func(ctx context.Context, _ []accounts.Account) ([]selectacct.Score, int) {
+			scoreCtxErr = ctx.Err()
+			_, scoreCtxHasDeadline = ctx.Deadline()
+			return []selectacct.Score{{
+				AccountID: "acct@example.com", Headroom: 0.5, ShortHeadroom: 0.5,
+			}}, 1
+		},
+	}
+
+	requestCtx, cancel := context.WithCancel(context.Background())
+	cancel() // the triggering client is already gone
+	server.refreshUsageScoresIfStale(requestCtx)
+
+	if scoreCtxErr != nil {
+		t.Fatalf("score refresh ran on the canceled request context: %v", scoreCtxErr)
+	}
+	if !scoreCtxHasDeadline {
+		t.Fatal("detached score refresh context has no deadline; a wedged upstream would hold account selection open forever")
+	}
+	got := schedulerRef.Get().ScoreFor(accounts.ProviderCodex, "acct@example.com")
+	if got.Headroom != 0.5 {
+		t.Fatalf("refresh result was not published: headroom = %v, want 0.5", got.Headroom)
+	}
+}


### PR DESCRIPTION
Live evidence on cmux-lawrence: five of six Claude OAuth accounts have dead refresh tokens, and in the last five hours of the current error log the one healthy account's recovery refresh died 1086 times with `context canceled` while 11,571 requests were forced onto the Bedrock fallback chain, each holding one of four global upload-limiter slots through the Bedrock commit-window peek. Clients saw multi-minute hangs and retries.

Fixes, each with a regression test:

1. **Usage-score refresh detached from the triggering request's context.** The refresh ran on whichever request found the scores stale; a client disconnect canceled every remaining per-account refresh, and `finishRefreshLocked` stamped the TTL window anyway, so exhausted accounts stayed pinned exhausted long after their windows reset. Now detached (`context.WithoutCancel`), bounded by its own 60s deadline, and the refresh claim is released on panic instead of freezing scoring for the process lifetime.
2. **Small POSTs bypass the 4-slot upload limiter.** One slot spans the whole nested retry chain (account failover, overload sleeps, the Fable fallback including the Bedrock peek, header wait), so gating every POST serialized all message traffic proxy-wide behind 4 slots. Bodies under 8 MiB skip it; it still bounds genuinely large uploads (the body is buffered before the transport either way, so the limiter bounds bandwidth, not memory).
3. **`ResponseHeaderTimeout` (10 min) on the outbound transport.** Dial and TLS were bounded but the header wait was not: a blackholed upstream held the request, its goroutine, and its limiter slot forever.
4. **Bedrock peek force-commits past 120s or 8 MiB.** A stream of pings, unparseable frames, or unclassifiable deltas buffered raw bytes forever while the client had received no response headers at all.
5. **Unknown delta types are gated by the commit window** instead of committing instantly (which silently reintroduces the unreplayable post-commit shed whenever a new invisible delta type ships), and they anchor the window like thinking deltas.
6. **Exhausted-pool sticky dead end fails selection directly.** The sticky branch logged "rerouting cold sticky session" to an account that was itself exhausted, then the post-selection check rejected it before anything persisted, once per request, forever.
7. **`bedrockStreamUsageWriter` carries the `cache_creation` TTL split** that #266 added to the Fable transcoder, so 1h cache writes on the gateway path stop being priced at the 5m rate.

Full `go test ./...` is green (two `cmd/subrouter` GCP/VM timing tests flaked once under parallel full-suite load; both pass in isolation and in a full serial package run on this branch and on main).

Not fixed here, filed mentally for follow-up: session-store blocking flock on the hot path, singleFlight panic/ctx safety on the codex catalog path, mid-stream idle watchdog for committed streams. The five dead OAuth refresh tokens need interactive re-login and no code can fix them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic/Claude path hangs and upload-limiter starvation by bounding header waits, capping Bedrock peek buffering, hardening usage-score refresh, and refining upload limiting behavior.

**Bug Fixes**
- Detaches usage-score refresh from the request, adds a 60s deadline, and releases its claim on panic.
- Small POSTs with a known body <8 MiB bypass the 4-slot upload limiter; unknown-length or large bodies still contend.
- Adds a 10-minute `ResponseHeaderTimeout` so silent upstreams can’t wedge requests and limiter slots.
- Bedrock peek force-commits after 120s or 8 MiB and uses a watchdog to abort silent streams; raced commits become retryable failures.
- Unknown `content_block_delta` types are buffered by the commit window and anchor it like thinking deltas.
- Exhausted Claude pool sticky selection fails fast to the fallback chain instead of logging a false reroute.
- `bedrockStreamUsageWriter` includes the `cache_creation` TTL split for correct cache write pricing.

<sup>Written for commit 29b0d1e01cae77b9a1b86c28c355c7d74a9cd46b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability by preventing indefinite buffering and safely handling unknown response events.
  * Preserved cache usage details for more accurate usage-based pricing.
  * Added safeguards for stalled upstream responses and refresh operations.
  * Improved handling of small uploads and exhausted sticky-session pools.
  * Ensured usage refreshes continue when the triggering request is canceled.
* **Tests**
  * Added regression coverage for streaming, timeout, pricing, session, limiter, and refresh reliability scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->