### PR TITLE
Fix Claude profile firewall environment and account sweep latency

### DIFF
--- a/cmd/subrouter/sr_claude.go
+++ b/cmd/subrouter/sr_claude.go
@@ -324,11 +324,14 @@ func (r claudeRunner) add(ctx context.Context, name string) error {
 	fmt.Fprintln(r.out, "Complete the OAuth login in your browser; Claude closes automatically once the login lands.")
 	fmt.Fprintln(r.out)
 
-	cmd := exec.CommandContext(ctx, claudePath)
+	// Passing "/login" as the initial prompt triggers the login flow; with
+	// forceLoginMethod seeded, Claude opens the browser directly.
+	cmd := exec.CommandContext(ctx, claudePath, "/login")
+	cmd.Dir = claudeConfigDir
 	cmd.Stdin = r.in
 	cmd.Stdout = r.out
 	cmd.Stderr = r.errOut
-	cmd.Env = append(os.Environ(), "CLAUDE_CONFIG_DIR="+claudeConfigDir)
+	cmd.Env = claude.EnvForConfigDir(claudeConfigDir)
 	exitErr, autoClosed := r.runClaudeUntilCredential(ctx, cmd, claudeConfigDir)
 	if exitErr != nil && !autoClosed {
 		if name != "" {
@@ -668,7 +671,7 @@ func (r claudeRunner) runClaude(ctx context.Context, name string, extra []string
 	cmd.Stdin = r.in
 	cmd.Stdout = r.out
 	cmd.Stderr = r.errOut
-	cmd.Env = append(os.Environ(), "CLAUDE_CONFIG_DIR="+r.store.ClaudeConfigDir(profile.Name))
+	cmd.Env = claude.EnvForConfigDir(r.store.ClaudeConfigDir(profile.Name))
 	return cmd.Run()
 }
 

--- a/cmd/subrouter/sr_claude_test.go
+++ b/cmd/subrouter/sr_claude_test.go
@@ -87,11 +87,15 @@ func TestClaudeFlagsRunActiveProfile(t *testing.T) {
 	}
 	recordPath := filepath.Join(home, "claude-run.txt")
 	claudePath := filepath.Join(binDir, "claude")
-	script := "#!/bin/sh\nprintf 'config=%s\\nargs=%s\\n' \"$CLAUDE_CONFIG_DIR\" \"$*\" > " + shellQuote(recordPath) + "\n"
+	script := "#!/bin/sh\n{ printf 'config=%s\\nargs=%s\\n' \"$CLAUDE_CONFIG_DIR\" \"$*\"; env | grep -E '^(ANTHROPIC_BASE_URL|ANTHROPIC_AUTH_TOKEN|CLAUDE_CODE_OAUTH_TOKEN)=' || true; } > " + shellQuote(recordPath) + "\n"
 	if err := os.WriteFile(claudePath, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("ANTHROPIC_BASE_URL", "http://subrouter-team:31415")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "subrouter")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "direct-token")
+	t.Setenv("CLAUDE_CONFIG_DIR", "/old/config")
 
 	var out bytes.Buffer
 	runner := claudeRunner{store: store, in: strings.NewReader(""), out: &out, errOut: &out}
@@ -110,6 +114,11 @@ func TestClaudeFlagsRunActiveProfile(t *testing.T) {
 	}
 	if !strings.Contains(got, "args=--dangerously-skip-permissions --resume 1721c0ce-b3bd-4d73-8b33-b3d02b677074") {
 		t.Fatalf("Claude did not receive flags:\n%s", got)
+	}
+	for _, needle := range []string{"ANTHROPIC_BASE_URL=", "ANTHROPIC_AUTH_TOKEN=", "CLAUDE_CODE_OAUTH_TOKEN="} {
+		if strings.Contains(got, needle) {
+			t.Fatalf("Claude inherited %s env:\n%s", needle, got)
+		}
 	}
 }
 

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -1041,6 +1041,32 @@ func DetectCLI() (string, bool) {
 	return path, err == nil && path != ""
 }
 
+func EnvForConfigDir(instancePath string) []string {
+	remove := map[string]bool{
+		"ANTHROPIC_API_KEY":        true,
+		"ANTHROPIC_AUTH_TOKEN":     true,
+		"ANTHROPIC_BASE_URL":       true,
+		"CLAUDE_CODE_OAUTH_TOKEN":  true,
+		"CLAUDE_CONFIG_DIR":        true,
+		"CLAUDE_CODE_API_KEY":      true,
+		"CLAUDE_CODE_AUTH_TOKEN":   true,
+		"CLAUDE_CODE_BASE_URL":     true,
+		"CLAUDE_CODE_CONFIG_DIR":   true,
+		"CLAUDE_CODE_USE_BEDROCK":  true,
+		"CLAUDE_CODE_USE_VERTEX":   true,
+		"ANTHROPIC_VERTEX_PROJECT": true,
+	}
+	env := make([]string, 0, len(os.Environ())+1)
+	for _, item := range os.Environ() {
+		key, _, ok := strings.Cut(item, "=")
+		if ok && remove[key] {
+			continue
+		}
+		env = append(env, item)
+	}
+	return append(env, "CLAUDE_CONFIG_DIR="+instancePath)
+}
+
 func AuthStatusForPath(ctx context.Context, claudePath, instancePath string) (*AuthStatus, error) {
 	if claudePath == "" {
 		return nil, nil
@@ -1051,7 +1077,7 @@ func AuthStatusForPath(ctx context.Context, claudePath, instancePath string) (*A
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, claudePath, "auth", "status")
-	cmd.Env = append(os.Environ(), "CLAUDE_CONFIG_DIR="+instancePath)
+	cmd.Env = EnvForConfigDir(instancePath)
 	body, err := cmd.Output()
 	if err != nil {
 		return nil, nil

--- a/internal/agents/claude/store_test.go
+++ b/internal/agents/claude/store_test.go
@@ -68,6 +68,73 @@ func TestRegisterProfileAllowsEmailName(t *testing.T) {
 	}
 }
 
+func TestEnvForConfigDirFiltersInheritedClaudeRouting(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "api-key")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "stale-token")
+	t.Setenv("ANTHROPIC_BASE_URL", "http://stale-proxy:31415")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("CLAUDE_CONFIG_DIR", "/old/config")
+
+	seen := make(map[string]string)
+	for _, item := range EnvForConfigDir("/new/config") {
+		key, value, ok := strings.Cut(item, "=")
+		if ok {
+			seen[key] = value
+		}
+	}
+	for _, key := range []string{
+		"ANTHROPIC_API_KEY",
+		"ANTHROPIC_AUTH_TOKEN",
+		"ANTHROPIC_BASE_URL",
+		"CLAUDE_CODE_OAUTH_TOKEN",
+	} {
+		if _, ok := seen[key]; ok {
+			t.Fatalf("%s was inherited by Claude", key)
+		}
+	}
+	if seen["CLAUDE_CONFIG_DIR"] != "/new/config" {
+		t.Fatalf("CLAUDE_CONFIG_DIR = %q, want /new/config", seen["CLAUDE_CONFIG_DIR"])
+	}
+}
+
+func TestAuthStatusForPathUsesProfileConfigWithoutInheritedRouting(t *testing.T) {
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	recordPath := filepath.Join(dir, "env.txt")
+	claudePath := filepath.Join(binDir, "claude")
+	script := "#!/bin/sh\nenv > \"$RECORD_ENV\"\nprintf '{\"loggedIn\":false}\n'\n"
+	if err := os.WriteFile(claudePath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("RECORD_ENV", recordPath)
+	t.Setenv("ANTHROPIC_BASE_URL", "http://stale-proxy:31415")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "stale-token")
+	t.Setenv("CLAUDE_CONFIG_DIR", "/old/config")
+
+	status, err := AuthStatusForPath(context.Background(), claudePath, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status == nil || status.LoggedIn {
+		t.Fatalf("status = %#v, want logged out", status)
+	}
+	body, err := os.ReadFile(recordPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"ANTHROPIC_BASE_URL=", "ANTHROPIC_AUTH_TOKEN="} {
+		if strings.Contains(string(body), key) {
+			t.Fatalf("Claude auth status inherited %s", key)
+		}
+	}
+	if !strings.Contains(string(body), "CLAUDE_CONFIG_DIR="+dir) {
+		t.Fatalf("Claude auth status did not receive config dir: %s", body)
+	}
+}
+
 func TestImportProfileCredentialKeepsSanitizedNameCollisionsIsolated(t *testing.T) {
 	store := Store{Dir: t.TempDir()}
 	firstName := "first.last@example.com"

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -241,11 +241,22 @@ type AccountRef struct {
 
 	usageWindowsMu sync.Mutex
 	usageWindows   map[string]usageWindowsEntry
+
+	credFailMu sync.Mutex
+	credFail   map[string]credFailure
 }
 
 type usageStatusSnapshot struct {
 	status AccountUsageStatus
 	at     time.Time
+}
+
+// credFailure remembers a terminal credential error for an account. These
+// errors recover through re-authentication, not by retrying the same refresh
+// request, so repeated status sweeps must not probe the account again.
+type credFailure struct {
+	err string
+	at  time.Time
 }
 
 type usageWindowsEntry struct {
@@ -255,6 +266,48 @@ type usageWindowsEntry struct {
 
 const usageWindowsTTL = 2 * time.Minute
 const usageWindowsLastGoodTTL = 15 * time.Minute
+
+// Keep one account's refresh and usage request from holding an interactive
+// status sweep open indefinitely. The sweep runs accounts concurrently, so a
+// slow account costs at most this timeout instead of adding to every other
+// account's latency.
+const usageStatusFetchTimeout = 5 * time.Second
+
+const credFailureTTL = credentialExhaustionTTL
+
+func (r *AccountRef) terminalCredFailure(provider accounts.Provider, id string) (string, bool) {
+	if r == nil {
+		return "", false
+	}
+	r.credFailMu.Lock()
+	defer r.credFailMu.Unlock()
+	failure, ok := r.credFail[credFailureKey(provider, id)]
+	if !ok || time.Since(failure.at) > credFailureTTL {
+		return "", false
+	}
+	return failure.err, true
+}
+
+func (r *AccountRef) noteCredResult(provider accounts.Provider, id string, err error) {
+	if r == nil {
+		return
+	}
+	r.credFailMu.Lock()
+	defer r.credFailMu.Unlock()
+	if r.credFail == nil {
+		r.credFail = make(map[string]credFailure)
+	}
+	key := credFailureKey(provider, id)
+	if isTerminalCredentialError(err) {
+		r.credFail[key] = credFailure{err: err.Error(), at: time.Now()}
+		return
+	}
+	delete(r.credFail, key)
+}
+
+func credFailureKey(provider accounts.Provider, id string) string {
+	return string(provider) + "\x00" + id
+}
 
 // FetchUsageWindowsCached is the single path for reading an account's usage
 // windows. Every consumer (scheduler scoring, the usage-status sweep,
@@ -703,7 +756,9 @@ func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus
 		}}
 	}
 	active, _ := r.store.DetectActiveAccount()
-	out := make([]AccountUsageStatus, len(storedAccounts))
+	claudeProfiles := r.claudeStore.ListProfiles()
+	claudeOffset := len(storedAccounts)
+	out := make([]AccountUsageStatus, claudeOffset+len(claudeProfiles))
 	var wg sync.WaitGroup
 	for i, stored := range storedAccounts {
 		i, stored := i, stored
@@ -725,12 +780,21 @@ func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus
 		}
 		status.AuthMode = accounts.AuthModeOAuth
 		status.AuthChecked = true
+		if failure, dead := r.terminalCredFailure(provider, stored.Email); dead {
+			status.AuthValid = false
+			status.Error = failure
+			out[i] = status
+			continue
+		}
 		out[i] = status
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			refreshCtx := accounts.WithCodexRefreshReason(ctx, "usage-status.if-expired")
+			fetchCtx, cancel := context.WithTimeout(ctx, usageStatusFetchTimeout)
+			defer cancel()
+			refreshCtx := accounts.WithCodexRefreshReason(fetchCtx, "usage-status.if-expired")
 			refreshed, didRefresh, refreshErr := r.store.RefreshStoredIfExpired(refreshCtx, r.client, stored)
+			r.noteCredResult(provider, stored.Email, refreshErr)
 			next := out[i]
 			next.Refreshed = didRefresh
 			if refreshErr != nil {
@@ -747,7 +811,7 @@ func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus
 				return
 			}
 			r.replace(account)
-			details, err := accounts.FetchCodexUsageDetails(ctx, r.client, account)
+			details, err := accounts.FetchCodexUsageDetails(fetchCtx, r.client, account)
 			if err != nil {
 				next.Error = err.Error()
 				out[i] = next
@@ -761,10 +825,6 @@ func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus
 			out[i] = next
 		}()
 	}
-	wg.Wait()
-	claudeProfiles := r.claudeStore.ListProfiles()
-	claudeOffset := len(out)
-	out = append(out, make([]AccountUsageStatus, len(claudeProfiles))...)
 	activeClaude := r.claudeStore.ActiveProfile()
 	for i, profile := range claudeProfiles {
 		i, profile := claudeOffset+i, profile
@@ -779,11 +839,20 @@ func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus
 			},
 			Active: profile.Name == activeClaude,
 		}
