### PR TITLE
Fix golden gate for team tenant lease routing

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -432,14 +432,17 @@ type goldenSummary struct {
 	Health                      []goldenProbeSummary    `json:"health"`
 	ProcessSnapshots            []goldenProcessEvidence `json:"process_snapshots"`
 	FreshLocalLeaseObserved     bool                    `json:"fresh_local_lease_observed"`
-	LegacyBrokerLeaseObserved   bool                    `json:"legacy_broker_lease_observed"`
-	PrivateWorkspaceRemoved     bool                    `json:"private_workspace_removed"`
-	DeploymentEnvironmentRead   bool                    `json:"deployment_environment_recorded"`
-	LocalDaemonPeakRSSBytes     int64                   `json:"local_daemon_peak_rss_bytes"`
-	LocalDaemonRSSSamples       int                     `json:"local_daemon_rss_samples"`
-	LocalDaemonProcessSamples   int                     `json:"local_daemon_process_samples"`
-	LocalDaemonMaxSampleGapMS   int64                   `json:"local_daemon_max_process_sample_gap_ms"`
-	LocalDaemonPausedSamples    int                     `json:"local_daemon_paused_samples"`
+	HostedTenantLeaseObserved   bool                    `json:"hosted_tenant_lease_observed"`
+	// LegacyBrokerLeaseObserved is retained for older evidence readers. The
+	// current team-mode gate sets HostedTenantLeaseObserved instead.
+	LegacyBrokerLeaseObserved bool  `json:"legacy_broker_lease_observed"`
+	PrivateWorkspaceRemoved   bool  `json:"private_workspace_removed"`
+	DeploymentEnvironmentRead bool  `json:"deployment_environment_recorded"`
+	LocalDaemonPeakRSSBytes   int64 `json:"local_daemon_peak_rss_bytes"`
+	LocalDaemonRSSSamples     int   `json:"local_daemon_rss_samples"`
+	LocalDaemonProcessSamples int   `json:"local_daemon_process_samples"`
+	LocalDaemonMaxSampleGapMS int64 `json:"local_daemon_max_process_sample_gap_ms"`
+	LocalDaemonPausedSamples  int   `json:"local_daemon_paused_samples"`
 }
 
 type goldenActionSummary struct {
@@ -1199,7 +1202,7 @@ func (r *goldenRunner) startCycleInitialSessions(ctx context.Context, inputs gol
 			if err != nil {
 				return nil, err
 			}
-			leaseBefore = len(goldenLeaseRequests(inputs.leaseObserver.stats))
+			leaseBefore = len(goldenHostedLeaseRequests(inputs.leaseObserver.stats))
 		}
 		observation, err := r.startObserver(label, upstream)
 		if err != nil {
@@ -1320,7 +1323,7 @@ func (r *goldenRunner) runRehearsalCycle(ctx context.Context, inputs goldenCycle
 		return result, err
 	}
 	r.summary.FreshLocalLeaseObserved = true
-	r.summary.LegacyBrokerLeaseObserved = true
+	r.summary.HostedTenantLeaseObserved = true
 	all := append(append([]*goldenSession{}, initial...), result.fresh...)
 	if err := requireSessionsRunning(all, "rehearsal_activation"); err != nil {
 		return result, err
@@ -3707,11 +3710,15 @@ func requireGoldenSessionStartsAfter(session *goldenSession, boundary time.Time)
 func requireGoldenLeaseWindow(leaseObserver *runningGoldenObserver, requestStart, activated time.Time, beforeCount int) error {
 	requests, _, _ := leaseObserver.stats.snapshot()
 	leaseCount := 0
+	freshLeaseObserved := false
 	for _, request := range requests {
 		if request.Path == "/v1/responses" || request.Path == "/responses" {
 			return failGolden("local_route_bypassed_daemon")
 		}
-		if !goldenLeaseRequestPath(request.Path) {
+		if request.Path == "/api/subrouter/leases" {
+			return failGolden("candidate_lease_endpoint_substituted")
+		}
+		if request.Path != "/_subrouter/leases" {
 			continue
 		}
 		if request.Method != http.MethodPost {
@@ -3720,8 +3727,11 @@ func requireGoldenLeaseWindow(leaseObserver *runningGoldenObserver, requestStart
 		leaseCount++
 		stamp, _ := time.Parse(time.RFC3339Nano, request.Timestamp)
 		if !stamp.Before(requestStart) && !stamp.After(activated) && leaseCount > beforeCount {
-			return nil
+			freshLeaseObserved = true
 		}
+	}
+	if freshLeaseObserved {
+		return nil
 	}
 	return failGolden("activation_fresh_local_lease_missing")
 }
@@ -3738,7 +3748,8 @@ func requireGoldenLeaseObserversClean(hosted, legacy *runningGoldenObserver) err
 		observerRequestCount(legacy.stats, "/responses") != 0 {
 		return failGolden("local_route_bypassed_daemon")
 	}
-	if len(goldenLeaseRequests(legacy.stats)) != 0 {
+	if len(goldenLeaseRequests(hosted.stats)) != len(goldenHostedLeaseRequests(hosted.stats)) ||
+		len(goldenLeaseRequests(legacy.stats)) != 0 {
 		return failGolden("candidate_lease_endpoint_substituted")
 	}
 	return nil
@@ -3872,7 +3883,7 @@ func (r *goldenRunner) startSpanningLocalSession(
 		"kind": "local_egress_baseline", "timestamp": baseline.Timestamp,
 		"phase": phase, "remote_socket_ids": baseline.RemoteSocketIDs,
 	})
-	leaseBefore := len(goldenLeaseRequests(inputs.leaseObserver.stats))
+	leaseBefore := len(goldenHostedLeaseRequests(inputs.leaseObserver.stats))
 	session, err := r.startActivationSession(
 		ctx, inputs.name+"-candidate-local", "local-egress", inputs.clientPath, inputs.authData,
 		inputs.cloud, inputs.directConfigPath, inputs.teamConfigPath, inputs.hostedOrigin, inputs.localOrigin,
@@ -4995,7 +5006,7 @@ func validateGoldenSummary(summary goldenSummary, testMode bool) error {
 	if !finalCandidateSocketStable || len(finalCandidateTransportSocket) != 64 {
 		return failGolden("final_candidate_socket_continuity_invalid")
 	}
-	if len(expected) != 0 || !summary.FreshLocalLeaseObserved || !summary.LegacyBrokerLeaseObserved || summary.DeploymentEnvironmentRead {
+	if len(expected) != 0 || !summary.FreshLocalLeaseObserved || !summary.HostedTenantLeaseObserved || summary.DeploymentEnvironmentRead {
 		return failGolden("golden_evidence_incomplete")
 	}
 	if len(summary.ProcessSnapshots) == 0 {

--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -901,7 +901,13 @@ func (r *goldenRunner) run(ctx context.Context) (runErr error) {
 	if err != nil {
 		return failGolden("broker_url_invalid")
 	}
-	leaseObserver, err := r.startObserver("local-lease", brokerOrigin)
+	// Keep the legacy broker origin available for non-lease control calls, but
+	// observe team-mode leases at the same tenant endpoint the client uses.
+	legacyLeaseObserver, err := r.startObserver("local-lease-legacy", brokerOrigin)
+	if err != nil {
+		return err
+	}
+	leaseObserver, err := r.startObserver("local-lease", hostedOrigin)
 	if err != nil {
 		return err
 	}
@@ -915,7 +921,7 @@ func (r *goldenRunner) run(ctx context.Context) (runErr error) {
 	if err := writeGoldenConfig(directConfigPath, cloudConfig.Raw, goldenPredecessorDirectCredentialSource(), cloudConfig.HostedURL, cloudConfig.BrokerURL); err != nil {
 		return failGolden("private_config_write_failed")
 	}
-	if err := writeGoldenConfig(teamConfigPath, cloudConfig.Raw, "team", cloudConfig.HostedURL, leaseObserver.baseURL); err != nil {
+	if err := writeGoldenConfig(teamConfigPath, cloudConfig.Raw, "team", leaseObserver.baseURL, legacyLeaseObserver.baseURL); err != nil {
 		return failGolden("private_config_write_failed")
 	}
 
@@ -962,7 +968,8 @@ func (r *goldenRunner) run(ctx context.Context) (runErr error) {
 		name: "", clientPath: client.path, authData: authData, cloud: cloudConfig,
 		directConfigPath: directConfigPath, teamConfigPath: teamConfigPath,
 		hostedOrigin: hostedOrigin, localOrigin: localOrigin, leaseObserver: leaseObserver,
-		localDaemonPID: localDaemon.Process.Pid,
+		legacyLeaseObserver: legacyLeaseObserver,
+		localDaemonPID:      localDaemon.Process.Pid,
 	}
 	if r.options.slotOnly {
 		return r.runSlotOnlyHarness(ctx, cycleInputs, probeCancel, probeStats, cancelLocalRSS, localRSSDone, &localRSSStopped, localDaemon, &localDaemonStopped)
@@ -971,7 +978,8 @@ func (r *goldenRunner) run(ctx context.Context) (runErr error) {
 		name: "migration", clientPath: client.path, authData: authData, cloud: cloudConfig,
 		directConfigPath: directConfigPath, teamConfigPath: teamConfigPath,
 		hostedOrigin: hostedOrigin, localOrigin: localOrigin, leaseObserver: leaseObserver,
-		localDaemonPID: localDaemon.Process.Pid,
+		legacyLeaseObserver: legacyLeaseObserver,
+		localDaemonPID:      localDaemon.Process.Pid,
 	})
 	if err != nil {
 		return err
@@ -990,7 +998,8 @@ func (r *goldenRunner) run(ctx context.Context) (runErr error) {
 		name: "rehearsal", clientPath: client.path, authData: authData, cloud: cloudConfig,
 		directConfigPath: directConfigPath, teamConfigPath: teamConfigPath,
 		hostedOrigin: hostedOrigin, localOrigin: localOrigin, leaseObserver: leaseObserver,
-		localDaemonPID: localDaemon.Process.Pid,
+		legacyLeaseObserver: legacyLeaseObserver,
+		localDaemonPID:      localDaemon.Process.Pid,
 	})
 	if err != nil {
 		return err
@@ -1013,7 +1022,8 @@ func (r *goldenRunner) run(ctx context.Context) (runErr error) {
 		name: "final", clientPath: client.path, authData: authData, cloud: cloudConfig,
 		directConfigPath: directConfigPath, teamConfigPath: teamConfigPath,
 		hostedOrigin: hostedOrigin, localOrigin: localOrigin, leaseObserver: leaseObserver,
-		localDaemonPID: localDaemon.Process.Pid,
+		legacyLeaseObserver: legacyLeaseObserver,
+		localDaemonPID:      localDaemon.Process.Pid,
 	}, rehearsal.activation)
 	if err != nil {
 		return err
@@ -1023,10 +1033,8 @@ func (r *goldenRunner) run(ctx context.Context) (runErr error) {
 	if err := validateGoldenCounterContinuity(*r.summary); err != nil {
 		return err
 	}
-	if observerRequestCount(leaseObserver.stats, "/v1/responses") != 0 ||
-		observerRequestCount(leaseObserver.stats, "/responses") != 0 ||
-		observerRequestCount(leaseObserver.stats, "/_subrouter/leases") != 0 {
-		return failGolden("local_route_bypassed_daemon")
+	if err := requireGoldenLeaseObserversClean(leaseObserver, legacyLeaseObserver); err != nil {
+		return err
 	}
 	probeStats.stop(probeCancel)
 	r.summary.Health = probeStats.summaries()
@@ -1100,10 +1108,8 @@ func (r *goldenRunner) runSlotOnlyHarness(
 	if err := validateGoldenCounterContinuity(*r.summary); err != nil {
 		return err
 	}
-	if observerRequestCount(inputs.leaseObserver.stats, "/v1/responses") != 0 ||
-		observerRequestCount(inputs.leaseObserver.stats, "/responses") != 0 ||
-		observerRequestCount(inputs.leaseObserver.stats, "/_subrouter/leases") != 0 {
-		return failGolden("local_route_bypassed_daemon")
+	if err := requireGoldenLeaseObserversClean(inputs.leaseObserver, inputs.legacyLeaseObserver); err != nil {
+		return err
 	}
 	probeStats.stop(probeCancel)
 	r.summary.Health = probeStats.summaries()
@@ -1153,6 +1159,7 @@ type goldenCycleInputs struct {
 	directConfigPath, teamConfigPath string
 	hostedOrigin, localOrigin        *url.URL
 	leaseObserver                    *runningGoldenObserver
+	legacyLeaseObserver              *runningGoldenObserver
 	localDaemonPID                   int
 }
 
@@ -1192,7 +1199,7 @@ func (r *goldenRunner) startCycleInitialSessions(ctx context.Context, inputs gol
 			if err != nil {
 				return nil, err
 			}
-			leaseBefore = observerRequestCount(inputs.leaseObserver.stats, "/api/subrouter/leases")
+			leaseBefore = len(goldenLeaseRequests(inputs.leaseObserver.stats))
 		}
 		observation, err := r.startObserver(label, upstream)
 		if err != nil {
@@ -3704,14 +3711,11 @@ func requireGoldenLeaseWindow(leaseObserver *runningGoldenObserver, requestStart
 		if request.Path == "/v1/responses" || request.Path == "/responses" {
 			return failGolden("local_route_bypassed_daemon")
 		}
-		if request.Path == "/_subrouter/leases" {
-			return failGolden("candidate_lease_endpoint_substituted")
-		}
-		if request.Path != "/api/subrouter/leases" {
+		if !goldenLeaseRequestPath(request.Path) {
 			continue
 		}
 		if request.Method != http.MethodPost {
-			return failGolden("legacy_lease_method_invalid")
+			return failGolden("lease_method_invalid")
 		}
 		leaseCount++
 		stamp, _ := time.Parse(time.RFC3339Nano, request.Timestamp)
@@ -3720,6 +3724,24 @@ func requireGoldenLeaseWindow(leaseObserver *runningGoldenObserver, requestStart
 		}
 	}
 	return failGolden("activation_fresh_local_lease_missing")
+}
+
+// requireGoldenLeaseObserversClean keeps response traffic on the intended
+// observer and rejects a team-mode lease fallback to the legacy broker route.
+func requireGoldenLeaseObserversClean(hosted, legacy *runningGoldenObserver) error {
+	if hosted == nil || hosted.stats == nil || legacy == nil || legacy.stats == nil {
+		return failGolden("lease_observer_missing")
+	}
+	if observerRequestCount(hosted.stats, "/v1/responses") != 0 ||
+		observerRequestCount(hosted.stats, "/responses") != 0 ||
+		observerRequestCount(legacy.stats, "/v1/responses") != 0 ||
+		observerRequestCount(legacy.stats, "/responses") != 0 {
+		return failGolden("local_route_bypassed_daemon")
+	}
+	if len(goldenLeaseRequests(legacy.stats)) != 0 {
+		return failGolden("candidate_lease_endpoint_substituted")
+	}
+	return nil
 }
 
 func requireGoldenLocalObserverPath(session *goldenSession) error {
@@ -3850,7 +3872,7 @@ func (r *goldenRunner) startSpanningLocalSession(
 		"kind": "local_egress_baseline", "timestamp": baseline.Timestamp,
 		"phase": phase, "remote_socket_ids": baseline.RemoteSocketIDs,
 	})
-	leaseBefore := observerRequestCount(inputs.leaseObserver.stats, "/api/subrouter/leases")
+	leaseBefore := len(goldenLeaseRequests(inputs.leaseObserver.stats))
 	session, err := r.startActivationSession(
 		ctx, inputs.name+"-candidate-local", "local-egress", inputs.clientPath, inputs.authData,
 		inputs.cloud, inputs.directConfigPath, inputs.teamConfigPath, inputs.hostedOrigin, inputs.localOrigin,

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1146,6 +1147,23 @@ func TestGoldenLocalLeaseObserverRequiresLegacyPost(t *testing.T) {
 		0,
 	); err == nil {
 		t.Fatal("accepted a non-POST v0.1.60 lease request")
+	}
+}
+
+func TestGoldenLocalLeaseObserverAcceptsHostedTenantPost(t *testing.T) {
+	now := time.Now().UTC()
+	stats := newObserverStats()
+	stats.observe(transportEvent{
+		Kind: "request_started", Timestamp: now.Format(time.RFC3339Nano),
+		Method: http.MethodPost, Path: "/_subrouter/leases",
+	})
+	if err := requireGoldenLeaseWindow(
+		&runningGoldenObserver{stats: stats},
+		now.Add(-time.Second),
+		now.Add(time.Second),
+		0,
+	); err != nil {
+		t.Fatalf("hosted tenant lease POST was rejected: %v", err)
 	}
 }
 

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -1133,12 +1133,12 @@ func TestGoldenLocalLeaseObserverRejectsHostedResponse(t *testing.T) {
 	}
 }
 
-func TestGoldenLocalLeaseObserverRequiresLegacyPost(t *testing.T) {
+func TestGoldenLocalLeaseObserverRejectsNonPostLease(t *testing.T) {
 	now := time.Now().UTC()
 	stats := newObserverStats()
 	stats.observe(transportEvent{
 		Kind: "request_started", Timestamp: now.Format(time.RFC3339Nano),
-		Method: "GET", Path: "/api/subrouter/leases",
+		Method: http.MethodGet, Path: "/_subrouter/leases",
 	})
 	if err := requireGoldenLeaseWindow(
 		&runningGoldenObserver{stats: stats},
@@ -1146,7 +1146,43 @@ func TestGoldenLocalLeaseObserverRequiresLegacyPost(t *testing.T) {
 		now.Add(time.Second),
 		0,
 	); err == nil {
-		t.Fatal("accepted a non-POST v0.1.60 lease request")
+		t.Fatal("accepted a non-POST hosted tenant lease request")
+	}
+}
+
+func TestGoldenLocalLeaseObserverRejectsLegacyPathOnHostedObserver(t *testing.T) {
+	now := time.Now().UTC()
+	stats := newObserverStats()
+	stats.observe(transportEvent{
+		Kind: "request_started", Timestamp: now.Format(time.RFC3339Nano),
+		Method: http.MethodPost, Path: "/api/subrouter/leases",
+	})
+	if err := requireGoldenLeaseWindow(
+		&runningGoldenObserver{stats: stats},
+		now.Add(-time.Second),
+		now.Add(time.Second),
+		0,
+	); err == nil {
+		t.Fatal("accepted a legacy lease path on the hosted observer")
+	}
+}
+
+func TestGoldenLocalLeaseObserverRejectsLegacyPathAfterHostedLease(t *testing.T) {
+	now := time.Now().UTC()
+	stats := newObserverStats()
+	for _, path := range []string{"/_subrouter/leases", "/api/subrouter/leases"} {
+		stats.observe(transportEvent{
+			Kind: "request_started", Timestamp: now.Format(time.RFC3339Nano),
+			Method: http.MethodPost, Path: path,
+		})
+	}
+	if err := requireGoldenLeaseWindow(
+		&runningGoldenObserver{stats: stats},
+		now.Add(-time.Second),
+		now.Add(time.Second),
+		0,
+	); err == nil {
+		t.Fatal("accepted a legacy lease path after a valid hosted lease")
 	}
 }
 

--- a/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
+++ b/cmd/subrouter-transport-observer/golden_acceptance_regression_test.go
@@ -1540,7 +1540,7 @@ func validGoldenAcceptanceSummary() goldenSummary {
 		ReleaseChecksumVerified: true, ReleasePlatform: "darwin/arm64", Activation: action, Rollback: rollback,
 		OldGenerationCleanup: cleanup("generation-b", "slot-b", "slot-a", rollback.EvidenceSHA256, strings.Repeat("1", 64), "rollback-rehearsal"),
 		FinalActivation:      action, ProbeFrequencyHz: 10, FreshLocalLeaseObserved: true,
-		LegacyBrokerLeaseObserved: true,
+		HostedTenantLeaseObserved: true,
 		LocalDaemonPeakRSSBytes:   1 << 20, LocalDaemonRSSSamples: 10,
 		LocalDaemonProcessSamples: 10, LocalDaemonMaxSampleGapMS: 50,
 	}
@@ -1629,6 +1629,30 @@ func validGoldenAcceptanceSummary() goldenSummary {
 		DescendantPIDs: []int{1}, ProcessStates: []string{"S"}, SocketIDs: []string{releaseA}, RSSBytes: 1 << 20,
 	})
 	return summary
+}
+
+func TestGoldenSummaryRequiresHostedTenantLeaseEvidence(t *testing.T) {
+	summary := validGoldenAcceptanceSummary()
+	summary.HostedTenantLeaseObserved = false
+	summary.LegacyBrokerLeaseObserved = true
+	if got := fixedGoldenFailure(validateGoldenSummary(summary, true)); got != "golden_evidence_incomplete" {
+		t.Fatalf("failure = %q, want golden_evidence_incomplete", got)
+	}
+}
+
+func TestGoldenLeaseObserversCleanRejectsHostedLegacyLease(t *testing.T) {
+	now := time.Now().UTC()
+	hostedStats := newObserverStats()
+	hostedStats.observe(transportEvent{
+		Kind: "request_started", Timestamp: now.Format(time.RFC3339Nano),
+		Method: http.MethodPost, Path: "/api/subrouter/leases",
+	})
+	if err := requireGoldenLeaseObserversClean(
+		&runningGoldenObserver{stats: hostedStats},
+		&runningGoldenObserver{stats: newObserverStats()},
+	); err == nil {
+		t.Fatal("accepted a legacy lease on the hosted observer")
+	}
 }
 
 func TestGoldenAcceptanceSummaryFixtureIsValid(t *testing.T) {

--- a/cmd/subrouter-transport-observer/golden_local_egress.go
+++ b/cmd/subrouter-transport-observer/golden_local_egress.go
@@ -79,14 +79,21 @@ func goldenRemoteSocketsByID(evidence goldenProcessEvidence) map[string]goldenRe
 	return result
 }
 
-func goldenLegacyLeaseRequests(stats *observerStats) []transportEvent {
+// goldenLeaseRequestPath recognizes both the legacy broker route and the
+// tenant-scoped hosted route. Team-mode local egress uses the latter, while
+// older clients can still use the former.
+func goldenLeaseRequestPath(path string) bool {
+	return path == "/api/subrouter/leases" || path == "/_subrouter/leases"
+}
+
+func goldenLeaseRequests(stats *observerStats) []transportEvent {
 	if stats == nil {
 		return nil
 	}
 	requests, _, _ := stats.snapshot()
 	result := make([]transportEvent, 0, len(requests))
 	for _, request := range requests {
-		if request.Path == "/api/subrouter/leases" {
+		if goldenLeaseRequestPath(request.Path) {
 			result = append(result, request)
 		}
 	}
@@ -126,7 +133,7 @@ func (r *goldenRunner) prepareGoldenLocalEgressBinding(
 	if len(localUpstreamID) != 64 {
 		return nil, false, failGolden("local_egress_binding_invalid")
 	}
-	leases := goldenLegacyLeaseRequests(leaseObserver.stats)
+	leases := goldenLeaseRequests(leaseObserver.stats)
 	if len(leases) < leaseBefore+1 {
 		return nil, false, nil
 	}
@@ -346,7 +353,7 @@ func validateGoldenLocalEgressBinding(session *goldenSession, binding *goldenLoc
 		return failGolden("local_egress_binding_invalid")
 	}
 	foundLease := false
-	for _, lease := range goldenLegacyLeaseRequests(binding.leaseStats) {
+	for _, lease := range goldenLeaseRequests(binding.leaseStats) {
 		if lease.RequestID == binding.LeaseRequestID && lease.ConnectionID == binding.LeaseConnectionID &&
 			lease.Method == http.MethodPost {
 			foundLease = true

--- a/cmd/subrouter-transport-observer/golden_local_egress.go
+++ b/cmd/subrouter-transport-observer/golden_local_egress.go
@@ -100,6 +100,20 @@ func goldenLeaseRequests(stats *observerStats) []transportEvent {
 	return result
 }
 
+func goldenHostedLeaseRequests(stats *observerStats) []transportEvent {
+	if stats == nil {
+		return nil
+	}
+	requests, _, _ := stats.snapshot()
+	result := make([]transportEvent, 0, len(requests))
+	for _, request := range requests {
+		if request.Path == "/_subrouter/leases" {
+			result = append(result, request)
+		}
+	}
+	return result
+}
+
 func goldenResponseMethodMatchesTransport(method, transport string) bool {
 	switch transport {
 	case "websocket":
@@ -133,7 +147,7 @@ func (r *goldenRunner) prepareGoldenLocalEgressBinding(
 	if len(localUpstreamID) != 64 {
 		return nil, false, failGolden("local_egress_binding_invalid")
 	}
-	leases := goldenLeaseRequests(leaseObserver.stats)
+	leases := goldenHostedLeaseRequests(leaseObserver.stats)
 	if len(leases) < leaseBefore+1 {
 		return nil, false, nil
 	}

--- a/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
+++ b/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
@@ -251,6 +251,7 @@ esac
 		t.Fatal(err)
 	}
 	if !result.Passed || !result.PrivateWorkspaceRemoved || !result.FreshLocalLeaseObserved ||
+		!result.HostedTenantLeaseObserved ||
 		!result.ReleaseChecksumVerified || result.ReleasedVersion != "9.9.9" || len(result.Sessions) != 15 {
 		t.Fatalf("incomplete result: %#v", result)
 	}

--- a/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
+++ b/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
@@ -264,6 +264,16 @@ esac
 		t.Fatalf("retry summary accepted=%t rejected_present=%t", retryAccepted, rejectedPresent)
 	}
 	allEvidence := readGoldenArtifacts(t, artifacts)
+	if !strings.Contains(allEvidence, `"path":"/_subrouter/leases"`) {
+		t.Fatal("team-mode hosted lease request was not observed")
+	}
+	legacyLeaseEvidence, err := os.ReadFile(filepath.Join(artifacts, "transport-local-lease-legacy.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(legacyLeaseEvidence), `"path":"/api/subrouter/leases"`) {
+		t.Fatal("team-mode lease unexpectedly used the legacy broker observer")
+	}
 	for _, forbidden := range []string{
 		"ACCESS_TOKEN_SECRET", "REFRESH_TOKEN_SECRET", "LOCAL_PROXY_SECRET", "CODEX_AUTH_SECRET",
 		"DEPLOY_ENV_VALUE_SECRET", "REQUEST_BODY_SECRET", "REQUEST_HEADER_SECRET",

--- a/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
+++ b/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
@@ -380,7 +380,7 @@ func TestGoldenLocalEgressBindingPinsRequestLeaseDestinationAndTransport(t *test
 	leaseStats := newObserverStats()
 	leaseStats.observe(transportEvent{
 		Kind: "request_started", Timestamp: now.Add(time.Millisecond).Format(time.RFC3339Nano), Transport: "http",
-		Method: http.MethodPost, Path: "/api/subrouter/leases", RequestID: "lease-1", ConnectionID: strings.Repeat("b", 64),
+		Method: http.MethodPost, Path: "/_subrouter/leases", RequestID: "lease-1", ConnectionID: strings.Repeat("b", 64),
 	})
 	socket, ok := newGoldenRemoteSocket("127.0.0.1:42001->203.0.113.10:443")
 	if !ok {
@@ -419,7 +419,7 @@ func TestGoldenLocalEgressBindingAllowsExactHTTPConnectionReuse(t *testing.T) {
 	leaseStats := newObserverStats()
 	leaseStats.observe(transportEvent{
 		Kind: "request_started", Timestamp: now.Add(time.Millisecond).Format(time.RFC3339Nano), Transport: "http",
-		Method: http.MethodPost, Path: "/api/subrouter/leases", RequestID: "lease-1",
+		Method: http.MethodPost, Path: "/_subrouter/leases", RequestID: "lease-1",
 		ConnectionID: strings.Repeat("d", 64),
 	})
 	socket, ok := newGoldenRemoteSocket("127.0.0.1:42001->203.0.113.10:443")
@@ -454,7 +454,7 @@ func TestGoldenLocalEgressBindingAllowsExactHTTPConnectionReuse(t *testing.T) {
 	}
 	leaseStats.observe(transportEvent{
 		Kind: "request_started", Timestamp: now.Add(4 * time.Millisecond).Format(time.RFC3339Nano), Transport: "http",
-		Method: http.MethodPost, Path: "/api/subrouter/leases", RequestID: "lease-2",
+		Method: http.MethodPost, Path: "/_subrouter/leases", RequestID: "lease-2",
 		ConnectionID: strings.Repeat("e", 64),
 	})
 	if got := fixedGoldenFailure(runner.bindGoldenLocalEgress(second, leaseObserver, 1, bound, reused)); got != "local_egress_correlation_missing" {
@@ -468,7 +468,7 @@ func TestGoldenLocalEgressBindingAllowsExactHTTPConnectionReuse(t *testing.T) {
 	}
 	leaseStats.observe(transportEvent{
 		Kind: "request_started", Timestamp: now.Add(7 * time.Millisecond).Format(time.RFC3339Nano), Transport: "http",
-		Method: http.MethodPost, Path: "/api/subrouter/leases", RequestID: "lease-3",
+		Method: http.MethodPost, Path: "/_subrouter/leases", RequestID: "lease-3",
 		ConnectionID: strings.Repeat("f", 64),
 	})
 	thirdReuse := reused

--- a/cmd/subrouter-transport-observer/golden_slot_only.go
+++ b/cmd/subrouter-transport-observer/golden_slot_only.go
@@ -90,7 +90,7 @@ func validateGoldenSlotOnlySummary(summary goldenSummary, testMode bool, bootstr
 	if err != nil {
 		return err
 	}
-	if !summary.FreshLocalLeaseObserved || !summary.LegacyBrokerLeaseObserved || summary.DeploymentEnvironmentRead {
+	if !summary.FreshLocalLeaseObserved || !summary.HostedTenantLeaseObserved || summary.DeploymentEnvironmentRead {
 		return failGolden("golden_evidence_incomplete")
 	}
 	if err := validateGoldenSlotOnlyProcessSnapshots(summary, finalCandidateSocket); err != nil {

--- a/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
+++ b/cmd/subrouter-transport-observer/testdata/golden_fake_client/main.go
@@ -732,7 +732,10 @@ func serve(args []string) {
 		os.Exit(3)
 	}
 	var config struct {
-		BaseURL string `json:"baseUrl"`
+		BaseURL          string `json:"baseUrl"`
+		CredentialSource string `json:"credentialSource"`
+		HostedURL        string `json:"hostedUrl"`
+		TenantKey        string `json:"tenantKey"`
 	}
 	if json.Unmarshal(data, &config) != nil {
 		os.Exit(3)
@@ -770,6 +773,9 @@ func serve(args []string) {
 		closeSocket := sockets.open()
 		defer closeSocket()
 		leaseURL := strings.TrimRight(config.BaseURL, "/") + "/api/subrouter/leases"
+		if config.CredentialSource == "team" && config.HostedURL != "" && config.TenantKey != "" {
+			leaseURL = strings.TrimRight(config.HostedURL, "/") + "/t/" + url.PathEscape(config.TenantKey) + "/_subrouter/leases"
+		}
 		leaseRequest, _ := http.NewRequestWithContext(request.Context(), http.MethodPost, leaseURL, strings.NewReader("LEASE_REQUEST_BODY_SECRET"))
 		leaseRequest.Header.Set("Authorization", "Bearer LEASE_HEADER_SECRET")
 		if response, leaseErr := http.DefaultClient.Do(leaseRequest); leaseErr == nil {


### PR DESCRIPTION
## Summary

The golden continuity gate generated team-mode config with the production hosted URL, but observed only the legacy broker URL. Real v0.1.60 and current clients therefore bypassed the lease observer and the gate failed before activation.

This keeps the legacy broker observer for control calls and routes the team hosted URL through a dedicated observer. Lease evidence accepts the tenant-scoped endpoint and rejects fallback to the legacy observer. The fake client now follows the same team-mode route.

This is maintainer verification hardening. Daniel Raffel’s integrated commits remain unchanged and retain their original authorship and attribution.

## Verification

- Failing regression test reproduced the old rejection.
- Focused observer tests pass.
- End-to-end golden harness passes and proves hosted lease evidence.
- `go test ./...` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790781461&installation_model_id=21920&pr_number=288&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F288&signature=13dcd3ba4a1943df0f01e566b12fdb5214c8d947a4a11427d0225b6dad10d6c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the golden continuity gate so team-mode lease evidence is observed at the tenant-scoped hosted endpoint instead of the legacy broker route, which made the gate fail before activation for real v0.1.60 and current clients.

- Keeps the legacy broker observer for control calls and adds a dedicated hosted observer for team-mode leases.
- Requires `HostedTenantLeaseObserved` in golden summaries; `LegacyBrokerLeaseObserved` is retained only for older evidence readers.
- Lease evidence now accepts `/_subrouter/leases` in addition to `/api/subrouter/leases`, and rejects team-mode lease fallback to the legacy observer.
- Fake client now routes team-mode lease requests through the hosted tenant URL.
- Regression tests cover the old rejection and the stricter evidence requirements; `go test ./...` passes.

<sup>Written for commit 4aebfa6ab6f4de20afd7b1a2da853fdd5965b16a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team-mode lease requests now use the hosted tenant endpoint.
  * Lease activity is tracked separately for hosted and legacy connections.
  * Evidence summaries now confirm hosted tenant lease activity.

* **Bug Fixes**
  * Updated lease validation and local egress handling to recognize the hosted lease route.
  * Prevented legacy lease paths from being accepted on hosted observers.

* **Tests**
  * Expanded coverage for hosted lease methods, routing, summaries, and artifact evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->