### PR TITLE
Add an idle watchdog to committed Fable Bedrock streams

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -217,7 +218,15 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 			commitReason := peek.commitReason
 			commitAt := peek.commitAt
 			go func() {
-				result := transcodeBedrockToSSESince(pw, io.MultiReader(bytes.NewReader(peeked), body), s.Logger, streamSource, streamRegion, streamStarted, commitReason, commitAt)
+				// Committed streams have no forced deadline: a stream that goes
+				// silent blocks inside Read until the client's own stall
+				// detector cancels the request minutes later. The watchdog
+				// closes the body after a bounded silence so the blocked Read
+				// fails now and the client gets an in-band retryable error
+				// instead of a dead connection.
+				watchdog := newBedrockIdleWatchdogReader(io.MultiReader(bytes.NewReader(peeked), body), body, claudeFableBedrockStreamIdleTimeout)
+				result := transcodeBedrockToSSESince(pw, watchdog, s.Logger, streamSource, streamRegion, streamStarted, commitReason, commitAt)
+				watchdog.stop()
 				_ = body.Close()
 				_ = pw.Close()
 				s.recordClaudeFableBedrockCost(streamStarted, streamRegion, http.StatusOK, result.Usage, result.HaveUsage)
@@ -579,6 +588,77 @@ var errBedrockPeekWatchdog = errors.New("bedrock stream silent past the peek dea
 // stream blocked inside Read is aborted.
 var claudeFableBedrockPeekSilenceGrace = 15 * time.Second
 
+// errBedrockStreamIdle marks a committed stream whose upstream sent nothing
+// for claudeFableBedrockStreamIdleTimeout, so the idle watchdog closed it.
+var errBedrockStreamIdle = errors.New("bedrock stream idle mid-response past the watchdog deadline")
+
+// claudeFableBedrockStreamIdleTimeout bounds silence on a committed stream.
+// Healthy Fable streams show long frame gaps (production logs: first visible
+// delta at 57s while thinking), so this must sit well above those; the client
+// stall detector that this watchdog preempts cancels around 300s of silence.
+// Any received frame, pings included, resets the clock. A var, not a const,
+// so tests can shrink it.
+var claudeFableBedrockStreamIdleTimeout = 120 * time.Second
+
+// bedrockIdleWatchdogReader closes closer when src delivers nothing for
+// timeout, which errors the blocked Read. The fire callback re-checks recency
+// under the mutex so a frame that arrives as the timer fires reschedules the
+// deadline instead of killing a live stream.
+type bedrockIdleWatchdogReader struct {
+	src     io.Reader
+	closer  io.Closer
+	timeout time.Duration
+
+	mu      sync.Mutex
+	timer   *time.Timer
+	last    time.Time
+	fired   bool
+	stopped bool
+}
+
+func newBedrockIdleWatchdogReader(src io.Reader, closer io.Closer, timeout time.Duration) *bedrockIdleWatchdogReader {
+	r := &bedrockIdleWatchdogReader{src: src, closer: closer, timeout: timeout, last: time.Now()}
+	r.timer = time.AfterFunc(timeout, r.fire)
+	return r
+}
+
+func (r *bedrockIdleWatchdogReader) fire() {
+	r.mu.Lock()
+	if r.stopped {
+		r.mu.Unlock()
+		return
+	}
+	if idle := time.Since(r.last); idle < r.timeout {
+		r.timer.Reset(r.timeout - idle)
+		r.mu.Unlock()
+		return
+	}
+	r.fired = true
+	r.mu.Unlock()
+	_ = r.closer.Close()
+}
+
+func (r *bedrockIdleWatchdogReader) Read(p []byte) (int, error) {
+	n, err := r.src.Read(p)
+	r.mu.Lock()
+	r.last = time.Now()
+	fired := r.fired
+	r.mu.Unlock()
+	if err != nil && fired {
+		return n, errBedrockStreamIdle
+	}
+	return n, err
+}
+
+// stop disarms the watchdog once the transcode loop has returned, so the
+// timer cannot fire while the caller is closing the body itself.
+func (r *bedrockIdleWatchdogReader) stop() {
+	r.mu.Lock()
+	r.stopped = true
+	r.timer.Stop()
+	r.mu.Unlock()
+}
+
 // claudeFableBedrockStreamAttempts bounds how many times a streaming Fable
 // request is re-sent to Bedrock when the stream fails before any content has
 // been forwarded to the client. Nothing was committed yet, so the request is
@@ -865,6 +945,9 @@ func transcodeBedrockToSSESince(w io.Writer, src io.Reader, logger *slog.Logger,
 	var scanner bedrockFrameScanner
 	var result bedrockStreamResult
 	eventsForwarded := 0
+	// output_tokens_so_far is always 0 mid-stream (usage arrives in the final
+	// message_delta), so the death logs also count visible progress directly.
+	contentDeltasForwarded := 0
 	sawTextBlock := false
 	exceptionHandled := false
 	finalize := func() bedrockStreamResult {
@@ -932,6 +1015,8 @@ func transcodeBedrockToSSESince(w io.Writer, src io.Reader, logger *slog.Logger,
 			}
 		case "message_stop":
 			result.SawMessageStop = true
+		case "content_block_delta":
+			contentDeltasForwarded++
 		case "content_block_start":
 			var block struct {
 				ContentBlock struct {
@@ -947,7 +1032,7 @@ func transcodeBedrockToSSESince(w io.Writer, src io.Reader, logger *slog.Logger,
 				// upstream died. events_forwarded and saw_text_block separate
 				// admission-time sheds (retryable pre-commit, handled by the
 				// peek) from mid-generation sheds (not replayable).
-				logger.Warn("claude-fable bedrock in-band error", "exception_type", "", "message", bedrockLogPreview(inner), "bedrock_source", bedrockSource, "region", region, "saw_message_stop", result.SawMessageStop, "events_forwarded", eventsForwarded, "saw_text_block", sawTextBlock, "output_tokens_so_far", result.Usage.OutputTokens, "elapsed_ms", time.Since(started).Milliseconds(), "commit_reason", commitReason, "commit_at_ms", commitAt.Milliseconds())
+				logger.Warn("claude-fable bedrock in-band error", "exception_type", "", "message", bedrockLogPreview(inner), "bedrock_source", bedrockSource, "region", region, "saw_message_stop", result.SawMessageStop, "events_forwarded", eventsForwarded, "content_deltas_forwarded", contentDeltasForwarded, "saw_text_block", sawTextBlock, "output_tokens_so_far", result.Usage.OutputTokens, "elapsed_ms", time.Since(started).Milliseconds(), "commit_reason", commitReason, "commit_at_ms", commitAt.Milliseconds())
 			}
 		}
 		eventType := ev.Type
@@ -974,10 +1059,20 @@ func transcodeBedrockToSSESince(w io.Writer, src io.Reader, logger *slog.Logger,
 		if readErr != nil {
 			if !result.SawMessageStop && !exceptionHandled {
 				result.ReadErr = readErr
-				if logger != nil {
-					logger.Error("claude-fable bedrock stream truncated", "bedrock_source", bedrockSource, "region", region, "read_err", readErr, "saw_message_stop", result.SawMessageStop, "exception_type", "", "message", "", "events_forwarded", eventsForwarded, "saw_text_block", sawTextBlock, "output_tokens_so_far", result.Usage.OutputTokens, "elapsed_ms", time.Since(started).Milliseconds(), "commit_reason", commitReason, "commit_at_ms", commitAt.Milliseconds())
+				logMessage := "claude-fable bedrock stream truncated"
+				if errors.Is(readErr, errBedrockStreamIdle) {
+					logMessage = "claude-fable bedrock stream idle, aborted by watchdog"
 				}
-				writeErrorEvent("api_error", "Bedrock stream interrupted")
+				if logger != nil {
+					logger.Error(logMessage, "bedrock_source", bedrockSource, "region", region, "read_err", readErr, "saw_message_stop", result.SawMessageStop, "exception_type", "", "message", "", "events_forwarded", eventsForwarded, "content_deltas_forwarded", contentDeltasForwarded, "saw_text_block", sawTextBlock, "output_tokens_so_far", result.Usage.OutputTokens, "elapsed_ms", time.Since(started).Milliseconds(), "commit_reason", commitReason, "commit_at_ms", commitAt.Milliseconds())
+				}
+				if errors.Is(readErr, errBedrockStreamIdle) {
+					// overloaded_error is the error type clients already retry
+					// with backoff; the request is replayable from their side.
+					writeErrorEvent("overloaded_error", "Bedrock stream went idle mid-response")
+				} else {
+					writeErrorEvent("api_error", "Bedrock stream interrupted")
+				}
 			} else if readErr != io.EOF {
 				result.ReadErr = readErr
 			}

--- a/internal/proxy/bedrock_stream_test.go
+++ b/internal/proxy/bedrock_stream_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 type bedrockHeaderKV struct {
@@ -232,6 +234,121 @@ func TestServeClaudeFableBedrockPrimaryFallsThroughOnEmptyStream(t *testing.T) {
 	}
 	if string(restored) != bodyStr {
 		t.Fatalf("restored body = %q, want %q", string(restored), bodyStr)
+	}
+}
+
+// A committed stream that goes silent used to block inside Read until the
+// client's stall detector canceled the request minutes later ("The response
+// stopped arriving"). The idle watchdog must close the body and surface a
+// retryable in-band error instead.
+func TestTranscodeBedrockIdleWatchdogAbortsSilentStream(t *testing.T) {
+	frames := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":3}}}`),
+		buildEventStreamFrame(t, `{"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}`)...,
+	)
+	pr, pw := io.Pipe()
+	go func() {
+		_, _ = pw.Write(frames)
+		// Silence forever: only the watchdog closing pr can end the stream.
+	}()
+	watchdog := newBedrockIdleWatchdogReader(pr, pr, 50*time.Millisecond)
+	defer watchdog.stop()
+
+	var logBuf bytes.Buffer
+	rec := httptest.NewRecorder()
+	result := transcodeBedrockToSSE(rec, watchdog, slog.New(slog.NewTextHandler(&logBuf, nil)), "aw0", "us-east-1")
+
+	if !errors.Is(result.ReadErr, errBedrockStreamIdle) {
+		t.Fatalf("read err = %v, want errBedrockStreamIdle", result.ReadErr)
+	}
+	out := rec.Body.String()
+	if !strings.Contains(out, "event: content_block_delta") {
+		t.Fatalf("committed content missing from output:\n%s", out)
+	}
+	if !strings.Contains(out, "event: error") || !strings.Contains(out, `"type":"overloaded_error"`) || !strings.Contains(out, "went idle mid-response") {
+		t.Fatalf("missing retryable idle SSE error:\n%s", out)
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, "claude-fable bedrock stream idle, aborted by watchdog") ||
+		!strings.Contains(logs, "content_deltas_forwarded=1") {
+		t.Fatalf("missing idle watchdog log:\n%s", logs)
+	}
+}
+
+// Frames arriving within the timeout must keep resetting the watchdog: a slow
+// but alive stream reaches message_stop with no synthetic error.
+func TestBedrockIdleWatchdogSparesSlowButAliveStream(t *testing.T) {
+	var frames [][]byte
+	for i := 0; i < 5; i++ {
+		frames = append(frames, buildEventStreamFrame(t, `{"type":"content_block_delta","delta":{"type":"text_delta","text":"x"}}`))
+	}
+	frames = append(frames, buildEventStreamFrame(t, `{"type":"message_stop"}`))
+	pr, pw := io.Pipe()
+	go func() {
+		for _, frame := range frames {
+			time.Sleep(60 * time.Millisecond)
+			_, _ = pw.Write(frame)
+		}
+		_ = pw.Close()
+	}()
+	watchdog := newBedrockIdleWatchdogReader(pr, pr, 250*time.Millisecond)
+	defer watchdog.stop()
+
+	rec := httptest.NewRecorder()
+	result := transcodeBedrockToSSE(rec, watchdog, nil, "aw0", "us-east-1")
+	if !result.SawMessageStop || result.ReadErr != nil {
+		t.Fatalf("result = %+v, want clean message_stop", result)
+	}
+	if out := rec.Body.String(); strings.Contains(out, "event: error") {
+		t.Fatalf("live stream got a synthetic error:\n%s", out)
+	}
+}
+
+// End-to-end: the committed-stream goroutine in claudeFableBedrockResponse
+// must arm the watchdog, so a client reading the returned SSE body sees the
+// retryable error instead of a hang.
+func TestClaudeFableBedrockIdleWatchdogEndToEnd(t *testing.T) {
+	oldTimeout := claudeFableBedrockStreamIdleTimeout
+	claudeFableBedrockStreamIdleTimeout = 50 * time.Millisecond
+	defer func() { claudeFableBedrockStreamIdleTimeout = oldTimeout }()
+
+	frames := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":3}}}`),
+		buildEventStreamFrame(t, `{"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}`)...,
+	)
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		pr, pw := io.Pipe()
+		go func() {
+			_, _ = pw.Write(frames)
+			// Silence forever after commit.
+		}()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       pr,
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	resp, err := s.claudeFableBedrockResponse(t.Context(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want committed 200", resp.StatusCode)
+	}
+	done := make(chan []byte, 1)
+	go func() {
+		sse, _ := io.ReadAll(resp.Body)
+		done <- sse
+	}()
+	select {
+	case sse := <-done:
+		if !strings.Contains(string(sse), `"type":"overloaded_error"`) || !strings.Contains(string(sse), "went idle mid-response") {
+			t.Fatalf("missing idle error event: %q", sse)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("stream still hanging: watchdog never fired")
 	}
 }
 


### PR DESCRIPTION
Fixes #269.

A committed Bedrock stream that went silent blocked inside `Read` with nothing to interrupt it. The client's stall detector canceled the request minutes later, and agents saw `API Error: The response stopped arriving.` Production on cmux-lawrence logged silent gaps over 180s with client cancels near 300s.

The fix: `newBedrockIdleWatchdogReader` wraps the committed stream body. When no frames arrive for 120s, it closes the body, which errors the blocked `Read`. The transcoder then emits an in-band SSE `overloaded_error` event, so the client fails fast and retries with its normal backoff. Any received frame, pings included, resets the clock. The fire callback re-checks recency under the mutex, so a frame that races the timer reschedules the deadline instead of killing a live stream.

Timeout rationale: 120s sits well above the longest healthy frame gap seen in production (57s to first visible delta while thinking) and well below the ~300s client cancel it preempts. It is a var so tests shrink it.

Also: death logs gain `content_deltas_forwarded`. `output_tokens_so_far` is always 0 mid-stream because usage arrives only in the final `message_delta`, so it hid how much output was lost.

Tests: silent committed stream is aborted with the retryable error; a slow but alive stream (frames inside the timeout) is untouched through `message_stop`; end-to-end through `claudeFableBedrockResponse`, a reader of the returned SSE body sees the error instead of hanging. `go vet` and the full `go test ./...` suite pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790311179&installation_model_id=21920&pr_number=270&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F270&signature=197cc45a995045c5767a01a7c292a4e5e3df601fd5dd747c406063ab7870e0a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented Claude Fable streaming responses from hanging indefinitely when no data is received.
  - Silent streams now terminate and return a retryable overload error, allowing recovery through retry handling.
  - Slow but active streams continue successfully without being interrupted.
  - Improved stream-progress reporting for more accurate monitoring of ongoing responses.

- **Tests**
  - Added coverage for silent-stream failures, active slow streams, and end-to-end timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->