+		if failure, dead := r.terminalCredFailure(accounts.ProviderClaude, profile.Name); dead {
+			status.AuthValid = false
+			status.Error = failure
+			out[i] = status
+			continue
+		}
 		out[i] = status
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			account, didRefresh, err := r.claudeStore.RefreshCredentialIfExpired(ctx, r.client, profile)
+			fetchCtx, cancel := context.WithTimeout(ctx, usageStatusFetchTimeout)
+			defer cancel()
+			account, didRefresh, err := r.claudeStore.RefreshCredentialIfExpired(fetchCtx, r.client, profile)
+			r.noteCredResult(accounts.ProviderClaude, profile.Name, err)
 			next := out[i]
 			next.Refreshed = didRefresh
 			if err != nil {
@@ -794,7 +863,7 @@ func (r *AccountRef) usageStatusesLive(ctx context.Context) []AccountUsageStatus
 			}
 			next.AuthValid = true
 			r.replace(account)
-			windows, fresh, err := r.FetchUsageWindowsCached(ctx, r.client, account)
+			windows, fresh, err := r.FetchUsageWindowsCached(fetchCtx, r.client, account)
 			if err != nil {
 				next.Error = err.Error()
 				out[i] = next
@@ -2016,48 +2085,75 @@ func (s Server) scoreAccounts(ctx context.Context, available []accounts.Account)
 	if client == nil {
 		client = &http.Client{Timeout: defaultUsageFetchTimeout}
 	}
+	// Score each account in parallel and bound each refresh/usage pair. A dead
+	// account must not make every other account wait for its network timeout.
 	scored := 0
+	var scoreMu sync.Mutex
+	var wg sync.WaitGroup
 	for _, account := range available {
 		if account.AuthMode != accounts.AuthModeOAuth {
 			continue
 		}
-		refreshCtx := accounts.WithCodexRefreshReason(ctx, "proxy.score-accounts")
-		refreshed, err := s.refreshAccount(refreshCtx, account)
-		if err != nil {
+		if failure, dead := s.AccountRef.terminalCredFailure(account.Provider, account.ID); dead {
 			if s.Logger != nil {
-				s.Logger.Warn("account reload refresh failed", "account", account.ID, "error", err)
+				s.Logger.Debug("skipping account with known-dead credential", "account", account.ID, "error", failure)
 			}
-			// Only zero on a confident auth failure (dead/invalid token).
-			// Transient refresh errors preserve the seed.
-			if authLikeUsageError(err.Error()) {
-				setZeroScore(scores, scoreByID, account.Provider, account.ID)
-			}
+			scoreMu.Lock()
+			setZeroScore(scores, scoreByID, account.Provider, account.ID)
+			scoreMu.Unlock()
 			continue
 		}
-		windows, fresh, err := s.fetchAccountUsageWindows(ctx, client, refreshed)
-		if err != nil {
-			if s.Logger != nil {
-				s.Logger.Warn("account reload usage fetch failed", "account", account.ID, "error", err)
+		wg.Add(1)
+		go func(account accounts.Account) {
+			defer wg.Done()
+			fetchCtx, cancel := context.WithTimeout(ctx, usageStatusFetchTimeout)
+			defer cancel()
+			refreshCtx := accounts.WithCodexRefreshReason(fetchCtx, "proxy.score-accounts")
+			refreshed, err := s.refreshAccount(refreshCtx, account)
+			s.AccountRef.noteCredResult(account.Provider, account.ID, err)
+			if err != nil {
+				if s.Logger != nil {
+					s.Logger.Warn("account reload refresh failed", "account", account.ID, "error", err)
+				}
+				// Only zero on a confident auth failure (dead/invalid token).
+				// Transient refresh errors preserve the seed.
+				if authLikeUsageError(err.Error()) {
+					scoreMu.Lock()
+					setZeroScore(scores, scoreByID, account.Provider, account.ID)
+					scoreMu.Unlock()
+				}
+				return
 			}
-			// Auth failures mean the account is unusable; zero it so the
-			// scheduler avoids it. Transient failures preserve the seed.
-			if authLikeUsageError(err.Error()) {
-				setZeroScore(scores, scoreByID, account.Provider, account.ID)
+			windows, fresh, err := s.fetchAccountUsageWindows(fetchCtx, client, refreshed)
+			if err != nil {
+				if s.Logger != nil {
+					s.Logger.Warn("account reload usage fetch failed", "account", account.ID, "error", err)
+				}
+				// Auth failures mean the account is unusable; zero it so the
+				// scheduler avoids it. Transient failures preserve the seed.
+				if authLikeUsageError(err.Error()) {
+					scoreMu.Lock()
+					setZeroScore(scores, scoreByID, account.Provider, account.ID)
+					scoreMu.Unlock()
+				}
+				return
 			}
-			continue
-		}
-		if !fresh {
-			// Stale last-known-good windows are not a confident signal. Keep
-			// the seeded score rather than risk demoting a healthy account.
-			continue
-		}
-		if idx, ok := scoreByID[selectacct.ScoreKey(account.Provider, account.ID)]; ok {
-			next := scoreFromUsageWindows(account.Provider, account.ID, windows)
-			next.Fresh = true
-			scores[idx] = next
-			scored++
-		}
+			if !fresh {
+				// Stale last-known-good windows are not a confident signal. Keep
+				// the seeded score rather than risk demoting a healthy account.
+				return
+			}
+			scoreMu.Lock()
+			defer scoreMu.Unlock()
+			if idx, ok := scoreByID[selectacct.ScoreKey(account.Provider, account.ID)]; ok {
+				next := scoreFromUsageWindows(account.Provider, account.ID, windows)
+				next.Fresh = true
+				scores[idx] = next
+				scored++
+			}
+		}(account)
 	}
+	wg.Wait()
 	return scores, scored
 }
 

--- a/internal/proxy/scoreaccounts_test.go
+++ b/internal/proxy/scoreaccounts_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -50,6 +51,63 @@ func TestScoreAccountsPreservesHealthyScoreWhenUsageIsStale(t *testing.T) {
 	}
 	if scores[0].Headroom <= 0 || scores[0].ShortHeadroom <= 0 {
 		t.Fatalf("healthy account clobbered to exhausted by stale usage: %+v", scores[0])
+	}
+}
+
+// Regression: an account whose refresh token is dead (invalid_grant) only
+// recovers via human re-auth, so probing it again costs a doomed round trip on
+// a path that fronts proxy requests. With a fully expired Claude pool that made
+// every scoring sweep pay N dead round trips and `sr` stopped responding.
+// scoreAccounts must zero a known-dead account without any network call.
+func TestScoreAccountsSkipsKnownDeadCredentialWithoutNetwork(t *testing.T) {
+	transport := &usageRoundTripper{responses: []*http.Response{usageOKResponse()}}
+	ref := cacheTestAccountRef(t, transport)
+	account := accounts.Account{ID: "claude@example.com", Provider: accounts.ProviderClaude, AuthMode: accounts.AuthModeOAuth, Token: "tok"}
+
+	ref.noteCredResult(account.Provider, account.ID, errors.New(`Claude OAuth refresh failed: 400 Bad Request: {"error": "invalid_grant"}`))
+
+	server := Server{
+		AccountRef: ref,
+		SchedulerRef: selectacct.NewSchedulerRef(selectacct.NewScheduler([]selectacct.Score{
+			{AccountID: "claude@example.com", Provider: accounts.ProviderClaude, Headroom: 1, ShortHeadroom: 1},
+		})),
+	}
+
+	scores, scored := server.scoreAccounts(context.Background(), []accounts.Account{account})
+	if transport.calls != 0 {
+		t.Fatalf("transport.calls = %d, want 0 (a dead credential must not be re-probed)", transport.calls)
+	}
+	if scored != 0 {
+		t.Fatalf("scored = %d, want 0", scored)
+	}
+	if len(scores) != 1 {
+		t.Fatalf("scores = %d, want 1", len(scores))
+	}
+	if scores[0].Headroom != 0 || scores[0].ShortHeadroom != 0 {
+		t.Fatalf("dead credential must be zeroed out of routing: %+v", scores[0])
+	}
+}
+
+// A re-authed account must rejoin routing immediately rather than waiting out
+// the fast-fail TTL, so any non-terminal result clears the remembered failure.
+func TestNoteCredResultClearsRememberedFailure(t *testing.T) {
+	ref := &AccountRef{}
+	provider, id := accounts.ProviderClaude, "claude@example.com"
+
+	ref.noteCredResult(provider, id, errors.New("invalid_grant"))
+	if _, dead := ref.terminalCredFailure(provider, id); !dead {
+		t.Fatal("terminal credential error was not remembered")
+	}
+
+	ref.noteCredResult(provider, id, nil)
+	if _, dead := ref.terminalCredFailure(provider, id); dead {
+		t.Fatal("a successful refresh must clear the remembered failure")
+	}
+
+	// A transient error is not a credential verdict and must not re-arm it.
+	ref.noteCredResult(provider, id, context.DeadlineExceeded)
+	if _, dead := ref.terminalCredFailure(provider, id); dead {
+		t.Fatal("a timeout must not be treated as a dead credential")
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove inherited Claude/Anthropic auth and routing variables from local profile launches
- start `sr claude add` with the explicit `/login` flow
- bound and parallelize account status/scoring refreshes; remember terminal OAuth failures

## Verification
- `go test ./...`
- `go test -race ./internal/proxy ./internal/agents/claude ./cmd/subrouter`

The change is based on current `main`; the existing account-import deployment path is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude profile launches inheriting stale auth/routing variables, and speeds up account status and scoring sweeps so dead accounts no longer block or hold the scheduler.

**Claude Profile Environment**
- Local profile launches and `auth status` now strip inherited `ANTHROPIC_*` and `CLAUDE_CODE_*` variables.
- `sr claude add` launches with the explicit `/login` prompt.

**Account Sweep Latency**
- Status and scoring refreshes run concurrently with a 5s per-account timeout.
- Terminal credential failures (e.g., `invalid_grant`) are cached; dead accounts are zeroed out without network probes.
- A successful refresh clears the cached failure so re-authed accounts rejoin routing immediately.

<sup>Written for commit 160fb0202548fca97ed16340307a2c9f6d336b56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude profile commands now use the correct profile configuration and login flow.
  * Prevented inherited Claude and Anthropic credentials or routing settings from affecting profile sessions.
  * Improved proxy reliability by skipping known-invalid credentials and limiting account status checks to avoid hangs.
  * Claude profiles are now consistently included in usage and account scoring results.
  * Temporary credential failures can recover automatically after a successful refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->