### PR TITLE
fix: make account ID validation macOS-safe

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -1903,6 +1903,70 @@ esac
 	}
 }
 
+func TestGoldenWrapperAccountIDLengthValidationIsPortable(t *testing.T) {
+	requireDeployScriptTools(t, "bash", "jq", "python3")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	fakeBin := t.TempDir()
+	externalLog := filepath.Join(t.TempDir(), "external.log")
+	writeExecutableTestFile(t, filepath.Join(fakeBin, "uname"), `#!/bin/sh
+case "$1" in
+  -s) printf '%s\n' Darwin ;;
+  -m) printf '%s\n' arm64 ;;
+  *) exit 1 ;;
+esac
+`)
+	for _, name := range []string{"gh", "gcloud", "go"} {
+		writeExecutableTestFile(t, filepath.Join(fakeBin, name), "#!/bin/sh\nprintf '%s\\n' \"$0 $*\" >>\"$EXTERNAL_LOG\"\nexit 99\n")
+	}
+	config := filepath.Join(t.TempDir(), "cloud.json")
+	if err := os.WriteFile(config, []byte(`{"hostedUrl":"https://sr.cmux.com"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run := func(accountID string) ([]byte, error) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		command := exec.CommandContext(ctx,
+			mustLookPath(t, "bash"),
+			filepath.Join(repoRoot, "deploy", "gcp", "golden-local-mac-production-continuity.sh"),
+			"--cloud-config", config,
+			"--artifact-dir", t.TempDir(),
+			"--account-id", accountID,
+		)
+		command.Env = append(os.Environ(),
+			"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+			"EXTERNAL_LOG="+externalLog,
+			"SUBROUTER_GCP_PROJECT=project",
+			"SUBROUTER_GCP_ZONE=us-south1-a",
+			"SUBROUTER_GCP_INSTANCE=subrouter-team",
+			"SUBROUTER_PUBLIC_BASE_URL=https://sr.cmux.com",
+		)
+		output, err := runDeployTestCommand(command)
+		if ctx.Err() != nil {
+			t.Fatalf("account validation command timed out: %v\n%s", ctx.Err(), output)
+		}
+		return output, err
+	}
+
+	validOutput, validErr := run(strings.Repeat("a", 256))
+	if validErr == nil {
+		t.Fatalf("valid 256-byte account ID unexpectedly completed:\n%s", validOutput)
+	}
+	if body, err := os.ReadFile(externalLog); err != nil || len(body) == 0 {
+		t.Fatalf("valid account ID did not pass validation before the first external operation: read=%v run=%v\noutput=%s", err, validErr, validOutput)
+	}
+	if err := os.WriteFile(externalLog, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output, err := run(strings.Repeat("a", 257))
+	if err == nil || !strings.Contains(string(output), "valid Codex OAuth account ID") {
+		t.Fatalf("overlong account ID was not rejected locally: %v\n%s", err, output)
+	}
+	if body, readErr := os.ReadFile(externalLog); readErr != nil || len(body) != 0 {
+		t.Fatalf("overlong account ID reached an external operation: %v\n%s", readErr, body)
+	}
+}
+
 func TestGoldenReleaseHelperCoherenceRejectsDrift(t *testing.T) {
 	requireDeployScriptTools(t, "bash")
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -135,6 +135,16 @@ normalized_public_base_url="$(python3 "${deployment_contract}" validate-target \
 SUBROUTER_PUBLIC_BASE_URL="${normalized_public_base_url}"
 export SUBROUTER_PUBLIC_BASE_URL
 
+valid_account_id() {
+  local value="$1"
+  [[ -n "${value}" && ${#value} -le 256 && "${value}" =~ ^[A-Za-z0-9._@:+/-]+$ ]]
+}
+
+if [[ "${account_id_supplied}" == true ]] && ! valid_account_id "${account_id}"; then
+  echo "a valid Codex OAuth account ID is required; pass --account-id or use a signed-in Codex home" >&2
+  exit 1
+fi
+
 private_root="$(mktemp -d "${TMPDIR:-/tmp}/subrouter-golden-production.XXXXXX")"
 cleanup() {
   if [[ -n "${private_root:-}" && -d "${private_root}" ]]; then
@@ -417,7 +427,7 @@ if isinstance(account_id, str):
 PY
   )"
 fi
-[[ "${account_id}" =~ ^[A-Za-z0-9._@:+/-]{1,256}$ ]] || {
+valid_account_id "${account_id}" || {
   echo "a valid Codex OAuth account ID is required; pass --account-id or use a signed-in Codex home" >&2
   exit 1
 }


### PR DESCRIPTION
## Summary
- Validate supplied account IDs before release-network work starts.
- Replace the macOS-incompatible `{1,256}` regex with separate length and allowed-character checks.
- Add behavior coverage for the 256-byte boundary and early rejection of 257 bytes.

## Verification
- The test-only commit fails before the implementation because valid IDs do not reach the first external operation.
- The fix makes the test pass.
- Focused deployment-wrapper tests and Bash syntax checks pass.

## Attribution
This is maintainer deployment hardening. Daniel Raffel’s integrated commits and authorship remain unchanged in `main` and are not rewritten.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790779556&installation_model_id=21920&pr_number=287&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F287&signature=25b4fe5d0dfc53c778dcd6d238e579caeeb7d73a671214b695176d1d18aac63c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes account ID validation in the GCP deployment wrapper macOS-safe and runs it before any external commands. Invalid or overlong IDs are now rejected locally instead of failing later during release-network work.

- Replaces the macOS-incompatible `{1,256}` regex with a separate 256-byte length check and an allowed-character check.
- Adds tests for the 256-byte boundary and early rejection of 257-byte IDs.

<sup>Written for commit 95f86cef520255b4ee20bd585784d391e9e8305a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved account ID validation in the Golden deployment workflow.
  - Accepts valid account IDs up to the supported length.
  - Rejects oversized account IDs locally with a clear validation error before external operations begin.
  - Applies validation consistently to both supplied and automatically detected account IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->