### PR TITLE
fix: accept listener takeover in GCP preflight

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -284,6 +284,12 @@ func TestGCPPreflightAcceptsPostMigrationListenerTakeoverRoute(t *testing.T) {
 set -euo pipefail
 command_line="$*"
 if [[ "${command_line}" == *"compute url-maps describe"* ]]; then
+  if [[ "${FAKE_ROUTE_STATE:-valid}" == reversed ]]; then
+    cat <<'JSON'
+{"defaultService":"https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-front-backend","hostRules":[{"hosts":["front-canary.sr.cmux.internal"],"pathMatcher":"subrouter-front-canary"}],"pathMatchers":[{"defaultService":"https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-backend","name":"subrouter-front-canary"}]}
+JSON
+    exit 0
+  fi
   cat <<'JSON'
 {"defaultService":"https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-backend","hostRules":[{"hosts":["front-canary.sr.cmux.internal"],"pathMatcher":"subrouter-front-canary"}],"pathMatchers":[{"defaultService":"https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-front-backend","name":"subrouter-front-canary"}]}
 JSON
@@ -310,6 +316,7 @@ if [[ "${1:-}" == compute && "${2:-}" == ssh ]]; then
       printf '%s\n' '{"accepting":true,"retiring":false,"active":{"id":"generation-a"},"backends":[{"id":"generation-a","connections":0}]}'
       ;;
     *"ss -H -lntp"*)
+      if [[ "${FAKE_LEGACY_ENABLED:-0}" == 1 ]]; then exit 1; fi
       printf '%s\n' '{"verified":true,"service":"subrouter-front.service","port":31415,"pid":1234}'
       ;;
     *MainPID*)
