### PR TITLE
Split the pre-content silence deadline by whether the stream answered

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -214,20 +214,32 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 		// the prefill each round; riding lets the client's own context
 		// bound the wait, and a client cancel still errors the blocked Read
 		// through the request context.
+		// Non-final attempts split the silence deadline by whether the
+		// stream has answered at all (production 2026-08-26: stalled
+		// attempts held ~1KB of early frames then went silent, and two
+		// 135s kills exhausted the client's patience before the riding
+		// final attempt began):
+		//   - zero bytes yet: the initial deadline (forced-commit + grace)
+		//     tolerates long prefill, which is silent by nature;
+		//   - after first bytes: prefill is over, so silence past the
+		//     shorter idle deadline is a stall; killing it fast leaves the
+		//     client patience for the retries and the riding final attempt.
+		// The watchdog binds the attempt-local body at construction, so a
+		// callback that fires as its peek fails can never close a later
+		// attempt's body.
 		finalAttempt := attempt >= claudeFableBedrockStreamAttempts
-		var peekWatchdog *time.Timer
+		var peekWatchdog *bedrockIdleWatchdogReader
+		peekSrc := io.Reader(resp.Body)
 		if !finalAttempt {
-			// Close the attempt-local body, never resp.Body through the loop
-			// variable: a callback that fires as its peek fails runs
-			// concurrently with the next attempt, and resolving resp late
-			// would close the WRONG attempt's body (fatal for the riding
-			// final attempt, which has no watchdog of its own).
-			attemptBody := resp.Body
-			peekWatchdog = time.AfterFunc(claudeFableBedrockPeekForceCommitAfter+claudeFableBedrockPeekSilenceGrace, func() { _ = attemptBody.Close() })
+			peekWatchdog = newBedrockIdleWatchdogReader(resp.Body, resp.Body, claudeFableBedrockPeekForceCommitAfter+claudeFableBedrockPeekSilenceGrace, claudeFableBedrockPeekIdleTimeout)
+			peekSrc = peekWatchdog
 		}
