### PR TITLE
Let the final Fable Bedrock attempt ride without the silence watchdog

### DIFF
--- a/internal/proxy/anthropic_hang_fixes_test.go
+++ b/internal/proxy/anthropic_hang_fixes_test.go
@@ -131,9 +131,13 @@ func TestBedrockPeekForcesCommitOnBufferCap(t *testing.T) {
 }
 
 // A stream that goes completely silent blocks inside Read, where the peek's
-// between-read deadline can never fire; the watchdog must close the body so
-// the attempt fails retryably instead of withholding response headers forever.
-func TestBedrockPeekWatchdogAbortsSilentStream(t *testing.T) {
+// between-read deadline can never fire. Non-final attempts must be freed by
+// the watchdog (fail retryably); the FINAL attempt rides without it, because
+// pre-frame silence is indistinguishable from a long prefill, so only the
+// client's own context bounds it. Silent bodies on every attempt: the
+// watchdog frees attempts 1 and 2, attempt 3 blocks until the client
+// cancels, and the call returns.
+func TestBedrockPeekWatchdogFreesNonFinalAttemptsAndFinalRides(t *testing.T) {
 	savedAfter := claudeFableBedrockPeekForceCommitAfter
 	savedGrace := claudeFableBedrockPeekSilenceGrace
 	claudeFableBedrockPeekForceCommitAfter = 10 * time.Millisecond
@@ -143,8 +147,22 @@ func TestBedrockPeekWatchdogAbortsSilentStream(t *testing.T) {
 		claudeFableBedrockPeekSilenceGrace = savedGrace
 	}()
 
-	rt := bedrockRoundTripFunc(func(*http.Request) (*http.Response, error) {
-		pr, _ := io.Pipe() // never written: Read blocks until the watchdog closes it
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	finalAttemptStarted := make(chan struct{})
+	calls := 0
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if calls == claudeFableBedrockStreamAttempts {
+			close(finalAttemptStarted)
+		}
+		pr, _ := io.Pipe() // never written: Read blocks until close or cancel
+		go func() {
+			// The real http.Transport errors body reads when the request
+			// context is canceled; the fake must do the same.
+			<-req.Context().Done()
+			_ = pr.CloseWithError(req.Context().Err())
+		}()
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       pr,
@@ -157,12 +175,26 @@ func TestBedrockPeekWatchdogAbortsSilentStream(t *testing.T) {
 	var respErr error
 	go func() {
 		defer close(done)
-		resp, respErr = s.claudeFableBedrockResponse(context.Background(), fableStreamTestBody)
+		resp, respErr = s.claudeFableBedrockResponse(ctx, fableStreamTestBody)
 	}()
+	// The watchdog must free attempts 1 and 2 on its own: reaching the final
+	// attempt before any cancel proves it.
+	select {
+	case <-finalAttemptStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("watchdog never freed the non-final silent attempts")
+	}
+	// The final attempt rides: it must still be blocked now.
+	select {
+	case <-done:
+		t.Fatal("final attempt returned without a client cancel")
+	case <-time.After(100 * time.Millisecond):
+	}
+	cancel()
 	select {
 	case <-done:
 	case <-time.After(10 * time.Second):
-		t.Fatal("silent Bedrock stream still hangs the request")
+		t.Fatal("client cancel did not unblock the riding final attempt")
 	}
 	if resp != nil && resp.Body != nil {
 		defer func() { _ = resp.Body.Close() }()
@@ -171,7 +203,72 @@ func TestBedrockPeekWatchdogAbortsSilentStream(t *testing.T) {
 		t.Fatal(respErr)
 	}
 	if resp.StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want 503 after aborting silent streams", resp.StatusCode)
+		t.Fatalf("status = %d, want 503 after the canceled final attempt", resp.StatusCode)
+	}
+	if calls != claudeFableBedrockStreamAttempts {
+		t.Fatalf("upstream calls = %d, want %d", calls, claudeFableBedrockStreamAttempts)
+	}
+}
+
+// A large cache-miss prompt is silent until prefill finishes, far past the
+// watchdog deadline. On the final attempt that slow-but-alive stream must be
+// served, not killed: frames arriving well after deadline+grace still commit.
+func TestBedrockFinalAttemptServesSlowPrefill(t *testing.T) {
+	savedAfter := claudeFableBedrockPeekForceCommitAfter
+	savedGrace := claudeFableBedrockPeekSilenceGrace
+	claudeFableBedrockPeekForceCommitAfter = 10 * time.Millisecond
+	claudeFableBedrockPeekSilenceGrace = 10 * time.Millisecond
+	defer func() {
+		claudeFableBedrockPeekForceCommitAfter = savedAfter
+		claudeFableBedrockPeekSilenceGrace = savedGrace
+	}()
+
+	frames := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":200000}}}`),
+		buildEventStreamFrame(t, `{"type":"message_stop"}`)...,
+	)
+	calls := 0
+	rt := bedrockRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		pr, pw := io.Pipe()
+		if calls < claudeFableBedrockStreamAttempts {
+			// Non-final attempts stay silent; the watchdog frees them.
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       pr,
+				Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+			}, nil
+		}
+		go func() {
+			// First frame lands 10x past deadline+grace, like a long prefill.
+			time.Sleep(200 * time.Millisecond)
+			_, _ = pw.Write(frames)
+			_ = pw.Close()
+		}()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       pr,
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := fableStreamTestServer(rt)
+	resp, err := s.claudeFableBedrockResponse(context.Background(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: slow prefill on the final attempt must be served", resp.StatusCode)
+	}
+	sse, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(sse), "event: message_stop") {
+		t.Fatalf("slow-prefill stream incomplete: %q", sse)
+	}
+	if calls != claudeFableBedrockStreamAttempts {
+		t.Fatalf("upstream calls = %d, want %d", calls, claudeFableBedrockStreamAttempts)
 	}
 }
 

--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -203,9 +203,24 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 		// close errors the blocked Read and the attempt fails retryably. If
 		// the watchdog raced a commit, the body is already unusable: downgrade
 		// to the same retryable failure instead of streaming a closed body.
-		peekWatchdog := time.AfterFunc(claudeFableBedrockPeekForceCommitAfter+claudeFableBedrockPeekSilenceGrace, func() { _ = resp.Body.Close() })
+		//
+		// The FINAL attempt rides without the watchdog. Before the first
+		// frame, a hung stream and a long prefill are indistinguishable:
+		// Bedrock sends message_start only after prefill, so a large
+		// cache-miss prompt is silent for minutes on every attempt (seen
+		// live 2026-08-26: one request watchdog-killed at 135s on attempts
+		// 1 and 2, abandoned by the client mid-attempt 3). Killing the last
+		// attempt makes such requests permanently unservable and re-bills
+		// the prefill each round; riding lets the client's own context
+		// bound the wait, and a client cancel still errors the blocked Read
+		// through the request context.
+		finalAttempt := attempt >= claudeFableBedrockStreamAttempts
+		var peekWatchdog *time.Timer
+		if !finalAttempt {
+			peekWatchdog = time.AfterFunc(claudeFableBedrockPeekForceCommitAfter+claudeFableBedrockPeekSilenceGrace, func() { _ = resp.Body.Close() })
+		}
 		peek := peekBedrockStreamUntilCommit(resp.Body)
-		if !peekWatchdog.Stop() && peek.outcome == bedrockPeekCommit {
+		if peekWatchdog != nil && !peekWatchdog.Stop() && peek.outcome == bedrockPeekCommit {
 			peek = bedrockStreamPeek{outcome: bedrockPeekReadErr, readErr: errBedrockPeekWatchdog, peeked: peek.peeked}
 		}
 		if peek.outcome == bedrockPeekCommit {
@@ -246,7 +261,9 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 		// Error bodies only (never message content): the failing frame is an
 		// exception or an Anthropic error event, so logging it is safe.
 		if s.Logger != nil {
-			attrs := []any{"bedrock_source", sourceName, "region", region, "saw_message_stop", false, "attempt", attempt, "retryable", retryable}
+			// elapsed_ms and peeked_bytes separate a hung connection (long
+			// elapsed, zero bytes) from an upstream that answered and shed.
+			attrs := []any{"bedrock_source", sourceName, "region", region, "saw_message_stop", false, "attempt", attempt, "retryable", retryable, "elapsed_ms", time.Since(started).Milliseconds(), "peeked_bytes", len(peek.peeked)}
 			if peek.errorFrame.exceptionType != "" {
 				attrs = append(attrs, "exception_type", peek.errorFrame.exceptionType)
 			}

--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -217,7 +217,13 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 		finalAttempt := attempt >= claudeFableBedrockStreamAttempts
 		var peekWatchdog *time.Timer
 		if !finalAttempt {
-			peekWatchdog = time.AfterFunc(claudeFableBedrockPeekForceCommitAfter+claudeFableBedrockPeekSilenceGrace, func() { _ = resp.Body.Close() })
+			// Close the attempt-local body, never resp.Body through the loop
+			// variable: a callback that fires as its peek fails runs
+			// concurrently with the next attempt, and resolving resp late
+			// would close the WRONG attempt's body (fatal for the riding
+			// final attempt, which has no watchdog of its own).
+			attemptBody := resp.Body
+			peekWatchdog = time.AfterFunc(claudeFableBedrockPeekForceCommitAfter+claudeFableBedrockPeekSilenceGrace, func() { _ = attemptBody.Close() })
 		}
 		peek := peekBedrockStreamUntilCommit(resp.Body)
 		if peekWatchdog != nil && !peekWatchdog.Stop() && peek.outcome == bedrockPeekCommit {


### PR DESCRIPTION
Follow-up to #270/#271, from live monitoring on 2026-08-26 18:05-18:18: one request was watchdog-killed at exactly 135s pre-content on attempts 1 and 2 (`read_err="use of closed network connection"`), the client abandoned attempt 3, and the request cycled again. Meanwhile 468 other streams succeeded in the same window. That signature is a large cache-miss prompt, not a hung connection: Bedrock sends `message_start` only after prefill, so a slow prefill is silent past the watchdog deadline on every fresh attempt, making the request permanently unservable and re-billing the prefill each round.

Fix: non-final attempts keep the silence watchdog (fast retries still free genuinely hung connections), but the final attempt rides without it. The client's own request context bounds the wait; the real `http.Transport` errors the blocked body read on cancel. The `failed before content` log line gains `elapsed_ms` and `peeked_bytes` so hung connections (long elapsed, zero bytes) separate from upstreams that answered and shed.

Tests: silent bodies on all attempts show the watchdog freeing attempts 1-2, attempt 3 blocking until client cancel, then a clean 503; a final-attempt stream whose first frame lands 10x past deadline+grace is served to `message_stop` (killed under the old behavior); the fake RoundTripper now mirrors the transport's cancel-errors-body-reads contract. `go vet` and the full `go test ./...` suite pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets the final Fable Bedrock attempt ride without the silence watchdog so large cache-miss prompts that prefill silently can finish. Previously, the watchdog killed such requests on every attempt at ~135s, making them permanently unservable and re-billing prefill each round.

- Keeps the watchdog on non-final attempts so genuinely hung connections still retry quickly.
- Final attempt waits on the client's request context; a client cancel errors the blocked read.
- Closes the attempt-local body in the watchdog callback so a late-firing callback can't close the next attempt's body.
- Adds `elapsed_ms` and `peeked_bytes` to the failed-before-content log to distinguish hung connections from upstreams that answered.

<sup>Written for commit f92b1635cee14b182e927496eb2a4bf8f06e3067. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability for responses with long prefill times.
  * Final response attempts are no longer prematurely terminated during extended periods before the first content arrives.
  * Non-final retry attempts still fail promptly when upstream streams remain silent.
  * Enhanced diagnostics for pre-content streaming failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->