### PR TITLE
Fix golden lease correlation with pre-response metadata

### DIFF
--- a/cmd/subrouter-transport-observer/golden_local_egress.go
+++ b/cmd/subrouter-transport-observer/golden_local_egress.go
@@ -158,9 +158,11 @@ func (r *goldenRunner) prepareGoldenLocalEgressBinding(
 	// A proxy can acquire leases for metadata requests before it acquires the
 	// lease used by the response. Bind to the earliest new hosted lease that
 	// starts at or after the observed response request. The process snapshot is
-	// the upper bound, so a lease observed after it is still incomplete.
+	// the upper bound, so a lease observed after it is still incomplete. More
+	// than one eligible lease is ambiguous and must fail closed.
 	var lease transportEvent
 	var leaseStarted time.Time
+	eligibleLeases := 0
 	for _, candidate := range leases[leaseBefore:] {
 		if candidate.Method != http.MethodPost || candidate.RequestID == "" || candidate.ConnectionID == "" {
 			return nil, false, failGolden("local_egress_lease_binding_invalid")
@@ -172,14 +174,18 @@ func (r *goldenRunner) prepareGoldenLocalEgressBinding(
 		if candidateStarted.Before(requestStarted) {
 			continue
 		}
+		if candidateStarted.After(afterCaptured) {
+			continue
+		}
+		eligibleLeases++
+		if eligibleLeases > 1 {
+			return nil, false, failGolden("local_egress_lease_binding_invalid")
+		}
 		if lease.RequestID == "" || candidateStarted.Before(leaseStarted) {
 			lease, leaseStarted = candidate, candidateStarted
 		}
 	}
 	if lease.RequestID == "" {
-		return nil, false, nil
-	}
-	if leaseStarted.After(afterCaptured) {
 		return nil, false, nil
 	}
 	left := goldenRemoteSocketsByID(before)

--- a/cmd/subrouter-transport-observer/golden_local_egress.go
+++ b/cmd/subrouter-transport-observer/golden_local_egress.go
@@ -147,19 +147,37 @@ func (r *goldenRunner) prepareGoldenLocalEgressBinding(
 	if len(localUpstreamID) != 64 {
 		return nil, false, failGolden("local_egress_binding_invalid")
 	}
+	afterCaptured, afterErr := parseGoldenEvidenceTime(after.Timestamp)
+	if afterErr != nil {
+		return nil, false, afterErr
+	}
 	leases := goldenHostedLeaseRequests(leaseObserver.stats)
-	if len(leases) < leaseBefore+1 {
+	if leaseBefore > len(leases) {
 		return nil, false, nil
 	}
-	if len(leases) > leaseBefore+1 {
-		return nil, false, failGolden("local_egress_lease_binding_invalid")
+	// A proxy can acquire leases for metadata requests before it acquires the
+	// lease used by the response. Bind to the earliest new hosted lease that
+	// starts at or after the observed response request. The process snapshot is
+	// the upper bound, so a lease observed after it is still incomplete.
+	var lease transportEvent
+	var leaseStarted time.Time
+	for _, candidate := range leases[leaseBefore:] {
+		if candidate.Method != http.MethodPost || candidate.RequestID == "" || candidate.ConnectionID == "" {
+			return nil, false, failGolden("local_egress_lease_binding_invalid")
+		}
+		candidateStarted, parseErr := parseGoldenEvidenceTime(candidate.Timestamp)
+		if parseErr != nil {
+			return nil, false, failGolden("local_egress_lease_binding_invalid")
+		}
+		if candidateStarted.Before(requestStarted) {
+			continue
+		}
+		if lease.RequestID == "" || candidateStarted.Before(leaseStarted) {
+			lease, leaseStarted = candidate, candidateStarted
+		}
 	}
-	lease := leases[leaseBefore]
-	leaseStarted, parseErr := parseGoldenEvidenceTime(lease.Timestamp)
-	afterCaptured, afterErr := parseGoldenEvidenceTime(after.Timestamp)
-	if parseErr != nil || afterErr != nil || lease.Method != http.MethodPost ||
-		lease.RequestID == "" || lease.ConnectionID == "" || leaseStarted.Before(requestStarted) {
-		return nil, false, failGolden("local_egress_lease_binding_invalid")
+	if lease.RequestID == "" {
+		return nil, false, nil
 	}
 	if leaseStarted.After(afterCaptured) {
 		return nil, false, nil

--- a/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
+++ b/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -411,6 +412,44 @@ func TestGoldenLocalEgressBindingPinsRequestLeaseDestinationAndTransport(t *test
 		map[string]goldenProcessEvidence{"local-daemon": reconnectedEvidence},
 	)); got != "local_egress_socket_reconnected" {
 		t.Fatalf("failure = %q, want local_egress_socket_reconnected", got)
+	}
+}
+
+func TestGoldenLocalEgressBindingSelectsResponseLeaseAfterMetadataLeases(t *testing.T) {
+	now := time.Now().UTC()
+	requestStarted := now.Add(10 * time.Millisecond)
+	requestStats := newObserverStats()
+	requestStats.observe(transportEvent{
+		Kind: "request_started", Timestamp: requestStarted.Format(time.RFC3339Nano), Transport: "websocket",
+		Method: http.MethodGet, Path: "/responses", RequestID: "response-1", ConnectionID: strings.Repeat("a", 64),
+	})
+	leaseStats := newObserverStats()
+	for index, stamp := range []time.Time{now, now.Add(5 * time.Millisecond), requestStarted.Add(time.Microsecond)} {
+		leaseStats.observe(transportEvent{
+			Kind: "request_started", Timestamp: stamp.Format(time.RFC3339Nano), Transport: "http",
+			Method: http.MethodPost, Path: "/_subrouter/leases", RequestID: fmt.Sprintf("lease-%d", index+1),
+			ConnectionID: strings.Repeat(string(rune('b'+index)), 64),
+		})
+	}
+	socket, ok := newGoldenRemoteSocket("127.0.0.1:42001->203.0.113.10:443")
+	if !ok {
+		t.Fatal("test socket was not remote")
+	}
+	session := &goldenSession{
+		label: "rehearsal-local-websocket", route: "local-egress", transport: "websocket",
+		observer: &runningGoldenObserver{stats: requestStats}, localUpstreamSocket: strings.Repeat("c", 64),
+	}
+	before := goldenProcessEvidence{Timestamp: now.Add(-time.Millisecond).Format(time.RFC3339Nano), Label: "local-daemon"}
+	after := goldenProcessEvidence{
+		Timestamp: now.Add(20 * time.Millisecond).Format(time.RFC3339Nano), Label: "local-daemon",
+		RemoteSocketIDs: []string{socket.SocketID}, remoteSockets: []goldenRemoteSocket{socket},
+	}
+	runner := &goldenRunner{evidence: &jsonlRecorder{writer: io.Discard}}
+	if err := runner.bindGoldenLocalEgress(session, &runningGoldenObserver{stats: leaseStats}, 0, before, after); err != nil {
+		t.Fatalf("metadata leases before the response lease should not invalidate binding: %v", err)
+	}
+	if got := session.localEgressBinding.LeaseRequestID; got != "lease-3" {
+		t.Fatalf("bound lease = %q, want response lease", got)
 	}
 }
 

--- a/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
+++ b/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
@@ -453,6 +453,43 @@ func TestGoldenLocalEgressBindingSelectsResponseLeaseAfterMetadataLeases(t *test
 	}
 }
 
+func TestGoldenLocalEgressBindingRejectsMultipleResponseLeases(t *testing.T) {
+	now := time.Now().UTC()
+	requestStarted := now.Add(10 * time.Millisecond)
+	requestStats := newObserverStats()
+	requestStats.observe(transportEvent{
+		Kind: "request_started", Timestamp: requestStarted.Format(time.RFC3339Nano), Transport: "websocket",
+		Method: http.MethodGet, Path: "/responses", RequestID: "response-1", ConnectionID: strings.Repeat("a", 64),
+	})
+	leaseStats := newObserverStats()
+	for index, stamp := range []time.Time{requestStarted.Add(time.Microsecond), requestStarted.Add(2 * time.Microsecond)} {
+		leaseStats.observe(transportEvent{
+			Kind: "request_started", Timestamp: stamp.Format(time.RFC3339Nano), Transport: "http",
+			Method: http.MethodPost, Path: "/_subrouter/leases", RequestID: fmt.Sprintf("lease-%d", index+1),
+			ConnectionID: strings.Repeat(string(rune('b'+index)), 64),
+		})
+	}
+	socket, ok := newGoldenRemoteSocket("127.0.0.1:42001->203.0.113.10:443")
+	if !ok {
+		t.Fatal("test socket was not remote")
+	}
+	session := &goldenSession{
+		label: "rehearsal-local-websocket", route: "local-egress", transport: "websocket",
+		observer: &runningGoldenObserver{stats: requestStats}, localUpstreamSocket: strings.Repeat("c", 64),
+	}
+	before := goldenProcessEvidence{Timestamp: now.Add(-time.Millisecond).Format(time.RFC3339Nano), Label: "local-daemon"}
+	after := goldenProcessEvidence{
+		Timestamp: now.Add(20 * time.Millisecond).Format(time.RFC3339Nano), Label: "local-daemon",
+		RemoteSocketIDs: []string{socket.SocketID}, remoteSockets: []goldenRemoteSocket{socket},
+	}
+	runner := &goldenRunner{evidence: &jsonlRecorder{writer: io.Discard}}
+	if got := fixedGoldenFailure(runner.bindGoldenLocalEgress(
+		session, &runningGoldenObserver{stats: leaseStats}, 0, before, after,
+	)); got != "local_egress_lease_binding_invalid" {
+		t.Fatalf("failure = %q, want local_egress_lease_binding_invalid", got)
+	}
+}
+
 func TestGoldenLocalEgressBindingAllowsExactHTTPConnectionReuse(t *testing.T) {
 	now := time.Now().UTC()
 	leaseStats := newObserverStats()


### PR DESCRIPTION
## Summary
- bind local egress to the earliest new hosted lease at or after the observed response request
- allow earlier hosted leases for metadata requests without weakening route, method, identity, or timestamp validation
- add a test-first regression for the production v0.1.60 request sequence

## Verification
- `go test ./cmd/subrouter-transport-observer -count=1`
- full `go test ./...` pending on the PR head

This is maintainer hardening for the Daniel Raffel integration. Daniel-authored commits and attribution remain unchanged in `main` and in the release history.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790784052&installation_model_id=21920&pr_number=289&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F289&signature=0ef894f0593c12a023334939036129e662f4ce9d32332150bf7031a3221f62f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes golden lease binding so leases acquired for metadata requests before the response lease no longer invalidate correlation.

**Bug Fixes**
- Binds the egress to the earliest new hosted lease at or after the observed response request, skipping earlier metadata leases.
- Fails closed when more than one eligible lease is observed, preserving route, method, identity, and timestamp validation.
- Adds regression tests for the production v0.1.60 request sequence and ambiguous lease rejection.

<sup>Written for commit 5c580f168228a3c00ba7f4a8235b5711ced25d3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local egress lease selection when multiple metadata leases are present.
  * Correctly binds the response to the earliest eligible lease rather than requiring a single new lease.
  * Preserved validation that the selected lease begins within the observed response timeframe.

* **Tests**
  * Added coverage for selecting the correct response lease when earlier metadata leases exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->