### PR TITLE
Keep observer upstream evidence request-scoped

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -3770,7 +3770,7 @@ func requireGoldenLocalObserverPath(session *goldenSession) error {
 			continue
 		}
 		switch event.Kind {
-		case "upstream_connection_opened":
+		case "upstream_connection_opened", "upstream_connection_used":
 			if opened != "" && opened != event.ConnectionID {
 				return failGolden("local_upstream_socket_changed")
 			}

--- a/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
+++ b/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -140,6 +142,75 @@ func TestGoldenObserverStopWaitsForConnectionClosureBeforeClosingEvidence(t *tes
 	}
 	if _, err := events.Stat(); err == nil {
 		t.Error("observer finalize left evidence writer open")
+	}
+}
+
+func TestGoldenObserverAttributesUpstreamEvidenceToEachRequest(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "text/plain")
+		_, _ = writer.Write([]byte("ok"))
+	}))
+	t.Cleanup(upstream.Close)
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats := newObserverStats()
+	observation := newObserver(io.Discard, stats)
+	proxy := httptest.NewServer(newObserverHandlerWithObserverAndGate(upstreamURL, observation, nil))
+	t.Cleanup(proxy.Close)
+
+	request := func(method, path string) {
+		t.Helper()
+		request, err := http.NewRequest(method, proxy.URL+path, strings.NewReader("request"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.Copy(io.Discard, response.Body); err != nil {
+			response.Body.Close()
+			t.Fatal(err)
+		}
+		if err := response.Body.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	request(http.MethodGet, "/metadata")
+	request(http.MethodPost, "/v1/responses")
+
+	requests, _, _ := stats.snapshot()
+	var responseRequest transportEvent
+	for _, candidate := range requests {
+		if candidate.Path == "/v1/responses" {
+			responseRequest = candidate
+			break
+		}
+	}
+	if responseRequest.RequestID == "" {
+		t.Fatal("response request was not observed")
+	}
+	opened, requestBytes, responseBytes := 0, int64(0), int64(0)
+	for _, event := range stats.upstreamSnapshot() {
+		if event.RequestID != responseRequest.RequestID {
+			continue
+		}
+		if event.Path != "/v1/responses" {
+			t.Fatalf("response upstream event path = %q, want /v1/responses", event.Path)
+		}
+		switch event.Kind {
+		case "upstream_connection_opened":
+			opened++
+		case "upstream_request_chunk":
+			requestBytes += event.Bytes
+		case "upstream_response_chunk":
+			responseBytes += event.Bytes
+		}
+	}
+	if opened != 1 || requestBytes <= 0 || responseBytes <= 0 {
+		t.Fatalf("response upstream evidence = opened %d, request bytes %d, response bytes %d; want one complete upstream request", opened, requestBytes, responseBytes)
 	}
 }
 

--- a/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
+++ b/cmd/subrouter-transport-observer/golden_runtime_continuity_test.go
@@ -162,7 +162,11 @@ func TestGoldenObserverAttributesUpstreamEvidenceToEachRequest(t *testing.T) {
 
 	request := func(method, path string) {
 		t.Helper()
-		request, err := http.NewRequest(method, proxy.URL+path, strings.NewReader("request"))
+		var body io.Reader
+		if method != http.MethodGet {
+			body = strings.NewReader("request")
+		}
+		request, err := http.NewRequest(method, proxy.URL+path, body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -201,7 +205,7 @@ func TestGoldenObserverAttributesUpstreamEvidenceToEachRequest(t *testing.T) {
 			t.Fatalf("response upstream event path = %q, want /v1/responses", event.Path)
 		}
 		switch event.Kind {
-		case "upstream_connection_opened":
+		case "upstream_connection_used":
 			opened++
 		case "upstream_request_chunk":
 			requestBytes += event.Bytes
@@ -211,6 +215,98 @@ func TestGoldenObserverAttributesUpstreamEvidenceToEachRequest(t *testing.T) {
 	}
 	if opened != 1 || requestBytes <= 0 || responseBytes <= 0 {
 		t.Fatalf("response upstream evidence = opened %d, request bytes %d, response bytes %d; want one complete upstream request", opened, requestBytes, responseBytes)
+	}
+}
+
+func TestGoldenObserverKeepsUpstreamEvidenceRequestScopedOnPooledConnections(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "text/plain")
+		_, _ = writer.Write([]byte("ok"))
+	}))
+	t.Cleanup(upstream.Close)
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats := newObserverStats()
+	observation := newObserver(io.Discard, stats)
+	proxy := httptest.NewServer(newObserverHandlerWithObserverAndGate(upstreamURL, observation, nil))
+	t.Cleanup(proxy.Close)
+
+	request := func(method, path string) {
+		t.Helper()
+		var body io.Reader
+		if method != http.MethodGet {
+			body = strings.NewReader("request")
+		}
+		request, err := http.NewRequest(method, proxy.URL+path, body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.Copy(io.Discard, response.Body); err != nil {
+			response.Body.Close()
+			t.Fatal(err)
+		}
+		if err := response.Body.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	request(http.MethodGet, "/metadata")
+	request(http.MethodGet, "/metadata")
+	request(http.MethodPost, "/v1/responses")
+	request(http.MethodPost, "/v1/responses")
+
+	requests, _, _ := stats.snapshot()
+	requestIDs := make(map[string]bool)
+	for _, candidate := range requests {
+		switch candidate.Path {
+		case "/other", "/v1/responses":
+			requestIDs[candidate.RequestID] = true
+		}
+	}
+	if len(requestIDs) != 4 {
+		t.Fatalf("request IDs = %d, want four", len(requestIDs))
+	}
+	physicalConnections := make(map[string]bool)
+	connectionsByRequest := make(map[string]map[string]bool)
+	requestBytesByRequest := make(map[string]int64)
+	responseBytesByRequest := make(map[string]int64)
+	for _, event := range stats.upstreamSnapshot() {
+		if event.Kind == "upstream_connection_opened" {
+			physicalConnections[event.ConnectionID] = true
+		}
+		if !requestIDs[event.RequestID] {
+			continue
+		}
+		switch event.Kind {
+		case "upstream_connection_used":
+			if connectionsByRequest[event.RequestID] == nil {
+				connectionsByRequest[event.RequestID] = make(map[string]bool)
+			}
+			connectionsByRequest[event.RequestID][event.ConnectionID] = true
+		case "upstream_request_chunk":
+			requestBytesByRequest[event.RequestID] += event.Bytes
+		case "upstream_response_chunk":
+			responseBytesByRequest[event.RequestID] += event.Bytes
+		}
+	}
+	if len(physicalConnections) == 0 {
+		t.Fatal("no physical upstream connection was observed")
+	}
+	for requestID := range requestIDs {
+		connections := connectionsByRequest[requestID]
+		if len(connections) != 1 || requestBytesByRequest[requestID] <= 0 || responseBytesByRequest[requestID] <= 0 {
+			t.Fatalf("request %s upstream evidence = connections %d, request bytes %d, response bytes %d; want one complete exchange", requestID, len(connections), requestBytesByRequest[requestID], responseBytesByRequest[requestID])
+		}
+		for connectionID := range connections {
+			if !physicalConnections[connectionID] {
+				t.Fatalf("request %s used unknown connection %q", requestID, connectionID)
+			}
+		}
 	}
 }
 

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -360,7 +361,7 @@ func (s *observerStats) observe(event transportEvent) {
 		s.requests = append(s.requests, event)
 	case "request_chunk", "response_chunk":
 		s.chunks = append(s.chunks, event)
-	case "upstream_connection_opened", "upstream_request_chunk", "upstream_response_chunk", "upstream_connection_closed":
+	case "upstream_connection_opened", "upstream_connection_used", "upstream_request_chunk", "upstream_response_chunk", "upstream_connection_closed":
 		s.upstream = append(s.upstream, event)
 	case "connection_closed":
 		s.closed = append(s.closed, event)
@@ -405,13 +406,15 @@ func (s *observerStats) upstreamSnapshot() []transportEvent {
 }
 
 type observer struct {
-	recorder      *eventRecorder
-	stats         *observerStats
-	requests      *observerRequestLifecycle
-	requestSeq    atomic.Uint64
-	connectionSeq atomic.Uint64
-	connectionsMu sync.Mutex
-	connections   map[string]string
+	recorder              *eventRecorder
+	stats                 *observerStats
+	requests              *observerRequestLifecycle
+	requestSeq            atomic.Uint64
+	connectionSeq         atomic.Uint64
+	connectionsMu         sync.Mutex
+	connections           map[string]string
+	upstreamConnectionsMu sync.Mutex
+	upstreamConnections   map[string]*countingUpstreamConn
 }
 
 type observerRequestLifecycle struct {
@@ -465,10 +468,11 @@ func newObserver(events io.Writer, stats *observerStats) *observer {
 		stats = newObserverStats()
 	}
 	return &observer{
-		recorder:    &eventRecorder{writer: events},
-		stats:       stats,
-		requests:    newObserverRequestLifecycle(),
-		connections: make(map[string]string),
+		recorder:            &eventRecorder{writer: events},
+		stats:               stats,
+		requests:            newObserverRequestLifecycle(),
+		connections:         make(map[string]string),
+		upstreamConnections: make(map[string]*countingUpstreamConn),
 	}
 }
 
@@ -481,6 +485,58 @@ func (o *observer) emit(event transportEvent) {
 		return
 	}
 	o.stats.observe(event)
+}
+
+func (o *observer) registerUpstreamConnection(connection net.Conn, meta requestEvidence) *countingUpstreamConn {
+	if connection == nil || connection.LocalAddr() == nil {
+		return nil
+	}
+	id := goldenSocketEndpointID(connection.LocalAddr().String())
+	if id == "" {
+		return nil
+	}
+	wrapped := &countingUpstreamConn{Conn: connection, observer: o, id: id}
+	o.upstreamConnectionsMu.Lock()
+	o.upstreamConnections[id] = wrapped
+	o.upstreamConnectionsMu.Unlock()
+	if meta.requestID != "" {
+		event := meta.event("upstream_connection_opened")
+		event.ConnectionID = id
+		o.emit(event)
+	}
+	return wrapped
+}
+
+func (o *observer) bindUpstreamConnection(connection net.Conn, meta requestEvidence) *countingUpstreamConn {
+	if connection == nil || connection.LocalAddr() == nil {
+		return nil
+	}
+	id := goldenSocketEndpointID(connection.LocalAddr().String())
+	if id == "" {
+		return nil
+	}
+	o.upstreamConnectionsMu.Lock()
+	wrapped := o.upstreamConnections[id]
+	o.upstreamConnectionsMu.Unlock()
+	if wrapped == nil {
+		return nil
+	}
+	wrapped.bind(meta)
+	event := meta.event("upstream_connection_used")
+	event.ConnectionID = id
+	o.emit(event)
+	return wrapped
+}
+
+func (o *observer) forgetUpstreamConnection(id string, connection *countingUpstreamConn) {
+	if id == "" || connection == nil {
+		return
+	}
+	o.upstreamConnectionsMu.Lock()
+	if o.upstreamConnections[id] == connection {
+		delete(o.upstreamConnections, id)
+	}
+	o.upstreamConnectionsMu.Unlock()
 }
 
 func (o *observer) requestID() string {
@@ -696,19 +752,17 @@ type countingConn struct {
 type countingUpstreamConn struct {
 	net.Conn
 	observer *observer
-	meta     requestEvidence
 	id       string
+	metaMu   sync.RWMutex
+	meta     requestEvidence
+	bound    bool
 	closed   atomic.Bool
 }
 
 func (c *countingUpstreamConn) Read(p []byte) (int, error) {
 	n, err := c.Conn.Read(p)
 	if n > 0 {
-		event := c.meta.event("upstream_response_chunk")
-		event.ConnectionID = c.id
-		event.Direction = "upstream_to_observer"
-		event.Bytes = int64(n)
-		c.observer.emit(event)
+		c.emitChunk("upstream_response_chunk", "upstream_to_observer", n)
 	}
 	return n, err
 }
@@ -716,18 +770,46 @@ func (c *countingUpstreamConn) Read(p []byte) (int, error) {
 func (c *countingUpstreamConn) Write(p []byte) (int, error) {
 	n, err := c.Conn.Write(p)
 	if n > 0 {
-		event := c.meta.event("upstream_request_chunk")
-		event.ConnectionID = c.id
-		event.Direction = "observer_to_upstream"
-		event.Bytes = int64(n)
-		c.observer.emit(event)
+		c.emitChunk("upstream_request_chunk", "observer_to_upstream", n)
 	}
 	return n, err
 }
 
 func (c *countingUpstreamConn) Close() error {
-	c.closed.CompareAndSwap(false, true)
+	if c.closed.CompareAndSwap(false, true) {
+		c.observer.forgetUpstreamConnection(c.id, c)
+	}
 	return c.Conn.Close()
+}
+
+func (c *countingUpstreamConn) bind(meta requestEvidence) {
+	c.metaMu.Lock()
+	c.meta = meta
+	c.bound = true
+	c.metaMu.Unlock()
+}
+
+func (c *countingUpstreamConn) unbind(requestID string) {
+	c.metaMu.Lock()
+	if c.bound && c.meta.requestID == requestID {
+		c.meta = requestEvidence{}
+		c.bound = false
+	}
+	c.metaMu.Unlock()
+}
+
+func (c *countingUpstreamConn) emitChunk(kind, direction string, bytes int) {
+	c.metaMu.RLock()
+	meta, bound := c.meta, c.bound
+	c.metaMu.RUnlock()
+	if !bound {
+		return
+	}
+	event := meta.event(kind)
+	event.ConnectionID = c.id
+	event.Direction = direction
+	event.Bytes = int64(bytes)
+	c.observer.emit(event)
 }
 
 func (c *countingConn) Read(p []byte) (int, error) {
@@ -783,14 +865,25 @@ func newObserverHandlerWithObserver(upstream *url.URL, observation *observer) ht
 	return newObserverHandlerWithObserverAndGate(upstream, observation, nil)
 }
 
+func newGoldenObserverHTTPTransport() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// The observer records bytes on one physical connection. HTTP/2 can
+	// multiplex unrelated requests on that connection, so constrain this
+	// transport to pooled HTTP/1.1 and bind its metadata at GotConn time.
+	transport.ForceAttemptHTTP2 = false
+	transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{}
+	} else {
+		transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+	}
+	transport.TLSClientConfig.NextProtos = []string{"http/1.1"}
+	return transport
+}
+
 func newObserverHandlerWithObserverAndGate(upstream *url.URL, observation *observer, gate *goldenResponseGate) http.Handler {
 	proxy := httputil.NewSingleHostReverseProxy(upstream)
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	// ReverseProxy resets the outbound request's Close flag, so a per-request
-	// observer context cannot safely identify events on a reused connection.
-	// Keep each upstream exchange on its own connection so evidence remains
-	// attributable to the request that produced it.
-	transport.DisableKeepAlives = true
+	transport := newGoldenObserverHTTPTransport()
 	dialer := &net.Dialer{}
 	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
 		connection, err := dialer.DialContext(ctx, network, address)
@@ -809,13 +902,15 @@ func newObserverHandlerWithObserverAndGate(upstream *url.URL, observation *obser
 				}
 			}
 		}
-		id := goldenSocketEndpointID(connection.LocalAddr().String())
-		event := meta.event("upstream_connection_opened")
-		event.ConnectionID = id
-		observation.emit(event)
-		return &countingUpstreamConn{Conn: connection, observer: observation, meta: meta, id: id}, nil
+		if wrapped := observation.registerUpstreamConnection(connection, meta); wrapped != nil {
+			return wrapped, nil
+		}
+		return connection, nil
 	}
-	proxy.Transport = &goldenResponseAttemptHeaderStripTransport{base: transport}
+	proxy.Transport = &goldenUpstreamEvidenceTransport{
+		base:        &goldenResponseAttemptHeaderStripTransport{base: transport},
+		observation: observation,
+	}
 	if goldenTestHooks.enabled {
 		proxy.Transport = &goldenRequestWriteTransport{
 			base:   proxy.Transport,
@@ -892,6 +987,99 @@ type goldenResponseAttemptHeaderStripTransport struct {
 func (transport *goldenResponseAttemptHeaderStripTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 	request.Header.Del(goldenResponseAttemptTokenHeader)
 	return transport.base.RoundTrip(request)
+}
+
+type goldenUpstreamEvidenceTransport struct {
+	base        http.RoundTripper
+	observation *observer
+}
+
+func (transport *goldenUpstreamEvidenceTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	meta, ok := request.Context().Value(requestEvidenceContextKey{}).(requestEvidence)
+	if !ok || transport.observation == nil {
+		return transport.base.RoundTrip(request)
+	}
+	var bound *countingUpstreamConn
+	trace := &httptrace.ClientTrace{GotConn: func(info httptrace.GotConnInfo) {
+		if bound != nil {
+			bound.unbind(meta.requestID)
+		}
+		bound = transport.observation.bindUpstreamConnection(info.Conn, meta)
+	}}
+	request = request.WithContext(httptrace.WithClientTrace(request.Context(), trace))
+	response, err := transport.base.RoundTrip(request)
+	if err != nil {
+		if bound != nil {
+			bound.unbind(meta.requestID)
+		}
+		return nil, err
+	}
+	if bound == nil || response == nil || response.Body == nil {
+		if bound != nil {
+			bound.unbind(meta.requestID)
+		}
+		return response, nil
+	}
+	binding := &goldenUpstreamEvidenceBinding{connection: bound, requestID: meta.requestID}
+	if body, ok := response.Body.(io.ReadWriteCloser); ok {
+		response.Body = &goldenUpstreamReadWriteCloser{ReadWriteCloser: body, binding: binding}
+	} else {
+		response.Body = &goldenUpstreamReadCloser{ReadCloser: response.Body, binding: binding}
+	}
+	return response, nil
+}
+
+type goldenUpstreamEvidenceBinding struct {
+	connection *countingUpstreamConn
+	requestID  string
+	once       sync.Once
+}
+
+func (binding *goldenUpstreamEvidenceBinding) release() {
+	if binding == nil || binding.connection == nil {
+		return
+	}
+	binding.once.Do(func() {
+		binding.connection.unbind(binding.requestID)
+	})
+}
+
+type goldenUpstreamReadCloser struct {
+	io.ReadCloser
+	binding *goldenUpstreamEvidenceBinding
+}
+
+func (body *goldenUpstreamReadCloser) Read(p []byte) (int, error) {
+	n, err := body.ReadCloser.Read(p)
+	if err != nil {
+		body.binding.release()
+	}
+	return n, err
+}
+
+func (body *goldenUpstreamReadCloser) Close() error {
+	err := body.ReadCloser.Close()
+	body.binding.release()
+	return err
+}
+
+type goldenUpstreamReadWriteCloser struct {
+	io.ReadWriteCloser
+	binding *goldenUpstreamEvidenceBinding
+}
+
+func (body *goldenUpstreamReadWriteCloser) Read(p []byte) (int, error) {
+	n, err := body.ReadWriteCloser.Read(p)
+	if err != nil {
+		body.binding.release()
+	}
+	return n, err
+}
+
+func (body *goldenUpstreamReadWriteCloser) Close() error {
+	err := body.ReadWriteCloser.Close()
+	body.binding.release()
+	return err
 }
 
 func goldenResponseAttemptToken(header http.Header) string {

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -786,6 +786,11 @@ func newObserverHandlerWithObserver(upstream *url.URL, observation *observer) ht
 func newObserverHandlerWithObserverAndGate(upstream *url.URL, observation *observer, gate *goldenResponseGate) http.Handler {
 	proxy := httputil.NewSingleHostReverseProxy(upstream)
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// ReverseProxy resets the outbound request's Close flag, so a per-request
+	// observer context cannot safely identify events on a reused connection.
+	// Keep each upstream exchange on its own connection so evidence remains
+	// attributable to the request that produced it.
+	transport.DisableKeepAlives = true
 	dialer := &net.Dialer{}
 	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
 		connection, err := dialer.DialContext(ctx, network, address)


### PR DESCRIPTION
## Summary
- keep each observer upstream exchange on a dedicated connection so ReverseProxy cannot reuse a connection with stale request metadata
- add an integration regression that sends a metadata request followed by a response request and checks complete request-scoped evidence

## Verification
- `go test ./cmd/subrouter-transport-observer -count=1`
- `go test ./...`

This is maintainer hardening for the Daniel Raffel integration. Daniel-authored commits and attribution remain unchanged in `main` and in the release history.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790785649&installation_model_id=21920&pr_number=290&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F290&signature=06153db5f0cb45bed530fcc29089912528fd8fddb7f3409a92560be2773aa19e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes upstream evidence attribution in the `subrouter-transport-observer` so each request's upstream events are tied to the request that produced them, even when the reverse proxy reuses a pooled connection.

**Bug Fixes**
- Binds connection metadata at `GotConn` time and releases it when the response body closes, so reused connections don't inherit stale request evidence.
- Constrains the observer transport to HTTP/1.1 so a connection can never carry more than one request.
- Adds two tests: one for a single metadata request and one for repeated requests over pooled connections.

<sup>Written for commit f4f5b0ce54797fc31ea31b8563167633d40511ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved upstream connection tracking for more accurate request-level evidence.
  * Upstream request and response byte counts are now associated with the correct request, including when connections are reused.
  * Connection usage is recorded consistently across supported upstream connection events.

* **Tests**
  * Added coverage for GET and POST requests, pooled connections, connection reuse, and request-scoped evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->