### PR TITLE
Verify watchdogs self-heal a down service instead of only alerting

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -2196,6 +2196,79 @@ exit 0
 	}
 }
 
+// gcpVerifierRecoveryEnv runs the gcp verifier with a stopped service: fake
+// systemctl reports inactive and records `start` calls to startMarker; fake
+// curl fails the health probe until startMarker exists, simulating a service
+// that answers again once started.
+func runGCPVerifierWithStoppedService(t *testing.T, stateDir string) (string, string) {
+	t.Helper()
+	requireDeployScriptTools(t, "bash", "python3", "curl")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	fakeBin := t.TempDir()
+	startMarker := filepath.Join(t.TempDir(), "started")
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "curl"), `#!/bin/sh
+case "$*" in
+  *"/_subrouter/health"*)
+    [ -e "$SUBROUTER_TEST_START_MARKER" ] && { printf '%s\n' '{"ok":true}'; exit 0; }
+    exit 1 ;;
+  *) exit 1 ;;
+esac
+`)
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "systemctl"), `#!/bin/sh
+case "$*" in
+  *"is-active"*) exit 3 ;;
+  "start "*) : >"$SUBROUTER_TEST_START_MARKER"; exit 0 ;;
+esac
+exit 0
+`)
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "journalctl"), "#!/bin/sh\nexit 0\n")
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "sleep"), "#!/bin/sh\nexit 0\n")
+
+	command := exec.Command(mustLookPath(t, "bash"), filepath.Join(repoRoot, "deploy", "gcp", "subrouter-verify.sh"))
+	command.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"SUBROUTER_VERIFY_STATE="+stateDir,
+		"SUBROUTER_TEST_START_MARKER="+startMarker,
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("subrouter-verify.sh failed: %v\n%s", err, output)
+	}
+	return string(output), startMarker
+}
+
+func TestGCPVerifierRestartsAStoppedService(t *testing.T) {
+	output, startMarker := runGCPVerifierWithStoppedService(t, t.TempDir())
+	for _, want := range []string{
+		"[ALERT] recovery: starting subrouter.service",
+		"[INFO] recovery succeeded: health endpoint answering again",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("verifier output missing %q:\n%s", want, output)
+		}
+	}
+	if _, err := os.Stat(startMarker); err != nil {
+		t.Fatalf("verifier never called systemctl start: %v", err)
+	}
+}
+
+func TestGCPVerifierHonorsFreshMaintenanceSentinel(t *testing.T) {
+	stateDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stateDir, "maintenance"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	output, startMarker := runGCPVerifierWithStoppedService(t, stateDir)
+	if !strings.Contains(output, "skipping recovery") {
+		t.Fatalf("verifier output missing sentinel skip:\n%s", output)
+	}
+	if !strings.Contains(output, "[ALERT] subrouter health endpoint not responding") {
+		t.Fatalf("sentinel must never suppress the down alert:\n%s", output)
+	}
+	if _, err := os.Stat(startMarker); err == nil {
+		t.Fatal("verifier called systemctl start despite a fresh maintenance sentinel")
+	}
+}
+
 func TestGCPDeploymentEvidenceGateValidatesOutcomes(t *testing.T) {
 	requireDeployScriptTools(t, "python3")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/deploy/gcp/subrouter-verify.sh
+++ b/deploy/gcp/subrouter-verify.sh
@@ -98,10 +98,41 @@ fi
 if ! systemctl is-active --quiet "$UNIT"; then
   emit ALERT "subrouter service is not active"
 fi
-if ! curl -fsS "$HEALTH" >/dev/null 2>&1; then
+health_ok=1
+curl -fsS "$HEALTH" >/dev/null 2>&1 || health_ok=0
+if [ "$health_ok" -eq 0 ]; then
   emit ALERT "subrouter health endpoint not responding"
 fi
 ver=$(cat "$VERSION_FILE" 2>/dev/null || echo unknown)
+
+# --- 1a. self-heal a down service (recovery, not only detection) ---
+# systemd's Restart= revives a crashed process, but a unit left stopped (a
+# `systemctl stop` with no matching start, the systemd analogue of the
+# 2026-08-27 macOS bootout outage) stays stopped forever while this watchdog
+# only alerts. When the service is down and not intentionally held down,
+# start it, then report what happened.
+#
+# Intentional maintenance: `touch $STATE/maintenance` suppresses recovery
+# (never the alerts) while the sentinel is younger than 90 minutes. The age
+# cap exists so a forgotten sentinel cannot recreate the outage it allows.
+MAINTENANCE="$STATE/maintenance"
+if [ "$health_ok" -eq 0 ] && ! systemctl is-active --quiet "$UNIT"; then
+  if [ -e "$MAINTENANCE" ] && [ -n "$(find "$MAINTENANCE" -mmin -90 2>/dev/null)" ]; then
+    emit INFO "service down; maintenance sentinel is fresh, skipping recovery ($MAINTENANCE)"
+  else
+    if [ -e "$MAINTENANCE" ]; then
+      emit ALERT "maintenance sentinel is stale (>90m), recovering anyway; remove $MAINTENANCE"
+    fi
+    emit ALERT "recovery: starting $UNIT"
+    systemctl start "$UNIT" >/dev/null 2>&1
+    sleep 5
+    if curl -fsS "$HEALTH" >/dev/null 2>&1; then
+      emit INFO "recovery succeeded: health endpoint answering again"
+    else
+      emit ALERT "recovery attempted but health endpoint still not answering"
+    fi
+  fi
+fi
 
 # --- 1b. account import capability (a server nobody can add accounts to) ---
 # An unset admin/account-import credential makes the server reject every

--- a/deploy/macos/subrouter-verify.sh
+++ b/deploy/macos/subrouter-verify.sh
@@ -19,7 +19,7 @@ HEALTH="${SUBROUTER_HEALTH_URL:-http://127.0.0.1:31415/_subrouter/health}"
 USAGE="${SUBROUTER_USAGE_URL:-http://127.0.0.1:31415/_subrouter/usage-status}"
 PROXY="${SUBROUTER_PROXY_URL:-http://127.0.0.1:31415/v1/messages}"
 LOGS=("/var/log/subrouter.err.log" "/var/log/subrouter.log")
-STATE=/var/lib/subrouter-verify
+STATE="${SUBROUTER_VERIFY_STATE:-/var/lib/subrouter-verify}"
 CANARY_STAMP="$STATE/canary.last"
 ALERTS="$STATE/alerts.log"
 STATUS="$STATE/status.json"
@@ -78,16 +78,75 @@ total_claude=$(awk '{print $2}' <<<"$counts"); : "${total_claude:=0}"
 
 # --- 1. health + version (detect a down service or silent rollback) ---
 state_line=$(launchctl print "system/${LABEL}" 2>/dev/null | awk -F'= ' '/[^a-z]state = /{print $2; exit}')
-if [ "${state_line:-}" != "running" ]; then
-  # launchctl phrasing varies by macOS; fall back to the health probe.
-  if ! curl -fsS "$HEALTH" >/dev/null 2>&1; then
-    emit ALERT "subrouter LaunchDaemon ${LABEL} not running (state=${state_line:-unknown})"
-  fi
+health_ok=1
+curl -fsS "$HEALTH" >/dev/null 2>&1 || health_ok=0
+if [ "${state_line:-}" != "running" ] && [ "$health_ok" -eq 0 ]; then
+  # launchctl phrasing varies by macOS; the health probe is the arbiter.
+  emit ALERT "subrouter LaunchDaemon ${LABEL} not running (state=${state_line:-unknown})"
 fi
-if ! curl -fsS "$HEALTH" >/dev/null 2>&1; then
+if [ "$health_ok" -eq 0 ]; then
   emit ALERT "subrouter health endpoint not responding"
 fi
 ver=$(cat /etc/subrouter-version 2>/dev/null || echo unknown)
+
+# --- 1a. self-heal a down service (recovery, not only detection) ---
+# 2026-08-27: a manual update ran `launchctl bootout` on the LaunchDaemon and
+# never bootstrapped it back. KeepAlive cannot revive a service that has been
+# removed from the launchd domain, so the fleet's one proxy stayed down while
+# this watchdog wrote ALERT lines to a log nobody was reading. On a box with
+# no alert delivery, detection without recovery is not enough: when the
+# service is down, put it back, then report what happened.
+#
+# Intentional maintenance: `sudo touch $STATE/maintenance` suppresses recovery
+# (never the alerts) while the sentinel is younger than 90 minutes. The age
+# cap exists so a forgotten sentinel cannot recreate the outage it allows.
+PLIST="${SUBROUTER_PLIST:-/Library/LaunchDaemons/${LABEL}.plist}"
+MAINTENANCE="$STATE/maintenance"
+DOWN_MARKER="$STATE/health.down"
+if [ "$health_ok" -eq 0 ]; then
+  if [ -e "$MAINTENANCE" ] && [ -n "$(find "$MAINTENANCE" -mmin -90 2>/dev/null)" ]; then
+    emit INFO "service down; maintenance sentinel is fresh, skipping recovery ($MAINTENANCE)"
+  else
+    if [ -e "$MAINTENANCE" ]; then
+      emit ALERT "maintenance sentinel is stale (>90m), recovering anyway; remove $MAINTENANCE"
+    fi
+    if ! launchctl print "system/${LABEL}" >/dev/null 2>&1; then
+      # Booted out of the launchd domain entirely (the 2026-08-27 case).
+      # Bootstrapping cannot hurt anything: there is no service to disturb.
+      if [ -f "$PLIST" ]; then
+        emit ALERT "recovery: ${LABEL} missing from launchd domain, bootstrapping ${PLIST}"
+        launchctl bootstrap system "$PLIST" >/dev/null 2>&1
+      else
+        emit ALERT "recovery impossible: ${PLIST} does not exist"
+      fi
+    elif [ "${state_line:-}" != "running" ]; then
+      # Loaded but not running: plain kickstart starts it without killing
+      # anything, so it is safe on the first failed probe.
+      emit ALERT "recovery: kickstarting stopped ${LABEL}"
+      launchctl kickstart "system/${LABEL}" >/dev/null 2>&1
+    elif [ -e "$DOWN_MARKER" ]; then
+      # Running but not answering for two consecutive cycles: a wedged
+      # process. kickstart -k kills the survivor, so it waits for the second
+      # cycle to rule out a transient probe failure.
+      emit ALERT "recovery: ${LABEL} running but unhealthy two cycles, kickstart -k"
+      launchctl kickstart -k "system/${LABEL}" >/dev/null 2>&1
+    else
+      emit INFO "service running but health probe failed; will kickstart -k if it persists next cycle"
+    fi
+    sleep 5
+    if curl -fsS "$HEALTH" >/dev/null 2>&1; then
+      emit INFO "recovery succeeded: health endpoint answering again"
+      health_ok=1
+    else
+      emit ALERT "recovery attempted or deferred; health endpoint still not answering"
+    fi
+  fi
+fi
+if [ "$health_ok" -eq 0 ]; then
+  : >"$DOWN_MARKER"
+else
+  rm -f "$DOWN_MARKER"
+fi
 
 # --- 1b. account import capability (a server nobody can add accounts to) ---
 # An unset admin/account-import credential makes the server reject every


### PR DESCRIPTION
## Summary

2026-08-27 outage: a manual update ran `launchctl bootout` on the macOS team-server LaunchDaemon and never bootstrapped it back. `KeepAlive` cannot revive a service removed from the launchd domain, so the fleet's one proxy stayed down for an hour while `subrouter-verify` wrote ALERT lines every 5 minutes to a log nobody was reading.

Both verify scripts now recover instead of only detecting:

- **macOS**: bootstrap a service missing from the launchd domain, plain-kickstart a loaded-but-stopped one (both non-destructive, so immediate), and `kickstart -k` a running-but-unhealthy one only after two consecutive failed cycles so a transient probe blip never kills live connections.
- **gcp**: `systemctl start` a unit that is inactive with health down (`Restart=` covers crashes; a stop with no matching start does not).
- A maintenance sentinel (`$STATE/maintenance`) suppresses recovery — never the alerts — while younger than 90 minutes, so intentional downtime is supported but a forgotten sentinel cannot recreate the outage it exists to allow.
- The macOS script gains the `SUBROUTER_VERIFY_STATE` override the gcp script already had (used by the live drill below).

## Verification

- `go test ./cmd/subrouter/` passes, including two new tests: the verifier calls `systemctl start` and reports recovery when the unit is stopped and health is down; a fresh maintenance sentinel suppresses the start but never the down-alert.
- shellcheck clean on both scripts.
- Live drill on the incident machine (cmux-lawrence Mac mini) with a scratch LaunchDaemon: booted it out of the domain, ran the script — it bootstrapped the service back (`DRILL1_OK`); with a fresh sentinel it alerted but left the service down (`DRILL2_OK`). Deployed script's real-label run is green: `checks passed (version=v0.1.124)`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Both `subrouter-verify` scripts now recover a down service instead of only alerting, so an outage like the 2026-08-27 `launchctl bootout` self-heals without a human.

**Recovery behavior**
- macOS bootstraps a service missing from the launchd domain, plain-kickstarts a loaded-but-stopped one, and runs `kickstart -k` on a running-but-unhealthy one only after two consecutive failed cycles.
- gcp runs `systemctl start` when the unit is inactive and health is down.
- A fresh `$STATE/maintenance` sentinel (younger than 90 minutes) suppresses recovery but never the alerts; a stale sentinel is warned and recovery proceeds.
- macOS gains the `SUBROUTER_VERIFY_STATE` override the gcp script already had.
- Adds tests covering gcp recovery and the maintenance sentinel.

<sup>Written for commit 685c57f32da0322b6ad17ee5d961bd57474e96c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health verification now automatically attempts to recover stopped or unhealthy services.
  * Recovery is skipped during active maintenance windows and retried when maintenance markers are stale.
  * Verification now confirms service health after recovery and reports whether recovery succeeded or failed.
  * macOS monitoring can track consecutive failures to trigger recovery only when needed.
* **Improvements**
  * The macOS verification state directory can now be configured for different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->