### PR TITLE
Buffer tool-input deltas in the Fable Bedrock commit window

### DIFF
--- a/internal/proxy/anthropic_hang_fixes_test.go
+++ b/internal/proxy/anthropic_hang_fixes_test.go
@@ -190,7 +190,7 @@ func TestBedrockFrameDecisionGatesUnknownDeltaTypes(t *testing.T) {
 	if !strings.Contains(reason, "window_expired") {
 		t.Fatalf("reason = %q, want window_expired_*", reason)
 	}
-	if !bedrockFrameIsThinkingDelta(frame) {
+	if !bedrockFrameIsBufferedDelta(frame) {
 		t.Fatal("unknown invisible delta must anchor the commit window")
 	}
 }

--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -702,10 +702,12 @@ type bedrockStreamPeek struct {
 // live: committed on a late first delta, shed 743ms later). Surfaced sheds on
 // 2026-08-19/20 clustered at 5-20s, mostly during thinking; twenty seconds
 // buys absorption of that whole cluster. The cost is visible thinking starting
-// up to this much later on thinking-heavy responses; visible text and tool
-// input still commit instantly, and agent sessions never watch live thinking. Any visible delta (text or tool input) commits immediately, so
-// answers without long thinking pay nothing. A var, not a const, so tests can
-// shrink it.
+// up to this much later on thinking-heavy responses; visible text still
+// commits instantly, so answers without long thinking pay nothing. Tool-input
+// deltas are buffered too (since 2026-08-26): clients neither render nor
+// execute a tool call before the message ends, so gating them is free and
+// absorbs the stall cluster that begins seconds into tool-JSON emission. A
+// var, not a const, so tests can shrink it.
 var claudeFableBedrockCommitWindow = 20 * time.Second
 
 // The peek loop otherwise runs until a decisive frame arrives, and nothing
@@ -721,19 +723,23 @@ var claudeFableBedrockPeekForceCommitAfter = 120 * time.Second
 
 // bedrockFrameDecision reports whether a frame decides the stream's fate at
 // the given elapsed time since the stream opened. Errors and exceptions are
-// failures. A visible delta (text_delta, input_json_delta), a usage delta, or
-// message_stop proves the stream viable immediately. Thinking deltas prove it
-// only once the commit window has elapsed: Bedrock regularly sheds a stream
-// within the first seconds of thinking, and holding those frames back keeps
-// the request replayable. message_start, content_block_start/stop, and pings
-// prove nothing.
-// sinceFirstThinking is how long thinking deltas have been flowing (zero
-// until the first one arrives): the commit window is anchored there, not at
-// stream start, because display delay only begins to cost once there is
-// something to display. Fable regularly thinks silently for 30s+ before its
-// first delta (seen live: first delta at 38.6s, shed 3s later), and a
+// failures. A text delta, a usage delta, or message_stop proves the stream
+// viable immediately. Thinking and tool-input deltas prove it only once the
+// commit window has elapsed: Bedrock regularly sheds or stalls a stream in
+// the first seconds of thinking OR of tool-JSON emission (production
+// 2026-08-26: four of seven watchdog aborts began idling 3-7s after an
+// input_json_delta commit), and holding those frames back keeps the request
+// replayable. Buffering tool input is free for the client: no client renders
+// or executes a tool call before the message ends, and the typical tool-call
+// turn commits on its message_delta anyway. message_start,
+// content_block_start/stop, and pings prove nothing.
+// sinceFirstBuffered is how long buffered-class deltas have been flowing
+// (zero until the first one arrives): the commit window is anchored there,
+// not at stream start, because delay only begins to cost once there is
+// something to hold back. Fable regularly thinks silently for 30s+ before
+// its first delta (seen live: first delta at 38.6s, shed 3s later), and a
 // stream-start anchor expires the window during that silence for no benefit.
-func bedrockFrameDecision(frame bedrockFrame, sinceFirstThinking time.Duration) (decisive, failure bool, reason string) {
+func bedrockFrameDecision(frame bedrockFrame, sinceFirstBuffered time.Duration) (decisive, failure bool, reason string) {
 	if strings.EqualFold(frame.messageType, "exception") {
 		return true, true, "exception"
 	}
@@ -754,24 +760,19 @@ func bedrockFrameDecision(frame bedrockFrame, sinceFirstThinking time.Duration) 
 		return true, false, ev.Type
 	case "content_block_delta":
 		switch ev.Delta.Type {
-		case "thinking_delta", "signature_delta":
-			if sinceFirstThinking >= claudeFableBedrockCommitWindow {
+		case "thinking_delta", "signature_delta", "input_json_delta":
+			if sinceFirstBuffered >= claudeFableBedrockCommitWindow {
 				return true, false, "window_expired_" + ev.Delta.Type
 			}
 			return false, false, ""
 		case "text_delta":
 			// Bedrock primes every block with an EMPTY first delta (seen in
-			// transcripts: text_delta{text:""}, input_json_delta
-			// {partial_json:""}). An empty delta carries nothing the client
-			// needs, so it proves nothing; committing on it made a shed one
-			// frame later non-replayable. Only a delta with payload commits.
+			// transcripts: text_delta{text:""}). An empty delta carries
+			// nothing the client needs, so it proves nothing; committing on
+			// it made a shed one frame later non-replayable. Only a delta
+			// with payload commits.
 			if ev.Delta.Text != "" {
 				return true, false, "text_delta"
-			}
-			return false, false, ""
-		case "input_json_delta":
-			if ev.Delta.PartialJSON != "" {
-				return true, false, "input_json_delta"
 			}
 			return false, false, ""
 		}
@@ -780,7 +781,7 @@ func bedrockFrameDecision(frame bedrockFrame, sinceFirstThinking time.Duration) 
 		// the unreplayable post-commit shed the window exists to absorb, so
 		// gate them like thinking deltas; the peek's forced deadline backstops
 		// a stream made only of them.
-		if sinceFirstThinking >= claudeFableBedrockCommitWindow {
+		if sinceFirstBuffered >= claudeFableBedrockCommitWindow {
 			return true, false, "window_expired_delta_" + ev.Delta.Type
 		}
 		return false, false, ""
@@ -793,9 +794,10 @@ func bedrockFrameDecision(frame bedrockFrame, sinceFirstThinking time.Duration) 
 // read error). Nothing is forwarded to the client while peeking, so a failed
 // stream can be retried without duplicating output. peeked carries every raw
 // byte read, for replay into the transcoder on commit.
-// bedrockFrameIsThinkingDelta reports whether a frame is a thinking or
-// signature delta, the frame class the commit window buffers.
-func bedrockFrameIsThinkingDelta(frame bedrockFrame) bool {
+// bedrockFrameIsBufferedDelta reports whether a frame belongs to the class
+// the commit window buffers (and therefore anchors it): every
+// content_block_delta except live-rendered text.
+func bedrockFrameIsBufferedDelta(frame bedrockFrame) bool {
 	var ev struct {
 		Type  string `json:"type"`
 		Delta struct {
@@ -805,13 +807,10 @@ func bedrockFrameIsThinkingDelta(frame bedrockFrame) bool {
 	if json.Unmarshal(frame.payload, &ev) != nil || ev.Type != "content_block_delta" {
 		return false
 	}
-	switch ev.Delta.Type {
-	case "text_delta", "input_json_delta":
-		return false
-	}
-	// thinking_delta, signature_delta, and any future invisible delta type:
-	// all are buffered by the commit window, so all anchor it.
-	return true
+	// thinking_delta, signature_delta, input_json_delta, and any future
+	// invisible delta type: all are buffered by the commit window, so all
+	// anchor it. Only text_delta streams to the client live.
+	return ev.Delta.Type != "text_delta"
 }
 
 func peekBedrockStreamUntilCommit(src io.Reader) bedrockStreamPeek {
@@ -822,20 +821,20 @@ func peekBedrockStreamUntilCommit(src io.Reader) bedrockStreamPeek {
 	failed := false
 	commitReason := ""
 	var commitAt time.Duration
-	var firstThinkingAt time.Time
+	var firstBufferedAt time.Time
 	var errorFrame bedrockFrame
 	emit := func(frame bedrockFrame) {
 		if decided {
 			return
 		}
-		if firstThinkingAt.IsZero() && bedrockFrameIsThinkingDelta(frame) {
-			firstThinkingAt = time.Now()
+		if firstBufferedAt.IsZero() && bedrockFrameIsBufferedDelta(frame) {
+			firstBufferedAt = time.Now()
 		}
-		var sinceFirstThinking time.Duration
-		if !firstThinkingAt.IsZero() {
-			sinceFirstThinking = time.Since(firstThinkingAt)
+		var sinceFirstBuffered time.Duration
+		if !firstBufferedAt.IsZero() {
+			sinceFirstBuffered = time.Since(firstBufferedAt)
 		}
-		decisive, failure, reason := bedrockFrameDecision(frame, sinceFirstThinking)
+		decisive, failure, reason := bedrockFrameDecision(frame, sinceFirstBuffered)
 		if !decisive {
 			return
 		}

--- a/internal/proxy/claude_fable_test.go
+++ b/internal/proxy/claude_fable_test.go
@@ -1106,15 +1106,77 @@ func TestClaudeFableBedrockRetriesShedAfterEmptyPrimingDelta(t *testing.T) {
 	}
 }
 
-// A delta with real tool-input payload still commits immediately.
-func TestClaudeFableBedrockCommitsOnNonEmptyToolDelta(t *testing.T) {
-	stream := append(
+// Tool-input deltas are buffered by the commit window (production
+// 2026-08-26: streams stalled 3-7s after emitting tool JSON), so a shed
+// during tool-JSON emission inside the window must retry invisibly: no
+// client renders or executes a tool call before the message ends.
+func TestClaudeFableBedrockRetriesShedDuringToolJSONInsideWindow(t *testing.T) {
+	bad := append(
 		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
 		append(
 			buildEventStreamFrame(t, `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_y","name":"Bash","input":{}}}`),
 			append(
 				buildEventStreamFrame(t, `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"comm"}}`),
 				buildEventStreamFrame(t, `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)...,
+			)...,
+		)...,
+	)
+	good := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		append(
+			buildEventStreamFrame(t, `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`),
+			buildEventStreamFrame(t, `{"type":"message_stop"}`)...,
+		)...,
+	)
+	calls := 0
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		body := bad
+		if calls >= 2 {
+			body = good
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	resp, err := s.claudeFableBedrockResponse(req.Context(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after retrying a tool-JSON shed", resp.StatusCode)
+	}
+	sse, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(sse), "overloaded_error") || strings.Contains(string(sse), "toolu_y") {
+		t.Fatalf("failed attempt leaked into retried stream: %q", sse)
+	}
+	if calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2", calls)
+	}
+}
+
+// A complete tool-call turn commits on its message_delta, so buffering the
+// tool JSON adds no latency to the normal case and the full block reaches
+// the client.
+func TestClaudeFableBedrockToolTurnCommitsOnMessageDelta(t *testing.T) {
+	stream := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		append(
+			buildEventStreamFrame(t, `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_y","name":"Bash","input":{}}}`),
+			append(
+				buildEventStreamFrame(t, `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"command\":\"ls\"}"}}`),
+				append(
+					buildEventStreamFrame(t, `{"type":"content_block_stop","index":0}`),
+					append(
+						buildEventStreamFrame(t, `{"type":"message_delta","usage":{"output_tokens":9}}`),
+						buildEventStreamFrame(t, `{"type":"message_stop"}`)...,
+					)...,
+				)...,
 			)...,
 		)...,
 	)
@@ -1138,8 +1200,10 @@ func TestClaudeFableBedrockCommitsOnNonEmptyToolDelta(t *testing.T) {
 		t.Fatalf("status=%d calls=%d, want committed 200 with 1 call", resp.StatusCode, calls)
 	}
 	sse, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(sse), "toolu_y") || !strings.Contains(string(sse), "overloaded_error") {
-		t.Fatalf("committed stream must pass tool block and error through: %q", sse)
+	for _, want := range []string{"toolu_y", `{\"command\":\"ls\"}`, "event: message_stop"} {
+		if !strings.Contains(string(sse), want) {
+			t.Fatalf("committed tool turn missing %q: %q", want, sse)
+		}
 	}
 }
 


### PR DESCRIPTION
Follow-up to #270. Production telemetry since the idle watchdog deployed (2026-08-26): four of seven watchdog aborts began idling 3-7 seconds after the stream committed on an `input_json_delta` (log lines `commit_reason=input_json_delta`, then `stream idle, aborted by watchdog`). The early commit made those stalls non-replayable, so clients saw `API Error: Server error mid-response` instead of a silent server-side retry.

Committing on tool JSON buys nothing: no client renders or executes a tool call before the message ends, and a normal tool-call turn commits on its trailing `message_delta` anyway. So `input_json_delta` joins the buffered class: it anchors the commit window and only expires it. `text_delta` (live-rendered) still commits instantly. Sheds and stalls during tool-JSON emission inside the 20s window are now retried invisibly, like thinking-phase sheds.

Tests: a shed during tool JSON inside the window retries with no leak of the failed attempt; a complete tool-call turn still commits on `message_delta` with the full block delivered in one upstream call; existing empty-priming-delta and window tests updated to the renamed `bedrockFrameIsBufferedDelta`. `go vet` and the proxy package pass; the one full-suite failure (`TestCreateVMTempFilesSurviveInterruptedAndRepeatedMacOSRuns`) is an unrelated timing flake that passes 3/3 in isolation with this diff applied.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790383446&installation_model_id=21920&pr_number=271&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F271&signature=cd1394c6244ec844f0ca17e7fd526d35690554dc6867f1fd9fc31ec66568ca82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Buffers Bedrock `input_json_delta` frames in the Fable commit window so stalls during tool-JSON emission are silently retried instead of surfacing as mid-response errors. Previously, tool-input deltas committed the stream immediately, which made post-commit sheds non-replayable; they now anchor the commit window like thinking deltas. `text_delta` still commits instantly. Renames `bedrockFrameIsThinkingDelta` to `bedrockFrameIsBufferedDelta` to reflect the broader buffered class.

<sup>Written for commit 5b41d94b1ff7cafee599810c1dfd19d1194d5a64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bedrock streaming reliability when tool inputs and thinking content are generated.
  * Prevented incomplete tool-call data and temporary overload errors from being exposed during stream retries.
  * Ensured complete tool-call responses are delivered when the message is finalized.
  * Empty text updates no longer prematurely finalize a response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->