### PR TITLE
Give tool-JSON streams their own longer commit window

### DIFF
--- a/internal/proxy/bedrock.go
+++ b/internal/proxy/bedrock.go
@@ -819,6 +819,15 @@ var claudeFableBedrockCommitWindow = 20 * time.Second
 var claudeFableBedrockPeekMaxBytes = 8 << 20
 var claudeFableBedrockPeekForceCommitAfter = 120 * time.Second
 
+// claudeFableBedrockToolJSONCommitWindow is the commit window for streams
+// whose newest buffered delta is tool JSON. Longer than the thinking window
+// because tool input is invisible until message end, so the only cost is
+// buffer memory (bounded by the peek byte cap); the benefit is that stalls
+// during slow tool-JSON emission stay pre-commit and retry invisibly. A
+// stream that mixes thinking past its shorter window still commits on the
+// next thinking delta. A var, not a const, so tests can shrink it.
+var claudeFableBedrockToolJSONCommitWindow = 90 * time.Second
+
 // bedrockFrameDecision reports whether a frame decides the stream's fate at
 // the given elapsed time since the stream opened. Errors and exceptions are
 // failures. A text delta, a usage delta, or message_stop proves the stream
@@ -858,8 +867,19 @@ func bedrockFrameDecision(frame bedrockFrame, sinceFirstBuffered time.Duration) 
 		return true, false, ev.Type
 	case "content_block_delta":
 		switch ev.Delta.Type {
-		case "thinking_delta", "signature_delta", "input_json_delta":
+		case "thinking_delta", "signature_delta":
 			if sinceFirstBuffered >= claudeFableBedrockCommitWindow {
+				return true, false, "window_expired_" + ev.Delta.Type
+			}
+			return false, false, ""
+		case "input_json_delta":
+			// Tool JSON gets its own, much longer window: unlike thinking it
+			// is never rendered live (clients execute the tool at message
+			// end), so buffering costs nothing, and production shows streams
+			// stalling 20-60s into slow tool-JSON emission right after the
+			// short window force-committed them (3 visible aborts with
+			// commit_reason=window_expired_input_json_delta on 2026-08-27).
+			if sinceFirstBuffered >= claudeFableBedrockToolJSONCommitWindow {
 				return true, false, "window_expired_" + ev.Delta.Type
 			}
 			return false, false, ""

--- a/internal/proxy/bedrock_stream_test.go
+++ b/internal/proxy/bedrock_stream_test.go
@@ -472,3 +472,23 @@ func TestClaudeFableBedrockRetryEscalatesToNextRegion(t *testing.T) {
 		t.Fatalf("hosts = %v, want primary first then escalation", hosts)
 	}
 }
+
+// Tool JSON buffers under its own longer window: a shed during slow tool-JSON
+// emission past the thinking window but inside the JSON window must retry
+// invisibly, and JSON-window expiry still commits.
+func TestBedrockToolJSONWindowOutlivesThinkingWindow(t *testing.T) {
+	jsonFrame := bedrockFrame{payload: []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"x"}}`)}
+	thinkFrame := bedrockFrame{payload: []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hm"}}`)}
+
+	past := claudeFableBedrockCommitWindow + time.Second
+	if decisive, _, _ := bedrockFrameDecision(jsonFrame, past); decisive {
+		t.Fatal("tool JSON committed at the thinking window; it must use its own longer window")
+	}
+	if decisive, _, _ := bedrockFrameDecision(thinkFrame, past); !decisive {
+		t.Fatal("thinking must still commit at its own window")
+	}
+	decisive, failure, reason := bedrockFrameDecision(jsonFrame, claudeFableBedrockToolJSONCommitWindow)
+	if !decisive || failure || reason != "window_expired_input_json_delta" {
+		t.Fatalf("JSON window expiry: decisive=%v failure=%v reason=%q", decisive, failure, reason)
+	}
+}


### PR DESCRIPTION
Three visible aborts on 2026-08-27 (02:10, 23:15 x2) shared one shape: a stream carrying only tool JSON was force-committed when the shared 20s commit window expired (`commit_reason=window_expired_input_json_delta`), then stalled 20-60s into emission, past the point of replay, and the client saw "Server error mid-response".

Tool input is never rendered live: clients execute the tool at message end, so buffering it longer is free apart from memory already bounded by the peek byte cap. `input_json_delta` now expires a 90s window of its own (`claudeFableBedrockToolJSONCommitWindow`), keeping slow tool-JSON emission replayable through the observed stall zone. Thinking keeps the 20s window because it displays live, and a mixed stream still commits on its next thinking delta. Typical tool turns are unaffected: they commit on their trailing `message_delta` regardless.

Test covers both directions at the boundary: past the thinking window, JSON stays buffered while thinking commits; at the JSON window it commits with the right reason. Full suite and -race pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives tool-JSON streams their own 90s commit window so slow tool-JSON emission stays replayable instead of being force-committed after 20s and aborting mid-stream.

- Thinking and signature deltas keep the existing 20s window since they render live.
- A mixed stream still commits on its next thinking delta once past the 20s window.
- Typical tool turns are unaffected because they commit on their trailing `message_delta`.
- Test verifies tool JSON stays buffered past the thinking window and commits with the correct reason at its own window.

<sup>Written for commit d16d70aefa5384cecdbf3cb7e9061f442eff0366. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

