### PR TITLE
fix: validate noisy listener takeover proof

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -394,7 +394,9 @@ if [[ "${1:-}" == compute && "${2:-}" == ssh ]]; then
       ;;
     *"ss -H -lntp"*)
       if [[ "${FAKE_LEGACY_ENABLED:-0}" == 1 ]]; then exit 1; fi
+      if [[ "${FAKE_LISTENER_NOISE:-0}" == 1 ]]; then printf '%s\n' 'WARNING: remote login banner'; fi
       printf '%s\n' '{"verified":true,"service":"subrouter-front.service","port":31415,"pid":1234}'
+      if [[ "${FAKE_LISTENER_NOISE:-0}" == 1 ]]; then printf '%s\n' 'remote command completed'; fi
       ;;
     *MainPID*)
       printf '%s\n' '1234'
@@ -478,6 +480,16 @@ exit 1
 	}
 	if evidence.Topology.Current != "front-listener" || !evidence.Topology.Verified {
 		t.Fatalf("listener takeover evidence = %+v, want verified front-listener", evidence.Topology)
+	}
+
+	noisy := exec.Command(
+		mustLookPath(t, "bash"),
+		filepath.Join(repoRoot, "deploy", "gcp", "preflight-deployment.sh"),
+		"--evidence-json", filepath.Join(t.TempDir(), "noisy.json"),
+	)
+	noisy.Env = append(command.Env, "FAKE_LISTENER_NOISE=1")
+	if output, err := noisy.CombinedOutput(); err != nil {
+		t.Fatalf("listener-takeover preflight rejected harmless remote output: %v\n%s", err, output)
 	}
 
 	reversed := exec.Command(

--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -395,8 +395,8 @@ if [[ "${1:-}" == compute && "${2:-}" == ssh ]]; then
     *"ss -H -lntp"*)
       if [[ "${FAKE_LEGACY_ENABLED:-0}" == 1 ]]; then exit 1; fi
       if [[ "${FAKE_LISTENER_NOISE:-0}" == 1 ]]; then printf '%s\n' 'WARNING: remote login banner'; fi
-      printf '%s\n' '{"verified":true,"service":"subrouter-front.service","port":31415,"pid":1234}'
-      if [[ "${FAKE_LISTENER_NOISE:-0}" == 1 ]]; then printf '%s\n' 'remote command completed'; fi
+      printf '%s\n' 'SUBROUTER_LISTENER_TAKEOVER_PROOF={"verified":true,"service":"subrouter-front.service","port":31415,"pid":1234}'
+      if [[ "${FAKE_LISTENER_NOISE:-0}" == 1 ]]; then printf '%s\n' '{"noise":"after-proof"}'; fi
       ;;
     *MainPID*)
       printf '%s\n' '1234'

--- a/deploy/gcp/preflight-deployment.sh
+++ b/deploy/gcp/preflight-deployment.sh
@@ -212,7 +212,20 @@ else
     canary_access_control_json="$(printf '%s\n' "${policy_json}" | python3 "${SCRIPT_DIR}/canary-security-policy.py" \
       assert-ready - "${CANARY_SECURITY_POLICY}" "${CANARY_HOST}")" \
       || die "canary security policy does not satisfy the access boundary"
-    listener_takeover_json="$(gcloud_ssh "set -eu; front_pid=\$(systemctl show subrouter-front.service -p MainPID --value); test \"\${front_pid}\" -gt 1; systemctl is-active --quiet subrouter-front.service; ! systemctl is-active --quiet subrouter.service; ! systemctl is-active --quiet subrouter.socket; ! systemctl is-enabled --quiet subrouter.service; ! systemctl is-enabled --quiet subrouter.socket; sudo ss -H -lntp 'sport = :31415' | grep -F \"pid=\${front_pid},\" >/dev/null; printf '%s\\n' \"{\\\"verified\\\":true,\\\"service\\\":\\\"subrouter-front.service\\\",\\\"port\\\":31415,\\\"pid\\\":\${front_pid}}\"")"
+    listener_takeover_output=""
+    if ! listener_takeover_output="$(gcloud_ssh "set -eu; front_pid=\$(systemctl show subrouter-front.service -p MainPID --value); test \"\${front_pid}\" -gt 1; systemctl is-active --quiet subrouter-front.service; ! systemctl is-active --quiet subrouter.service; ! systemctl is-active --quiet subrouter.socket; ! systemctl is-enabled --quiet subrouter.service; ! systemctl is-enabled --quiet subrouter.socket; sudo ss -H -lntp 'sport = :31415' | grep -F \"pid=\${front_pid},\" >/dev/null; printf '%s\\n' \"{\\\"verified\\\":true,\\\"service\\\":\\\"subrouter-front.service\\\",\\\"port\\\":31415,\\\"pid\\\":\${front_pid}}\"")"; then
+      die "listener takeover proof command failed"
+    fi
+    listener_takeover_json=""
+    while IFS= read -r listener_takeover_line; do
+      case "${listener_takeover_line}" in
+        \{*\}) listener_takeover_json="${listener_takeover_line}" ;;
+      esac
+    done <<<"${listener_takeover_output}"
+    [[ -n "${listener_takeover_json}" ]] || die "listener takeover proof is missing"
+    jq -e 'type == "object" and .verified == true and .service == "subrouter-front.service" and .port == 31415 and (.pid | type) == "number" and .pid > 1' \
+      <<<"${listener_takeover_json}" >/dev/null \
+      || die "listener takeover proof is invalid"
     listener_takeover_verified=true
   else
     die "URL map does not describe a supported post-migration route"

