### PR TITLE
Fable Bedrock: primary-region-first attempts with retry escalation

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -183,7 +183,7 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 	started := time.Now()
 	for attempt := 1; ; attempt++ {
 		started = time.Now()
-		resp, sourceName, region, err = s.signAndForwardBedrock(ctx, http.MethodPost, path, newBody)
+		resp, sourceName, region, err = s.signAndForwardBedrock(ctx, attempt-1, http.MethodPost, path, newBody)
 		if err != nil {
 			return nil, err
 		}
@@ -296,9 +296,9 @@ func (s Server) claudeFableBedrockResponse(ctx context.Context, body []byte) (*h
 		_ = resp.Body.Close()
 		s.recordClaudeFableBedrockCost(started, region, http.StatusServiceUnavailable, bedrockUsage{}, false)
 		if retryable && attempt < claudeFableBedrockStreamAttempts && bedrockRetryBackoff(ctx, attempt) {
-			// A fresh signAndForwardBedrock call starts from the next
-			// credential source/region rotation, so the retry prefers a
-			// different endpoint when more than one is configured.
+			// The next loop iteration passes a higher retry index to
+			// signAndForwardBedrock, so the retry starts one region/source
+			// tuple further along when more than one is configured.
 			continue
 		}
 		errBody := peek.errorFrame.payload
@@ -440,15 +440,28 @@ func (s Server) recordClaudeFableBedrockCost(started time.Time, region string, s
 }
 
 // signAndForwardBedrock SigV4-signs a JSON body to bedrock-runtime and returns
-// the raw response plus the Bedrock source name that handled it.
-func (s Server) signAndForwardBedrock(ctx context.Context, method, upstreamPath string, body []byte) (*http.Response, string, string, error) {
+// the raw response plus the Bedrock source name that handled it. Used by the
+// fable path. retryIndex selects where the region/source order starts: 0 (a
+// request's first attempt) keeps the CONFIGURED order, so steady-state fable
+// traffic always lands on the primary region and its per-region prompt cache
+// (agent sessions carry huge cached contexts; splitting turns across regions
+// shatters that cache); 1+ (stream-stall retries) start one tuple further
+// along, so a retry escalates to a different region/source instead of
+// re-drawing from the endpoint that just stalled.
+func (s Server) signAndForwardBedrock(ctx context.Context, retryIndex int, method, upstreamPath string, body []byte) (*http.Response, string, string, error) {
 	headers := http.Header{"Content-Type": []string{"application/json"}}
-	return s.signAndForwardBedrockWithHeaders(ctx, method, upstreamPath, "", headers, body)
+	return s.signAndForwardBedrockFrom(ctx, s.Bedrock.orderedAttempts(retryIndex), method, upstreamPath, "", headers, body)
 }
 
+// signAndForwardBedrockWithHeaders serves the /bedrock/* gateway path, which
+// keeps its round-robin start across region/source pairs to spread load and
+// per-account TPM.
 func (s Server) signAndForwardBedrockWithHeaders(ctx context.Context, method, upstreamPath, rawQuery string, headers http.Header, body []byte) (*http.Response, string, string, error) {
+	return s.signAndForwardBedrockFrom(ctx, s.Bedrock.roundRobinAttempts(), method, upstreamPath, rawQuery, headers, body)
+}
+
+func (s Server) signAndForwardBedrockFrom(ctx context.Context, attempts []bedrockAttempt, method, upstreamPath, rawQuery string, headers http.Header, body []byte) (*http.Response, string, string, error) {
 	cfg := s.Bedrock
-	attempts := cfg.orderedAttempts()
 	var firstErr error
 	for i, attempt := range attempts {
 		resp, err := s.signAndForwardBedrockWithSource(ctx, attempt.Source, attempt.Region, method, upstreamPath, rawQuery, headers, body)
@@ -559,7 +572,12 @@ func (cfg *BedrockConfig) sources() []BedrockCredentialSource {
 	return out
 }
 
-func (cfg *BedrockConfig) orderedAttempts() []bedrockAttempt {
+// orderedAttempts builds the region x source attempt list rotated to begin
+// at `start` (modulo the list length). start 0 preserves the configured
+// order; the fable retry loop passes its retry index so each retry begins
+// one tuple further along. See signAndForwardBedrock for why the fable path
+// must not round-robin.
+func (cfg *BedrockConfig) orderedAttempts(start int) []bedrockAttempt {
 	regions := cfg.regions()
 	sources := cfg.sources()
 	if len(regions) == 0 || len(sources) == 0 {
@@ -571,14 +589,19 @@ func (cfg *BedrockConfig) orderedAttempts() []bedrockAttempt {
 			attempts = append(attempts, bedrockAttempt{Region: region, Source: source})
 		}
 	}
-	if len(attempts) <= 1 {
+	if len(attempts) <= 1 || start%len(attempts) == 0 {
 		return attempts
 	}
-	start := int(cfg.nextAttempt.Add(1)-1) % len(attempts)
+	start = start % len(attempts)
 	ordered := make([]bedrockAttempt, 0, len(attempts))
 	ordered = append(ordered, attempts[start:]...)
 	ordered = append(ordered, attempts[:start]...)
 	return ordered
+}
+
+// roundRobinAttempts rotates the start across calls (gateway path only).
+func (cfg *BedrockConfig) roundRobinAttempts() []bedrockAttempt {
+	return cfg.orderedAttempts(int(cfg.nextAttempt.Add(1) - 1))
 }
 
 func (cfg *BedrockConfig) onThrottle(sourceName, region, model string) {

--- a/internal/proxy/bedrock_stream_test.go
+++ b/internal/proxy/bedrock_stream_test.go
@@ -406,3 +406,69 @@ func TestBedrockIdleWatchdogSplitsInitialAndIdleTimeouts(t *testing.T) {
 		t.Fatalf("silent stream killed after %v, want the longer initial deadline to govern before first bytes", elapsed)
 	}
 }
+
+// Steady-state traffic must always start on the primary (first configured)
+// region so per-region prompt caches stay hot; only retries escalate.
+func TestOrderedAttemptsPrimaryFirstAndRetryEscalation(t *testing.T) {
+	cfg := &BedrockConfig{
+		Regions: []string{"us-east-1", "us-west-2"},
+		Sources: []BedrockCredentialSource{{Name: "aw1", Credentials: staticBedrockCreds()}},
+	}
+	for i := 0; i < 3; i++ {
+		if got := cfg.orderedAttempts(0)[0].Region; got != "us-east-1" {
+			t.Fatalf("first attempt %d starts at %s, want the primary region every time", i, got)
+		}
+	}
+	if got := cfg.orderedAttempts(1)[0].Region; got != "us-west-2" {
+		t.Fatalf("retry index 1 starts at %s, want us-west-2", got)
+	}
+	if got := cfg.orderedAttempts(2)[0].Region; got != "us-east-1" {
+		t.Fatalf("retry index 2 starts at %s, want wraparound to us-east-1", got)
+	}
+}
+
+// End to end: a fable stream that sheds on the primary region must be retried
+// on the next region, and the client sees only the good stream.
+func TestClaudeFableBedrockRetryEscalatesToNextRegion(t *testing.T) {
+	overloaded := buildEventStreamFrame(t, `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)
+	good := append(
+		buildEventStreamFrame(t, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`),
+		append(
+			buildEventStreamFrame(t, `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`),
+			buildEventStreamFrame(t, `{"type":"message_stop"}`)...,
+		)...,
+	)
+	var hosts []string
+	rt := bedrockRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		hosts = append(hosts, req.Host)
+		body := overloaded
+		if strings.Contains(req.Host, "us-west-2") {
+			body = good
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+		}, nil
+	})
+	s := Server{Bedrock: &BedrockConfig{
+		Regions:   []string{"us-east-1", "us-west-2"},
+		Sources:   []BedrockCredentialSource{{Name: "aw1", Credentials: staticBedrockCreds()}},
+		Transport: rt,
+	}}
+	resp, err := s.claudeFableBedrockResponse(t.Context(), fableStreamTestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after regional escalation", resp.StatusCode)
+	}
+	sse, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(sse), "event: message_stop") || strings.Contains(string(sse), "overloaded_error") {
+		t.Fatalf("escalated stream wrong: %q", sse)
+	}
+	if len(hosts) != 2 || !strings.Contains(hosts[0], "us-east-1") || !strings.Contains(hosts[1], "us-west-2") {
+		t.Fatalf("hosts = %v, want primary first then escalation", hosts)
+	}
+}


### PR DESCRIPTION
Prep for multi-region fable failover, the fix for the remaining "Server error mid-response" class: today every attempt of every fable request lands on aw1/us-east-1, so when that endpoint silently stalls a stream (~1-2% under load, worse in brownouts), retries re-draw from the same degraded pool, and a post-text stall reaches the client.

Blocker this PR removes: with more than one region configured, `orderedAttempts` advanced a global counter per call, round-robining every request across regions. Bedrock prompt caches are per region, so agent sessions with large cached contexts would alternate cache-cold regions and multiply cache-write cost. The fable path now passes its retry index instead: attempt 1 always uses the configured order (primary region first, caches hot), and each stream-stall retry starts one region/source tuple further along, escalating away from the endpoint that just stalled. The `/bedrock/*` gateway path keeps its round-robin start (deliberate TPM spreading; its existing test still passes unchanged).

Deployment note: us-west-2 and us-east-2 now accept fable for the aw1 account. The blocker was the account's per-region data-retention mode; fable requires `provider_data_share`, which was set for us-east-1 on 2026-07-03 and mirrored to the other two regions today via `PUT /data-retention` (no console UI exists for it). Verified with real invokes in both regions.

Tests: `orderedAttempts(0)` is stable on the primary across calls, retry indexes rotate and wrap; end-to-end, a stream shed on us-east-1 retries on us-west-2 with primary-first host order and no leak of the failed attempt. Full suite and -race pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares multi-region fable failover by making the fable path primary-region-first: attempt 1 always lands on the first configured region, and each retry escalates one region/source tuple further. Previously every fable request round-robined across regions, shattering per-region prompt caches and multiplying cache-write costs.

- The `/bedrock/*` gateway path keeps its round-robin start for TPM spreading.
- `signAndForwardBedrock` now takes a retry index; `orderedAttempts(start)` rotates from that index instead of a global per-call counter.
- Rollout note: us-west-2 and us-east-2 now accept fable for the aw1 account (`provider_data_share` data-retention mode was set there).

<sup>Written for commit 89f9864504d8e9d5e88028f0a0c8c2b7b9629b84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bedrock request retries by escalating to an alternate region and source when the primary route is overloaded.
  * Ensured successful retry responses are returned without exposing errors from failed initial attempts.
  * Preserved round-robin routing for standard Bedrock gateway requests.

* **Tests**
  * Added coverage for primary-region selection, retry escalation, and fallback behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->