@@ -393,6 +400,26 @@ exit 1
 	}
 	if evidence.Topology.Current != "front-listener" || !evidence.Topology.Verified {
 		t.Fatalf("listener takeover evidence = %+v, want verified front-listener", evidence.Topology)
+	}
+
+	reversed := exec.Command(
+		mustLookPath(t, "bash"),
+		filepath.Join(repoRoot, "deploy", "gcp", "preflight-deployment.sh"),
+		"--evidence-json", filepath.Join(t.TempDir(), "reversed.json"),
+	)
+	reversed.Env = append(command.Env, "FAKE_ROUTE_STATE=reversed")
+	if output, err := reversed.CombinedOutput(); err == nil {
+		t.Fatalf("reversed active/canary route was accepted:\n%s", output)
+	}
+
+	enabled := exec.Command(
+		mustLookPath(t, "bash"),
+		filepath.Join(repoRoot, "deploy", "gcp", "preflight-deployment.sh"),
+		"--evidence-json", filepath.Join(t.TempDir(), "enabled.json"),
+	)
+	enabled.Env = append(command.Env, "FAKE_LEGACY_ENABLED=1")
+	if output, err := enabled.CombinedOutput(); err == nil {
+		t.Fatalf("enabled legacy unit was accepted:\n%s", output)
 	}
 }
 

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -283,6 +283,55 @@ func TestGCPPreflightAcceptsPostMigrationListenerTakeoverRoute(t *testing.T) {
 	writeExecutableTestFile(t, fakeGcloud, `#!/usr/bin/env bash
 set -euo pipefail
 command_line="$*"
+if [[ "${command_line}" == *"compute url-maps export"* ]]; then
+  destination=""
+  for ((index = 1; index <= $#; index++)); do
+    if [[ "${!index}" == "--destination" ]]; then
+      next=$((index + 1))
+      destination="${!next}"
+      break
+    fi
+  done
+  if [[ "${FAKE_ROUTE_STATE:-valid}" == reversed ]]; then
+    cat >"${destination}" <<'YAML'
+defaultService: https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-front-backend
+hostRules:
+- hosts:
+  - front-canary.sr.cmux.internal
+  pathMatcher: subrouter-front-canary
+pathMatchers:
+- defaultService: https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-backend
+  name: subrouter-front-canary
+YAML
+  elif [[ "${FAKE_ROUTE_STATE:-valid}" == path-override ]]; then
+    cat >"${destination}" <<'YAML'
+defaultService: https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-backend
+hostRules:
+- hosts:
+  - front-canary.sr.cmux.internal
+  pathMatcher: subrouter-front-canary
+pathMatchers:
+- defaultService: https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-front-backend
+  name: subrouter-front-canary
+  pathRules:
+  - paths:
+    - /override
+    service: https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/other-backend
+YAML
+  else
+    cat >"${destination}" <<'YAML'
+defaultService: https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-backend
+hostRules:
+- hosts:
+  - front-canary.sr.cmux.internal
+  pathMatcher: subrouter-front-canary
+pathMatchers:
+- defaultService: https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-front-backend
+  name: subrouter-front-canary
+YAML
+  fi
+  exit 0
+fi
 if [[ "${command_line}" == *"compute url-maps describe"* ]]; then
   if [[ "${FAKE_ROUTE_STATE:-valid}" == reversed ]]; then
     cat <<'JSON'
@@ -401,6 +450,7 @@ exit 1
 		"SUBROUTER_RELEASE_ATTESTATION_VERIFIED=true",
 		"SUBROUTER_RELEASE_IMMUTABLE=true",
 		"SUBROUTER_PUBLIC_BASE_URL=https://example.test",
+		"SUBROUTER_DEPLOY_ARTIFACT_DIR="+filepath.Dir(artifact),
 	)
 	output, err := command.CombinedOutput()
 	if err != nil {

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -306,6 +306,10 @@ if [[ "${command_line}" == *"compute instance-groups describe"* ]]; then
   exit 0
 fi
 if [[ "${command_line}" == *"compute backend-services describe"* ]]; then
+  if [[ "${command_line}" == *"subrouter-backend"* ]]; then
+    printf '%s\n' '{"name":"subrouter-backend","portName":"http","protocol":"HTTP","backends":[{"group":"https://www.googleapis.com/compute/v1/projects/test-project/zones/test-zone/instanceGroups/subrouter-ig"}]}'
+    exit 0
+  fi
   if [[ "${FAKE_POLICY_STATE:-valid}" == detached ]]; then
     printf '%s\n' '{"securityPolicy":"https://www.googleapis.com/compute/v1/projects/test-project/global/securityPolicies/other-policy"}'
     exit 0

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -307,6 +307,10 @@ if [[ "${command_line}" == *"compute instance-groups describe"* ]]; then
 fi
 if [[ "${command_line}" == *"compute backend-services describe"* ]]; then
   if [[ "${command_line}" == *"subrouter-backend"* ]]; then
+    if [[ "${FAKE_BACKEND_STATE:-valid}" == wrong-port ]]; then
+      printf '%s\n' '{"name":"subrouter-backend","portName":"https","protocol":"HTTP","backends":[{"group":"https://www.googleapis.com/compute/v1/projects/test-project/zones/test-zone/instanceGroups/subrouter-ig"}]}'
+      exit 0
+    fi
     printf '%s\n' '{"name":"subrouter-backend","portName":"http","protocol":"HTTP","backends":[{"group":"https://www.googleapis.com/compute/v1/projects/test-project/zones/test-zone/instanceGroups/subrouter-ig"}]}'
     exit 0
   fi
@@ -464,6 +468,16 @@ exit 1
 	detachedPolicy.Env = append(command.Env, "FAKE_POLICY_STATE=detached")
 	if output, err := detachedPolicy.CombinedOutput(); err == nil {
 		t.Fatalf("detached canary policy was accepted:\n%s", output)
+	}
+
+	wrongBackend := exec.Command(
+		mustLookPath(t, "bash"),
+		filepath.Join(repoRoot, "deploy", "gcp", "preflight-deployment.sh"),
+		"--evidence-json", filepath.Join(t.TempDir(), "wrong-backend.json"),
+	)
+	wrongBackend.Env = append(command.Env, "FAKE_BACKEND_STATE=wrong-port")
+	if output, err := wrongBackend.CombinedOutput(); err == nil {
+		t.Fatalf("legacy backend with the wrong port name was accepted:\n%s", output)
 	}
 }
 

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -290,6 +290,12 @@ if [[ "${command_line}" == *"compute url-maps describe"* ]]; then
 JSON
     exit 0
   fi
+  if [[ "${FAKE_ROUTE_STATE:-valid}" == path-override ]]; then
+    cat <<'JSON'
+{"defaultService":"https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-backend","hostRules":[{"hosts":["front-canary.sr.cmux.internal"],"pathMatcher":"subrouter-front-canary"}],"pathMatchers":[{"defaultService":"https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-front-backend","name":"subrouter-front-canary","pathRules":[{"paths":["/override"],"service":"https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/other-backend"}]}]}
+JSON
+    exit 0
+  fi
   cat <<'JSON'
 {"defaultService":"https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-backend","hostRules":[{"hosts":["front-canary.sr.cmux.internal"],"pathMatcher":"subrouter-front-canary"}],"pathMatchers":[{"defaultService":"https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-front-backend","name":"subrouter-front-canary"}]}
 JSON
@@ -297,6 +303,20 @@ JSON
 fi
 if [[ "${command_line}" == *"compute instance-groups describe"* ]]; then
   printf '%s\n' '{"namedPorts":[{"name":"http","port":31415},{"name":"front","port":31416}]}'
+  exit 0
+fi
+if [[ "${command_line}" == *"compute backend-services describe"* ]]; then
+  if [[ "${FAKE_POLICY_STATE:-valid}" == detached ]]; then
+    printf '%s\n' '{"securityPolicy":"https://www.googleapis.com/compute/v1/projects/test-project/global/securityPolicies/other-policy"}'
+    exit 0
+  fi
+  printf '%s\n' '{"securityPolicy":"https://www.googleapis.com/compute/v1/projects/test-project/global/securityPolicies/subrouter-front-canary-policy"}'
+  exit 0
+fi
+if [[ "${command_line}" == *"compute security-policies describe"* ]]; then
+  cat <<'JSON'
+{"name":"subrouter-front-canary-policy","description":"Subrouter front migration canary access boundary","type":"CLOUD_ARMOR","rules":[{"action":"allow","description":"allow authenticated Subrouter front migration canary","headerAction":{"requestHeadersToAdds":[{"headerName":"X-Subrouter-Canary-Token","headerValue":"canary-authorized"}]},"match":{"expr":{"expression":"has(request.headers['host']) && request.headers['host'].lower() == 'front-canary.sr.cmux.internal' && has(request.headers['x-subrouter-canary-token']) && request.headers['x-subrouter-canary-token'] == 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'"}},"preview":false,"priority":900},{"action":"deny(403)","description":"deny unauthenticated Subrouter front migration canary","match":{"expr":{"expression":"has(request.headers['host']) && request.headers['host'].lower() == 'front-canary.sr.cmux.internal'"}},"preview":false,"priority":1000},{"action":"allow","description":"default rule","match":{"config":{"srcIpRanges":["*"]},"versionedExpr":"SRC_IPS_V1"},"preview":false,"priority":2147483647}]}
+JSON
   exit 0
 fi
 if [[ "${1:-}" == compute && "${2:-}" == ssh ]]; then
@@ -420,6 +440,26 @@ exit 1
 	enabled.Env = append(command.Env, "FAKE_LEGACY_ENABLED=1")
 	if output, err := enabled.CombinedOutput(); err == nil {
 		t.Fatalf("enabled legacy unit was accepted:\n%s", output)
+	}
+
+	pathOverride := exec.Command(
+		mustLookPath(t, "bash"),
+		filepath.Join(repoRoot, "deploy", "gcp", "preflight-deployment.sh"),
+		"--evidence-json", filepath.Join(t.TempDir(), "path-override.json"),
+	)
+	pathOverride.Env = append(command.Env, "FAKE_ROUTE_STATE=path-override")
+	if output, err := pathOverride.CombinedOutput(); err == nil {
+		t.Fatalf("canary path override was accepted:\n%s", output)
+	}
+
+	detachedPolicy := exec.Command(
+		mustLookPath(t, "bash"),
+		filepath.Join(repoRoot, "deploy", "gcp", "preflight-deployment.sh"),
+		"--evidence-json", filepath.Join(t.TempDir(), "detached-policy.json"),
+	)
+	detachedPolicy.Env = append(command.Env, "FAKE_POLICY_STATE=detached")
+	if output, err := detachedPolicy.CombinedOutput(); err == nil {
+		t.Fatalf("detached canary policy was accepted:\n%s", output)
 	}
 }
 

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -274,6 +274,128 @@ pathMatchers:
 	}
 }
 
+func TestGCPPreflightAcceptsPostMigrationListenerTakeoverRoute(t *testing.T) {
+	requireDeployScriptTools(t, "bash", "python3", "jq", "sha256sum")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	fakeBin := t.TempDir()
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "curl"), "#!/bin/sh\nexit 0\n")
+	fakeGcloud := filepath.Join(fakeBin, "gcloud")
+	writeExecutableTestFile(t, fakeGcloud, `#!/usr/bin/env bash
+set -euo pipefail
+command_line="$*"
+if [[ "${command_line}" == *"compute url-maps describe"* ]]; then
+  cat <<'JSON'
+{"defaultService":"https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-backend","hostRules":[{"hosts":["front-canary.sr.cmux.internal"],"pathMatcher":"subrouter-front-canary"}],"pathMatchers":[{"defaultService":"https://www.googleapis.com/compute/v1/projects/test-project/global/backendServices/subrouter-front-backend","name":"subrouter-front-canary"}]}
+JSON
+  exit 0
+fi
+if [[ "${command_line}" == *"compute instance-groups describe"* ]]; then
+  printf '%s\n' '{"namedPorts":[{"name":"http","port":31415},{"name":"front","port":31416}]}'
+  exit 0
+fi
+if [[ "${1:-}" == compute && "${2:-}" == ssh ]]; then
+  remote_command=""
+  for ((index = 1; index <= $#; index++)); do
+    if [[ "${!index}" == "--command" ]]; then
+      next=$((index + 1))
+      remote_command="${!next}"
+      break
+    fi
+  done
+  case "${remote_command}" in
+    *front-status*)
+      printf '%s\n' '{"active":{"id":"slot-a","network":"tcp","address":"127.0.0.1:31417"},"backends":[{"id":"slot-a","connections":0,"active":true}]}'
+      ;;
+    *supervisor-status*)
+      printf '%s\n' '{"accepting":true,"retiring":false,"active":{"id":"generation-a"},"backends":[{"id":"generation-a","connections":0}]}'
+      ;;
+    *"ss -H -lntp"*)
+      printf '%s\n' '{"verified":true,"service":"subrouter-front.service","port":31415,"pid":1234}'
+      ;;
+    *MainPID*)
+      printf '%s\n' '1234'
+      ;;
+    *MemoryMax*)
+      if [[ "${remote_command}" == *"subrouter-front.service"* ]]; then printf '%s\n' '134217728'; else printf '%s\n' '201326592'; fi
+      ;;
+    *"/opt/subrouter/slots/slot-a/worker"*)
+      printf '%s\n' 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      ;;
+    *"/opt/subrouter/control/subrouter"*)
+      printf '%s\n' 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+      ;;
+    *"/opt/subrouter/front/subrouter"*)
+      printf '%s\n' 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc'
+      ;;
+    *)
+      printf '%s\n' 'true'
+      ;;
+  esac
+  exit 0
+fi
+echo "unexpected fake gcloud invocation: ${command_line}" >&2
+exit 1
+`)
+	candidate := filepath.Join(t.TempDir(), "candidate")
+	candidateBody := []byte("candidate release bytes\n")
+	if err := os.WriteFile(candidate, candidateBody, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	digest := fmt.Sprintf("%x", sha256.Sum256(candidateBody))
+	checksum := filepath.Join(t.TempDir(), "candidate.sha256")
+	if err := os.WriteFile(checksum, []byte(digest+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	artifact := filepath.Join(t.TempDir(), "evidence.json")
+	command := exec.Command(
+		mustLookPath(t, "bash"),
+		filepath.Join(repoRoot, "deploy", "gcp", "preflight-deployment.sh"),
+		"--evidence-json", artifact,
+	)
+	command.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"SUBROUTER_GCP_PROJECT=test-project",
+		"SUBROUTER_GCP_ZONE=test-zone",
+		"SUBROUTER_GCP_INSTANCE=subrouter-team",
+		"SUBROUTER_PREFLIGHT_TOPOLOGY=slot",
+		"SUBROUTER_RELEASE_TAG=v0.1.128",
+		"SUBROUTER_DEPLOY_BINARY="+candidate,
+		"SUBROUTER_RELEASE_SHA256_FILE="+checksum,
+		"SUBROUTER_DEPLOY_REVISION="+strings.Repeat("d", 40),
+		"SUBROUTER_RELEASE_TAG_ON_MAIN=true",
+		"SUBROUTER_RELEASE_ATTESTATION_VERIFIED=true",
+		"SUBROUTER_RELEASE_IMMUTABLE=true",
+		"SUBROUTER_PUBLIC_BASE_URL=https://example.test",
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("listener-takeover preflight failed: %v\n%s", err, output)
+	}
+	var evidence struct {
+		Routing struct {
+			Legacy int `json:"legacy_backend_references"`
+			Front  int `json:"front_backend_references"`
+		} `json:"routing"`
+		Topology struct {
+			Current  string `json:"routing_current"`
+			Verified bool   `json:"listener_takeover_verified"`
+		} `json:"topology"`
+	}
+	body, err := os.ReadFile(artifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(body, &evidence); err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Routing.Legacy != 1 || evidence.Routing.Front != 1 {
+		t.Fatalf("route references = %+v, want legacy=1/front=1", evidence.Routing)
+	}
+	if evidence.Topology.Current != "front-listener" || !evidence.Topology.Verified {
+		t.Fatalf("listener takeover evidence = %+v, want verified front-listener", evidence.Topology)
+	}
+}
+
 func TestGCPCanarySecurityPolicyRequiresAnAuthenticatedHeader(t *testing.T) {
 	requireDeployScriptTools(t, "python3")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -64,6 +64,10 @@ with an environment, an existing `v...` release tag, and one operation:
   GitHub release, verifies the checksum and tag commit provenance, retains the
   binary under `/opt/subrouter/releases/<tag>/`, and starts it in the inactive
   loopback supervisor slot. The same bytes run the slot supervisor and worker.
+  After the listener handoff, the URL map intentionally still names the legacy
+  backend for port `31415`; the stable front owns that listener, while the
+  front backend remains the protected canary route. The preflight proves this
+  ownership before a slot change.
 
 Routine deployment starts unpaused real Codex WebSocket and HTTP sessions
 through the public hostname. It enables the candidate slot, atomically persists

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -64,10 +64,12 @@ with an environment, an existing `v...` release tag, and one operation:
   GitHub release, verifies the checksum and tag commit provenance, retains the
   binary under `/opt/subrouter/releases/<tag>/`, and starts it in the inactive
   loopback supervisor slot. The same bytes run the slot supervisor and worker.
-  After the listener handoff, the URL map intentionally still names the legacy
-  backend for port `31415`; the stable front owns that listener, while the
-  front backend remains the protected canary route. The preflight proves this
-  ownership before a slot change.
+After the listener handoff, the URL map intentionally still names the legacy
+backend for port `31415`; the stable front owns that listener, while the
+front backend remains the protected canary route. The preflight proves this
+ownership before a slot change. It exports the live URL map and delegates
+route semantics to `url-map-routing.py`, then checks the legacy `http:31415`
+backend mapping and the Cloud Armor canary boundary.
 
 Routine deployment starts unpaused real Codex WebSocket and HTTP sessions
 through the public hostname. It enables the candidate slot, atomically persists

--- a/deploy/gcp/preflight-deployment.sh
+++ b/deploy/gcp/preflight-deployment.sh
@@ -50,6 +50,7 @@ case "${INSTANCE}" in
     ACTIVE_MATCHER="__root__"
     CANARY_MATCHER="subrouter-front-canary"
     CANARY_HOST="front-canary.sr.cmux.internal"
+    CANARY_SECURITY_POLICY="subrouter-front-canary-policy"
     ;;
   subrouter-staging)
     LEGACY_BACKEND_SERVICE="${SUBROUTER_GCP_BACKEND_SERVICE:-subrouter-staging-backend}"
@@ -58,6 +59,7 @@ case "${INSTANCE}" in
     ACTIVE_MATCHER="staging-subrouter"
     CANARY_MATCHER="staging-subrouter-front-canary"
     CANARY_HOST="front-canary.staging.sr.cmux.internal"
+    CANARY_SECURITY_POLICY="subrouter-staging-front-canary-policy"
     ;;
   *)
     LEGACY_BACKEND_SERVICE="${SUBROUTER_GCP_BACKEND_SERVICE:?set SUBROUTER_GCP_BACKEND_SERVICE}"
@@ -66,6 +68,7 @@ case "${INSTANCE}" in
     ACTIVE_MATCHER="${SUBROUTER_GCP_ACTIVE_MATCHER:?set SUBROUTER_GCP_ACTIVE_MATCHER}"
     CANARY_MATCHER="${SUBROUTER_GCP_CANARY_MATCHER:?set SUBROUTER_GCP_CANARY_MATCHER}"
     CANARY_HOST="${SUBROUTER_GCP_CANARY_HOST:?set SUBROUTER_GCP_CANARY_HOST}"
+    CANARY_SECURITY_POLICY="${SUBROUTER_GCP_CANARY_SECURITY_POLICY:?set SUBROUTER_GCP_CANARY_SECURITY_POLICY}"
     ;;
 esac
 
@@ -110,6 +113,7 @@ active_backend_url=""
 canary_backend_url="${front_backend_url}"
 route_assignments_verified=false
 canary_present=false
+canary_access_control_json='null'
 
 if [[ "${MODE}" == migrate-front ]]; then
   [[ "${legacy_refs}" == 1 && "${front_refs}" == 0 ]] || die "URL map is not exactly on the legacy backend"
@@ -195,13 +199,25 @@ else
             .active_backends == [$legacy_url]
             and (.canary_rules | length) == 1
             and .canary_rules[0].hosts == [$canary_host]
+            and ((.canary_rules[0] | keys | sort) == ["hosts", "pathMatcher"])
             and (.canary_matchers | length) == 1
             and .canary_matchers[0].defaultService == $front_url
+            and ((.canary_matchers[0] | keys | sort) == ["defaultService", "name"])
           )
         | {verified:true,active_backend:$legacy_url,canary_backend:$front_url}
       ' < <(stream_shell_value "${url_map_json}"))" \
       || die "URL map active and canary assignments do not match the post-migration route"
     route_assignments_verified=true
+    expected_policy_url="https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/global/securityPolicies/${CANARY_SECURITY_POLICY}"
+    backend_policy_json="$("${GCLOUD_BINARY}" compute backend-services describe "${FRONT_BACKEND_SERVICE}" \
+      --project "${PROJECT_ID}" --global --format=json)"
+    [[ "$(jq -r '.securityPolicy // empty' < <(stream_shell_value "${backend_policy_json}"))" == "${expected_policy_url}" ]] \
+      || die "front backend is not attached to the expected canary security policy"
+    policy_json="$("${GCLOUD_BINARY}" compute security-policies describe "${CANARY_SECURITY_POLICY}" \
+      --project "${PROJECT_ID}" --global --format=json)"
+    canary_access_control_json="$(printf '%s\n' "${policy_json}" | python3 "${SCRIPT_DIR}/canary-security-policy.py" \
+      assert-ready - "${CANARY_SECURITY_POLICY}" "${CANARY_HOST}")" \
+      || die "canary security policy does not satisfy the access boundary"
     listener_takeover_json="$(gcloud_ssh "set -eu; front_pid=\$(systemctl show subrouter-front.service -p MainPID --value); test \"\${front_pid}\" -gt 1; systemctl is-active --quiet subrouter-front.service; ! systemctl is-active --quiet subrouter.service; ! systemctl is-active --quiet subrouter.socket; ! systemctl is-enabled --quiet subrouter.service; ! systemctl is-enabled --quiet subrouter.socket; sudo ss -H -lntp 'sport = :31415' | grep -F \"pid=\${front_pid},\" >/dev/null; printf '%s\\n' \"{\\\"verified\\\":true,\\\"service\\\":\\\"subrouter-front.service\\\",\\\"port\\\":31415,\\\"pid\\\":\${front_pid}}\"")"
     listener_takeover_verified=true
   else
@@ -256,6 +272,7 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type deploy
   --arg legacy_backend_url "${legacy_backend_url}" --arg front_backend_url "${front_backend_url}" \
   --arg canary_matcher "${CANARY_MATCHER}" --arg canary_host "${CANARY_HOST}" \
   --arg canary_backend_url "${canary_backend_url}" \
+  --argjson canary_access_control "${canary_access_control_json}" \
   --argjson legacy_refs "${legacy_refs}" --argjson front_refs "${front_refs}" \
   --argjson route_assignments_verified "${route_assignments_verified}" \
   --argjson canary_present "${canary_present}" \
@@ -270,7 +287,8 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type deploy
       active_backend_url:$active_backend_url,legacy_backend_url:$legacy_backend_url,
       front_backend_url:$front_backend_url,route_assignments_verified:$route_assignments_verified,
       canary:{present:$canary_present,host:$canary_host,matcher:$canary_matcher,
-        backend_url:$canary_backend_url}},topology:$topology,evidence_emitted_at:$emitted_at}' \
+        backend_url:$canary_backend_url,access_control:$canary_access_control}},
+      topology:$topology,evidence_emitted_at:$emitted_at}' \
   >"${evidence_tmp}"
 python3 "${SCRIPT_DIR}/validate-deploy-evidence.py" --expect deployment-preflight "${evidence_tmp}" >/dev/null
 chmod 0600 "${evidence_tmp}"

--- a/deploy/gcp/preflight-deployment.sh
+++ b/deploy/gcp/preflight-deployment.sh
@@ -121,7 +121,32 @@ if [[ "${MODE}" == migrate-front ]]; then
       generation:$generation,checksum:$checksum,active_connections:$active,
       inactive_connections:$inactive},candidate_differs_from_active:true}')"
 else
-  [[ "${legacy_refs}" == 0 && "${front_refs}" == 1 ]] || die "URL map is not exactly on the front backend"
+  # After the listener handoff, the public URL map still names the legacy
+  # backend. That backend's :31415 named port is now owned by the stable front,
+  # while the front backend remains referenced by the protected canary host.
+  # A routine slot deployment must accept that deliberate state and prove the
+  # listener owner. Keep accepting the direct-front shape for fresh topology
+  # and older installations.
+  routing_current=""
+  listener_takeover_verified=false
+  listener_takeover_json='null'
+  if [[ "${legacy_refs}" == 0 && "${front_refs}" == 1 ]]; then
+    routing_current="front"
+  elif [[ "${legacy_refs}" == 1 && "${front_refs}" == 1 ]]; then
+    routing_current="front-listener"
+    listener_takeover_json="$(gcloud_ssh "set -eu
+      front_pid=\$(systemctl show subrouter-front.service -p MainPID --value)
+      test \"\${front_pid}\" -gt 1
+      systemctl is-active --quiet subrouter-front.service
+      ! systemctl is-active --quiet subrouter.service
+      ! systemctl is-active --quiet subrouter.socket
+      sudo ss -H -lntp \"sport = :31415\" | grep -F \"pid=\${front_pid},\" >/dev/null
+      jq -nc --argjson pid \"\${front_pid}\" \
+        '{verified:true,service:"subrouter-front.service",port:31415,pid:\$pid}'")"
+    listener_takeover_verified=true
+  else
+    die "URL map does not describe a supported post-migration route"
+  fi
   front_status="$(gcloud_ssh "systemctl is-active --quiet subrouter-front.service; sudo curl -fsS --unix-socket /var/lib/subrouter/front.sock http://localhost/_subrouter/front-status")"
   active_slot="$(jq -r '.active.id // empty' < <(stream_shell_value "${front_status}"))"
   [[ "${active_slot}" == slot-a || "${active_slot}" == slot-b ]] || die "front active slot is invalid"
@@ -141,14 +166,18 @@ else
     || die "front topology checksum is invalid"
   [[ "${worker_checksum}" != "${EXPECTED_SHA256}" ]] || die "slot candidate is already active"
   [[ "${slot_memory}" == 201326592 && "${front_memory}" == 134217728 ]] || die "front topology MemoryMax is incorrect"
-  topology="$(jq -nc --arg kind front-slots --arg current front --arg slot "${active_slot}" \
+  topology="$(jq -nc --arg kind front-slots --arg current "${routing_current}" --arg slot "${active_slot}" \
     --arg generation "${slot_generation}" --arg worker "${worker_checksum}" \
     --arg control "${control_checksum}" --arg front "${front_checksum}" \
     --argjson inactive "${slot_inactive_connections}" \
+    --argjson listener_takeover_verified "${listener_takeover_verified}" \
+    --argjson listener_takeover "${listener_takeover_json}" \
     '{kind:$kind,routing_current:$current,front:{service_active:true,active_slot:$slot,
       checksum:$front,memory_max_bytes:134217728},slot:{service_active:true,
       generation:$generation,worker_checksum:$worker,control_checksum:$control,
-      inactive_connections:$inactive,memory_max_bytes:201326592},candidate_differs_from_active:true}')"
+      inactive_connections:$inactive,memory_max_bytes:201326592},
+      listener_takeover_verified:$listener_takeover_verified,
+      listener_takeover:$listener_takeover,candidate_differs_from_active:true}')"
 fi
 
 emitted_at="$(utc_now)"

--- a/deploy/gcp/preflight-deployment.sh
+++ b/deploy/gcp/preflight-deployment.sh
@@ -134,15 +134,7 @@ else
     routing_current="front"
   elif [[ "${legacy_refs}" == 1 && "${front_refs}" == 1 ]]; then
     routing_current="front-listener"
-    listener_takeover_json="$(gcloud_ssh "set -eu
-      front_pid=\$(systemctl show subrouter-front.service -p MainPID --value)
-      test \"\${front_pid}\" -gt 1
-      systemctl is-active --quiet subrouter-front.service
-      ! systemctl is-active --quiet subrouter.service
-      ! systemctl is-active --quiet subrouter.socket
-      sudo ss -H -lntp \"sport = :31415\" | grep -F \"pid=\${front_pid},\" >/dev/null
-      jq -nc --argjson pid \"\${front_pid}\" \
-        '{verified:true,service:"subrouter-front.service",port:31415,pid:\$pid}'")"
+    listener_takeover_json="$(gcloud_ssh "set -eu; front_pid=\$(systemctl show subrouter-front.service -p MainPID --value); test \"\${front_pid}\" -gt 1; systemctl is-active --quiet subrouter-front.service; ! systemctl is-active --quiet subrouter.service; ! systemctl is-active --quiet subrouter.socket; sudo ss -H -lntp 'sport = :31415' | grep -F \"pid=\${front_pid},\" >/dev/null; printf '%s\\n' \"{\\\"verified\\\":true,\\\"service\\\":\\\"subrouter-front.service\\\",\\\"port\\\":31415,\\\"pid\\\":\${front_pid}}\"")"
     listener_takeover_verified=true
   else
     die "URL map does not describe a supported post-migration route"

--- a/deploy/gcp/preflight-deployment.sh
+++ b/deploy/gcp/preflight-deployment.sh
@@ -47,16 +47,25 @@ case "${INSTANCE}" in
     LEGACY_BACKEND_SERVICE="${SUBROUTER_GCP_BACKEND_SERVICE:-subrouter-backend}"
     FRONT_BACKEND_SERVICE="${SUBROUTER_GCP_FRONT_BACKEND_SERVICE:-subrouter-front-backend}"
     INSTANCE_GROUP="${SUBROUTER_GCP_INSTANCE_GROUP:-subrouter-ig}"
+    ACTIVE_MATCHER="__root__"
+    CANARY_MATCHER="subrouter-front-canary"
+    CANARY_HOST="front-canary.sr.cmux.internal"
     ;;
   subrouter-staging)
     LEGACY_BACKEND_SERVICE="${SUBROUTER_GCP_BACKEND_SERVICE:-subrouter-staging-backend}"
     FRONT_BACKEND_SERVICE="${SUBROUTER_GCP_FRONT_BACKEND_SERVICE:-subrouter-staging-front-backend}"
     INSTANCE_GROUP="${SUBROUTER_GCP_INSTANCE_GROUP:-subrouter-staging-ig}"
+    ACTIVE_MATCHER="staging-subrouter"
+    CANARY_MATCHER="staging-subrouter-front-canary"
+    CANARY_HOST="front-canary.staging.sr.cmux.internal"
     ;;
   *)
     LEGACY_BACKEND_SERVICE="${SUBROUTER_GCP_BACKEND_SERVICE:?set SUBROUTER_GCP_BACKEND_SERVICE}"
     FRONT_BACKEND_SERVICE="${SUBROUTER_GCP_FRONT_BACKEND_SERVICE:?set SUBROUTER_GCP_FRONT_BACKEND_SERVICE}"
     INSTANCE_GROUP="${SUBROUTER_GCP_INSTANCE_GROUP:?set SUBROUTER_GCP_INSTANCE_GROUP}"
+    ACTIVE_MATCHER="${SUBROUTER_GCP_ACTIVE_MATCHER:?set SUBROUTER_GCP_ACTIVE_MATCHER}"
+    CANARY_MATCHER="${SUBROUTER_GCP_CANARY_MATCHER:?set SUBROUTER_GCP_CANARY_MATCHER}"
+    CANARY_HOST="${SUBROUTER_GCP_CANARY_HOST:?set SUBROUTER_GCP_CANARY_HOST}"
     ;;
 esac
 
@@ -97,9 +106,27 @@ legacy_backend_url="https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}
 front_backend_url="https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/global/backendServices/${FRONT_BACKEND_SERVICE}"
 legacy_refs="$(jq -r --arg value "${legacy_backend_url}" '[.. | strings | select(. == $value)] | length' < <(stream_shell_value "${url_map_json}"))"
 front_refs="$(jq -r --arg value "${front_backend_url}" '[.. | strings | select(. == $value)] | length' < <(stream_shell_value "${url_map_json}"))"
+active_backend_url=""
+canary_backend_url="${front_backend_url}"
+route_assignments_verified=false
+canary_present=false
 
 if [[ "${MODE}" == migrate-front ]]; then
   [[ "${legacy_refs}" == 1 && "${front_refs}" == 0 ]] || die "URL map is not exactly on the legacy backend"
+  route_assignments_json="$(jq -c -e \
+    --arg active_matcher "${ACTIVE_MATCHER}" --arg legacy_url "${legacy_backend_url}" '
+      def active_backends:
+        if $active_matcher == "__root__"
+        then [(.defaultService // empty)]
+        else [.pathMatchers[]? | select(.name == $active_matcher) | .defaultService // empty]
+        end;
+      {active_backends: active_backends}
+      | select(.active_backends == [$legacy_url])
+      | {verified:true,active_backend:$legacy_url}
+    ' < <(stream_shell_value "${url_map_json}"))" \
+    || die "URL map active route does not point to the legacy backend"
+  active_backend_url="$(jq -r '.active_backend' < <(stream_shell_value "${route_assignments_json}"))"
+  route_assignments_verified=true
   jq -e '[.namedPorts[]? | select(.name == "http" and .port == 31415)] | length == 1' < <(stream_shell_value "${group_json}") >/dev/null \
     || die "legacy named port http:31415 is missing"
   front_state="$(gcloud_ssh "if systemctl is-active --quiet subrouter-front.service || sudo test -S /var/lib/subrouter/front.sock; then echo present; else echo absent; fi" | tail -n 1)"
@@ -128,17 +155,62 @@ else
   # listener owner. Keep accepting the direct-front shape for fresh topology
   # and older installations.
   routing_current=""
+  route_assignments_json='null'
+  route_assignments_verified=false
   listener_takeover_verified=false
   listener_takeover_json='null'
   if [[ "${legacy_refs}" == 0 && "${front_refs}" == 1 ]]; then
     routing_current="front"
+    route_assignments_json="$(jq -c -e \
+      --arg active_matcher "${ACTIVE_MATCHER}" --arg front_url "${front_backend_url}" '
+        def active_backends:
+          if $active_matcher == "__root__"
+          then [(.defaultService // empty)]
+          else [.pathMatchers[]? | select(.name == $active_matcher) | .defaultService // empty]
+          end;
+        {active_backends: active_backends}
+        | select(.active_backends == [$front_url])
+        | {verified:true,active_backend:$front_url}
+      ' < <(stream_shell_value "${url_map_json}"))" \
+      || die "URL map active route does not point to the front backend"
+    route_assignments_verified=true
   elif [[ "${legacy_refs}" == 1 && "${front_refs}" == 1 ]]; then
     routing_current="front-listener"
-    listener_takeover_json="$(gcloud_ssh "set -eu; front_pid=\$(systemctl show subrouter-front.service -p MainPID --value); test \"\${front_pid}\" -gt 1; systemctl is-active --quiet subrouter-front.service; ! systemctl is-active --quiet subrouter.service; ! systemctl is-active --quiet subrouter.socket; sudo ss -H -lntp 'sport = :31415' | grep -F \"pid=\${front_pid},\" >/dev/null; printf '%s\\n' \"{\\\"verified\\\":true,\\\"service\\\":\\\"subrouter-front.service\\\",\\\"port\\\":31415,\\\"pid\\\":\${front_pid}}\"")"
+    route_assignments_json="$(jq -c -e \
+      --arg active_matcher "${ACTIVE_MATCHER}" --arg canary_matcher "${CANARY_MATCHER}" \
+      --arg canary_host "${CANARY_HOST}" --arg legacy_url "${legacy_backend_url}" \
+      --arg front_url "${front_backend_url}" '
+        def active_backends:
+          if $active_matcher == "__root__"
+          then [(.defaultService // empty)]
+          else [.pathMatchers[]? | select(.name == $active_matcher) | .defaultService // empty]
+          end;
+        def canary_rules:
+          [.hostRules[]? | select(.pathMatcher == $canary_matcher)];
+        def canary_matchers:
+          [.pathMatchers[]? | select(.name == $canary_matcher)];
+        {active_backends: active_backends, canary_rules: canary_rules,
+         canary_matchers: canary_matchers}
+        | select(
+            .active_backends == [$legacy_url]
+            and (.canary_rules | length) == 1
+            and .canary_rules[0].hosts == [$canary_host]
+            and (.canary_matchers | length) == 1
+            and .canary_matchers[0].defaultService == $front_url
+          )
+        | {verified:true,active_backend:$legacy_url,canary_backend:$front_url}
+      ' < <(stream_shell_value "${url_map_json}"))" \
+      || die "URL map active and canary assignments do not match the post-migration route"
+    route_assignments_verified=true
+    listener_takeover_json="$(gcloud_ssh "set -eu; front_pid=\$(systemctl show subrouter-front.service -p MainPID --value); test \"\${front_pid}\" -gt 1; systemctl is-active --quiet subrouter-front.service; ! systemctl is-active --quiet subrouter.service; ! systemctl is-active --quiet subrouter.socket; ! systemctl is-enabled --quiet subrouter.service; ! systemctl is-enabled --quiet subrouter.socket; sudo ss -H -lntp 'sport = :31415' | grep -F \"pid=\${front_pid},\" >/dev/null; printf '%s\\n' \"{\\\"verified\\\":true,\\\"service\\\":\\\"subrouter-front.service\\\",\\\"port\\\":31415,\\\"pid\\\":\${front_pid}}\"")"
     listener_takeover_verified=true
   else
     die "URL map does not describe a supported post-migration route"
   fi
+  active_backend_url="$(jq -r '.active_backend' < <(stream_shell_value "${route_assignments_json}"))"
+  canary_backend_url="${front_backend_url}"
+  canary_present=false
+  [[ "${routing_current}" == front-listener ]] && canary_present=true
   front_status="$(gcloud_ssh "systemctl is-active --quiet subrouter-front.service; sudo curl -fsS --unix-socket /var/lib/subrouter/front.sock http://localhost/_subrouter/front-status")"
   active_slot="$(jq -r '.active.id // empty' < <(stream_shell_value "${front_status}"))"
   [[ "${active_slot}" == slot-a || "${active_slot}" == slot-b ]] || die "front active slot is invalid"
@@ -162,6 +234,8 @@ else
     --arg generation "${slot_generation}" --arg worker "${worker_checksum}" \
     --arg control "${control_checksum}" --arg front "${front_checksum}" \
     --argjson inactive "${slot_inactive_connections}" \
+    --argjson route_assignments_verified "${route_assignments_verified}" \
+    --argjson canary_present "${canary_present}" \
     --argjson listener_takeover_verified "${listener_takeover_verified}" \
     --argjson listener_takeover "${listener_takeover_json}" \
     '{kind:$kind,routing_current:$current,front:{service_active:true,active_slot:$slot,
@@ -178,7 +252,13 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type deploy
   --arg mode "${MODE}" --arg run_id "${RUN_LABEL}" --arg project "${PROJECT_ID}" \
   --arg zone "${ZONE}" --arg instance "${INSTANCE}" --arg tag "${RELEASE_TAG}" \
   --arg sha "${EXPECTED_SHA256}" --arg revision "${DEPLOY_REVISION}" --arg url_map "${URL_MAP}" \
+  --arg active_matcher "${ACTIVE_MATCHER}" --arg active_backend_url "${active_backend_url}" \
+  --arg legacy_backend_url "${legacy_backend_url}" --arg front_backend_url "${front_backend_url}" \
+  --arg canary_matcher "${CANARY_MATCHER}" --arg canary_host "${CANARY_HOST}" \
+  --arg canary_backend_url "${canary_backend_url}" \
   --argjson legacy_refs "${legacy_refs}" --argjson front_refs "${front_refs}" \
+  --argjson route_assignments_verified "${route_assignments_verified}" \
+  --argjson canary_present "${canary_present}" \
   --argjson topology "${topology}" --arg emitted_at "${emitted_at}" \
   '{schema:$schema,evidence_type:$evidence_type,mode:$mode,success:true,
     mutation_performed:false,local_golden_required:true,
@@ -186,7 +266,11 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type deploy
     release:{tag:$tag,sha256:$sha,source_revision:$revision,tag_on_main:true,
       attestation_verified:true,immutable:true},public:{health:true,ready:true},
     routing:{url_map:$url_map,legacy_backend_references:$legacy_refs,
-      front_backend_references:$front_refs},topology:$topology,evidence_emitted_at:$emitted_at}' \
+      front_backend_references:$front_refs,active_matcher:$active_matcher,
+      active_backend_url:$active_backend_url,legacy_backend_url:$legacy_backend_url,
+      front_backend_url:$front_backend_url,route_assignments_verified:$route_assignments_verified,
+      canary:{present:$canary_present,host:$canary_host,matcher:$canary_matcher,
+        backend_url:$canary_backend_url}},topology:$topology,evidence_emitted_at:$emitted_at}' \
   >"${evidence_tmp}"
 python3 "${SCRIPT_DIR}/validate-deploy-evidence.py" --expect deployment-preflight "${evidence_tmp}" >/dev/null
 chmod 0600 "${evidence_tmp}"

--- a/deploy/gcp/preflight-deployment.sh
+++ b/deploy/gcp/preflight-deployment.sh
@@ -99,6 +99,24 @@ gcloud_ssh() {
   "${GCLOUD_BINARY}" compute ssh "${INSTANCE}" --project "${PROJECT_ID}" --zone "${ZONE}" \
     --tunnel-through-iap --quiet --command "$1"
 }
+verify_legacy_backend_port() {
+  local backend_json expected_group_url
+  backend_json="$("${GCLOUD_BINARY}" compute backend-services describe "${LEGACY_BACKEND_SERVICE}" \
+    --project "${PROJECT_ID}" --global --format=json)"
+  expected_group_url="https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/zones/${ZONE}/instanceGroups/${INSTANCE_GROUP}"
+  jq -e --arg group_url "${expected_group_url}" \
+    '.portName == "http" and .protocol == "HTTP" and
+     (.backends | type == "array" and length == 1) and
+     .backends[0].group == $group_url' \
+    < <(stream_shell_value "${backend_json}") >/dev/null \
+    || die "legacy backend is not pinned to the http:31415 listener"
+  jq -e '[.namedPorts[]? | select(.name == "http" and .port == 31415)] | length == 1' \
+    < <(stream_shell_value "${group_json}") >/dev/null \
+    || die "instance group http:31415 mapping is missing"
+  backend_port_verified=true
+  legacy_backend_port_name="http"
+  instance_group_http_port=31415
+}
 utc_now() { python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z"))'; }
 
 curl -fsS --max-time 10 "${PUBLIC_BASE_URL}/_subrouter/health" >/dev/null || die "public health failed"
@@ -129,11 +147,7 @@ if [[ "${MODE}" == migrate-front ]]; then
   [[ "${active_backend_url}" == "${legacy_backend_url}" ]] \
     || die "URL map active route does not point to the legacy backend"
   route_assignments_verified=true
-  jq -e '[.namedPorts[]? | select(.name == "http" and .port == 31415)] | length == 1' < <(stream_shell_value "${group_json}") >/dev/null \
-    || die "legacy named port http:31415 is missing"
-  backend_port_verified=true
-  legacy_backend_port_name="http"
-  instance_group_http_port=31415
+  verify_legacy_backend_port
   front_state="$(gcloud_ssh "if systemctl is-active --quiet subrouter-front.service || sudo test -S /var/lib/subrouter/front.sock; then echo present; else echo absent; fi" | tail -n 1)"
   [[ "${front_state}" == absent ]] || die "front topology already exists; use a slot preflight or finish the existing migration"
   legacy_status="$(gcloud_ssh "systemctl is-active --quiet subrouter.service; sudo curl -fsS --unix-socket /var/lib/subrouter/supervisor.sock http://localhost/_subrouter/supervisor-status")"
@@ -180,21 +194,7 @@ else
     active_backend_url="${legacy_backend_url}"
     route_assignments_verified=true
     [[ -n "${CANARY_SECURITY_POLICY}" ]] || die "canary security policy is not configured for the listener-takeover route"
-    backend_json="$("${GCLOUD_BINARY}" compute backend-services describe "${LEGACY_BACKEND_SERVICE}" \
-      --project "${PROJECT_ID}" --global --format=json)"
-    expected_group_url="https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/zones/${ZONE}/instanceGroups/${INSTANCE_GROUP}"
-    jq -e --arg group_url "${expected_group_url}" \
-      '.portName == "http" and .protocol == "HTTP" and
-       (.backends | type == "array" and length == 1) and
-       .backends[0].group == $group_url' \
-      < <(stream_shell_value "${backend_json}") >/dev/null \
-      || die "legacy backend is not pinned to the http:31415 listener"
-    jq -e '[.namedPorts[]? | select(.name == "http" and .port == 31415)] | length == 1' \
-      < <(stream_shell_value "${group_json}") >/dev/null \
-      || die "instance group http:31415 mapping is missing"
-    backend_port_verified=true
-    legacy_backend_port_name="http"
-    instance_group_http_port=31415
+    verify_legacy_backend_port
     expected_policy_url="https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/global/securityPolicies/${CANARY_SECURITY_POLICY}"
     backend_policy_json="$("${GCLOUD_BINARY}" compute backend-services describe "${FRONT_BACKEND_SERVICE}" \
       --project "${PROJECT_ID}" --global --format=json)"

--- a/deploy/gcp/preflight-deployment.sh
+++ b/deploy/gcp/preflight-deployment.sh
@@ -105,6 +105,9 @@ curl -fsS --max-time 10 "${PUBLIC_BASE_URL}/_subrouter/health" >/dev/null || die
 curl -fsS --max-time 10 "${PUBLIC_BASE_URL}/_subrouter/ready" >/dev/null || die "public readiness failed"
 url_map_json="$("${GCLOUD_BINARY}" compute url-maps describe "${URL_MAP}" --project "${PROJECT_ID}" --global --format=json)"
 group_json="$("${GCLOUD_BINARY}" compute instance-groups describe "${INSTANCE_GROUP}" --project "${PROJECT_ID}" --zone "${ZONE}" --format=json)"
+URL_MAP_YAML="${ARTIFACT_DIR}/url-map-${RUN_LABEL}.yaml"
+"${GCLOUD_BINARY}" compute url-maps export "${URL_MAP}" --project "${PROJECT_ID}" --global \
+  --destination "${URL_MAP_YAML}" --quiet
 legacy_backend_url="https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/global/backendServices/${LEGACY_BACKEND_SERVICE}"
 front_backend_url="https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/global/backendServices/${FRONT_BACKEND_SERVICE}"
 legacy_refs="$(jq -r --arg value "${legacy_backend_url}" '[.. | strings | select(. == $value)] | length' < <(stream_shell_value "${url_map_json}"))"
@@ -120,19 +123,11 @@ instance_group_http_port=0
 
 if [[ "${MODE}" == migrate-front ]]; then
   [[ "${legacy_refs}" == 1 && "${front_refs}" == 0 ]] || die "URL map is not exactly on the legacy backend"
-  route_assignments_json="$(jq -c -e \
-    --arg active_matcher "${ACTIVE_MATCHER}" --arg legacy_url "${legacy_backend_url}" '
-      def active_backends:
-        if $active_matcher == "__root__"
-        then [(.defaultService // empty)]
-        else [.pathMatchers[]? | select(.name == $active_matcher) | .defaultService // empty]
-        end;
-      {active_backends: active_backends}
-      | select(.active_backends == [$legacy_url])
-      | {verified:true,active_backend:$legacy_url}
-    ' < <(stream_shell_value "${url_map_json}"))" \
+  active_backend_url="$(python3 "${SCRIPT_DIR}/url-map-routing.py" active-backend \
+    "${URL_MAP_YAML}" "${ACTIVE_MATCHER}")" \
+    || die "URL map active route could not be parsed"
+  [[ "${active_backend_url}" == "${legacy_backend_url}" ]] \
     || die "URL map active route does not point to the legacy backend"
-  active_backend_url="$(jq -r '.active_backend' < <(stream_shell_value "${route_assignments_json}"))"
   route_assignments_verified=true
   jq -e '[.namedPorts[]? | select(.name == "http" and .port == 31415)] | length == 1' < <(stream_shell_value "${group_json}") >/dev/null \
     || die "legacy named port http:31415 is missing"
@@ -165,54 +160,24 @@ else
   # listener owner. Keep accepting the direct-front shape for fresh topology
   # and older installations.
   routing_current=""
-  route_assignments_json='null'
   route_assignments_verified=false
   listener_takeover_verified=false
   listener_takeover_json='null'
   if [[ "${legacy_refs}" == 0 && "${front_refs}" == 1 ]]; then
     routing_current="front"
-    route_assignments_json="$(jq -c -e \
-      --arg active_matcher "${ACTIVE_MATCHER}" --arg front_url "${front_backend_url}" '
-        def active_backends:
-          if $active_matcher == "__root__"
-          then [(.defaultService // empty)]
-          else [.pathMatchers[]? | select(.name == $active_matcher) | .defaultService // empty]
-          end;
-        {active_backends: active_backends}
-        | select(.active_backends == [$front_url])
-        | {verified:true,active_backend:$front_url}
-      ' < <(stream_shell_value "${url_map_json}"))" \
+    active_backend_url="$(python3 "${SCRIPT_DIR}/url-map-routing.py" active-backend \
+      "${URL_MAP_YAML}" "${ACTIVE_MATCHER}")" \
+      || die "URL map active route could not be parsed"
+    [[ "${active_backend_url}" == "${front_backend_url}" ]] \
       || die "URL map active route does not point to the front backend"
     route_assignments_verified=true
   elif [[ "${legacy_refs}" == 1 && "${front_refs}" == 1 ]]; then
     routing_current="front-listener"
-    route_assignments_json="$(jq -c -e \
-      --arg active_matcher "${ACTIVE_MATCHER}" --arg canary_matcher "${CANARY_MATCHER}" \
-      --arg canary_host "${CANARY_HOST}" --arg legacy_url "${legacy_backend_url}" \
-      --arg front_url "${front_backend_url}" '
-        def active_backends:
-          if $active_matcher == "__root__"
-          then [(.defaultService // empty)]
-          else [.pathMatchers[]? | select(.name == $active_matcher) | .defaultService // empty]
-          end;
-        def canary_rules:
-          [.hostRules[]? | select(.pathMatcher == $canary_matcher)];
-        def canary_matchers:
-          [.pathMatchers[]? | select(.name == $canary_matcher)];
-        {active_backends: active_backends, canary_rules: canary_rules,
-         canary_matchers: canary_matchers}
-        | select(
-            .active_backends == [$legacy_url]
-            and (.canary_rules | length) == 1
-            and .canary_rules[0].hosts == [$canary_host]
-            and ((.canary_rules[0] | keys | sort) == ["hosts", "pathMatcher"])
-            and (.canary_matchers | length) == 1
-            and .canary_matchers[0].defaultService == $front_url
-            and ((.canary_matchers[0] | keys | sort) == ["defaultService", "name"])
-          )
-        | {verified:true,active_backend:$legacy_url,canary_backend:$front_url}
-      ' < <(stream_shell_value "${url_map_json}"))" \
+    python3 "${SCRIPT_DIR}/url-map-routing.py" assert-state \
+      "${URL_MAP_YAML}" "${ACTIVE_MATCHER}" "${legacy_backend_url}" \
+      "${CANARY_MATCHER}" "${CANARY_HOST}" "${front_backend_url}" \
       || die "URL map active and canary assignments do not match the post-migration route"
+    active_backend_url="${legacy_backend_url}"
     route_assignments_verified=true
     [[ -n "${CANARY_SECURITY_POLICY}" ]] || die "canary security policy is not configured for the listener-takeover route"
     backend_json="$("${GCLOUD_BINARY}" compute backend-services describe "${LEGACY_BACKEND_SERVICE}" \
@@ -245,7 +210,6 @@ else
   else
     die "URL map does not describe a supported post-migration route"
   fi
-  active_backend_url="$(jq -r '.active_backend' < <(stream_shell_value "${route_assignments_json}"))"
   canary_backend_url="${front_backend_url}"
   canary_present=false
   [[ "${routing_current}" == front-listener ]] && canary_present=true

--- a/deploy/gcp/preflight-deployment.sh
+++ b/deploy/gcp/preflight-deployment.sh
@@ -68,7 +68,7 @@ case "${INSTANCE}" in
     ACTIVE_MATCHER="${SUBROUTER_GCP_ACTIVE_MATCHER:?set SUBROUTER_GCP_ACTIVE_MATCHER}"
     CANARY_MATCHER="${SUBROUTER_GCP_CANARY_MATCHER:?set SUBROUTER_GCP_CANARY_MATCHER}"
     CANARY_HOST="${SUBROUTER_GCP_CANARY_HOST:?set SUBROUTER_GCP_CANARY_HOST}"
-    CANARY_SECURITY_POLICY="${SUBROUTER_GCP_CANARY_SECURITY_POLICY:?set SUBROUTER_GCP_CANARY_SECURITY_POLICY}"
+    CANARY_SECURITY_POLICY="${SUBROUTER_GCP_CANARY_SECURITY_POLICY:-}"
     ;;
 esac
 
@@ -114,6 +114,9 @@ canary_backend_url="${front_backend_url}"
 route_assignments_verified=false
 canary_present=false
 canary_access_control_json='null'
+backend_port_verified=false
+legacy_backend_port_name=""
+instance_group_http_port=0
 
 if [[ "${MODE}" == migrate-front ]]; then
   [[ "${legacy_refs}" == 1 && "${front_refs}" == 0 ]] || die "URL map is not exactly on the legacy backend"
@@ -133,6 +136,9 @@ if [[ "${MODE}" == migrate-front ]]; then
   route_assignments_verified=true
   jq -e '[.namedPorts[]? | select(.name == "http" and .port == 31415)] | length == 1' < <(stream_shell_value "${group_json}") >/dev/null \
     || die "legacy named port http:31415 is missing"
+  backend_port_verified=true
+  legacy_backend_port_name="http"
+  instance_group_http_port=31415
   front_state="$(gcloud_ssh "if systemctl is-active --quiet subrouter-front.service || sudo test -S /var/lib/subrouter/front.sock; then echo present; else echo absent; fi" | tail -n 1)"
   [[ "${front_state}" == absent ]] || die "front topology already exists; use a slot preflight or finish the existing migration"
   legacy_status="$(gcloud_ssh "systemctl is-active --quiet subrouter.service; sudo curl -fsS --unix-socket /var/lib/subrouter/supervisor.sock http://localhost/_subrouter/supervisor-status")"
@@ -208,6 +214,22 @@ else
       ' < <(stream_shell_value "${url_map_json}"))" \
       || die "URL map active and canary assignments do not match the post-migration route"
     route_assignments_verified=true
+    [[ -n "${CANARY_SECURITY_POLICY}" ]] || die "canary security policy is not configured for the listener-takeover route"
+    backend_json="$("${GCLOUD_BINARY}" compute backend-services describe "${LEGACY_BACKEND_SERVICE}" \
+      --project "${PROJECT_ID}" --global --format=json)"
+    expected_group_url="https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/zones/${ZONE}/instanceGroups/${INSTANCE_GROUP}"
+    jq -e --arg group_url "${expected_group_url}" \
+      '.portName == "http" and .protocol == "HTTP" and
+       (.backends | type == "array" and length == 1) and
+       .backends[0].group == $group_url' \
+      < <(stream_shell_value "${backend_json}") >/dev/null \
+      || die "legacy backend is not pinned to the http:31415 listener"
+    jq -e '[.namedPorts[]? | select(.name == "http" and .port == 31415)] | length == 1' \
+      < <(stream_shell_value "${group_json}") >/dev/null \
+      || die "instance group http:31415 mapping is missing"
+    backend_port_verified=true
+    legacy_backend_port_name="http"
+    instance_group_http_port=31415
     expected_policy_url="https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/global/securityPolicies/${CANARY_SECURITY_POLICY}"
     backend_policy_json="$("${GCLOUD_BINARY}" compute backend-services describe "${FRONT_BACKEND_SERVICE}" \
       --project "${PROJECT_ID}" --global --format=json)"
@@ -272,8 +294,11 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type deploy
   --arg legacy_backend_url "${legacy_backend_url}" --arg front_backend_url "${front_backend_url}" \
   --arg canary_matcher "${CANARY_MATCHER}" --arg canary_host "${CANARY_HOST}" \
   --arg canary_backend_url "${canary_backend_url}" \
+  --arg legacy_backend_port_name "${legacy_backend_port_name}" \
+  --argjson instance_group_http_port "${instance_group_http_port}" \
   --argjson canary_access_control "${canary_access_control_json}" \
   --argjson legacy_refs "${legacy_refs}" --argjson front_refs "${front_refs}" \
+  --argjson backend_port_verified "${backend_port_verified}" \
   --argjson route_assignments_verified "${route_assignments_verified}" \
   --argjson canary_present "${canary_present}" \
   --argjson topology "${topology}" --arg emitted_at "${emitted_at}" \
@@ -286,6 +311,8 @@ jq -n --arg schema 'subrouter.gcp.deploy-evidence/v1' --arg evidence_type deploy
       front_backend_references:$front_refs,active_matcher:$active_matcher,
       active_backend_url:$active_backend_url,legacy_backend_url:$legacy_backend_url,
       front_backend_url:$front_backend_url,route_assignments_verified:$route_assignments_verified,
+      backend_port_verified:$backend_port_verified,legacy_backend_port_name:$legacy_backend_port_name,
+      instance_group_http_port:$instance_group_http_port,
       canary:{present:$canary_present,host:$canary_host,matcher:$canary_matcher,
         backend_url:$canary_backend_url,access_control:$canary_access_control}},
       topology:$topology,evidence_emitted_at:$emitted_at}' \

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -1272,11 +1272,39 @@ def validate_preflight_routing(
     else:
         fail("preflight URL-map reference shape is unsupported")
     exact(active_backend_url, expected_active_url, "routing.active_backend_url")
-    exact(
-        boolean(field(canary, "present", "routing.canary"), "routing.canary.present"),
-        expected_canary_present,
-        "routing.canary.present",
-    )
+    canary_present = boolean(field(canary, "present", "routing.canary"), "routing.canary.present")
+    exact(canary_present, expected_canary_present, "routing.canary.present")
+    access_value = field(canary, "access_control", "routing.canary")
+    if canary_present:
+        access = obj(access_value, "routing.canary.access_control")
+        expected_policy = {
+            "subrouter-team": "subrouter-front-canary-policy",
+            "subrouter-staging": "subrouter-staging-front-canary-policy",
+        }.get(run["instance"])
+        if expected_policy is not None:
+            exact(field(access, "name", "routing.canary.access_control"), expected_policy,
+                  "routing.canary.access_control.name")
+        exact(field(access, "type", "routing.canary.access_control"), "CLOUD_ARMOR",
+              "routing.canary.access_control.type")
+        exact(boolean(field(access, "attached", "routing.canary.access_control"),
+                      "routing.canary.access_control.attached"), True,
+              "routing.canary.access_control.attached")
+        for name, expected in (
+            ("allow_priority", 900),
+            ("deny_priority", 1000),
+            ("unauthorized_status", 403),
+            ("authorized_status", 400),
+        ):
+            exact(integer(field(access, name, "routing.canary.access_control"),
+                          f"routing.canary.access_control.{name}"), expected,
+                  f"routing.canary.access_control.{name}")
+        exact(boolean(field(access, "key_redacted_before_backend", "routing.canary.access_control"),
+                      "routing.canary.access_control.key_redacted_before_backend"), True,
+              "routing.canary.access_control.key_redacted_before_backend")
+        sha(field(access, "key_fingerprint_sha256", "routing.canary.access_control"),
+            "routing.canary.access_control.key_fingerprint_sha256")
+    else:
+        exact(access_value, None, "routing.canary.access_control")
 
 
 def validate_deployment_preflight(document: dict[str, Any]) -> None:

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -1214,6 +1214,71 @@ def validate_legacy_retirement(document: dict[str, Any]) -> None:
         fail("legacy retirement evidence was emitted before absence")
 
 
+def validate_preflight_routing(
+    run: dict[str, Any],
+    routing: dict[str, Any],
+    mode: str,
+    legacy_refs: int,
+    front_refs: int,
+) -> None:
+    legacy_url = text(field(routing, "legacy_backend_url", "routing"), "routing.legacy_backend_url")
+    front_url = text(field(routing, "front_backend_url", "routing"), "routing.front_backend_url")
+    if legacy_url == front_url or not legacy_url.startswith("https://") or not front_url.startswith("https://"):
+        fail("preflight backend URLs must be distinct HTTPS resources")
+    project_prefix = f"https://www.googleapis.com/compute/v1/projects/{run['project']}/global/backendServices/"
+    if not legacy_url.startswith(project_prefix) or not front_url.startswith(project_prefix):
+        fail("preflight backend URLs must target the deployment project")
+
+    expected_routing = {
+        "subrouter-staging": (
+            "staging-subrouter",
+            "staging-subrouter-front-canary",
+            "front-canary.staging.sr.cmux.internal",
+        ),
+        "subrouter-team": (
+            "__root__",
+            "subrouter-front-canary",
+            "front-canary.sr.cmux.internal",
+        ),
+    }
+    target = expected_routing.get(run["instance"])
+    active_matcher = text(field(routing, "active_matcher", "routing"), "routing.active_matcher")
+    canary = obj(field(routing, "canary", "routing"), "routing.canary")
+    canary_matcher = text(field(canary, "matcher", "routing.canary"), "routing.canary.matcher")
+    canary_host = text(field(canary, "host", "routing.canary"), "routing.canary.host")
+    canary_backend_url = text(field(canary, "backend_url", "routing.canary"), "routing.canary.backend_url")
+    if target is not None:
+        expected_active_matcher, expected_canary_matcher, expected_canary_host = target
+        exact(active_matcher, expected_active_matcher, "routing.active_matcher")
+        exact(canary_matcher, expected_canary_matcher, "routing.canary.matcher")
+        exact(canary_host, expected_canary_host, "routing.canary.host")
+    exact(canary_backend_url, front_url, "routing.canary.backend_url")
+    exact(
+        boolean(field(routing, "route_assignments_verified", "routing"), "routing.route_assignments_verified"),
+        True,
+        "routing.route_assignments_verified",
+    )
+
+    active_backend_url = text(field(routing, "active_backend_url", "routing"), "routing.active_backend_url")
+    expected_shape = (legacy_refs, front_refs)
+    if mode == "migrate-front":
+        expected_shape = (1, 0)
+    if mode == "slot" and expected_shape == (0, 1):
+        expected_active_url = front_url
+        expected_canary_present = False
+    elif expected_shape in {(1, 0), (1, 1)}:
+        expected_active_url = legacy_url
+        expected_canary_present = expected_shape == (1, 1)
+    else:
+        fail("preflight URL-map reference shape is unsupported")
+    exact(active_backend_url, expected_active_url, "routing.active_backend_url")
+    exact(
+        boolean(field(canary, "present", "routing.canary"), "routing.canary.present"),
+        expected_canary_present,
+        "routing.canary.present",
+    )
+
+
 def validate_deployment_preflight(document: dict[str, Any]) -> None:
     exact(field(document, "evidence_type", "root"), "deployment-preflight", "evidence_type")
     mode = text(field(document, "mode", "root"), "mode")
@@ -1230,7 +1295,7 @@ def validate_deployment_preflight(document: dict[str, Any]) -> None:
         True,
         "local_golden_required",
     )
-    validate_run(field(document, "run", "root"))
+    run = validate_run(field(document, "run", "root"))
     release = validate_release(field(document, "release", "root"))
     public = obj(field(document, "public", "root"), "public")
     exact(boolean(field(public, "health", "public"), "public.health"), True, "public.health")
@@ -1239,6 +1304,7 @@ def validate_deployment_preflight(document: dict[str, Any]) -> None:
     text(field(routing, "url_map", "routing"), "routing.url_map")
     legacy_refs = integer(field(routing, "legacy_backend_references", "routing"), "routing.legacy_backend_references")
     front_refs = integer(field(routing, "front_backend_references", "routing"), "routing.front_backend_references")
+    validate_preflight_routing(run, routing, mode, legacy_refs, front_refs)
     topology = obj(field(document, "topology", "root"), "topology")
     exact(
         boolean(field(topology, "candidate_differs_from_active", "topology"),

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -1263,10 +1263,41 @@ def validate_deployment_preflight(document: dict[str, Any]) -> None:
         exact(integer(field(legacy, "inactive_connections", "topology.legacy"),
                       "topology.legacy.inactive_connections"), 0, "topology.legacy.inactive_connections")
     else:
-        exact(legacy_refs, 0, "routing.legacy_backend_references")
-        exact(front_refs, 1, "routing.front_backend_references")
         exact(field(topology, "kind", "topology"), "front-slots", "topology.kind")
-        exact(field(topology, "routing_current", "topology"), "front", "topology.routing_current")
+        routing_current = text(field(topology, "routing_current", "topology"), "topology.routing_current")
+        if (legacy_refs, front_refs) == (0, 1):
+            exact(routing_current, "front", "topology.routing_current")
+        elif (legacy_refs, front_refs) == (1, 1):
+            # The migration keeps the legacy backend as the URL-map route so
+            # existing connections remain addressable. The stable front owns
+            # its :31415 listener through descriptor takeover, and the front
+            # backend is still present as the protected canary route.
+            exact(routing_current, "front-listener", "topology.routing_current")
+            exact(
+                boolean(
+                    field(topology, "listener_takeover_verified", "topology"),
+                    "topology.listener_takeover_verified",
+                ),
+                True,
+                "topology.listener_takeover_verified",
+            )
+            takeover = obj(field(topology, "listener_takeover", "topology"), "topology.listener_takeover")
+            exact(boolean(field(takeover, "verified", "topology.listener_takeover"),
+                          "topology.listener_takeover.verified"), True,
+                  "topology.listener_takeover.verified")
+            exact(text(field(takeover, "service", "topology.listener_takeover"),
+                       "topology.listener_takeover.service"),
+                  "subrouter-front.service", "topology.listener_takeover.service")
+            exact(integer(field(takeover, "port", "topology.listener_takeover"),
+                          "topology.listener_takeover.port"), 31415,
+                  "topology.listener_takeover.port")
+            integer(field(takeover, "pid", "topology.listener_takeover"),
+                    "topology.listener_takeover.pid", minimum=2)
+        else:
+            fail(
+                "slot preflight URL-map references must be legacy=0/front=1 "
+                "or listener-takeover legacy=1/front=1"
+            )
         front = obj(field(topology, "front", "topology"), "topology.front")
         exact(boolean(field(front, "service_active", "topology.front"), "topology.front.service_active"), True,
               "topology.front.service_active")

--- a/deploy/gcp/validate-deploy-evidence.py
+++ b/deploy/gcp/validate-deploy-evidence.py
@@ -1272,6 +1272,23 @@ def validate_preflight_routing(
     else:
         fail("preflight URL-map reference shape is unsupported")
     exact(active_backend_url, expected_active_url, "routing.active_backend_url")
+    backend_port_verified = boolean(
+        field(routing, "backend_port_verified", "routing"),
+        "routing.backend_port_verified",
+    )
+    backend_port_required = mode == "migrate-front" or expected_shape == (1, 1)
+    exact(backend_port_verified, backend_port_required, "routing.backend_port_verified")
+    port_name = field(routing, "legacy_backend_port_name", "routing")
+    port_number = field(routing, "instance_group_http_port", "routing")
+    if backend_port_required:
+        exact(text(port_name, "routing.legacy_backend_port_name"), "http",
+              "routing.legacy_backend_port_name")
+        exact(integer(port_number, "routing.instance_group_http_port"), 31415,
+              "routing.instance_group_http_port")
+    else:
+        exact(port_name, "", "routing.legacy_backend_port_name")
+        exact(integer(port_number, "routing.instance_group_http_port"), 0,
+              "routing.instance_group_http_port")
     canary_present = boolean(field(canary, "present", "routing.canary"), "routing.canary.present")
     exact(canary_present, expected_canary_present, "routing.canary.present")
     access_value = field(canary, "access_control", "routing.canary")


### PR DESCRIPTION
## Summary

Fixes the production slot preflight after the front listener migration. The migration intentionally leaves the URL map on the legacy backend so existing connections remain addressable, while the stable front owns port 31415 and the front backend stays on the protected canary route.

The preflight now accepts that exact `legacy=1/front=1` state only after proving the front service owns the public listener and the legacy units are inactive. It continues to support the direct-front shape used by fresh or older installations.

## Verification

- `go test ./cmd/subrouter`
- `go test ./cmd/subrouter -run '^TestGCPPreflightAcceptsPostMigrationListenerTakeoverRoute$' -count=1`
- `bash -n deploy/gcp/preflight-deployment.sh`
- `python3 -m py_compile deploy/gcp/validate-deploy-evidence.py`

This is a maintainer deployment fix. Daniel Raffel's provider and routing work remains in the original commits and is attributed in [PR279](https://github.com/manaflow-ai/subrouter/pull/279) and [release v0.1.128](https://github.com/manaflow-ai/subrouter/releases/tag/v0.1.128).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790758040&installation_model_id=21920&pr_number=283&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F283&signature=8eb849dd11cd1e48bc75edd647ddcacb32b5a22a469a2173046f14021e5a033f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GCP production slot preflight so it accepts the post-migration listener takeover state. The preflight previously only accepted the direct-front `legacy=0/front=1` URL map; it now admits the `legacy=1/front=1` state after proving the front service owns port 31415 and the legacy units are inactive.

**Bug Fixes**
- Exports the live URL map and reuses `url-map-routing.py` to verify the active matcher points at the legacy backend and the canary matcher, host, and route are exclusive to the front backend.
- Checks, via shared port verification, that the legacy backend service and instance group pin the `http:31415` named port and that the front backend is attached to the expected canary security policy.
- Proves takeover by checking the front service PID owns the `:31415` listener via `ss` and that the legacy units are inactive.
- Evidence validator now requires routing assignment, backend port, canary access control, and listener takeover details for the `front-listener` route.
- Adds a regression test that rejects reversed-route, path-override, enabled-legacy, detached-policy, and wrong-port variants.

<sup>Written for commit c4bf380958b45ee007a328a895f1a28094b8180a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slot-mode deployment checks now support post-migration routing where the front service has taken over the listener while the legacy backend remains referenced.
  * Deployment evidence now reports routing assignments, canary status, backend port verification, and listener takeover details.

* **Bug Fixes**
  * Improved validation for direct-front and post-migration routing, including backend ports, inactive legacy services, and canary access boundaries.

* **Documentation**
  * Updated slot workflow guidance to describe URL-map and listener ownership after migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->