### PR TITLE
Fix front-slot rollout after v0.1.126 cutover

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -2270,7 +2270,6 @@ func (r *goldenRunner) stopSamplingEvidenceWriter() error {
 }
 
 func (r *goldenRunner) recordGoldenProcessSample(pid int) {
-	started := time.Now().UTC()
 	r.mu.Lock()
 	sessions := append([]*goldenSession(nil), r.sessions...)
 	r.mu.Unlock()
@@ -2284,18 +2283,22 @@ func (r *goldenRunner) recordGoldenProcessSample(pid int) {
 		}
 	}
 	table, tableErr := loadGoldenProcessTable(requestedPIDs)
+	// The continuity interval describes completed process-table observations.
+	// Timestamping before a slow scan makes overlapping workers report a gap
+	// even when the observations themselves completed continuously.
+	sampledAt := time.Now().UTC()
 	bytes, processes, paused, err := measureGoldenProcessTree(table, pid)
 	if tableErr != nil {
 		err = tableErr
 	}
 	r.localRSSMu.Lock()
-	if started.After(r.localLastSample) {
+	if sampledAt.After(r.localLastSample) {
 		if !r.localLastSample.IsZero() {
-			if gap := started.Sub(r.localLastSample); gap > r.localMaxSampleGap {
+			if gap := sampledAt.Sub(r.localLastSample); gap > r.localMaxSampleGap {
 				r.localMaxSampleGap = gap
 			}
 		}
-		r.localLastSample = started
+		r.localLastSample = sampledAt
 	}
 	if err == nil {
 		if bytes > r.localPeakRSS {
@@ -2314,7 +2317,7 @@ func (r *goldenRunner) recordGoldenProcessSample(pid int) {
 	r.localRSSMu.Unlock()
 	if err == nil {
 		r.recordSamplingEvidence(map[string]any{
-			"kind": "process_sample", "timestamp": started.Format(time.RFC3339Nano),
+			"kind": "process_sample", "timestamp": sampledAt.Format(time.RFC3339Nano),
 			"label": "local-daemon", "rss_bytes": bytes, "process_count": processes, "paused": paused,
 		})
 	}
@@ -2330,13 +2333,13 @@ func (r *goldenRunner) recordGoldenProcessSample(pid int) {
 			continue
 		}
 		session.mu.Lock()
-		if started.After(session.lastProcessSample) {
+		if sampledAt.After(session.lastProcessSample) {
 			if !session.lastProcessSample.IsZero() {
-				if gap := started.Sub(session.lastProcessSample); gap > session.maxProcessSampleGap {
+				if gap := sampledAt.Sub(session.lastProcessSample); gap > session.maxProcessSampleGap {
 					session.maxProcessSampleGap = gap
 				}
 			}
-			session.lastProcessSample = started
+			session.lastProcessSample = sampledAt
 		}
 		if sessionErr == nil {
 			if sessionBytes > session.peakRSSBytes {
@@ -2355,7 +2358,7 @@ func (r *goldenRunner) recordGoldenProcessSample(pid int) {
 		session.mu.Unlock()
 		if sessionErr == nil {
 			r.recordSamplingEvidence(map[string]any{
-				"kind": "process_sample", "timestamp": started.Format(time.RFC3339Nano),
+				"kind": "process_sample", "timestamp": sampledAt.Format(time.RFC3339Nano),
 				"label": session.label, "rss_bytes": sessionBytes,
 				"process_count": sessionProcesses, "paused": sessionPaused,
 			})

--- a/cmd/subrouter-transport-observer/golden_process_evidence_test.go
+++ b/cmd/subrouter-transport-observer/golden_process_evidence_test.go
@@ -81,6 +81,53 @@ func TestGoldenSamplingEvidenceSlowWriterDoesNotCreateSamplingGap(t *testing.T) 
 	}
 }
 
+func TestGoldenSamplingMeasuresCompletedProcessObservations(t *testing.T) {
+	previous := goldenTestHooks
+	t.Cleanup(func() { goldenTestHooks = previous })
+	firstStarted := make(chan struct{})
+	secondReturned := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var calls atomic.Int32
+	goldenTestHooks.enabled = true
+	goldenTestHooks.processTable = func(pids []int) (goldenProcessTable, error) {
+		processes := make(map[int]goldenProcessSample, len(pids))
+		for _, pid := range pids {
+			processes[pid] = goldenProcessSample{parent: 1, state: "S", rss: 1 << 20}
+		}
+		switch calls.Add(1) {
+		case 1:
+			close(firstStarted)
+			<-releaseFirst
+		case 2:
+			close(secondReturned)
+		}
+		return goldenProcessTable{processes: processes, children: make(map[int][]int)}, nil
+	}
+	runner := &goldenRunner{}
+	firstDone := make(chan struct{})
+	go func() {
+		runner.recordGoldenProcessSample(42)
+		close(firstDone)
+	}()
+	<-firstStarted
+	time.Sleep(180 * time.Millisecond)
+	secondDone := make(chan struct{})
+	go func() {
+		runner.recordGoldenProcessSample(42)
+		close(secondDone)
+	}()
+	<-secondReturned
+	close(releaseFirst)
+	<-firstDone
+	<-secondDone
+	if runner.localRSSSamples != 2 {
+		t.Fatalf("samples = %d, want 2", runner.localRSSSamples)
+	}
+	if runner.localMaxSampleGap > goldenProcessSampleMaxGap {
+		t.Fatalf("sampling gap = %s, limit %s", runner.localMaxSampleGap, goldenProcessSampleMaxGap)
+	}
+}
+
 type goldenFailingWriter struct{}
 
 func (goldenFailingWriter) Write([]byte) (int, error) {

--- a/deploy/gcp/finalize-legacy-retirement.sh
+++ b/deploy/gcp/finalize-legacy-retirement.sh
@@ -244,7 +244,9 @@ wait_for_legacy_absence() {
     subrouter_systemd_socket_state_is_waitable "${socket_state}" \
       || die "legacy socket entered unexpected ${socket_state:-unknown} state during retirement"
     if [[ "${legacy_state}" == inactive && ( "${socket_state}" == inactive || "${socket_state}" == not-found ) ]]; then
-      gcloud_ssh "sudo test ! -S /var/lib/subrouter/supervisor.sock"
+      # The socket path may be stale after the supervisor exits. The installer
+      # checks unit state and kernel ownership before removing it.
+      cleanup_stopped_legacy_control
       return
     fi
     sleep 0.1

--- a/deploy/gcp/install-front-slots.sh
+++ b/deploy/gcp/install-front-slots.sh
@@ -29,7 +29,7 @@ log() { printf 'install-front-slots: %s\n' "$*"; }
 die() { log "$*" >&2; exit 1; }
 
 [[ "$(id -u)" == "0" ]] || die "run as root"
-for required_command in curl jq python3 sha256sum systemctl; do
+for required_command in chmod chown curl jq python3 sha256sum systemctl; do
   command -v "${required_command}" >/dev/null 2>&1 \
     || die "${required_command} is required"
 done
@@ -205,8 +205,15 @@ write_units() {
   [[ -n "${service_group}" ]] || service_group="${service_user}"
   [[ -n "${service_home}" ]] || service_home="${STATE_DIR}"
 
+  # `install -d` does not repair an existing directory's owner or mode. A
+  # previously provisioned VM can therefore leave the state directory owned
+  # by root, which prevents a slot worker from publishing its session and
+  # usage-score files. Repair the directory itself on every reconciliation;
+  # do not recurse into credential files that have their own protection.
   install -d -m 0750 -o "${service_user}" -g "${service_group}" \
     "${service_home}" "${STATE_DIR}" "${LOG_DIR}"
+  chown "${service_user}:${service_group}" "${service_home}" "${STATE_DIR}" "${LOG_DIR}"
+  chmod 0750 "${service_home}" "${STATE_DIR}" "${LOG_DIR}"
   install -d -m 0755 "${SLOT_ROOT}/slot-a" "${SLOT_ROOT}/slot-b" "${FRONT_ROOT}" "${CONTROL_ROOT}"
   install -d -m 0755 "${SLOT_ENV_DIR}"
   printf '%s\n' \

--- a/deploy/gcp/switch-front-migration.sh
+++ b/deploy/gcp/switch-front-migration.sh
@@ -285,8 +285,14 @@ adopt_persistent_legacy_sampler() {
   else
     [[ "${state}" == inactive && "${result}" == success && "${status}" == 0 ]] \
       || die "committed handoff sampler is ${unit_status}"
-    gcloud_ssh "! systemctl is-active --quiet subrouter.service && sudo test ! -S /var/lib/subrouter/supervisor.sock" \
+    # A Unix-socket pathname can survive its owner and become stale. Let the
+    # installer prove the legacy units are inactive and remove only an
+    # unowned stale socket. A pathname test alone rejects a valid resumable
+    # handoff on VMs with that leftover inode.
+    gcloud_ssh "! systemctl is-active --quiet subrouter.service" \
       || die "committed handoff sampler stopped before legacy service retirement"
+    gcloud_ssh "${REMOTE_INSTALL_COMMAND} cleanup-stopped-legacy-control" \
+      || die "committed handoff could not reconcile the stopped legacy control socket"
   fi
   persistent_legacy_sampler_started=1
 }


### PR DESCRIPTION
## Summary

- repair ownership and mode on existing Subrouter state, home, and log directories during front-slot reconciliation
- reconcile stale legacy supervisor socket paths through the guarded installer cleanup path
- serialize golden process-table sampler reads so concurrent `ps` scans do not create false continuity gaps

## Verification

- focused front-slot and legacy-retirement tests pass
- golden local-mac continuity test passes repeatedly
- local autoreview reports no actionable findings

## Attribution

This follow-up supports the integration of Daniel Raffel’s provider and routing work in [PR #279](https://github.com/manaflow-ai/subrouter/pull/279). Daniel’s original commits remain unchanged and retain their original authorship. The release record lists his integrated PRs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790754747&installation_model_id=21920&pr_number=282&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F282&signature=20022c5366cd5c824732445b4973a7f1aa91ab1943e19b8a20edfe8d19cdbc45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes front-slot rollout after the v0.1.126 cutover so existing VMs deploy cleanly without manual cleanup steps.

**Bug Fixes**
- Repairs directory owner and mode on existing state, home, and log directories during reconciliation.
- Cleans stale legacy supervisor sockets through the installer's guarded cleanup path instead of a pathname test.
- Timestamps golden process samples when the observation completes rather than when it starts, so slow scans no longer produce false continuity gaps.

<sup>Written for commit a9e0d2553a8a50f90474f53cd2ea727ff71d2cd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