-		peek := peekBedrockStreamUntilCommit(resp.Body)
-		if peekWatchdog != nil && !peekWatchdog.Stop() && peek.outcome == bedrockPeekCommit {
-			peek = bedrockStreamPeek{outcome: bedrockPeekReadErr, readErr: errBedrockPeekWatchdog, peeked: peek.peeked}
+		peek := peekBedrockStreamUntilCommit(peekSrc)
+		if peekWatchdog != nil {
+			peekWatchdog.stop()
+			if peekWatchdog.hasFired() && peek.outcome == bedrockPeekCommit {
+				peek = bedrockStreamPeek{outcome: bedrockPeekReadErr, readErr: errBedrockPeekWatchdog, peeked: peek.peeked}
+			}
 		}
 		if peek.outcome == bedrockPeekCommit {
 			pr, pw := io.Pipe()
@@ -245,7 +257,7 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 				// closes the body after a bounded silence so the blocked Read
 				// fails now and the client gets an in-band retryable error
 				// instead of a dead connection.
-				watchdog := newBedrockIdleWatchdogReader(io.MultiReader(bytes.NewReader(peeked), body), body, claudeFableBedrockStreamIdleTimeout)
+				watchdog := newBedrockIdleWatchdogReader(io.MultiReader(bytes.NewReader(peeked), body), body, claudeFableBedrockStreamIdleTimeout, claudeFableBedrockStreamIdleTimeout)
 				result := transcodeBedrockToSSESince(pw, watchdog, s.Logger, streamSource, streamRegion, streamStarted, commitReason, commitAt)
 				watchdog.stop()
 				_ = body.Close()
@@ -611,6 +623,15 @@ var errBedrockPeekWatchdog = errors.New("bedrock stream silent past the peek dea
 // stream blocked inside Read is aborted.
 var claudeFableBedrockPeekSilenceGrace = 15 * time.Second
 
+// claudeFableBedrockPeekIdleTimeout bounds pre-content silence AFTER the
+// stream's first bytes arrived. First bytes mean prefill finished, so a
+// silent stream is stalled, not working; healthy silent-thinking gaps
+// observed live top out near 40s, and 75s keeps ~2x margin while freeing a
+// stalled non-final attempt early enough that the riding final attempt
+// starts inside the client's patience (~270s observed). A var, not a const,
+// so tests can shrink it.
+var claudeFableBedrockPeekIdleTimeout = 75 * time.Second
+
 // errBedrockStreamIdle marks a committed stream whose upstream sent nothing
 // for claudeFableBedrockStreamIdleTimeout, so the idle watchdog closed it.
 var errBedrockStreamIdle = errors.New("bedrock stream idle mid-response past the watchdog deadline")
@@ -623,26 +644,39 @@ var errBedrockStreamIdle = errors.New("bedrock stream idle mid-response past the
 // so tests can shrink it.
 var claudeFableBedrockStreamIdleTimeout = 120 * time.Second
 
-// bedrockIdleWatchdogReader closes closer when src delivers nothing for
-// timeout, which errors the blocked Read. The fire callback re-checks recency
-// under the mutex so a frame that arrives as the timer fires reschedules the
-// deadline instead of killing a live stream.
+// bedrockIdleWatchdogReader closes closer when src delivers nothing for the
+// active timeout, which errors the blocked Read. Two timeouts: `initial`
+// applies while ZERO bytes have arrived (prefill patience: Bedrock sends its
+// first frame only after prompt prefill, which runs minutes on large
+// cache-miss prompts), `idle` applies once any byte has arrived (a stream
+// that answered and then went silent is stalled, not prefilling). The fire
+// callback re-checks recency under the mutex so a frame that arrives as the
+// timer fires reschedules the deadline instead of killing a live stream.
 type bedrockIdleWatchdogReader struct {
 	src     io.Reader
 	closer  io.Closer
-	timeout time.Duration
+	initial time.Duration
+	idle    time.Duration
 
-	mu      sync.Mutex
-	timer   *time.Timer
-	last    time.Time
-	fired   bool
-	stopped bool
+	mu       sync.Mutex
+	timer    *time.Timer
+	last     time.Time
+	sawBytes bool
+	fired    bool
+	stopped  bool
 }
 
-func newBedrockIdleWatchdogReader(src io.Reader, closer io.Closer, timeout time.Duration) *bedrockIdleWatchdogReader {
-	r := &bedrockIdleWatchdogReader{src: src, closer: closer, timeout: timeout, last: time.Now()}
-	r.timer = time.AfterFunc(timeout, r.fire)
+func newBedrockIdleWatchdogReader(src io.Reader, closer io.Closer, initial, idle time.Duration) *bedrockIdleWatchdogReader {
+	r := &bedrockIdleWatchdogReader{src: src, closer: closer, initial: initial, idle: idle, last: time.Now()}
+	r.timer = time.AfterFunc(initial, r.fire)
 	return r
+}
+
+func (r *bedrockIdleWatchdogReader) activeTimeout() time.Duration {
+	if r.sawBytes {
+		return r.idle
+	}
+	return r.initial
 }
 
 func (r *bedrockIdleWatchdogReader) fire() {
@@ -651,8 +685,9 @@ func (r *bedrockIdleWatchdogReader) fire() {
 		r.mu.Unlock()
 		return
 	}
-	if idle := time.Since(r.last); idle < r.timeout {
-		r.timer.Reset(r.timeout - idle)
+	timeout := r.activeTimeout()
+	if idle := time.Since(r.last); idle < timeout {
+		r.timer.Reset(timeout - idle)
 		r.mu.Unlock()
 		return
 	}
@@ -664,6 +699,15 @@ func (r *bedrockIdleWatchdogReader) fire() {
 func (r *bedrockIdleWatchdogReader) Read(p []byte) (int, error) {
 	n, err := r.src.Read(p)
 	r.mu.Lock()
+	if n > 0 && !r.sawBytes {
+		r.sawBytes = true
+		// The pending timer was armed for the initial deadline; the first
+		// bytes switch the contract to the idle deadline, so rearm now or a
+		// long initial would mask every idle expiry until it elapsed.
+		if !r.stopped && !r.fired {
+			r.timer.Reset(r.idle)
+		}
+	}
 	r.last = time.Now()
 	fired := r.fired
 	r.mu.Unlock()
@@ -671,6 +715,14 @@ func (r *bedrockIdleWatchdogReader) Read(p []byte) (int, error) {
 		return n, errBedrockStreamIdle
 	}
 	return n, err
+}
+
+// hasFired reports whether the watchdog closed the body, so a caller whose
+// read raced the close can downgrade an apparent success.
+func (r *bedrockIdleWatchdogReader) hasFired() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.fired
 }
 
 // stop disarms the watchdog once the transcode loop has returned, so the

--- a/internal/proxy/bedrock_stream_test.go
+++ b/internal/proxy/bedrock_stream_test.go
@@ -251,7 +251,7 @@ func TestTranscodeBedrockIdleWatchdogAbortsSilentStream(t *testing.T) {
 		_, _ = pw.Write(frames)
 		// Silence forever: only the watchdog closing pr can end the stream.
 	}()
-	watchdog := newBedrockIdleWatchdogReader(pr, pr, 50*time.Millisecond)
+	watchdog := newBedrockIdleWatchdogReader(pr, pr, 50*time.Millisecond, 50*time.Millisecond)
 	defer watchdog.stop()
 
 	var logBuf bytes.Buffer
@@ -291,7 +291,7 @@ func TestBedrockIdleWatchdogSparesSlowButAliveStream(t *testing.T) {
 		}
 		_ = pw.Close()
 	}()
-	watchdog := newBedrockIdleWatchdogReader(pr, pr, 250*time.Millisecond)
+	watchdog := newBedrockIdleWatchdogReader(pr, pr, 250*time.Millisecond, 250*time.Millisecond)
 	defer watchdog.stop()
 
 	rec := httptest.NewRecorder()
@@ -364,5 +364,45 @@ func TestTranscodeCarriesCacheCreationDetail(t *testing.T) {
 	}
 	if result.Usage.CacheWriteTokens != 100 {
 		t.Fatalf("cache write total = %d, want 100", result.Usage.CacheWriteTokens)
+	}
+}
+
+// The watchdog's two timeouts must switch on first bytes: before any byte the
+// long initial deadline governs (prefill is silent by nature), after first
+// bytes the short idle deadline governs (an answered stream that goes silent
+// is stalled).
+func TestBedrockIdleWatchdogSplitsInitialAndIdleTimeouts(t *testing.T) {
+	// Answered then silent: killed by the short idle deadline, far before
+	// the long initial one.
+	pr, pw := io.Pipe()
+	go func() { _, _ = pw.Write([]byte("x")) }()
+	watchdog := newBedrockIdleWatchdogReader(pr, pr, 10*time.Second, 40*time.Millisecond)
+	buf := make([]byte, 4)
+	start := time.Now()
+	if n, err := watchdog.Read(buf); n != 1 || err != nil {
+		t.Fatalf("first read = (%d, %v), want the answered byte", n, err)
+	}
+	_, err := watchdog.Read(buf) // silence: only the idle deadline can end this
+	elapsed := time.Since(start)
+	watchdog.stop()
+	if !errors.Is(err, errBedrockStreamIdle) {
+		t.Fatalf("read err = %v, want errBedrockStreamIdle", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("answered-then-silent stream killed after %v, want the short idle deadline", elapsed)
+	}
+
+	// Never answered: the initial deadline governs even when idle is shorter.
+	pr2, _ := io.Pipe()
+	watchdog2 := newBedrockIdleWatchdogReader(pr2, pr2, 200*time.Millisecond, 10*time.Millisecond)
+	start = time.Now()
+	_, err = watchdog2.Read(buf)
+	elapsed = time.Since(start)
+	watchdog2.stop()
+	if !errors.Is(err, errBedrockStreamIdle) {
+		t.Fatalf("read err = %v, want errBedrockStreamIdle", err)
+	}
+	if elapsed < 150*time.Millisecond {
+		t.Fatalf("silent stream killed after %v, want the longer initial deadline to govern before first bytes", elapsed)
 	}
 }


### PR DESCRIPTION
Follow-up to #272, from live monitoring 2026-08-26 19:29-19:38: stalled attempts deliver ~1KB of early frames (`peeked_bytes=1000-1054`) within seconds, then go silent and die at the blanket 135s deadline. Two such kills consume the client's ~270s patience before the riding final attempt begins, so the #272 ride never engages for a request that stalls twice.

Fix: the pre-content watchdog becomes the same two-phase idle reader the committed path uses. Before any byte, the long initial deadline (forced-commit + grace, 135s) governs, because prefill is silent by nature and `message_start` only arrives after it. After the first byte, prefill is over, and silence past a new 75s idle deadline (`claudeFableBedrockPeekIdleTimeout`) is a stall, killed early enough that both retries and the riding final attempt fit inside client patience. Healthy silent-thinking gaps observed live top out near 40s, so 75s keeps roughly 2x margin, and any byte (pings included) resets the clock. The watchdog binds the attempt-local body at construction, preserving the #272 review guarantee against closing a later attempt's body.

Tests: the split is unit-tested both ways (answered-then-silent dies on the short idle deadline; never-answered waits out the longer initial deadline even when idle is shorter); a first-bytes arrival rearms the pending timer, without which a long initial masks every idle expiry (caught by the new test before the fix). Existing ride, slow-prefill, and committed-stream watchdog tests updated to the two-timeout constructor and passing under -race. Full-suite failures in `cmd/subrouter` (`TestGCPBackendHealth...`, `TestFrontSlotInstaller...`) are pre-existing timing flakes that pass 2/2 in isolation; this diff touches only `internal/proxy`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790390351&installation_model_id=21920&pr_number=273&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F273&signature=abc22f6d782184f12077d98cb60331d4f268ee9894c83564102a8284a1ecefae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, a blanket 135s deadline killed every silent pre-content stream; stalled attempts deliver ~1KB of early frames then go silent, and two kills exhausted the client's ~270s patience before the riding final attempt began. The pre-content watchdog now splits its deadline by whether the stream has answered, matching the committed path's two-phase idle reader.

- Before the first byte, the long 135s initial deadline governs, since prefill is silent by nature.
- After the first byte, silence past the new 75s idle timeout (`claudeFableBedrockPeekIdleTimeout`) counts as a stall; any byte, pings included, resets the clock.
- The watchdog binds the attempt-local body at construction, so a stale callback can't close a later attempt's body.

Tests cover both directions — answered-then-silent dies on the short deadline, never-answered waits out the longer initial deadline — and the first-byte rearm that switches the pending timer.

<sup>Written for commit edd26739579ff37d9263e3d5e54e56feae684b89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability by distinguishing delays before content begins from pauses during an active stream.
  * Prevented answered streams from remaining idle too long, while allowing additional time for initial content to arrive.
  * Improved handling of timing races so recoverable stream interruptions can be retried appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->