### PR TITLE
fix: run golden continuity after listener handoff

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -4937,6 +4937,7 @@ func validateGoldenSummary(summary goldenSummary, testMode bool) error {
 			session.DuplicateMarkerCount != 0 || session.PeakRSSBytes <= 0 || session.PeakRSSBytes > goldenCodexRSSLimitBytes ||
 			session.RSSSamples == 0 || session.ProcessSamples == 0 || session.PausedProcessSamples != 0 ||
 			session.MaxProcessSampleGapMS > goldenProcessSampleMaxGap.Milliseconds() ||
+			session.MaxChunkGapMillis > session.AllowedChunkGapMillis ||
 			session.AllowedChunkGapMillis < goldenChunkGapFloor.Milliseconds() ||
 			session.DeployMaxChunkGapMillis > session.AllowedChunkGapMillis {
 			return fmt.Errorf("%w: invalid session %q", failGolden("session_evidence_incomplete"), session.Label)

--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -804,9 +804,20 @@ func (r *goldenRunner) prepareGoldenCodexShim() error {
 	contents := []byte("#!/bin/sh\n" +
 		"set -eu\n" +
 		": \"${SUBROUTER_GOLDEN_RAW_CODEX_BIN:?}\"\n" +
-		"exec \"${SUBROUTER_GOLDEN_RAW_CODEX_BIN}\" \"$@\" \\\n" +
-		"  -c 'model_providers.subrouter.supports_websockets=false' \\\n" +
-		"  -c 'model_providers.subrouter.env_http_headers={\"" + goldenResponseAttemptTokenHeader + "\"=\"" + goldenResponseRequestTokenEnv + "\"}'\n")
+		"case \"${SUBROUTER_GOLDEN_TRANSPORT:-websocket}\" in\n" +
+		"  http)\n" +
+		"    exec \"${SUBROUTER_GOLDEN_RAW_CODEX_BIN}\" \"$@\" \\\n" +
+		"      -c 'model_providers.subrouter.supports_websockets=false' \\\n" +
+		"      -c 'model_providers.subrouter.env_http_headers={\"" + goldenResponseAttemptTokenHeader + "\"=\"" + goldenResponseRequestTokenEnv + "\"}'\n" +
+		"    ;;\n" +
+		"  websocket)\n" +
+		"    exec \"${SUBROUTER_GOLDEN_RAW_CODEX_BIN}\" \"$@\" \\\n" +
+		"      -c 'model_providers.subrouter.env_http_headers={\"" + goldenResponseAttemptTokenHeader + "\"=\"" + goldenResponseRequestTokenEnv + "\"}'\n" +
+		"    ;;\n" +
+		"  *)\n" +
+		"    exit 64\n" +
+		"    ;;\n" +
+		"esac\n")
 	if err := os.WriteFile(shimPath, contents, 0o700); err != nil {
 		return failGolden("golden_codex_shim_failed")
 	}
@@ -3005,6 +3016,7 @@ func (r *goldenRunner) launchSession(ctx context.Context, clientPath string, ses
 		"SUBROUTER_DISABLE_FALLBACK":  "1",
 		"SUBROUTER_STATE_DIR":         filepath.Join(session.home, ".subrouter"),
 		goldenResponseRequestTokenEnv: session.streamReleaseToken,
+		"SUBROUTER_GOLDEN_TRANSPORT":  session.transport,
 	}
 	if r.goldenCodexShimPath != "" {
 		overrides["SUBROUTER_CODEX_BIN"] = r.goldenCodexShimPath

--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 )
 
 const (
@@ -177,7 +178,7 @@ func parseGoldenArgs(args []string) (goldenOptions, error) {
 		return options, errors.New("--timeout must be positive")
 	}
 	options.accountID = strings.TrimSpace(options.accountID)
-	if len(options.accountID) > 320 || strings.ContainsAny(options.accountID, "\r\n\x00") {
+	if options.accountID != "" && !validGoldenAccountID(options.accountID) {
 		return options, errors.New("--account-id is invalid")
 	}
 	if !goldenTestHooks.enabled {
@@ -268,7 +269,7 @@ func parseGoldenSlotArgs(args []string) (goldenOptions, error) {
 		return options, errors.New("--timeout must be positive")
 	}
 	options.accountID = strings.TrimSpace(options.accountID)
-	if len(options.accountID) > 320 || strings.ContainsAny(options.accountID, "\r\n\x00") {
+	if options.accountID != "" && !validGoldenAccountID(options.accountID) {
 		return options, errors.New("--account-id is invalid")
 	}
 	if !goldenTestHooks.enabled {
@@ -294,6 +295,18 @@ func parseGoldenSlotArgs(args []string) (goldenOptions, error) {
 		options.evidenceValidator = goldenTestHooks.evidenceValidator
 	}
 	return options, nil
+}
+
+func validGoldenAccountID(value string) bool {
+	if len(value) > 256 {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return strings.TrimSpace(value) != ""
 }
 
 type jsonlRecorder struct {

--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -84,11 +84,13 @@ func goldenProbeScheduleToleranceForRun() time.Duration {
 }
 
 type goldenOptions struct {
+	slotOnly          bool
 	cloudConfig       string
 	codexHome         string
 	codexBinary       string
 	releasedVersion   string
 	predecessorSHA256 string
+	bootstrapSHA256   string
 	candidateTag      string
 	candidateSHA256   string
 	candidateRevision string
@@ -189,6 +191,100 @@ func parseGoldenArgs(args []string) (goldenOptions, error) {
 		}
 		if options.accountID == "" {
 			return options, errors.New("--account-id is required for a deterministic golden credential")
+		}
+		if strings.TrimSpace(options.candidateTag) != goldenPinnedCandidateTag || !validGoldenSHA256(options.candidateSHA256) ||
+			len(strings.TrimSpace(options.candidateRevision)) != 40 {
+			return options, fmt.Errorf("the golden candidate must be the verified immutable %s release", goldenPinnedCandidateTag)
+		}
+	} else if options.evidenceValidator == "" {
+		options.evidenceValidator = goldenTestHooks.evidenceValidator
+	}
+	return options, nil
+}
+
+// parseGoldenSlotArgs is the post-listener-handoff variant of the continuity
+// gate. It keeps the historical client and the two slot transitions, while
+// omitting the one-time legacy migration actions that cannot run again after
+// the listener descriptor has moved to the stable front.
+func parseGoldenSlotArgs(args []string) (goldenOptions, error) {
+	var options goldenOptions
+	options.slotOnly = true
+	actionNames := []string{"--activate", "--rollback", "--old-generation-check"}
+	positions := make(map[string]int, len(actionNames))
+	for index, arg := range args {
+		for _, name := range actionNames {
+			if arg == name {
+				if _, exists := positions[name]; exists {
+					return options, fmt.Errorf("%s may appear only once", name)
+				}
+				positions[name] = index
+			}
+		}
+	}
+	previous := -1
+	for index, name := range actionNames {
+		position, ok := positions[name]
+		if !ok || position <= previous || (index+1 < len(actionNames) && position+1 == positions[actionNames[index+1]]) ||
+			(index+1 == len(actionNames) && position+1 == len(args)) {
+			return options, errors.New("slot-only golden actions must be supplied in canonical order with a command")
+		}
+		previous = position
+	}
+	flags := flag.NewFlagSet("golden-slot", flag.ContinueOnError)
+	flags.StringVar(&options.cloudConfig, "cloud-config", "", "source cmux.com cloud config")
+	flags.StringVar(&options.codexHome, "codex-home", "", "source Codex home containing auth.json")
+	flags.StringVar(&options.codexBinary, "codex-bin", "codex", "Codex CLI binary")
+	flags.StringVar(&options.releasedVersion, "predecessor-version", "", "explicit predecessor Subrouter release version")
+	flags.StringVar(&options.releasedVersion, "released-version", "", "deprecated alias for --predecessor-version")
+	flags.StringVar(&options.predecessorSHA256, "predecessor-sha256", "", "expected predecessor release asset SHA-256")
+	flags.StringVar(&options.bootstrapSHA256, "bootstrap-sha256", "", "verified active slot worker SHA-256")
+	flags.StringVar(&options.candidateTag, "candidate-tag", "", "immutable candidate release tag")
+	flags.StringVar(&options.candidateSHA256, "candidate-sha256", "", "verified Linux candidate asset SHA-256")
+	flags.StringVar(&options.candidateRevision, "candidate-revision", "", "verified candidate source revision")
+	flags.StringVar(&options.evidenceValidator, "deploy-evidence-validator", "", "canonical deployment evidence validator")
+	flags.StringVar(&options.predecessorClient, "predecessor-client", "", "locally verified pinned predecessor release asset")
+	flags.StringVar(&options.releasedClient, "released-client", "", "test-only released client override")
+	flags.StringVar(&options.artifactDir, "artifact-dir", "", "content-blind evidence directory")
+	flags.StringVar(&options.model, "model", "gpt-5.3-codex-spark", "Codex model")
+	flags.StringVar(&options.accountID, "account-id", "", "Subrouter OAuth account selected for every golden Codex session")
+	flags.IntVar(&options.streamLines, "stream-lines", 400, "numbered lines requested from each continuity turn")
+	flags.DurationVar(&options.timeout, "timeout", 20*time.Minute, "overall golden gate timeout")
+	if err := flags.Parse(args[:positions[actionNames[0]]]); err != nil {
+		return options, err
+	}
+	if flags.NArg() != 0 {
+		return options, fmt.Errorf("unexpected golden-slot arguments")
+	}
+	activationStart, activationEnd := positions[actionNames[0]]+1, positions[actionNames[1]]
+	rollbackStart, rollbackEnd := positions[actionNames[1]]+1, positions[actionNames[2]]
+	oldGenerationStart := positions[actionNames[2]] + 1
+	options.activation = append([]string(nil), args[activationStart:activationEnd]...)
+	options.rollback = append([]string(nil), args[rollbackStart:rollbackEnd]...)
+	options.oldGenerationTest = append([]string(nil), args[oldGenerationStart:]...)
+	if options.streamLines < 100 && !goldenTestHooks.enabled {
+		return options, errors.New("--stream-lines must be at least 100")
+	}
+	if options.timeout <= 0 {
+		return options, errors.New("--timeout must be positive")
+	}
+	options.accountID = strings.TrimSpace(options.accountID)
+	if len(options.accountID) > 320 || strings.ContainsAny(options.accountID, "\r\n\x00") {
+		return options, errors.New("--account-id is invalid")
+	}
+	if !goldenTestHooks.enabled {
+		version := strings.TrimPrefix(strings.TrimSpace(options.releasedVersion), "v")
+		if version != goldenPinnedPredecessorVersion ||
+			strings.ToLower(strings.TrimSpace(options.predecessorSHA256)) != goldenPinnedPredecessorSHA256 {
+			return options, errors.New("the golden predecessor must be pinned v0.1.60 with its Darwin SHA-256")
+		}
+		if strings.TrimSpace(options.evidenceValidator) == "" {
+			return options, errors.New("--deploy-evidence-validator is required")
+		}
+		if options.accountID == "" {
+			return options, errors.New("--account-id is required for a deterministic golden credential")
+		}
+		if strings.TrimSpace(options.bootstrapSHA256) != goldenPinnedBootstrapLinuxSHA256 {
+			return options, errors.New("the active slot worker must be the verified v0.1.63 bootstrap")
 		}
 		if strings.TrimSpace(options.candidateTag) != goldenPinnedCandidateTag || !validGoldenSHA256(options.candidateSHA256) ||
 			len(strings.TrimSpace(options.candidateRevision)) != 40 {
@@ -448,6 +544,18 @@ func runGolden(args []string) (runErr error) {
 	if err != nil {
 		return err
 	}
+	return runGoldenOptions(options)
+}
+
+func runGoldenSlot(args []string) (runErr error) {
+	options, err := parseGoldenSlotArgs(args)
+	if err != nil {
+		return err
+	}
+	return runGoldenOptions(options)
+}
+
+func runGoldenOptions(options goldenOptions) (runErr error) {
 	testMode := goldenTestHooks.enabled
 	if !testMode && (runtime.GOOS != "darwin" || runtime.GOARCH != "arm64") {
 		return errors.New("golden continuity gate must run locally on macOS arm64")
@@ -526,7 +634,12 @@ func runGolden(args []string) (runErr error) {
 	if err := runner.run(ctx); err != nil {
 		return err
 	}
-	if err := validateGoldenSummary(summary, testMode); err != nil {
+	if options.slotOnly {
+		if err := validateGoldenSlotOnlySummary(summary, testMode, options.bootstrapSHA256,
+			options.candidateTag, options.candidateSHA256, options.candidateRevision); err != nil {
+			return err
+		}
+	} else if err := validateGoldenSummary(summary, testMode); err != nil {
 		return err
 	}
 	return nil
@@ -550,11 +663,13 @@ func (e *goldenFailure) Error() string { return e.code }
 func failGolden(code string) error { return &goldenFailure{code: code} }
 
 type goldenRunner struct {
-	options     goldenOptions
-	artifactDir string
-	privateRoot string
-	summary     *goldenSummary
-	testMode    bool
+	options             goldenOptions
+	artifactDir         string
+	privateRoot         string
+	summary             *goldenSummary
+	testMode            bool
+	goldenCodexShimPath string
+	rawCodexBinary      string
 
 	mu                  sync.Mutex
 	observers           []*runningGoldenObserver
@@ -675,10 +790,43 @@ func goldenPredecessorDirectCredentialSource() string {
 	return "legacy"
 }
 
+// prepareGoldenCodexShim keeps the per-response attempt token in the child
+// environment while adding it after the pinned Subrouter client has finished
+// sanitizing provider-owned Codex overrides. The raw Codex binary is resolved
+// before the private shim is written, so the shim cannot recurse through the
+// Subrouter client.
+func (r *goldenRunner) prepareGoldenCodexShim() error {
+	raw, err := exec.LookPath(r.options.codexBinary)
+	if err != nil {
+		return failGolden("required_command_missing")
+	}
+	shimPath := filepath.Join(r.privateRoot, "golden-codex-shim")
+	contents := []byte("#!/bin/sh\n" +
+		"set -eu\n" +
+		": \"${SUBROUTER_GOLDEN_RAW_CODEX_BIN:?}\"\n" +
+		"exec \"${SUBROUTER_GOLDEN_RAW_CODEX_BIN}\" \"$@\" \\\n" +
+		"  -c 'model_providers.subrouter.supports_websockets=false' \\\n" +
+		"  -c 'model_providers.subrouter.env_http_headers={\"" + goldenResponseAttemptTokenHeader + "\"=\"" + goldenResponseRequestTokenEnv + "\"}'\n")
+	if err := os.WriteFile(shimPath, contents, 0o700); err != nil {
+		return failGolden("golden_codex_shim_failed")
+	}
+	if err := os.Chmod(shimPath, 0o700); err != nil {
+		return failGolden("golden_codex_shim_failed")
+	}
+	r.goldenCodexShimPath = shimPath
+	r.rawCodexBinary = raw
+	return nil
+}
+
 func (r *goldenRunner) run(ctx context.Context) (runErr error) {
 	for _, command := range []string{"lsof", "pgrep", "ps", r.options.codexBinary} {
 		if _, err := exec.LookPath(command); err != nil {
 			return failGolden("required_command_missing")
+		}
+	}
+	if !r.testMode {
+		if err := r.prepareGoldenCodexShim(); err != nil {
+			return err
 		}
 	}
 	evidenceFile, err := os.OpenFile(filepath.Join(r.artifactDir, "gate-events.jsonl"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
@@ -786,6 +934,15 @@ func (r *goldenRunner) run(ctx context.Context) (runErr error) {
 	}
 	r.probeStats = probeStats
 	defer probeStats.stop(probeCancel)
+	cycleInputs := goldenCycleInputs{
+		name: "", clientPath: client.path, authData: authData, cloud: cloudConfig,
+		directConfigPath: directConfigPath, teamConfigPath: teamConfigPath,
+		hostedOrigin: hostedOrigin, localOrigin: localOrigin, leaseObserver: leaseObserver,
+		localDaemonPID: localDaemon.Process.Pid,
+	}
+	if r.options.slotOnly {
+		return r.runSlotOnlyHarness(ctx, cycleInputs, probeCancel, probeStats, cancelLocalRSS, localRSSDone, &localRSSStopped, localDaemon, &localDaemonStopped)
+	}
 	migration, err := r.runMigrationCycle(ctx, goldenCycleInputs{
 		name: "migration", clientPath: client.path, authData: authData, cloud: cloudConfig,
 		directConfigPath: directConfigPath, teamConfigPath: teamConfigPath,
@@ -881,6 +1038,79 @@ func (r *goldenRunner) run(ctx context.Context) (runErr error) {
 	)
 	r.summary.Sessions = append(
 		r.summary.Sessions,
+		buildGoldenSessionSummaries(final.initial, final.resumes, final.fresh, final.before, final.after)...,
+	)
+	return nil
+}
+
+func (r *goldenRunner) runSlotOnlyHarness(
+	ctx context.Context,
+	inputs goldenCycleInputs,
+	probeCancel context.CancelFunc,
+	probeStats *goldenProbeStats,
+	cancelLocalRSS context.CancelFunc,
+	localRSSDone <-chan struct{},
+	localRSSStopped *bool,
+	localDaemon *exec.Cmd,
+	localDaemonStopped *bool,
+) error {
+	inputs.name = "rehearsal"
+	rehearsal, err := r.runRehearsalCycle(ctx, inputs)
+	if err != nil {
+		return err
+	}
+	r.summary.Activation = rehearsal.activation
+	r.summary.Rollback = rehearsal.rollback
+	r.summary.OldGenerationCleanup = rehearsal.cleanup
+	if err := validateGoldenCounterContinuity(*r.summary); err != nil {
+		return err
+	}
+
+	inputs.name = "final"
+	final, err := r.runFinalCycle(ctx, inputs, rehearsal.activation)
+	if err != nil {
+		return err
+	}
+	r.summary.FinalActivation = final.activation
+	r.summary.FinalOldGenerationCleanup = final.cleanup
+	if err := validateGoldenCounterContinuity(*r.summary); err != nil {
+		return err
+	}
+	if observerRequestCount(inputs.leaseObserver.stats, "/v1/responses") != 0 ||
+		observerRequestCount(inputs.leaseObserver.stats, "/responses") != 0 ||
+		observerRequestCount(inputs.leaseObserver.stats, "/_subrouter/leases") != 0 {
+		return failGolden("local_route_bypassed_daemon")
+	}
+	probeStats.stop(probeCancel)
+	r.summary.Health = probeStats.summaries()
+	cancelLocalRSS()
+	<-localRSSDone
+	*localRSSStopped = true
+	if err := r.stopSamplingEvidenceWriter(); err != nil {
+		return err
+	}
+	if r.evidence.failure() != nil || probeStats.record.failure() != nil {
+		return failGolden("evidence_write_failed")
+	}
+	if err := probeStats.validateInterval(parseSummaryTime(r.summary.StartedAt), parseSummaryTime(r.summary.FinalOldGenerationCleanup.FinishedAt)); err != nil {
+		return err
+	}
+	if err := r.finalizeLocalDaemonRSS(); err != nil {
+		return err
+	}
+	stopAndWaitCommand(localDaemon)
+	*localDaemonStopped = true
+	if err := r.waitGoldenLocalDaemonStderr(); err != nil {
+		return err
+	}
+	if err := r.requireGoldenLocalDaemonTransportClean(); err != nil {
+		return err
+	}
+	if err := r.finalizeObservers(ctx); err != nil {
+		return err
+	}
+	r.summary.Sessions = append(
+		buildGoldenSessionSummaries(rehearsal.initial, rehearsal.resumes, rehearsal.fresh, rehearsal.before, rehearsal.after),
 		buildGoldenSessionSummaries(final.initial, final.resumes, final.fresh, final.before, final.after)...,
 	)
 	return nil
@@ -1044,7 +1274,7 @@ func (r *goldenRunner) runRehearsalCycle(ctx context.Context, inputs goldenCycle
 	if err := validateGoldenTransitionAction(result.activation, true); err != nil {
 		return result, err
 	}
-	if err := validateGoldenProvenance(r.summary.MigrationPreparation.migrationCanonical.Bootstrap.SHA256, result.activation); err != nil {
+	if err := validateGoldenProvenance(r.expectedGoldenBootstrapSHA256(), result.activation); err != nil {
 		return result, err
 	}
 	if err := r.validateGoldenSlotCandidate(result.activation); err != nil {
@@ -1206,7 +1436,7 @@ func (r *goldenRunner) runFinalCycle(ctx context.Context, inputs goldenCycleInpu
 	if err := validateGoldenTransitionAction(result.activation, true); err != nil {
 		return result, err
 	}
-	if err := validateGoldenProvenance(r.summary.MigrationPreparation.migrationCanonical.Bootstrap.SHA256, result.activation); err != nil {
+	if err := validateGoldenProvenance(r.expectedGoldenBootstrapSHA256(), result.activation); err != nil {
 		return result, err
 	}
 	if err := r.validateGoldenSlotCandidate(result.activation); err != nil {
@@ -1464,6 +1694,16 @@ func validateGoldenProvenance(predecessorSHA string, activation goldenActionSumm
 		return failGolden("deployment_provenance_mismatch")
 	}
 	return nil
+}
+
+func (r *goldenRunner) expectedGoldenBootstrapSHA256() string {
+	if value := strings.TrimSpace(r.options.bootstrapSHA256); value != "" {
+		return value
+	}
+	if r.summary != nil && r.summary.MigrationPreparation.migrationCanonical != nil {
+		return r.summary.MigrationPreparation.migrationCanonical.Bootstrap.SHA256
+	}
+	return ""
 }
 
 func (r *goldenRunner) runRetirementCheck(
@@ -2765,6 +3005,10 @@ func (r *goldenRunner) launchSession(ctx context.Context, clientPath string, ses
 		"SUBROUTER_DISABLE_FALLBACK":  "1",
 		"SUBROUTER_STATE_DIR":         filepath.Join(session.home, ".subrouter"),
 		goldenResponseRequestTokenEnv: session.streamReleaseToken,
+	}
+	if r.goldenCodexShimPath != "" {
+		overrides["SUBROUTER_CODEX_BIN"] = r.goldenCodexShimPath
+		overrides["SUBROUTER_GOLDEN_RAW_CODEX_BIN"] = r.rawCodexBinary
 	}
 	if r.options.accountID != "" {
 		overrides["SUBROUTER_CODEX_ACCOUNT_ID"] = r.options.accountID

--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -1116,7 +1116,7 @@ func (r *goldenRunner) runSlotOnlyHarness(
 	if r.evidence.failure() != nil || probeStats.record.failure() != nil {
 		return failGolden("evidence_write_failed")
 	}
-	if err := probeStats.validateInterval(parseSummaryTime(r.summary.StartedAt), parseSummaryTime(r.summary.FinalOldGenerationCleanup.FinishedAt)); err != nil {
+	if err := probeStats.validateInterval(probeStats.startedAt, parseSummaryTime(r.summary.FinalOldGenerationCleanup.FinishedAt)); err != nil {
 		return err
 	}
 	if err := r.finalizeLocalDaemonRSS(); err != nil {
@@ -2709,12 +2709,13 @@ type goldenProbeEvent struct {
 }
 
 type goldenProbeStats struct {
-	mu       sync.Mutex
-	events   []goldenProbeEvent
-	record   *jsonlRecorder
-	loops    sync.WaitGroup
-	samples  sync.WaitGroup
-	finished chan struct{}
+	startedAt time.Time
+	mu        sync.Mutex
+	events    []goldenProbeEvent
+	record    *jsonlRecorder
+	loops     sync.WaitGroup
+	samples   sync.WaitGroup
+	finished  chan struct{}
 }
 
 func (r *goldenRunner) startProbes(ctx context.Context, publicOrigin, localOrigin *url.URL) (*goldenProbeStats, error) {
@@ -2726,7 +2727,7 @@ func (r *goldenRunner) startProbes(ctx context.Context, publicOrigin, localOrigi
 		file.Close()
 		return nil, failGolden("health_evidence_protect_failed")
 	}
-	stats := &goldenProbeStats{record: &jsonlRecorder{writer: file}, finished: make(chan struct{})}
+	stats := &goldenProbeStats{startedAt: time.Now().UTC(), record: &jsonlRecorder{writer: file}, finished: make(chan struct{})}
 	targets := []struct {
 		label string
 		url   string

--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -1298,7 +1298,7 @@ func (r *goldenRunner) runRehearsalCycle(ctx context.Context, inputs goldenCycle
 	if err := validateGoldenTransitionAction(result.activation, true); err != nil {
 		return result, err
 	}
-	if err := validateGoldenProvenance(r.expectedGoldenBootstrapSHA256(), result.activation); err != nil {
+	if err := validateGoldenProvenance(r.bootstrapForActivation(result.activation), result.activation); err != nil {
 		return result, err
 	}
 	if err := r.validateGoldenSlotCandidate(result.activation); err != nil {
@@ -1460,7 +1460,7 @@ func (r *goldenRunner) runFinalCycle(ctx context.Context, inputs goldenCycleInpu
 	if err := validateGoldenTransitionAction(result.activation, true); err != nil {
 		return result, err
 	}
-	if err := validateGoldenProvenance(r.expectedGoldenBootstrapSHA256(), result.activation); err != nil {
+	if err := validateGoldenProvenance(r.bootstrapForActivation(result.activation), result.activation); err != nil {
 		return result, err
 	}
 	if err := r.validateGoldenSlotCandidate(result.activation); err != nil {
@@ -1726,6 +1726,19 @@ func (r *goldenRunner) expectedGoldenBootstrapSHA256() string {
 	}
 	if r.summary != nil && r.summary.MigrationPreparation.migrationCanonical != nil {
 		return r.summary.MigrationPreparation.migrationCanonical.Bootstrap.SHA256
+	}
+	return ""
+}
+
+func (r *goldenRunner) bootstrapForActivation(activation goldenActionSummary) string {
+	if expected := r.expectedGoldenBootstrapSHA256(); expected != "" {
+		return expected
+	}
+	if r.testMode {
+		// Deterministic fixtures can carry their bootstrap identity in the
+		// activation evidence itself. Production parsing always supplies the
+		// pinned bootstrap checksum before a cycle can start.
+		return activation.FromReleaseSHA256
 	}
 	return ""
 }

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -109,6 +109,40 @@ func TestGoldenSlotOptionsRequirePinnedCandidateAndBootstrap(t *testing.T) {
 	}
 }
 
+func TestGoldenSlotOnlySummaryFixtureIsValid(t *testing.T) {
+	summary := validGoldenAcceptanceSummary()
+	filteredSessions := summary.Sessions[:0]
+	for _, session := range summary.Sessions {
+		if !strings.HasPrefix(session.Label, "migration-") &&
+			session.Label != "migration-candidate-front-final-destination-direct" {
+			filteredSessions = append(filteredSessions, session)
+		}
+	}
+	summary.Sessions = filteredSessions
+	filteredSnapshots := summary.ProcessSnapshots[:0]
+	for _, snapshot := range summary.ProcessSnapshots {
+		if !strings.HasPrefix(snapshot.Phase, "migration-") {
+			filteredSnapshots = append(filteredSnapshots, snapshot)
+		}
+	}
+	summary.ProcessSnapshots = filteredSnapshots
+	summary.MigrationPreparation = goldenActionSummary{}
+	summary.MigrationFinalCutover = goldenActionSummary{}
+	summary.LegacyCleanup = goldenActionSummary{}
+	if err := validateGoldenSlotOnlySummary(summary, false, goldenPinnedBootstrapLinuxSHA256,
+		goldenPinnedCandidateTag, strings.Repeat("b", 64), strings.Repeat("c", 40)); err != nil {
+		t.Fatalf("valid slot-only fixture rejected: %v", err)
+	}
+}
+
+func TestGoldenSlotOnlySummaryRejectsUnverifiedBootstrap(t *testing.T) {
+	summary := validGoldenAcceptanceSummary()
+	if err := validateGoldenSlotOnlySummary(summary, false, strings.Repeat("d", 64),
+		goldenPinnedCandidateTag, strings.Repeat("b", 64), strings.Repeat("c", 40)); err == nil {
+		t.Fatal("slot-only summary accepted an unverified bootstrap")
+	}
+}
+
 func TestGoldenOptionsPinSparkAndSelectedOAuthAccount(t *testing.T) {
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = true

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -110,11 +110,18 @@ func TestGoldenSlotOptionsRequirePinnedCandidateAndBootstrap(t *testing.T) {
 }
 
 func TestGoldenSlotOnlySummaryFixtureIsValid(t *testing.T) {
+	summary := validGoldenSlotOnlyAcceptanceSummary()
+	if err := validateGoldenSlotOnlySummary(summary, false, goldenPinnedBootstrapLinuxSHA256,
+		goldenPinnedCandidateTag, strings.Repeat("b", 64), strings.Repeat("c", 40)); err != nil {
+		t.Fatalf("valid slot-only fixture rejected: %v", err)
+	}
+}
+
+func validGoldenSlotOnlyAcceptanceSummary() goldenSummary {
 	summary := validGoldenAcceptanceSummary()
 	filteredSessions := summary.Sessions[:0]
 	for _, session := range summary.Sessions {
-		if !strings.HasPrefix(session.Label, "migration-") &&
-			session.Label != "migration-candidate-front-final-destination-direct" {
+		if !strings.HasPrefix(session.Label, "migration-") {
 			filteredSessions = append(filteredSessions, session)
 		}
 	}
@@ -129,17 +136,27 @@ func TestGoldenSlotOnlySummaryFixtureIsValid(t *testing.T) {
 	summary.MigrationPreparation = goldenActionSummary{}
 	summary.MigrationFinalCutover = goldenActionSummary{}
 	summary.LegacyCleanup = goldenActionSummary{}
-	if err := validateGoldenSlotOnlySummary(summary, false, goldenPinnedBootstrapLinuxSHA256,
-		goldenPinnedCandidateTag, strings.Repeat("b", 64), strings.Repeat("c", 40)); err != nil {
-		t.Fatalf("valid slot-only fixture rejected: %v", err)
-	}
+	return summary
 }
 
 func TestGoldenSlotOnlySummaryRejectsUnverifiedBootstrap(t *testing.T) {
-	summary := validGoldenAcceptanceSummary()
-	if err := validateGoldenSlotOnlySummary(summary, false, strings.Repeat("d", 64),
-		goldenPinnedCandidateTag, strings.Repeat("b", 64), strings.Repeat("c", 40)); err == nil {
-		t.Fatal("slot-only summary accepted an unverified bootstrap")
+	summary := validGoldenSlotOnlyAcceptanceSummary()
+	if got := fixedGoldenFailure(validateGoldenSlotOnlySummary(summary, false, strings.Repeat("d", 64),
+		goldenPinnedCandidateTag, strings.Repeat("b", 64), strings.Repeat("c", 40))); got != "deployment_provenance_mismatch" {
+		t.Fatalf("failure = %q, want deployment_provenance_mismatch", got)
+	}
+}
+
+func TestGoldenSlotOnlySummaryRejectsChunkGapAboveAllowed(t *testing.T) {
+	summary := validGoldenSlotOnlyAcceptanceSummary()
+	for index := range summary.Sessions {
+		if summary.Sessions[index].Label == "rehearsal-direct-websocket" {
+			summary.Sessions[index].MaxChunkGapMillis = summary.Sessions[index].AllowedChunkGapMillis + 1
+		}
+	}
+	if got := fixedGoldenFailure(validateGoldenSlotOnlySummary(summary, false, goldenPinnedBootstrapLinuxSHA256,
+		goldenPinnedCandidateTag, strings.Repeat("b", 64), strings.Repeat("c", 40))); got != "session_evidence_incomplete" {
+		t.Fatalf("failure = %q, want session_evidence_incomplete", got)
 	}
 }
 

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -73,6 +73,42 @@ func TestGoldenOptionsRequirePinnedCandidate(t *testing.T) {
 	}
 }
 
+func TestGoldenSlotOptionsRequirePinnedCandidateAndBootstrap(t *testing.T) {
+	previousHooks := goldenTestHooks
+	goldenTestHooks.enabled = false
+	t.Cleanup(func() { goldenTestHooks = previousHooks })
+
+	args := []string{
+		"--predecessor-version", "v0.1.60",
+		"--predecessor-sha256", goldenPinnedPredecessorSHA256,
+		"--candidate-tag", goldenPinnedCandidateTag,
+		"--candidate-sha256", strings.Repeat("b", 64),
+		"--candidate-revision", strings.Repeat("c", 40),
+		"--bootstrap-sha256", goldenPinnedBootstrapLinuxSHA256,
+		"--deploy-evidence-validator", "validator",
+		"--account-id", "test@example.invalid",
+		"--activate", "true",
+		"--rollback", "true",
+		"--old-generation-check", "true",
+	}
+	options, err := parseGoldenSlotArgs(args)
+	if err != nil {
+		t.Fatalf("valid slot-only options were rejected: %v", err)
+	}
+	if options.bootstrapSHA256 != goldenPinnedBootstrapLinuxSHA256 {
+		t.Fatalf("bootstrap checksum = %q, want pinned checksum", options.bootstrapSHA256)
+	}
+	for index := range args {
+		if args[index] == goldenPinnedBootstrapLinuxSHA256 {
+			args[index] = strings.Repeat("d", 64)
+			break
+		}
+	}
+	if _, err := parseGoldenSlotArgs(args); err == nil {
+		t.Fatal("unverified bootstrap checksum was accepted")
+	}
+}
+
 func TestGoldenOptionsPinSparkAndSelectedOAuthAccount(t *testing.T) {
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = true

--- a/cmd/subrouter-transport-observer/golden_slot_only.go
+++ b/cmd/subrouter-transport-observer/golden_slot_only.go
@@ -11,6 +11,11 @@ import (
 // transition, counter, session, and process requirements as the full gate,
 // but does not accept or require the one-time legacy migration evidence.
 func validateGoldenSlotOnlySummary(summary goldenSummary, testMode bool, bootstrapSHA, candidateTag, candidateSHA, candidateRevision string) error {
+	if summary.MigrationPreparation != (goldenActionSummary{}) ||
+		summary.MigrationFinalCutover != (goldenActionSummary{}) ||
+		summary.LegacyCleanup != (goldenActionSummary{}) {
+		return failGolden("slot_only_migration_evidence_present")
+	}
 	if summary.ReleasedVersion == "" || len(summary.ReleasedSHA256) != 64 ||
 		!summary.ReleaseChecksumVerified || summary.ReleasePlatform != "darwin/arm64" {
 		return failGolden("release_evidence_incomplete")
@@ -151,6 +156,7 @@ func validateGoldenSlotOnlySessions(sessions []goldenSessionSummary) (string, er
 			session.PeakRSSBytes > goldenCodexRSSLimitBytes || session.RSSSamples == 0 ||
 			session.ProcessSamples == 0 || session.PausedProcessSamples != 0 ||
 			session.MaxProcessSampleGapMS > goldenProcessSampleMaxGap.Milliseconds() ||
+			session.MaxChunkGapMillis > session.AllowedChunkGapMillis ||
 			session.AllowedChunkGapMillis < goldenChunkGapFloor.Milliseconds() ||
 			session.DeployMaxChunkGapMillis > session.AllowedChunkGapMillis {
 			return "", fmt.Errorf("%w: invalid session %q", failGolden("session_evidence_incomplete"), session.Label)
@@ -225,11 +231,14 @@ func validateGoldenSlotOnlyProcessSnapshots(summary goldenSummary, finalCandidat
 			return failGolden("process_evidence_incomplete")
 		}
 		for _, state := range item.ProcessStates {
-			if state == "" || strings.HasPrefix(state, "T") {
+			if state == "" || strings.HasPrefix(strings.ToUpper(state), "T") {
 				return failGolden("paused_process_detected")
 			}
 		}
 		isObserver := strings.HasPrefix(item.Label, "observer-")
+		if !goldenSlotOnlyProcessSnapshotAllowed(item, required) {
+			return failGolden("process_evidence_incomplete")
+		}
 		if !isObserver && (len(item.DescendantPIDs) == 0 || item.RSSBytes <= 0 ||
 			item.RSSBytes > goldenProcessRSSLimit(item.Label)) {
 			return failGolden("socket_evidence_incomplete")
@@ -273,4 +282,32 @@ func validateGoldenSlotOnlyProcessSnapshots(summary goldenSummary, finalCandidat
 		}
 	}
 	return nil
+}
+
+func goldenSlotOnlyProcessSnapshotAllowed(item goldenProcessEvidence, required map[string]bool) bool {
+	if strings.HasPrefix(item.Label, "observer-") {
+		return item.Phase != "" && !strings.HasPrefix(item.Phase, "migration-")
+	}
+	key := item.Phase + "\x00" + item.Label
+	if _, ok := required[key]; ok {
+		return true
+	}
+	for _, cycle := range []string{"rehearsal", "final"} {
+		if item.Phase == cycle+"-provisional-activation" {
+			for _, label := range []string{
+				cycle + "-direct-websocket", cycle + "-direct-http",
+				cycle + "-local-websocket", cycle + "-local-http",
+				cycle + "-candidate-local", "local-daemon",
+			} {
+				if item.Label == label {
+					return true
+				}
+			}
+		}
+		if item.Phase == cycle+"-candidate-local-ready" &&
+			(item.Label == cycle+"-candidate-local" || item.Label == "local-daemon") {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/subrouter-transport-observer/golden_slot_only.go
+++ b/cmd/subrouter-transport-observer/golden_slot_only.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// validateGoldenSlotOnlySummary validates the continuity evidence produced
+// after listener-fd handoff. It deliberately shares the same release,
+// transition, counter, session, and process requirements as the full gate,
+// but does not accept or require the one-time legacy migration evidence.
+func validateGoldenSlotOnlySummary(summary goldenSummary, testMode bool, bootstrapSHA, candidateTag, candidateSHA, candidateRevision string) error {
+	if summary.ReleasedVersion == "" || len(summary.ReleasedSHA256) != 64 ||
+		!summary.ReleaseChecksumVerified || summary.ReleasePlatform != "darwin/arm64" {
+		return failGolden("release_evidence_incomplete")
+	}
+	if !testMode && (summary.ExpectedPredecessorSHA256 != summary.ReleasedSHA256 ||
+		!validGoldenSHA256(summary.ExpectedPredecessorSHA256)) {
+		return failGolden("predecessor_evidence_incomplete")
+	}
+	if !testMode && (summary.ReleasedVersion != goldenPinnedPredecessorVersion ||
+		summary.ReleasedSHA256 != goldenPinnedPredecessorSHA256 ||
+		summary.PredecessorRevision != goldenPinnedPredecessorRevision ||
+		!summary.PredecessorRevisionVerified) {
+		return failGolden("predecessor_evidence_incomplete")
+	}
+	if !testMode && summary.ReleasedVersion == "test-override" {
+		return failGolden("candidate_client_forbidden")
+	}
+
+	bootstrapSHA = strings.ToLower(strings.TrimSpace(bootstrapSHA))
+	if testMode && bootstrapSHA == "" {
+		bootstrapSHA = summary.Activation.FromReleaseSHA256
+	}
+	if !testMode && bootstrapSHA != goldenPinnedBootstrapLinuxSHA256 {
+		return failGolden("deployment_provenance_mismatch")
+	}
+	if err := validateGoldenTransitionAction(summary.Activation, true); err != nil {
+		return err
+	}
+	if err := validateGoldenProvenance(bootstrapSHA, summary.Activation); err != nil {
+		return err
+	}
+	if err := validateGoldenSlotCandidateStandalone(summary.Activation, testMode, candidateTag, candidateSHA, candidateRevision); err != nil {
+		return err
+	}
+	if err := validateGoldenTransitionAction(summary.Rollback, false); err != nil {
+		return err
+	}
+	if err := validateGoldenRollback(summary.Activation, summary.Rollback); err != nil {
+		return err
+	}
+	if err := validateGoldenTransitionAction(summary.FinalActivation, true); err != nil {
+		return err
+	}
+	if err := validateGoldenProvenance(bootstrapSHA, summary.FinalActivation); err != nil {
+		return err
+	}
+	if err := validateGoldenSlotCandidateStandalone(summary.FinalActivation, testMode, candidateTag, candidateSHA, candidateRevision); err != nil {
+		return err
+	}
+	if err := validateGoldenSameActivation(summary.Activation, summary.FinalActivation); err != nil {
+		return err
+	}
+	if err := validateGoldenCleanupSummary(summary.OldGenerationCleanup, summary.Activation.ToGenerationIDHash); err != nil {
+		return err
+	}
+	if summary.OldGenerationCleanup.LinkedEvidenceSHA256 != summary.Rollback.EvidenceSHA256 {
+		return failGolden("old_generation_evidence_invalid")
+	}
+	if err := validateGoldenCleanupSummary(summary.FinalOldGenerationCleanup, summary.Activation.FromGenerationIDHash); err != nil {
+		return err
+	}
+	if summary.FinalOldGenerationCleanup.LinkedEvidenceSHA256 != summary.FinalActivation.EvidenceSHA256 {
+		return failGolden("old_generation_evidence_invalid")
+	}
+	if err := validateGoldenCounterContinuity(summary); err != nil {
+		return err
+	}
+	if err := validateGoldenSlotOnlyHealth(summary); err != nil {
+		return err
+	}
+	finalCandidateSocket, err := validateGoldenSlotOnlySessions(summary.Sessions)
+	if err != nil {
+		return err
+	}
+	if !summary.FreshLocalLeaseObserved || !summary.LegacyBrokerLeaseObserved || summary.DeploymentEnvironmentRead {
+		return failGolden("golden_evidence_incomplete")
+	}
+	if err := validateGoldenSlotOnlyProcessSnapshots(summary, finalCandidateSocket); err != nil {
+		return err
+	}
+	if summary.LocalDaemonRSSSamples == 0 || summary.LocalDaemonProcessSamples == 0 ||
+		summary.LocalDaemonPausedSamples != 0 ||
+		summary.LocalDaemonMaxSampleGapMS > goldenProcessSampleMaxGap.Milliseconds() ||
+		summary.LocalDaemonPeakRSSBytes <= 0 || summary.LocalDaemonPeakRSSBytes > goldenRSSLimitBytes {
+		return failGolden("local_daemon_rss_missing")
+	}
+	return nil
+}
+
+func validateGoldenSlotCandidateStandalone(action goldenActionSummary, testMode bool, candidateTag, candidateSHA, candidateRevision string) error {
+	if testMode {
+		return nil
+	}
+	if action.ReleaseTag != candidateTag || action.ToReleaseSHA256 != candidateSHA ||
+		action.ReleaseSourceRevision != candidateRevision {
+		return failGolden("candidate_provenance_mismatch")
+	}
+	return nil
+}
+
+func validateGoldenSlotOnlyHealth(summary goldenSummary) error {
+	if summary.ProbeFrequencyHz != 10 || len(summary.Health) != 4 {
+		return failGolden("health_evidence_incomplete")
+	}
+	for _, health := range summary.Health {
+		if health.Label == "" || health.Samples == 0 || health.Failures != 0 || health.MaxStartGapMillis > 250 {
+			return failGolden("health_evidence_incomplete")
+		}
+	}
+	return nil
+}
+
+func validateGoldenSlotOnlySessions(sessions []goldenSessionSummary) (string, error) {
+	expected := make(map[string]struct{ route, transport string })
+	for _, cycle := range []string{"rehearsal", "final"} {
+		expected[cycle+"-direct-websocket"] = struct{ route, transport string }{"direct-hosted", "websocket"}
+		expected[cycle+"-direct-http"] = struct{ route, transport string }{"direct-hosted", "http"}
+		expected[cycle+"-local-websocket"] = struct{ route, transport string }{"local-egress", "websocket"}
+		expected[cycle+"-local-http"] = struct{ route, transport string }{"local-egress", "http"}
+		expected[cycle+"-candidate-direct"] = struct{ route, transport string }{"direct-hosted", "websocket"}
+		expected[cycle+"-candidate-local"] = struct{ route, transport string }{"local-egress", "websocket"}
+	}
+	if len(sessions) != len(expected) {
+		return "", fmt.Errorf("%w: got %d sessions, want %d", failGolden("session_evidence_incomplete"), len(sessions), len(expected))
+	}
+	finalCandidateTransportSocket := ""
+	finalCandidateSocketStable := false
+	for _, session := range sessions {
+		want, ok := expected[session.Label]
+		if !ok || session.Route != want.route || session.Transport != want.transport ||
+			session.ProcessID <= 0 || len(session.ThreadIDHash) != 64 || len(session.NonceHash) != 64 ||
+			session.ResponseRequests == 0 || session.ResponseConnections == 0 ||
+			len(session.ResponseTransportSocket) != 64 ||
+			(!strings.Contains(session.Label, "-candidate-") && !session.TransportSocketStable) ||
+			session.ResponseBytes <= 0 || session.MarkerCount != 1 || session.RetryCount != 0 ||
+			session.ReconnectCount != 0 || session.FallbackCount != 0 || session.ErrorCount != 0 ||
+			session.NonzeroExitCount != 0 || session.DuplicateMarkerCount != 0 || session.PeakRSSBytes <= 0 ||
+			session.PeakRSSBytes > goldenCodexRSSLimitBytes || session.RSSSamples == 0 ||
+			session.ProcessSamples == 0 || session.PausedProcessSamples != 0 ||
+			session.MaxProcessSampleGapMS > goldenProcessSampleMaxGap.Milliseconds() ||
+			session.AllowedChunkGapMillis < goldenChunkGapFloor.Milliseconds() ||
+			session.DeployMaxChunkGapMillis > session.AllowedChunkGapMillis {
+			return "", fmt.Errorf("%w: invalid session %q", failGolden("session_evidence_incomplete"), session.Label)
+		}
+		if strings.Contains(session.Label, "-candidate-") {
+			if session.ResumeMarkerCount != 0 || session.ResumeNonceCount != 0 {
+				return "", failGolden("activation_session_evidence_invalid")
+			}
+		} else if session.ResumeMarkerCount != 1 || session.ResumeNonceCount != 1 ||
+			len(session.SocketIDsBefore) == 0 || len(session.SocketIDsAfterRollback) == 0 {
+			return "", failGolden("resume_evidence_incomplete")
+		}
+		if session.Route == "local-egress" && len(session.LocalUpstreamSocket) != 64 {
+			return "", failGolden("local_upstream_evidence_missing")
+		}
+		if session.Route == "local-egress" &&
+			(!session.LocalEgressCorrelated || len(session.LocalEgressSocket) != 64) {
+			return "", failGolden("local_egress_correlation_missing")
+		}
+		allowed := 2 * session.PreDeployP99GapMillis
+		if allowed < goldenChunkGapFloor.Milliseconds() {
+			allowed = goldenChunkGapFloor.Milliseconds()
+		}
+		if !strings.Contains(session.Label, "-candidate-") && session.AllowedChunkGapMillis != allowed {
+			return "", failGolden("chunk_gap_threshold_invalid")
+		}
+		if session.Label == "final-candidate-direct" {
+			finalCandidateTransportSocket = session.ResponseTransportSocket
+			finalCandidateSocketStable = session.TransportSocketStable
+		}
+		delete(expected, session.Label)
+	}
+	if len(expected) != 0 || !finalCandidateSocketStable || len(finalCandidateTransportSocket) != 64 {
+		return "", failGolden("final_candidate_socket_continuity_invalid")
+	}
+	return finalCandidateTransportSocket, nil
+}
+
+func validateGoldenSlotOnlyProcessSnapshots(summary goldenSummary, finalCandidateSocket string) error {
+	if len(summary.ProcessSnapshots) == 0 {
+		return failGolden("process_evidence_incomplete")
+	}
+	required := make(map[string]bool)
+	for _, cycle := range []string{"rehearsal", "final"} {
+		phases := []string{cycle + "-before-activation", cycle + "-after-activation"}
+		if cycle == "rehearsal" {
+			phases = append(phases, cycle+"-after-rollback")
+		}
+		for _, phase := range phases {
+			for _, suffix := range []string{"direct-websocket", "direct-http", "local-websocket", "local-http"} {
+				required[phase+"\x00"+cycle+"-"+suffix] = false
+			}
+			required[phase+"\x00local-daemon"] = false
+			if phase != cycle+"-before-activation" {
+				required[phase+"\x00"+cycle+"-candidate-direct"] = false
+				required[phase+"\x00"+cycle+"-candidate-local"] = false
+			}
+		}
+	}
+	required["final-candidate-after-retirement\x00final-candidate-direct"] = false
+	retirementFinishedAt, err := time.Parse(time.RFC3339Nano, summary.FinalOldGenerationCleanup.FinishedAt)
+	if err != nil {
+		return failGolden("final_candidate_socket_continuity_invalid")
+	}
+	finalCandidateSnapshots := map[string]bool{
+		"final-after-activation":           false,
+		"final-candidate-after-retirement": false,
+	}
+	for _, item := range summary.ProcessSnapshots {
+		key := item.Phase + "\x00" + item.Label
+		if item.ProcessID <= 0 || item.Timestamp == "" || len(item.ProcessStates) == 0 {
+			return failGolden("process_evidence_incomplete")
+		}
+		for _, state := range item.ProcessStates {
+			if state == "" || strings.HasPrefix(state, "T") {
+				return failGolden("paused_process_detected")
+			}
+		}
+		isObserver := strings.HasPrefix(item.Label, "observer-")
+		if !isObserver && (len(item.DescendantPIDs) == 0 || item.RSSBytes <= 0 ||
+			item.RSSBytes > goldenProcessRSSLimit(item.Label)) {
+			return failGolden("socket_evidence_incomplete")
+		}
+		if !isObserver && len(item.SocketIDs) == 0 {
+			return failGolden("socket_evidence_incomplete")
+		}
+		if item.Label == "local-daemon" && len(item.RemoteSocketIDs) == 0 {
+			return failGolden("egress_evidence_incomplete")
+		}
+		if item.Label == "final-candidate-direct" {
+			if _, tracked := finalCandidateSnapshots[item.Phase]; tracked {
+				containsTransport := false
+				for _, socketID := range item.SocketIDs {
+					containsTransport = containsTransport || socketID == finalCandidateSocket
+				}
+				if !containsTransport {
+					return failGolden("final_candidate_socket_continuity_invalid")
+				}
+				if item.Phase == "final-candidate-after-retirement" {
+					capturedAt, parseErr := time.Parse(time.RFC3339Nano, item.Timestamp)
+					if parseErr != nil || capturedAt.Before(retirementFinishedAt) {
+						return failGolden("final_candidate_socket_continuity_invalid")
+					}
+				}
+				finalCandidateSnapshots[item.Phase] = true
+			}
+		}
+		if _, ok := required[key]; ok {
+			required[key] = true
+		}
+	}
+	for _, present := range finalCandidateSnapshots {
+		if !present {
+			return failGolden("final_candidate_socket_continuity_invalid")
+		}
+	}
+	for _, present := range required {
+		if !present {
+			return failGolden("process_evidence_incomplete")
+		}
+	}
+	return nil
+}

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -1129,6 +1129,8 @@ func main() {
 		err = runProxy(args)
 	case "golden":
 		err = runGolden(args)
+	case "golden-slot":
+		err = runGoldenSlot(args)
 	default:
 		err = fmt.Errorf("unknown command %q", command)
 	}

--- a/deploy/gcp/deploy-live-upgrade.sh
+++ b/deploy/gcp/deploy-live-upgrade.sh
@@ -94,11 +94,18 @@ INSTALL_FRONT_SLOTS="$(bash "${SCRIPT_DIR}/resolve-release-installer.sh" "${SCRI
 DEPLOYMENT_CONTRACT="$(bash "${SCRIPT_DIR}/resolve-release-contract.sh" "${SCRIPT_DIR}/deployment-contract.py")"
 REMOTE_INSTALL_COMMAND="sudo env SUBROUTER_DEPLOYMENT_CONTRACT='${REMOTE_DEPLOYMENT_CONTRACT}' bash '${REMOTE_INSTALLER}'"
 
-for command in "${GCLOUD_BINARY}" go jq curl python3 sha256sum; do
+for command in "${GCLOUD_BINARY}" go jq curl python3; do
   command -v "${command}" >/dev/null 2>&1 || die "required command not found: ${command}"
 done
-INSTALL_FRONT_SLOTS_SHA256="$(sha256sum "${INSTALL_FRONT_SLOTS}" | awk '{print $1}')"
-DEPLOYMENT_CONTRACT_SHA256="$(sha256sum "${DEPLOYMENT_CONTRACT}" | awk '{print $1}')"
+if command -v sha256sum >/dev/null 2>&1; then
+  hash_file() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+  hash_file() { shasum -a 256 "$1" | awk '{print $1}'; }
+else
+  die "required command not found: sha256sum or shasum"
+fi
+INSTALL_FRONT_SLOTS_SHA256="$(hash_file "${INSTALL_FRONT_SLOTS}")"
+DEPLOYMENT_CONTRACT_SHA256="$(hash_file "${DEPLOYMENT_CONTRACT}")"
 [[ -x "${DEPLOY_BINARY}" ]] || die "deploy binary is not executable: ${DEPLOY_BINARY}"
 [[ -f "${RELEASE_SHA256_FILE}" ]] || die "release checksum file is missing: ${RELEASE_SHA256_FILE}"
 [[ "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] \
@@ -122,7 +129,7 @@ bash "${SCRIPT_DIR}/verify-go-release-binary.sh" "${DEPLOY_BINARY}" "${DEPLOY_RE
 PUBLIC_BASE_URL="${PUBLIC_BASE_URL%/}"
 EXPECTED_SHA256="$(tr -d '[:space:]' <"${RELEASE_SHA256_FILE}")"
 [[ "${EXPECTED_SHA256}" =~ ^[0-9a-f]{64}$ ]] || die "release checksum is invalid"
-CANDIDATE_SHA256="$(sha256sum "${DEPLOY_BINARY}" | awk '{print $1}')"
+CANDIDATE_SHA256="$(hash_file "${DEPLOY_BINARY}")"
 [[ "${CANDIDATE_SHA256}" == "${EXPECTED_SHA256}" ]] \
   || die "deploy binary does not match the verified release checksum"
 
@@ -644,7 +651,7 @@ python3 "${DEPLOYMENT_CONTRACT}" validate-activation-ack \
   "${GOLDEN_ACK}" "${ack_challenge}" "${candidate_slot}" "${candidate_generation}" \
   "${upgrade_requested_at}" "${provisional_switch_at}" "${ack_received_at}"
 activated_at="$(jq -r '.activated_at' "${GOLDEN_ACK}")"
-golden_ack_sha256="$(sha256sum "${GOLDEN_ACK}" | awk '{print $1}')"
+golden_ack_sha256="$(hash_file "${GOLDEN_ACK}")"
 fresh_candidate_connection_id="$(jq -r '.fresh_candidate_connection_id' "${GOLDEN_ACK}")"
 acknowledged_front_status="$(front_status)"
 candidate_connections_after_ack="$(front_connections "${acknowledged_front_status}" "${candidate_slot}")"

--- a/deploy/gcp/finalize-slot-retirement.sh
+++ b/deploy/gcp/finalize-slot-retirement.sh
@@ -50,11 +50,18 @@ die() { log "$*" >&2; exit 1; }
 INSTALL_FRONT_SLOTS="$(bash "${SCRIPT_DIR}/resolve-release-installer.sh" "${SCRIPT_DIR}/install-front-slots.sh")"
 DEPLOYMENT_CONTRACT="$(bash "${SCRIPT_DIR}/resolve-release-contract.sh" "${SCRIPT_DIR}/deployment-contract.py")"
 REMOTE_INSTALL_COMMAND="sudo env SUBROUTER_DEPLOYMENT_CONTRACT='${REMOTE_DEPLOYMENT_CONTRACT}' bash '${REMOTE_INSTALLER}'"
-for command in "${GCLOUD_BINARY}" jq curl python3 sha256sum; do
+for command in "${GCLOUD_BINARY}" jq curl python3; do
   command -v "${command}" >/dev/null 2>&1 || die "required command not found: ${command}"
 done
-INSTALL_FRONT_SLOTS_SHA256="$(sha256sum "${INSTALL_FRONT_SLOTS}" | awk '{print $1}')"
-DEPLOYMENT_CONTRACT_SHA256="$(sha256sum "${DEPLOYMENT_CONTRACT}" | awk '{print $1}')"
+if command -v sha256sum >/dev/null 2>&1; then
+  hash_file() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+  hash_file() { shasum -a 256 "$1" | awk '{print $1}'; }
+else
+  die "required command not found: sha256sum or shasum"
+fi
+INSTALL_FRONT_SLOTS_SHA256="$(hash_file "${INSTALL_FRONT_SLOTS}")"
+DEPLOYMENT_CONTRACT_SHA256="$(hash_file "${DEPLOYMENT_CONTRACT}")"
 [[ "${DRAIN_TIMEOUT_SECONDS}" =~ ^[0-9]+$ ]] \
   || die "SUBROUTER_RETIRE_DRAIN_TIMEOUT_SECONDS must be an integer"
 (( DRAIN_TIMEOUT_SECONDS > 0 )) || die "SUBROUTER_RETIRE_DRAIN_TIMEOUT_SECONDS must be positive"
@@ -85,7 +92,7 @@ case "${transition_type}" in
     ;;
   *) die "transition evidence must be slot-activation or slot-rollback" ;;
 esac
-transition_sha256="$(sha256sum "${TRANSITION_EVIDENCE}" | awk '{print $1}')"
+transition_sha256="$(hash_file "${TRANSITION_EVIDENCE}")"
 [[ "$(jq -r '.run.project' "${TRANSITION_EVIDENCE}")" == "${PROJECT_ID}" &&
    "$(jq -r '.run.zone' "${TRANSITION_EVIDENCE}")" == "${ZONE}" &&
    "$(jq -r '.run.instance' "${TRANSITION_EVIDENCE}")" == "${INSTANCE}" ]] \

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -48,6 +48,7 @@ EOF
 artifact_dir=""
 cloud_config_path=""
 codex_home_path=""
+codex_home_supplied=false
 account_id=""
 account_id_supplied=false
 slot_only=false
@@ -68,6 +69,7 @@ while (( $# > 0 )); do
     --codex-home)
       (( $# >= 2 )) || { usage >&2; exit 2; }
       codex_home_path="$2"
+      codex_home_supplied=true
       golden_args+=("$1" "$2")
       shift 2
       ;;
@@ -365,17 +367,68 @@ export SUBROUTER_DEPLOY_ARTIFACT_DIR="${private_root}/deploy-internal"
 mkdir -p "${SUBROUTER_DEPLOY_ARTIFACT_DIR}"
 
 if [[ "${account_id_supplied}" == false ]]; then
-  account_id="$(jq -r '.tokens.account_id // empty' "${codex_home_path}/auth.json" 2>/dev/null || true)"
+  account_id="$(python3 - "${codex_home_path}/auth.json" <<'PY'
+import base64
+import json
+import sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        auth = json.load(handle)
+except (OSError, ValueError, TypeError):
+    auth = {}
+
+tokens = auth.get("tokens") if isinstance(auth, dict) else {}
+if not isinstance(tokens, dict):
+    tokens = {}
+account_id = tokens.get("account_id")
+if not isinstance(account_id, str) or not account_id.strip():
+    account_id = ""
+
+def claims(token):
+    if not isinstance(token, str):
+        return {}
+    parts = token.split(".")
+    if len(parts) < 2:
+        return {}
+    try:
+        payload = base64.urlsafe_b64decode(parts[1] + "=" * (-len(parts[1]) % 4))
+        value = json.loads(payload)
+        return value if isinstance(value, dict) else {}
+    except (ValueError, TypeError, base64.binascii.Error):
+        return {}
+
+if not account_id:
+    for token in (tokens.get("id_token"), tokens.get("access_token")):
+        value = claims(token)
+        account_id = value.get("chatgpt_account_id", "")
+        if not account_id and isinstance(value.get("https://api.openai.com/auth"), dict):
+            account_id = value["https://api.openai.com/auth"].get("chatgpt_account_id", "")
+        if not account_id and isinstance(value.get("organizations"), list) and value["organizations"]:
+            first = value["organizations"][0]
+            if isinstance(first, dict):
+                account_id = first.get("id", "")
+        if isinstance(account_id, str) and account_id.strip():
+            break
+        account_id = ""
+
+if isinstance(account_id, str):
+    print(account_id.strip())
+PY
+  )"
 fi
 [[ "${account_id}" =~ ^[A-Za-z0-9._@:+/-]{1,320}$ ]] || {
   echo "a valid Codex OAuth account ID is required; pass --account-id or use a signed-in Codex home" >&2
   exit 1
 }
+if [[ "${codex_home_supplied}" == false ]]; then
+  golden_args+=(--codex-home "${codex_home_path}")
+fi
 if [[ "${account_id_supplied}" == false ]]; then
   golden_args+=(--account-id "${account_id}")
 fi
 
-if [[ "${SUBROUTER_GCP_INSTANCE}" == subrouter-staging ]]; then
+if [[ "${SUBROUTER_GCP_INSTANCE}" == subrouter-staging && "${slot_only}" == false ]]; then
   normalization_evidence="${artifact_dir}/staging-predecessor-normalization.json"
   [[ ! -e "${normalization_evidence}" ]] || { echo "staging normalization evidence already exists" >&2; exit 1; }
   "${root}/deploy/gcp/normalize-staging-predecessor.sh" --evidence-json "${normalization_evidence}"

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -417,7 +417,7 @@ if isinstance(account_id, str):
 PY
   )"
 fi
-[[ "${account_id}" =~ ^[A-Za-z0-9._@:+/-]{1,320}$ ]] || {
+[[ "${account_id}" =~ ^[A-Za-z0-9._@:+/-]{1,256}$ ]] || {
   echo "a valid Codex OAuth account ID is required; pass --account-id or use a signed-in Codex home" >&2
   exit 1
 }

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Verify the immutable v0.1.60/v0.1.63/v0.1.129 release inputs, then run the complete
-# legacy-to-front migration and slot-upgrade continuity gate from a local Mac.
+# Verify the immutable v0.1.60/v0.1.63/v0.1.129 release inputs, then run the
+# complete migration or post-handoff slot-upgrade continuity gate from a local Mac.
 set -euo pipefail
 umask 077
 
@@ -24,9 +24,10 @@ usage() {
 Usage: ./deploy/gcp/golden-local-mac-production-continuity.sh [options]
 
 Requires SUBROUTER_GCP_PROJECT, SUBROUTER_GCP_ZONE,
-SUBROUTER_GCP_INSTANCE, and SUBROUTER_PUBLIC_BASE_URL. The target must already
-serve the v0.1.60 legacy topology. Staging is normalized to that exact worker
-before the gate begins.
+SUBROUTER_GCP_INSTANCE, and SUBROUTER_PUBLIC_BASE_URL. The default gate starts
+from the v0.1.60 legacy topology. With --slot-only, the target must already be
+in the front-slot topology with the verified v0.1.63 bootstrap worker. Staging
+is normalized to the required worker before the gate begins.
 
 Options:
   --artifact-dir PATH
@@ -34,6 +35,7 @@ Options:
   --codex-home PATH
   --codex-bin PATH
   --account-id ID
+  --slot-only
   --model MODEL
   --stream-lines N
   --timeout DURATION
@@ -45,6 +47,10 @@ EOF
 
 artifact_dir=""
 cloud_config_path=""
+codex_home_path=""
+account_id=""
+account_id_supplied=false
+slot_only=false
 golden_args=()
 while (( $# > 0 )); do
   case "$1" in
@@ -59,10 +65,27 @@ while (( $# > 0 )); do
       golden_args+=("$1" "$2")
       shift 2
       ;;
-    --codex-home|--codex-bin|--account-id|--model|--stream-lines|--timeout)
+    --codex-home)
+      (( $# >= 2 )) || { usage >&2; exit 2; }
+      codex_home_path="$2"
+      golden_args+=("$1" "$2")
+      shift 2
+      ;;
+    --account-id)
+      (( $# >= 2 )) || { usage >&2; exit 2; }
+      account_id="$2"
+      account_id_supplied=true
+      golden_args+=("$1" "$2")
+      shift 2
+      ;;
+    --codex-bin|--model|--stream-lines|--timeout)
       (( $# >= 2 )) || { usage >&2; exit 2; }
       golden_args+=("$1" "$2")
       shift 2
+      ;;
+    --slot-only)
+      slot_only=true
+      shift
       ;;
     --help|-h)
       usage
@@ -95,6 +118,9 @@ fi
 
 if [[ -z "${cloud_config_path}" ]]; then
   cloud_config_path="${SUBROUTER_CLOUD_CONFIG:-${HOME}/.config/subrouter/cloud.json}"
+fi
+if [[ -z "${codex_home_path}" ]]; then
+  codex_home_path="${CODEX_HOME:-${HOME}/.codex}"
 fi
 [[ -f "${cloud_config_path}" ]] || {
   echo "cloud config is missing: ${cloud_config_path}" >&2
@@ -338,6 +364,17 @@ export SUBROUTER_DEPLOYMENT_CONTRACT="${candidate_dir}/deployment-contract.py"
 export SUBROUTER_DEPLOY_ARTIFACT_DIR="${private_root}/deploy-internal"
 mkdir -p "${SUBROUTER_DEPLOY_ARTIFACT_DIR}"
 
+if [[ "${account_id_supplied}" == false ]]; then
+  account_id="$(jq -r '.tokens.account_id // empty' "${codex_home_path}/auth.json" 2>/dev/null || true)"
+fi
+[[ "${account_id}" =~ ^[A-Za-z0-9._@:+/-]{1,320}$ ]] || {
+  echo "a valid Codex OAuth account ID is required; pass --account-id or use a signed-in Codex home" >&2
+  exit 1
+}
+if [[ "${account_id_supplied}" == false ]]; then
+  golden_args+=(--account-id "${account_id}")
+fi
+
 if [[ "${SUBROUTER_GCP_INSTANCE}" == subrouter-staging ]]; then
   normalization_evidence="${artifact_dir}/staging-predecessor-normalization.json"
   [[ ! -e "${normalization_evidence}" ]] || { echo "staging normalization evidence already exists" >&2; exit 1; }
@@ -357,19 +394,47 @@ observer="${private_root}/subrouter-transport-observer"
   go build -trimpath -o "${observer}" ./cmd/subrouter-transport-observer
 )
 
-"${observer}" golden \
-  --predecessor-version "${predecessor_tag}" \
-  --predecessor-sha256 "${predecessor_darwin_sha}" \
-  --predecessor-client "${predecessor_darwin}" \
-  --candidate-tag "${candidate_tag}" \
-  --candidate-sha256 "${candidate_linux_sha}" \
-  --candidate-revision "${candidate_revision}" \
-  --deploy-evidence-validator "${root}/deploy/gcp/validate-deploy-evidence.py" \
-  --artifact-dir "${artifact_dir}" \
-  "${golden_args[@]}" \
-  --migration-prepare "${root}/deploy/gcp/migrate-to-front-slots.sh" \
-  --migration-switch "${root}/deploy/gcp/switch-front-migration.sh" \
-  --legacy-retirement "${root}/deploy/gcp/finalize-legacy-retirement.sh" \
-  --activate "${root}/deploy/gcp/deploy-live-upgrade.sh" \
-  --rollback "${root}/deploy/gcp/rollback-slot.sh" \
-  --old-generation-check "${root}/deploy/gcp/finalize-slot-retirement.sh"
+if [[ "${slot_only}" == true ]]; then
+  preflight_evidence="${artifact_dir}/preflight.json"
+  [[ ! -e "${preflight_evidence}" ]] || { echo "artifact directory already contains preflight.json" >&2; exit 1; }
+  SUBROUTER_PREFLIGHT_TOPOLOGY=slot \
+    SUBROUTER_DEPLOY_ARTIFACT_DIR="${private_root}/preflight-internal" \
+    "${root}/deploy/gcp/preflight-deployment.sh" --evidence-json "${preflight_evidence}"
+  jq -e --arg bootstrap "${bootstrap_linux_sha}" \
+    '.success == true and .mutation_performed == false and .topology.kind == "front-slots" and
+     .topology.slot.worker_checksum == $bootstrap and .topology.slot.service_active == true and
+     .topology.front.service_active == true and .local_golden_required == true' \
+    "${preflight_evidence}" >/dev/null \
+    || { echo "slot preflight does not prove the v0.1.63 bootstrap worker" >&2; exit 1; }
+  "${observer}" golden-slot \
+    --predecessor-version "${predecessor_tag}" \
+    --predecessor-sha256 "${predecessor_darwin_sha}" \
+    --predecessor-client "${predecessor_darwin}" \
+    --bootstrap-sha256 "${bootstrap_linux_sha}" \
+    --candidate-tag "${candidate_tag}" \
+    --candidate-sha256 "${candidate_linux_sha}" \
+    --candidate-revision "${candidate_revision}" \
+    --deploy-evidence-validator "${root}/deploy/gcp/validate-deploy-evidence.py" \
+    --artifact-dir "${artifact_dir}" \
+    "${golden_args[@]}" \
+    --activate "${root}/deploy/gcp/deploy-live-upgrade.sh" \
+    --rollback "${root}/deploy/gcp/rollback-slot.sh" \
+    --old-generation-check "${root}/deploy/gcp/finalize-slot-retirement.sh"
+else
+  "${observer}" golden \
+    --predecessor-version "${predecessor_tag}" \
+    --predecessor-sha256 "${predecessor_darwin_sha}" \
+    --predecessor-client "${predecessor_darwin}" \
+    --candidate-tag "${candidate_tag}" \
+    --candidate-sha256 "${candidate_linux_sha}" \
+    --candidate-revision "${candidate_revision}" \
+    --deploy-evidence-validator "${root}/deploy/gcp/validate-deploy-evidence.py" \
+    --artifact-dir "${artifact_dir}" \
+    "${golden_args[@]}" \
+    --migration-prepare "${root}/deploy/gcp/migrate-to-front-slots.sh" \
+    --migration-switch "${root}/deploy/gcp/switch-front-migration.sh" \
+    --legacy-retirement "${root}/deploy/gcp/finalize-legacy-retirement.sh" \
+    --activate "${root}/deploy/gcp/deploy-live-upgrade.sh" \
+    --rollback "${root}/deploy/gcp/rollback-slot.sh" \
+    --old-generation-check "${root}/deploy/gcp/finalize-slot-retirement.sh"
+fi

--- a/deploy/gcp/preflight-deployment.sh
+++ b/deploy/gcp/preflight-deployment.sh
@@ -74,15 +74,22 @@ esac
 
 log() { printf 'gcp-preflight: %s\n' "$*"; }
 die() { log "$*" >&2; exit 1; }
-for command in "${GCLOUD_BINARY}" curl jq python3 sha256sum; do
+for command in "${GCLOUD_BINARY}" curl jq python3; do
   command -v "${command}" >/dev/null 2>&1 || die "required command not found: ${command}"
 done
+if command -v sha256sum >/dev/null 2>&1; then
+  hash_file() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+  hash_file() { shasum -a 256 "$1" | awk '{print $1}'; }
+else
+  die "required command not found: sha256sum or shasum"
+fi
 [[ "${MODE}" == slot || "${MODE}" == migrate-front ]] || die "preflight topology must be slot or migrate-front"
 [[ "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || die "release tag is invalid"
 [[ -x "${DEPLOY_BINARY}" && -f "${RELEASE_SHA256_FILE}" ]] || die "verified release asset is missing"
 EXPECTED_SHA256="$(tr -d '[:space:]' <"${RELEASE_SHA256_FILE}")"
 [[ "${EXPECTED_SHA256}" =~ ^[0-9a-f]{64}$ ]] || die "release checksum is invalid"
-[[ "$(sha256sum "${DEPLOY_BINARY}" | awk '{print $1}')" == "${EXPECTED_SHA256}" ]] || die "release checksum changed"
+[[ "$(hash_file "${DEPLOY_BINARY}")" == "${EXPECTED_SHA256}" ]] || die "release checksum changed"
 [[ "${DEPLOY_REVISION}" =~ ^[0-9a-f]{40}$ ]] || die "release revision is invalid"
 [[ "${TAG_ON_MAIN}" == true && "${ATTESTATION_VERIFIED}" == true && "${RELEASE_IMMUTABLE}" == true ]] \
   || die "release trust proof is incomplete"

--- a/deploy/gcp/rollback-slot.sh
+++ b/deploy/gcp/rollback-slot.sh
@@ -51,13 +51,20 @@ INSTALL_FRONT_SLOTS="$(bash "${SCRIPT_DIR}/resolve-release-installer.sh" "${SCRI
 DEPLOYMENT_CONTRACT="$(bash "${SCRIPT_DIR}/resolve-release-contract.sh" "${SCRIPT_DIR}/deployment-contract.py")"
 REMOTE_INSTALL_COMMAND="sudo env SUBROUTER_DEPLOYMENT_CONTRACT='${REMOTE_DEPLOYMENT_CONTRACT}' bash '${REMOTE_INSTALLER}'"
 
-for command in "${GCLOUD_BINARY}" jq curl python3 sha256sum; do
+for command in "${GCLOUD_BINARY}" jq curl python3; do
   command -v "${command}" >/dev/null 2>&1 || die "required command not found: ${command}"
 done
-INSTALL_FRONT_SLOTS_SHA256="$(sha256sum "${INSTALL_FRONT_SLOTS}" | awk '{print $1}')"
-DEPLOYMENT_CONTRACT_SHA256="$(sha256sum "${DEPLOYMENT_CONTRACT}" | awk '{print $1}')"
+if command -v sha256sum >/dev/null 2>&1; then
+  hash_file() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+  hash_file() { shasum -a 256 "$1" | awk '{print $1}'; }
+else
+  die "required command not found: sha256sum or shasum"
+fi
+INSTALL_FRONT_SLOTS_SHA256="$(hash_file "${INSTALL_FRONT_SLOTS}")"
+DEPLOYMENT_CONTRACT_SHA256="$(hash_file "${DEPLOYMENT_CONTRACT}")"
 python3 "${SCRIPT_DIR}/validate-deploy-evidence.py" --expect slot-activation "${ACTIVATION_EVIDENCE}" >/dev/null
-activation_sha256="$(sha256sum "${ACTIVATION_EVIDENCE}" | awk '{print $1}')"
+activation_sha256="$(hash_file "${ACTIVATION_EVIDENCE}")"
 [[ "$(jq -r '.continuity.configured_original_clients' "${ACTIVATION_EVIDENCE}")" == 4 ]] \
   || die "activation evidence must require exactly four original clients"
 EXPECTED_CONNECTIONS="$(jq -r '.continuity.expected_candidate_connections_for_rollback' "${ACTIVATION_EVIDENCE}")"


### PR DESCRIPTION
## Summary

Add a supported `golden-slot` continuity gate for production instances that already use the front-slot listener topology. The gate runs rehearsal and final slot cycles, verifies the pinned v0.1.63 bootstrap worker, and proves direct and local-egress response continuity across activation, rollback, and retirement.

The Codex shim preserves the per-response proof header after the pinned v0.1.60 client sanitizes provider overrides. It keeps WebSocket sessions on WebSocket and disables WebSockets only for HTTP sessions.

The production wrapper now supports `--slot-only`, runs a read-only slot preflight, forwards the resolved Codex home, derives an account ID from the canonical token or JWT claims, and supports macOS `shasum` when `sha256sum` is absent.

## Attribution

This is maintainer hardening that follows the Daniel Raffel integration stack. Daniel's original commits remain unchanged with their original author metadata. The shipped release and prior integration record retain the Daniel Raffel PR links:

- https://github.com/manaflow-ai/subrouter/pull/229
- https://github.com/manaflow-ai/subrouter/pull/231
- https://github.com/manaflow-ai/subrouter/pull/234
- https://github.com/manaflow-ai/subrouter/pull/236
- https://github.com/manaflow-ai/subrouter/pull/238
- https://github.com/manaflow-ai/subrouter/pull/241
- https://github.com/manaflow-ai/subrouter/pull/242
- https://github.com/manaflow-ai/subrouter/pull/250
- https://github.com/manaflow-ai/subrouter/pull/251
- https://github.com/manaflow-ai/subrouter/pull/252
- https://github.com/manaflow-ai/subrouter/pull/253
- https://github.com/manaflow-ai/subrouter/pull/254
- https://github.com/manaflow-ai/subrouter/pull/267
- https://github.com/manaflow-ai/subrouter/pull/274

## Verification

- `go test ./...`
- local structured autoreview, clean
- `bash -n deploy/gcp/golden-local-mac-production-continuity.sh deploy/gcp/preflight-deployment.sh`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790775106&installation_model_id=21920&pr_number=285&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F285&signature=e90a3f7b0d4693ce6606e53122d0b4abc60a66e432ee884a5545a19e6967d476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `golden-slot` continuity gate for production instances already running the front-slot topology, so slot upgrades can be verified without rerunning the one-time legacy migration steps.

- The gate runs rehearsal and final slot cycles, verifies the pinned v0.1.63 bootstrap worker, and proves direct and local-egress continuity across activation, rollback, and retirement; slot-only evidence must match a strict session, process-snapshot, and final candidate socket continuity contract, while test fixtures may carry the bootstrap identity in activation evidence.
- The Codex shim preserves the per-response proof header after the client sanitizes overrides, keeping WebSocket sessions on WebSocket and disabling WebSockets only for HTTP sessions.
- The production wrapper supports `--slot-only`, runs a read-only slot preflight that requires the verified bootstrap worker, forwards the resolved Codex home, derives an account ID from the canonical token or JWT claims, and falls back to macOS `shasum` when `sha256sum` is absent.

<sup>Written for commit 063357c5d96079fb951029582473318f3cbece70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a slot-only continuity validation command for post-handoff upgrades.
  * Added pinned bootstrap verification for slot-only deployment checks.
  * Added automatic transport configuration during validation.
  * Added SHA-256 verification using either supported hashing utility.

* **Bug Fixes**
  * Improved deployment defaults and validation for Codex configuration and account details.
  * Slot-only checks now bypass legacy migration steps.
  * Tightened account ID validation for improved deployment safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->