--- a/deploy/gcp/preflight-deployment.sh
+++ b/deploy/gcp/preflight-deployment.sh
@@ -213,19 +213,26 @@ else
       assert-ready - "${CANARY_SECURITY_POLICY}" "${CANARY_HOST}")" \
       || die "canary security policy does not satisfy the access boundary"
     listener_takeover_output=""
-    if ! listener_takeover_output="$(gcloud_ssh "set -eu; front_pid=\$(systemctl show subrouter-front.service -p MainPID --value); test \"\${front_pid}\" -gt 1; systemctl is-active --quiet subrouter-front.service; ! systemctl is-active --quiet subrouter.service; ! systemctl is-active --quiet subrouter.socket; ! systemctl is-enabled --quiet subrouter.service; ! systemctl is-enabled --quiet subrouter.socket; sudo ss -H -lntp 'sport = :31415' | grep -F \"pid=\${front_pid},\" >/dev/null; printf '%s\\n' \"{\\\"verified\\\":true,\\\"service\\\":\\\"subrouter-front.service\\\",\\\"port\\\":31415,\\\"pid\\\":\${front_pid}}\"")"; then
+    if ! listener_takeover_output="$(gcloud_ssh "set -eu; front_pid=\$(systemctl show subrouter-front.service -p MainPID --value); test \"\${front_pid}\" -gt 1; systemctl is-active --quiet subrouter-front.service; ! systemctl is-active --quiet subrouter.service; ! systemctl is-active --quiet subrouter.socket; ! systemctl is-enabled --quiet subrouter.service; ! systemctl is-enabled --quiet subrouter.socket; sudo ss -H -lntp 'sport = :31415' | grep -F \"pid=\${front_pid},\" >/dev/null; printf '%s\\n' \"SUBROUTER_LISTENER_TAKEOVER_PROOF={\\\"verified\\\":true,\\\"service\\\":\\\"subrouter-front.service\\\",\\\"port\\\":31415,\\\"pid\\\":\${front_pid}}\"")"; then
       die "listener takeover proof command failed"
     fi
     listener_takeover_json=""
+    listener_takeover_records=0
     while IFS= read -r listener_takeover_line; do
       case "${listener_takeover_line}" in
-        \{*\}) listener_takeover_json="${listener_takeover_line}" ;;
+        SUBROUTER_LISTENER_TAKEOVER_PROOF=*)
+          listener_takeover_candidate="${listener_takeover_line#SUBROUTER_LISTENER_TAKEOVER_PROOF=}"
+          if ! jq -e 'type == "object" and .verified == true and .service == "subrouter-front.service" and .port == 31415 and (.pid | type) == "number" and .pid > 1' \
+            <<<"${listener_takeover_candidate}" >/dev/null; then
+            die "listener takeover proof is invalid"
+          fi
+          listener_takeover_json="${listener_takeover_candidate}"
+          listener_takeover_records=$((listener_takeover_records + 1))
+          ;;
       esac
     done <<<"${listener_takeover_output}"
-    [[ -n "${listener_takeover_json}" ]] || die "listener takeover proof is missing"
-    jq -e 'type == "object" and .verified == true and .service == "subrouter-front.service" and .port == 31415 and (.pid | type) == "number" and .pid > 1' \
-      <<<"${listener_takeover_json}" >/dev/null \
-      || die "listener takeover proof is invalid"
+    [[ "${listener_takeover_records}" == 1 && -n "${listener_takeover_json}" ]] \
+      || die "listener takeover proof is missing or duplicated"
     listener_takeover_verified=true
   else
     die "URL map does not describe a supported post-migration route"


### PR DESCRIPTION
## Summary
- Preserve the existing listener takeover checks while treating remote shell output as untrusted text.
- Extract and validate the proof JSON before passing it to jq, with explicit failure messages for missing or invalid proof.
- Add a regression test that includes harmless remote login noise.

## Verification
- The regression test fails on the first test-only commit and passes with the fix.
- `go test ./...` passes.
- Shell syntax checks pass.

## Attribution
This is maintainer hardening of the deployment preflight. Daniel Raffel’s integrated commits and authorship remain unchanged in main and are not rewritten.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790778533&installation_model_id=21920&pr_number=286&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F286&signature=5d00ababda9e19f3752afe87c213f18941973f237c985cd4f6668a1a172deee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the listener takeover proof validation so harmless remote shell noise no longer breaks the deployment preflight.

- Extracts the proof from remote output by its `SUBROUTER_LISTENER_TAKEOVER_PROOF=` marker and validates each candidate with `jq`.
- Requires exactly one valid proof and fails with explicit messages when the proof command fails, the proof is missing, duplicated, or invalid.
- Adds a regression test that injects remote login banner noise before and after the proof JSON.

<sup>Written for commit b384da581b660653f0061300a331b516ec321852. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment preflight checks for front-listener migrations.
  - Deployment validation now tolerates harmless diagnostic output from remote systems while still confirming the correct listener takeover.
  - Added stricter verification to prevent deployments from proceeding when takeover information is missing, duplicated, malformed, or invalid.
  - Expanded automated coverage for deployments that encounter unexpected remote output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->