### PR TITLE
Fix WebSocket pacing in continuity observer

### DIFF
--- a/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_real_stream_pacing_test.go
@@ -9,11 +9,13 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 )
 
 type accumulatingObserverDelay struct {
+	mu      sync.Mutex
 	elapsed time.Duration
 }
 
@@ -21,10 +23,19 @@ func (delay *accumulatingObserverDelay) wait(
 	_ context.Context,
 	_ <-chan struct{},
 	_ <-chan struct{},
+	_ <-chan struct{},
 	duration time.Duration,
-) error {
+) (bool, error) {
+	delay.mu.Lock()
 	delay.elapsed += duration
-	return nil
+	delay.mu.Unlock()
+	return false, nil
+}
+
+func (delay *accumulatingObserverDelay) elapsedDuration() time.Duration {
+	delay.mu.Lock()
+	defer delay.mu.Unlock()
+	return delay.elapsed
 }
 
 func TestGoldenObserverDefaultPacingOutlastsDeploymentGate(t *testing.T) {
@@ -43,8 +54,8 @@ func TestGoldenObserverDefaultPacingOutlastsDeploymentGate(t *testing.T) {
 	if _, err := pacer.write(context.Background(), payload.Bytes(), delivered.Write); err != nil {
 		t.Fatal(err)
 	}
-	if delay.elapsed < 20*time.Minute {
-		t.Fatalf("finite golden response pacing runway = %s, want at least 20m", delay.elapsed)
+	if elapsed := delay.elapsedDuration(); elapsed < 20*time.Minute {
+		t.Fatalf("finite golden response pacing runway = %s, want at least 20m", elapsed)
 	}
 	if delivered.Len() >= payload.Len() {
 		t.Fatal("finite golden response completed before gate release")

--- a/cmd/subrouter-transport-observer/golden_websocket_pacing.go
+++ b/cmd/subrouter-transport-observer/golden_websocket_pacing.go
@@ -252,7 +252,8 @@ func (p *goldenWebSocketPacer) writeFrameLocked(ctx context.Context, frame []byt
 	if p.base.wasSuperseded() {
 		return len(frame), nil
 	}
-	if p.started && !p.base.isReleased() && !goldenWebSocketImmediateControlFrame(frame) {
+	if p.started && !p.base.isReleased() && !goldenWebSocketImmediateControlFrame(frame) &&
+		!p.hasPendingImmediateControlFrameLocked() && !goldenWebSocketImmediateControlFramePrefix(p.parser.pending) {
 		if err := p.base.delay.wait(ctx, p.base.gateReleased, p.base.requestReleased, p.base.interval); err != nil {
 			return 0, err
 		}

--- a/cmd/subrouter-transport-observer/golden_websocket_pacing.go
+++ b/cmd/subrouter-transport-observer/golden_websocket_pacing.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"sync"
+)
+
+const (
+	// The observer is content-blind, so it only needs enough space for one
+	// realistic wire frame and its held tail. Rejecting larger declarations
+	// keeps a peer from turning an incomplete frame into an unbounded allocation.
+	goldenWebSocketMaxFrameBytes    = 16 << 20
+	goldenWebSocketMaxBufferedBytes = 32 << 20
+)
+
+// goldenWebSocketFrameParser reassembles complete wire frames without
+// inspecting their payload. WebSocket frames are transport records, so the
+// continuity pacer must never release a partial record to a client.
+type goldenWebSocketFrameParser struct {
+	pending []byte
+}
+
+func (p *goldenWebSocketFrameParser) append(payload []byte) ([][]byte, error) {
+	if len(payload) > goldenWebSocketMaxBufferedBytes ||
+		len(p.pending) > goldenWebSocketMaxBufferedBytes-len(payload) {
+		return nil, errors.New("golden WebSocket frame buffer exceeds limit")
+	}
+	if len(payload) > 0 {
+		p.pending = append(p.pending, payload...)
+	}
+	frames := make([][]byte, 0, 1)
+	for len(p.pending) > 0 {
+		frameLength, complete, err := goldenWebSocketFrameLength(p.pending)
+		if err != nil {
+			return nil, err
+		}
+		if !complete {
+			break
+		}
+		frame := append([]byte(nil), p.pending[:frameLength]...)
+		frames = append(frames, frame)
+		p.pending = p.pending[frameLength:]
+	}
+	if len(p.pending) == 0 {
+		p.pending = nil
+	}
+	return frames, nil
+}
+
+func goldenWebSocketFrameLength(payload []byte) (length int, complete bool, err error) {
+	if len(payload) < 2 {
+		return 0, false, nil
+	}
+	payloadLength := uint64(payload[1] & 0x7f)
+	headerLength := 2
+	switch payloadLength {
+	case 126:
+		if len(payload) < headerLength+2 {
+			return 0, false, nil
+		}
+		payloadLength = uint64(binary.BigEndian.Uint16(payload[headerLength : headerLength+2]))
+		headerLength += 2
+	case 127:
+		if len(payload) < headerLength+8 {
+			return 0, false, nil
+		}
+		extended := binary.BigEndian.Uint64(payload[headerLength : headerLength+8])
+		if extended&(uint64(1)<<63) != 0 {
+			return 0, false, errors.New("golden WebSocket frame length overflows 63 bits")
+		}
+		payloadLength = extended
+		headerLength += 8
+	}
+	if payload[1]&0x80 != 0 {
+		headerLength += 4
+	}
+	maxInt := uint64(^uint(0) >> 1)
+	if payloadLength > maxInt-uint64(headerLength) {
+		return 0, false, errors.New("golden WebSocket frame length overflows int")
+	}
+	frameLength := headerLength + int(payloadLength)
+	if frameLength > goldenWebSocketMaxFrameBytes {
+		return 0, false, errors.New("golden WebSocket frame exceeds size limit")
+	}
+	if len(payload) < frameLength {
+		return 0, false, nil
+	}
+	return frameLength, true, nil
+}
+
+// goldenWebSocketPacer applies the golden response gate to complete
+// WebSocket frames. It shares supersession and release state with the generic
+// response pacer, but uses one frame per pacing interval instead of splitting
+// arbitrary byte slices.
+type goldenWebSocketPacer struct {
+	base         *goldenResponsePacer
+	mu           sync.Mutex
+	parser       goldenWebSocketFrameParser
+	pending      [][]byte
+	pendingBytes int
+	started      bool
+	sink         func([]byte) (int, error)
+}
+
+func newGoldenWebSocketPacer(base *goldenResponsePacer) *goldenWebSocketPacer {
+	if base == nil {
+		return nil
+	}
+	return &goldenWebSocketPacer{
+		base: base,
+	}
+}
+
+func (p *goldenWebSocketPacer) releaseRequest() {
+	if p != nil {
+		p.base.releaseRequest()
+	}
+}
+
+func (p *goldenWebSocketPacer) hasPayload() bool {
+	return p != nil && p.base.hasPayload()
+}
+
+func (p *goldenWebSocketPacer) write(
+	ctx context.Context,
+	payload []byte,
+	write func([]byte) (int, error),
+) (int, error) {
+	if p == nil || len(payload) == 0 {
+		return write(payload)
+	}
+	p.base.payloadSeen.Store(true)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.sink = write
+	if p.base.wasSuperseded() {
+		p.clearLocked()
+		return len(payload), nil
+	}
+	bufferedBytes := p.pendingBytes + len(p.parser.pending)
+	if bufferedBytes > goldenWebSocketMaxBufferedBytes ||
+		len(payload) > goldenWebSocketMaxBufferedBytes-bufferedBytes {
+		p.base.releaseRequest()
+		return 0, errors.New("golden WebSocket frame buffer exceeds limit")
+	}
+	frames, err := p.parser.append(payload)
+	if err != nil {
+		p.base.releaseRequest()
+		return 0, err
+	}
+	for _, frame := range frames {
+		if p.pendingBytes > goldenWebSocketMaxBufferedBytes-len(frame) {
+			p.base.releaseRequest()
+			return 0, errors.New("golden WebSocket frame buffer exceeds limit")
+		}
+		p.pending = append(p.pending, frame)
+		p.pendingBytes += len(frame)
+		if err := p.flushEligibleLocked(ctx); err != nil {
+			p.base.releaseRequest()
+			return 0, err
+		}
+	}
+	if err := p.flushEligibleLocked(ctx); err != nil {
+		p.base.releaseRequest()
+		return 0, err
+	}
+	return len(payload), nil
+}
+
+func (p *goldenWebSocketPacer) flushEligibleLocked(ctx context.Context) error {
+	for len(p.pending) > 0 && p.shouldFlushFrameLocked() {
+		if err := p.writeQueuedFrameLocked(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *goldenWebSocketPacer) writeQueuedFrameLocked(ctx context.Context) error {
+	frame := p.pending[0]
+	written, err := p.writeFrameLocked(ctx, frame)
+	if written < 0 || written > len(frame) {
+		return errors.New("golden WebSocket writer returned an invalid byte count")
+	}
+	if written > 0 {
+		p.pendingBytes -= written
+		if written == len(frame) {
+			p.pending[0] = nil
+			p.pending = p.pending[1:]
+		} else {
+			p.pending[0] = append([]byte(nil), frame[written:]...)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	if written != len(frame) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+func (p *goldenWebSocketPacer) shouldFlushFrameLocked() bool {
+	if p.base.wasSuperseded() || p.base.isReleased() {
+		return true
+	}
+	// Control frames must not wait behind the deployment gate. They carry
+	// heartbeats and close handshakes, and delaying them can make an otherwise
+	// healthy peer time out while data is held. Flush any preceding data frames
+	// too, so the wire order stays intact.
+	if p.hasPendingImmediateControlFrameLocked() || goldenWebSocketImmediateControlFramePrefix(p.parser.pending) {
+		return true
+	}
+	// Include an incomplete trailing frame in the held tail. If there is only
+	// one complete frame and no trailing bytes, retain it until release so a
+	// finite response cannot complete early.
+	tailBytes := p.pendingBytes + len(p.parser.pending)
+	if tailBytes <= p.base.holdbackBytes {
+		return false
+	}
+	return len(p.pending) > 1 || len(p.parser.pending) > 0
+}
+
+func (p *goldenWebSocketPacer) hasPendingImmediateControlFrameLocked() bool {
+	for _, frame := range p.pending {
+		if goldenWebSocketImmediateControlFrame(frame) {
+			return true
+		}
+	}
+	return false
+}
+
+func goldenWebSocketImmediateControlFramePrefix(payload []byte) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	opcode := payload[0] & 0x0f
+	return opcode == 0x9 || opcode == 0xa
+}
+
+func goldenWebSocketImmediateControlFrame(frame []byte) bool {
+	return goldenWebSocketImmediateControlFramePrefix(frame)
+}
+
+func (p *goldenWebSocketPacer) writeFrameLocked(ctx context.Context, frame []byte) (int, error) {
+	if p.sink == nil {
+		return 0, errors.New("golden WebSocket pacing sink is unavailable")
+	}
+	if p.base.wasSuperseded() {
+		return len(frame), nil
+	}
+	if p.started && !p.base.isReleased() && !goldenWebSocketImmediateControlFrame(frame) {
+		if err := p.base.delay.wait(ctx, p.base.gateReleased, p.base.requestReleased, p.base.interval); err != nil {
+			return 0, err
+		}
+		if p.base.wasSuperseded() {
+			return len(frame), nil
+		}
+	}
+	// Complete frames are forwarded as whole records. The held tail keeps the
+	// request open across the deployment boundary while the interval preserves
+	// the pacing runway provided by the generic response pacer.
+	p.started = true
+	return goldenWriteAll(p.sink, frame)
+}
+
+func goldenWriteAll(write func([]byte) (int, error), payload []byte) (int, error) {
+	total := 0
+	for len(payload) > 0 {
+		n, err := write(payload)
+		if n < 0 || n > len(payload) {
+			return total, errors.New("golden WebSocket writer returned an invalid byte count")
+		}
+		total += n
+		payload = payload[n:]
+		if err != nil {
+			return total, err
+		}
+		if n == 0 {
+			return total, io.ErrShortWrite
+		}
+	}
+	return total, nil
+}
+
+func (p *goldenWebSocketPacer) clearLocked() {
+	p.parser.pending = nil
+	p.pending = nil
+	p.pendingBytes = 0
+}
+
+func (p *goldenWebSocketPacer) waitAndFlush() error {
+	if p == nil {
+		return nil
+	}
+	select {
+	case <-p.base.gateReleased:
+	case <-p.base.requestReleased:
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.base.wasSuperseded() {
+		p.clearLocked()
+		return nil
+	}
+	if len(p.parser.pending) != 0 {
+		return errors.New("golden WebSocket stream ended with an incomplete frame")
+	}
+	for len(p.pending) > 0 {
+		if err := p.writeQueuedFrameLocked(context.Background()); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/subrouter-transport-observer/golden_websocket_pacing.go
+++ b/cmd/subrouter-transport-observer/golden_websocket_pacing.go
@@ -54,7 +54,20 @@ func goldenWebSocketFrameLength(payload []byte) (length int, complete bool, err 
 	if len(payload) < 2 {
 		return 0, false, nil
 	}
+	first := payload[0]
+	opcode := first & 0x0f
 	payloadLength := uint64(payload[1] & 0x7f)
+	if opcode >= 0x8 {
+		if first&0x80 == 0 {
+			return 0, false, errors.New("golden WebSocket control frame is fragmented")
+		}
+		if opcode != 0x8 && opcode != 0x9 && opcode != 0xa {
+			return 0, false, errors.New("golden WebSocket control opcode is reserved")
+		}
+		if payloadLength >= 126 {
+			return 0, false, errors.New("golden WebSocket control frame is oversized")
+		}
+	}
 	headerLength := 2
 	switch payloadLength {
 	case 126:
@@ -92,17 +105,23 @@ func goldenWebSocketFrameLength(payload []byte) (length int, complete bool, err 
 }
 
 // goldenWebSocketPacer applies the golden response gate to complete
-// WebSocket frames. It shares supersession and release state with the generic
-// response pacer, but uses one frame per pacing interval instead of splitting
-// arbitrary byte slices.
+// WebSocket frames. Writes only parse and enqueue; a single writer goroutine
+// owns delivery, so upstream reads continue while data frames are paced.
 type goldenWebSocketPacer struct {
-	base         *goldenResponsePacer
-	mu           sync.Mutex
-	parser       goldenWebSocketFrameParser
-	pending      [][]byte
-	pendingBytes int
-	started      bool
-	sink         func([]byte) (int, error)
+	base          *goldenResponsePacer
+	mu            sync.Mutex
+	parser        goldenWebSocketFrameParser
+	pending       [][]byte
+	pendingBytes  int
+	started       bool
+	sink          func([]byte) (int, error)
+	ctx           context.Context
+	notify        chan struct{}
+	controlWake   chan struct{}
+	writerDone    chan struct{}
+	writerStarted bool
+	closing       bool
+	writerErr     error
 }
 
 func newGoldenWebSocketPacer(base *goldenResponsePacer) *goldenWebSocketPacer {
@@ -110,13 +129,17 @@ func newGoldenWebSocketPacer(base *goldenResponsePacer) *goldenWebSocketPacer {
 		return nil
 	}
 	return &goldenWebSocketPacer{
-		base: base,
+		base:        base,
+		notify:      make(chan struct{}, 1),
+		controlWake: make(chan struct{}, 1),
+		writerDone:  make(chan struct{}),
 	}
 }
 
 func (p *goldenWebSocketPacer) releaseRequest() {
 	if p != nil {
 		p.base.releaseRequest()
+		p.signal()
 	}
 }
 
@@ -132,94 +155,100 @@ func (p *goldenWebSocketPacer) write(
 	if p == nil || len(payload) == 0 {
 		return write(payload)
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	p.base.payloadSeen.Store(true)
 	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.sink = write
 	if p.base.wasSuperseded() {
-		p.clearLocked()
+		p.mu.Unlock()
 		return len(payload), nil
+	}
+	if p.writerErr != nil {
+		err := p.writerErr
+		p.mu.Unlock()
+		return 0, err
+	}
+	if p.closing {
+		p.mu.Unlock()
+		return 0, io.ErrClosedPipe
+	}
+	if p.sink == nil {
+		p.sink = write
+		p.ctx = ctx
 	}
 	bufferedBytes := p.pendingBytes + len(p.parser.pending)
 	if bufferedBytes > goldenWebSocketMaxBufferedBytes ||
 		len(payload) > goldenWebSocketMaxBufferedBytes-bufferedBytes {
-		p.base.releaseRequest()
-		return 0, errors.New("golden WebSocket frame buffer exceeds limit")
+		err := errors.New("golden WebSocket frame buffer exceeds limit")
+		p.setWriterErrorLocked(err)
+		p.mu.Unlock()
+		return 0, err
 	}
 	frames, err := p.parser.append(payload)
 	if err != nil {
-		p.base.releaseRequest()
+		p.setWriterErrorLocked(err)
+		p.mu.Unlock()
 		return 0, err
 	}
+	controlPending := goldenWebSocketImmediateControlFramePrefix(p.parser.pending)
 	for _, frame := range frames {
 		if p.pendingBytes > goldenWebSocketMaxBufferedBytes-len(frame) {
-			p.base.releaseRequest()
-			return 0, errors.New("golden WebSocket frame buffer exceeds limit")
+			err := errors.New("golden WebSocket frame buffer exceeds limit")
+			p.setWriterErrorLocked(err)
+			p.mu.Unlock()
+			return 0, err
 		}
 		p.pending = append(p.pending, frame)
 		p.pendingBytes += len(frame)
+		controlPending = controlPending || goldenWebSocketImmediateControlFrame(frame)
 	}
-	// Queue the whole parser batch before deciding whether to pace. A control
-	// frame later in this read must also make preceding data frames immediate.
-	if err := p.flushEligibleLocked(ctx); err != nil {
-		p.base.releaseRequest()
-		return 0, err
+	p.startWriterLocked()
+	p.signalLocked()
+	if controlPending {
+		p.signalControlLocked()
 	}
+	p.mu.Unlock()
 	return len(payload), nil
 }
 
-func (p *goldenWebSocketPacer) flushEligibleLocked(ctx context.Context) error {
-	for len(p.pending) > 0 && p.shouldFlushFrameLocked() {
-		if err := p.writeQueuedFrameLocked(ctx); err != nil {
-			return err
-		}
+func (p *goldenWebSocketPacer) startWriterLocked() {
+	if p.writerStarted {
+		return
 	}
-	return nil
+	p.writerStarted = true
+	go p.runWriter()
 }
 
-func (p *goldenWebSocketPacer) writeQueuedFrameLocked(ctx context.Context) error {
-	frame := p.pending[0]
-	written, err := p.writeFrameLocked(ctx, frame)
-	if written < 0 || written > len(frame) {
-		return errors.New("golden WebSocket writer returned an invalid byte count")
+func (p *goldenWebSocketPacer) signal() {
+	select {
+	case p.notify <- struct{}{}:
+	default:
 	}
-	if written > 0 {
-		p.pendingBytes -= written
-		if written == len(frame) {
-			p.pending[0] = nil
-			p.pending = p.pending[1:]
-		} else {
-			p.pending[0] = append([]byte(nil), frame[written:]...)
-		}
-	}
-	if err != nil {
-		return err
-	}
-	if written != len(frame) {
-		return io.ErrShortWrite
-	}
-	return nil
 }
 
-func (p *goldenWebSocketPacer) shouldFlushFrameLocked() bool {
-	if p.base.wasSuperseded() || p.base.isReleased() {
-		return true
+func (p *goldenWebSocketPacer) signalLocked() {
+	p.signal()
+}
+
+func (p *goldenWebSocketPacer) signalControlLocked() {
+	select {
+	case p.controlWake <- struct{}{}:
+	default:
 	}
-	// Control frames must not wait behind the deployment gate. They carry
-	// heartbeats and close handshakes, and delaying them can make an otherwise
-	// healthy peer time out while data is held. Flush any preceding data frames
-	// too, so the wire order stays intact.
-	if p.hasPendingImmediateControlFrameLocked() || goldenWebSocketImmediateControlFramePrefix(p.parser.pending) {
-		return true
-	}
-	// Include an incomplete trailing frame in the held tail. If there is only
-	// one complete frame and no trailing bytes, retain it until release so a
-	// finite response cannot complete early.
-	tailBytes := p.pendingBytes + len(p.parser.pending)
-	if tailBytes <= p.base.holdbackBytes {
+}
+
+func goldenWebSocketImmediateControlFramePrefix(payload []byte) bool {
+	if len(payload) < 2 {
 		return false
 	}
-	return len(p.pending) > 1 || len(p.parser.pending) > 0
+	opcode := payload[0] & 0x0f
+	return payload[0]&0x80 != 0 &&
+		(opcode == 0x9 || opcode == 0xa) && payload[1]&0x7f < 126
+}
+
+func goldenWebSocketImmediateControlFrame(frame []byte) bool {
+	return goldenWebSocketImmediateControlFramePrefix(frame)
 }
 
 func (p *goldenWebSocketPacer) hasPendingImmediateControlFrameLocked() bool {
@@ -229,41 +258,6 @@ func (p *goldenWebSocketPacer) hasPendingImmediateControlFrameLocked() bool {
 		}
 	}
 	return false
-}
-
-func goldenWebSocketImmediateControlFramePrefix(payload []byte) bool {
-	if len(payload) == 0 {
-		return false
-	}
-	opcode := payload[0] & 0x0f
-	return opcode == 0x9 || opcode == 0xa
-}
-
-func goldenWebSocketImmediateControlFrame(frame []byte) bool {
-	return goldenWebSocketImmediateControlFramePrefix(frame)
-}
-
-func (p *goldenWebSocketPacer) writeFrameLocked(ctx context.Context, frame []byte) (int, error) {
-	if p.sink == nil {
-		return 0, errors.New("golden WebSocket pacing sink is unavailable")
-	}
-	if p.base.wasSuperseded() {
-		return len(frame), nil
-	}
-	if p.started && !p.base.isReleased() && !goldenWebSocketImmediateControlFrame(frame) &&
-		!p.hasPendingImmediateControlFrameLocked() && !goldenWebSocketImmediateControlFramePrefix(p.parser.pending) {
-		if err := p.base.delay.wait(ctx, p.base.gateReleased, p.base.requestReleased, p.base.interval); err != nil {
-			return 0, err
-		}
-		if p.base.wasSuperseded() {
-			return len(frame), nil
-		}
-	}
-	// Complete frames are forwarded as whole records. The held tail keeps the
-	// request open across the deployment boundary while the interval preserves
-	// the pacing runway provided by the generic response pacer.
-	p.started = true
-	return goldenWriteAll(p.sink, frame)
 }
 
 func goldenWriteAll(write func([]byte) (int, error), payload []byte) (int, error) {
@@ -291,6 +285,185 @@ func (p *goldenWebSocketPacer) clearLocked() {
 	p.pendingBytes = 0
 }
 
+func (p *goldenWebSocketPacer) setWriterErrorLocked(err error) {
+	if err == nil || p.writerErr != nil {
+		return
+	}
+	p.writerErr = err
+	p.closing = true
+	p.base.releaseRequest()
+	p.signalLocked()
+}
+
+func (p *goldenWebSocketPacer) waitForNotification(ctx context.Context) error {
+	select {
+	case <-p.notify:
+		return nil
+	case <-p.base.gateReleased:
+		return nil
+	case <-p.base.requestReleased:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (p *goldenWebSocketPacer) waitForInterval(ctx context.Context) (bool, error) {
+	return p.base.delay.wait(ctx, p.base.gateReleased, p.base.requestReleased, p.controlWake, p.base.interval)
+}
+
+func (p *goldenWebSocketPacer) drainControlWakeLocked() {
+	for {
+		select {
+		case <-p.controlWake:
+		default:
+			return
+		}
+	}
+}
+
+func (p *goldenWebSocketPacer) shouldFlushFrameLocked() bool {
+	if p.base.wasSuperseded() || p.base.isReleased() {
+		return true
+	}
+	// Ping and Pong frames must not wait behind the deployment gate. Flush any
+	// preceding data frames too, so the wire order stays intact.
+	if p.hasPendingImmediateControlFrameLocked() || goldenWebSocketImmediateControlFramePrefix(p.parser.pending) {
+		return true
+	}
+	// Include an incomplete trailing frame in the held tail. If there is only
+	// one complete frame and no trailing bytes, retain it until release so a
+	// finite response cannot complete early.
+	tailBytes := p.pendingBytes + len(p.parser.pending)
+	if tailBytes <= p.base.holdbackBytes {
+		return false
+	}
+	return len(p.pending) > 1 || len(p.parser.pending) > 0
+}
+
+func (p *goldenWebSocketPacer) frameNeedsDelayLocked(frame []byte) bool {
+	return p.started && !p.base.isReleased() && !goldenWebSocketImmediateControlFrame(frame) &&
+		!p.hasPendingImmediateControlFrameLocked() && !goldenWebSocketImmediateControlFramePrefix(p.parser.pending)
+}
+
+func (p *goldenWebSocketPacer) runWriter() {
+	defer close(p.writerDone)
+	for {
+		p.mu.Lock()
+		if p.writerErr != nil {
+			p.mu.Unlock()
+			return
+		}
+		if p.base.wasSuperseded() {
+			p.clearLocked()
+			p.mu.Unlock()
+			return
+		}
+		if len(p.pending) == 0 {
+			if p.closing {
+				p.mu.Unlock()
+				return
+			}
+			ctx := p.ctx
+			p.mu.Unlock()
+			if err := p.waitForNotification(ctx); err != nil {
+				p.mu.Lock()
+				p.setWriterErrorLocked(err)
+				p.mu.Unlock()
+				return
+			}
+			continue
+		}
+		if !p.shouldFlushFrameLocked() {
+			ctx := p.ctx
+			p.mu.Unlock()
+			if err := p.waitForNotification(ctx); err != nil {
+				p.mu.Lock()
+				p.setWriterErrorLocked(err)
+				p.mu.Unlock()
+				return
+			}
+			continue
+		}
+		needDelay := p.frameNeedsDelayLocked(p.pending[0])
+		if needDelay {
+			p.drainControlWakeLocked()
+		}
+		ctx := p.ctx
+		p.mu.Unlock()
+		if needDelay {
+			woken, err := p.waitForInterval(ctx)
+			if err != nil {
+				p.mu.Lock()
+				p.setWriterErrorLocked(err)
+				p.mu.Unlock()
+				return
+			}
+			if woken {
+				continue
+			}
+		}
+
+		p.mu.Lock()
+		if p.writerErr != nil {
+			p.mu.Unlock()
+			return
+		}
+		if p.base.wasSuperseded() {
+			p.clearLocked()
+			p.mu.Unlock()
+			return
+		}
+		if len(p.pending) == 0 || !p.shouldFlushFrameLocked() {
+			p.mu.Unlock()
+			continue
+		}
+		frame := p.pending[0]
+		if p.frameNeedsDelayLocked(frame) {
+			p.mu.Unlock()
+			continue
+		}
+		sink := p.sink
+		p.mu.Unlock()
+		if sink == nil {
+			p.mu.Lock()
+			p.setWriterErrorLocked(errors.New("golden WebSocket pacing sink is unavailable"))
+			p.mu.Unlock()
+			return
+		}
+		written, err := goldenWriteAll(sink, frame)
+
+		p.mu.Lock()
+		if written < 0 || written > len(frame) {
+			p.setWriterErrorLocked(errors.New("golden WebSocket writer returned an invalid byte count"))
+			p.mu.Unlock()
+			return
+		}
+		if written > 0 {
+			p.pendingBytes -= written
+			if written == len(frame) {
+				p.pending[0] = nil
+				p.pending = p.pending[1:]
+			} else {
+				p.pending[0] = append([]byte(nil), frame[written:]...)
+			}
+		}
+		if err != nil {
+			p.setWriterErrorLocked(err)
+			p.mu.Unlock()
+			return
+		}
+		if written != len(frame) {
+			p.setWriterErrorLocked(io.ErrShortWrite)
+			p.mu.Unlock()
+			return
+		}
+		p.started = true
+		p.signalLocked()
+		p.mu.Unlock()
+	}
+}
+
 func (p *goldenWebSocketPacer) waitAndFlush() error {
 	if p == nil {
 		return nil
@@ -300,18 +473,28 @@ func (p *goldenWebSocketPacer) waitAndFlush() error {
 	case <-p.base.requestReleased:
 	}
 	p.mu.Lock()
+	p.closing = true
+	started := p.writerStarted
+	done := p.writerDone
+	p.signalLocked()
+	p.mu.Unlock()
+	if started {
+		<-done
+	}
+	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.base.wasSuperseded() {
 		p.clearLocked()
 		return nil
 	}
+	if p.writerErr != nil {
+		return p.writerErr
+	}
 	if len(p.parser.pending) != 0 {
 		return errors.New("golden WebSocket stream ended with an incomplete frame")
 	}
-	for len(p.pending) > 0 {
-		if err := p.writeQueuedFrameLocked(context.Background()); err != nil {
-			return err
-		}
+	if len(p.pending) != 0 {
+		return errors.New("golden WebSocket writer stopped with pending frames")
 	}
 	return nil
 }

--- a/cmd/subrouter-transport-observer/golden_websocket_pacing.go
+++ b/cmd/subrouter-transport-observer/golden_websocket_pacing.go
@@ -158,11 +158,9 @@ func (p *goldenWebSocketPacer) write(
 		}
 		p.pending = append(p.pending, frame)
 		p.pendingBytes += len(frame)
-		if err := p.flushEligibleLocked(ctx); err != nil {
-			p.base.releaseRequest()
-			return 0, err
-		}
 	}
+	// Queue the whole parser batch before deciding whether to pace. A control
+	// frame later in this read must also make preceding data frames immediate.
 	if err := p.flushEligibleLocked(ctx); err != nil {
 		p.base.releaseRequest()
 		return 0, err

--- a/cmd/subrouter-transport-observer/golden_websocket_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_websocket_pacing_test.go
@@ -180,6 +180,33 @@ func TestGoldenWebSocketPacerKeepsCloseFrameInHeldTail(t *testing.T) {
 	}
 }
 
+func TestGoldenWebSocketPacerDoesNotDelayQueuedPing(t *testing.T) {
+	gate := newGoldenResponseGate()
+	base := gate.newResponsePacer("queued-ping-test")
+	delay := &accumulatingObserverDelay{}
+	base.delay = delay
+	pacer := newGoldenWebSocketPacer(base)
+	sink := func(payload []byte) (int, error) { return len(payload), nil }
+	frames := make([]byte, 0, 300)
+	for index := 0; index < 100; index++ {
+		frames = append(frames, 0x81, 0x01, byte('a'+index%26))
+	}
+	if _, err := pacer.write(context.Background(), frames, sink); err != nil {
+		t.Fatalf("data write: %v", err)
+	}
+	beforePing := delay.elapsed
+	if _, err := pacer.write(context.Background(), []byte{0x89, 0x00}, sink); err != nil {
+		t.Fatalf("ping write: %v", err)
+	}
+	if delay.elapsed != beforePing {
+		t.Fatalf("queued Ping added a pacing delay: before=%s after=%s", beforePing, delay.elapsed)
+	}
+	gate.releasePacing()
+	if err := pacer.waitAndFlush(); err != nil {
+		t.Fatalf("waitAndFlush: %v", err)
+	}
+}
+
 func TestGoldenWebSocketFrameParserRejectsOversizedFrames(t *testing.T) {
 	parser := goldenWebSocketFrameParser{}
 	length := uint64(goldenWebSocketMaxFrameBytes)

--- a/cmd/subrouter-transport-observer/golden_websocket_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_websocket_pacing_test.go
@@ -207,6 +207,41 @@ func TestGoldenWebSocketPacerDoesNotDelayQueuedPing(t *testing.T) {
 	}
 }
 
+func TestGoldenWebSocketPacerDoesNotDelayControlFrameInSameWrite(t *testing.T) {
+	gate := newGoldenResponseGate()
+	base := gate.newResponsePacer("same-write-ping-test")
+	delay := &accumulatingObserverDelay{}
+	base.delay = delay
+	pacer := newGoldenWebSocketPacer(base)
+	var writes [][]byte
+	sink := func(payload []byte) (int, error) {
+		writes = append(writes, append([]byte(nil), payload...))
+		return len(payload), nil
+	}
+
+	// The ping is in the same read as enough data to cross the holdback. The
+	// pacer must inspect the complete batch before applying a data-frame delay.
+	stream := make([]byte, 0, 100*3+2)
+	for index := 0; index < 100; index++ {
+		stream = append(stream, 0x81, 0x01, byte('a'+index%26))
+	}
+	stream = append(stream, 0x89, 0x00)
+	if _, err := pacer.write(context.Background(), stream, sink); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if delay.elapsed != 0 {
+		t.Fatalf("same-write Ping added a pacing delay: %s", delay.elapsed)
+	}
+	if len(writes) != 101 || !bytes.Equal(writes[len(writes)-1], []byte{0x89, 0x00}) {
+		t.Fatalf("same-write Ping was not delivered promptly: %x", writes)
+	}
+
+	gate.releasePacing()
+	if err := pacer.waitAndFlush(); err != nil {
+		t.Fatalf("waitAndFlush: %v", err)
+	}
+}
+
 func TestGoldenWebSocketFrameParserRejectsOversizedFrames(t *testing.T) {
 	parser := goldenWebSocketFrameParser{}
 	length := uint64(goldenWebSocketMaxFrameBytes)
@@ -240,6 +275,36 @@ func TestGoldenWebSocketPacerRetainsPartialWriteProgress(t *testing.T) {
 	}
 	if !bytes.Equal(delivered.Bytes(), frame) {
 		t.Fatalf("partial write was duplicated or lost: got %x want %x", delivered.Bytes(), frame)
+	}
+}
+
+func TestCountingConnEmitsClosedEventWhenWebSocketFlushFails(t *testing.T) {
+	gate := newGoldenResponseGate()
+	base := gate.newResponsePacer("truncated-close-test")
+	stats := newObserverStats()
+	observation := newObserver(io.Discard, stats)
+	peer, connection := net.Pipe()
+	t.Cleanup(func() {
+		_ = peer.Close()
+		_ = connection.Close()
+	})
+
+	counted := &countingConn{
+		Conn: connection, observer: observation,
+		meta:    requestEvidence{connectionID: "truncated-websocket"},
+		context: context.Background(), pacer: base,
+		websocketPacer: newGoldenWebSocketPacer(base),
+	}
+	if _, err := counted.Write([]byte{0x81}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	gate.releasePacing()
+	if err := counted.Close(); err == nil {
+		t.Fatal("Close succeeded for a truncated WebSocket frame")
+	}
+	closed := stats.closedSnapshot()
+	if len(closed) != 1 || closed[0].ConnectionID != "truncated-websocket" {
+		t.Fatalf("closed events = %+v, want one truncated-websocket event", closed)
 	}
 }
 

--- a/cmd/subrouter-transport-observer/golden_websocket_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_websocket_pacing_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+)
+
+func TestGoldenWebSocketPacerKeepsFramesIntactWhileGateIsHeld(t *testing.T) {
+	gate := newGoldenResponseGate()
+	base := gate.newResponsePacer("0123456789abcdef0123456789abcdef")
+	pacer := newGoldenWebSocketPacer(base)
+	if pacer == nil {
+		t.Fatal("newGoldenWebSocketPacer returned nil")
+	}
+
+	var writes [][]byte
+	sink := func(payload []byte) (int, error) {
+		writes = append(writes, append([]byte(nil), payload...))
+		return len(payload), nil
+	}
+	frames := make([][]byte, 0, 128)
+	for index := 0; index < 128; index++ {
+		frame := []byte{0x81, 0x01, byte('a' + index%26)}
+		frames = append(frames, frame)
+	}
+	stream := bytes.Join(frames, nil)
+	for offset := 0; offset < len(stream); {
+		end := offset + 7
+		if end > len(stream) {
+			end = len(stream)
+		}
+		if n, err := pacer.write(context.Background(), stream[offset:end], sink); err != nil {
+			t.Fatalf("write: %v", err)
+		} else if n != end-offset {
+			t.Fatalf("write count = %d, want %d", n, end-offset)
+		}
+		offset = end
+	}
+
+	if len(writes) == 0 {
+		t.Fatal("pacer did not emit any complete frame while the stream was active")
+	}
+	for index, write := range writes {
+		if len(write)%3 != 0 {
+			t.Fatalf("write %d split a WebSocket frame: %d bytes", index, len(write))
+		}
+		for offset := 0; offset < len(write); offset += 3 {
+			if write[offset] != 0x81 || write[offset+1] != 0x01 {
+				t.Fatalf("write %d contains malformed frame at byte %d: %x", index, offset, write[offset:offset+3])
+			}
+		}
+	}
+
+	gate.releasePacing()
+	if err := pacer.waitAndFlush(); err != nil {
+		t.Fatalf("waitAndFlush: %v", err)
+	}
+	var delivered bytes.Buffer
+	for _, write := range writes {
+		_, _ = delivered.Write(write)
+	}
+	if !bytes.Equal(delivered.Bytes(), stream) {
+		t.Fatalf("delivered stream differs from input: got %d bytes, want %d", delivered.Len(), len(stream))
+	}
+}
+
+func TestGoldenWebSocketFrameParserSupportsFragmentedExtendedFrames(t *testing.T) {
+	parser := goldenWebSocketFrameParser{}
+	payload := bytes.Repeat([]byte{'x'}, 126)
+	frame := append([]byte{0x82, 126, 0, 126}, payload...)
+	frame = append(frame, 0x88, 0x00)
+
+	var frames [][]byte
+	for _, chunk := range [][]byte{frame[:1], frame[1:3], frame[3:17], frame[17:]} {
+		parsed, err := parser.append(chunk)
+		if err != nil {
+			t.Fatalf("append: %v", err)
+		}
+		frames = append(frames, parsed...)
+	}
+	if len(frames) != 2 {
+		t.Fatalf("parsed %d frames, want 2", len(frames))
+	}
+	if !bytes.Equal(frames[0], frame[:len(frame)-2]) {
+		t.Fatalf("extended frame changed during parsing")
+	}
+	if !bytes.Equal(frames[1], frame[len(frame)-2:]) {
+		t.Fatalf("control frame changed during parsing")
+	}
+	if pending := parser.pending; len(pending) != 0 {
+		t.Fatalf("parser retained %d bytes after complete frames", len(pending))
+	}
+}
+
+func TestGoldenWebSocketFrameParserRejectsInvalidLength(t *testing.T) {
+	parser := goldenWebSocketFrameParser{}
+	_, err := parser.append([]byte{0x82, 0x7f, 0x80, 0, 0, 0, 0, 0, 0})
+	if err == nil {
+		t.Fatal("parser accepted a frame with the reserved 64-bit length bit set")
+	}
+	if err == io.EOF {
+		t.Fatal("parser reported an incomplete frame instead of invalid length")
+	}
+}

--- a/cmd/subrouter-transport-observer/golden_websocket_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_websocket_pacing_test.go
@@ -1,15 +1,21 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
 func TestGoldenWebSocketPacerKeepsFramesIntactWhileGateIsHeld(t *testing.T) {
 	gate := newGoldenResponseGate()
 	base := gate.newResponsePacer("0123456789abcdef0123456789abcdef")
+	delay := &accumulatingObserverDelay{}
+	base.delay = delay
 	pacer := newGoldenWebSocketPacer(base)
 	if pacer == nil {
 		t.Fatal("newGoldenWebSocketPacer returned nil")
@@ -41,6 +47,9 @@ func TestGoldenWebSocketPacerKeepsFramesIntactWhileGateIsHeld(t *testing.T) {
 
 	if len(writes) == 0 {
 		t.Fatal("pacer did not emit any complete frame while the stream was active")
+	}
+	if delay.elapsed == 0 {
+		t.Fatal("pacer did not apply an interval between data frames")
 	}
 	for index, write := range writes {
 		if len(write)%3 != 0 {
@@ -96,11 +105,166 @@ func TestGoldenWebSocketFrameParserSupportsFragmentedExtendedFrames(t *testing.T
 
 func TestGoldenWebSocketFrameParserRejectsInvalidLength(t *testing.T) {
 	parser := goldenWebSocketFrameParser{}
-	_, err := parser.append([]byte{0x82, 0x7f, 0x80, 0, 0, 0, 0, 0, 0})
+	_, err := parser.append([]byte{0x82, 0x7f, 0x80, 0, 0, 0, 0, 0, 0, 0})
 	if err == nil {
 		t.Fatal("parser accepted a frame with the reserved 64-bit length bit set")
 	}
 	if err == io.EOF {
 		t.Fatal("parser reported an incomplete frame instead of invalid length")
+	}
+}
+
+func TestGoldenWebSocketPacerFlushesControlFramesBeforeGateRelease(t *testing.T) {
+	gate := newGoldenResponseGate()
+	base := gate.newResponsePacer("control-frame-test")
+	base.delay = &accumulatingObserverDelay{}
+	pacer := newGoldenWebSocketPacer(base)
+	var writes [][]byte
+	sink := func(payload []byte) (int, error) {
+		writes = append(writes, append([]byte(nil), payload...))
+		return len(payload), nil
+	}
+
+	// A control frame may arrive split across reads and after a held data frame.
+	// The complete data frame must be sent first to preserve wire order, then the
+	// control frame must be sent without waiting for the gate.
+	if _, err := pacer.write(context.Background(), []byte{0x81, 0x01, 'x'}, sink); err != nil {
+		t.Fatalf("data write: %v", err)
+	}
+	if _, err := pacer.write(context.Background(), []byte{0x89}, sink); err != nil {
+		t.Fatalf("partial control write: %v", err)
+	}
+	if len(writes) != 1 || !bytes.Equal(writes[0], []byte{0x81, 0x01, 'x'}) {
+		t.Fatalf("held data was not flushed before a control frame: %x", writes)
+	}
+	if _, err := pacer.write(context.Background(), []byte{0x00}, sink); err != nil {
+		t.Fatalf("control write: %v", err)
+	}
+	if len(writes) != 2 || !bytes.Equal(writes[1], []byte{0x89, 0x00}) {
+		t.Fatalf("control frame was held behind the gate: %x", writes)
+	}
+
+	gate.releasePacing()
+	if err := pacer.waitAndFlush(); err != nil {
+		t.Fatalf("waitAndFlush: %v", err)
+	}
+}
+
+func TestGoldenWebSocketPacerKeepsCloseFrameInHeldTail(t *testing.T) {
+	gate := newGoldenResponseGate()
+	base := gate.newResponsePacer("close-frame-test")
+	base.delay = &accumulatingObserverDelay{}
+	pacer := newGoldenWebSocketPacer(base)
+	var writes [][]byte
+	sink := func(payload []byte) (int, error) {
+		writes = append(writes, append([]byte(nil), payload...))
+		return len(payload), nil
+	}
+	stream := []byte{0x81, 0x01, 'x', 0x88, 0x00}
+	if _, err := pacer.write(context.Background(), stream, sink); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if len(writes) != 0 {
+		t.Fatalf("close/data tail was exposed before gate release: %x", writes)
+	}
+	gate.releasePacing()
+	if err := pacer.waitAndFlush(); err != nil {
+		t.Fatalf("waitAndFlush: %v", err)
+	}
+	var delivered bytes.Buffer
+	for _, write := range writes {
+		_, _ = delivered.Write(write)
+	}
+	if !bytes.Equal(delivered.Bytes(), stream) {
+		t.Fatalf("close frame was not released after gate release: %x", writes)
+	}
+}
+
+func TestGoldenWebSocketFrameParserRejectsOversizedFrames(t *testing.T) {
+	parser := goldenWebSocketFrameParser{}
+	length := uint64(goldenWebSocketMaxFrameBytes)
+	header := []byte{0x82, 0x7f, byte(length >> 56), byte(length >> 48), byte(length >> 40), byte(length >> 32), byte(length >> 24), byte(length >> 16), byte(length >> 8), byte(length)}
+	if _, err := parser.append(header); err == nil {
+		t.Fatal("parser accepted a frame larger than the observer limit")
+	}
+}
+
+func TestGoldenWebSocketPacerRetainsPartialWriteProgress(t *testing.T) {
+	gate := newGoldenResponseGate()
+	base := gate.newResponsePacer("partial-write-test")
+	pacer := newGoldenWebSocketPacer(base)
+	gate.releasePacing()
+	frame := []byte{0x82, 0x03, 'a', 'b', 'c'}
+	var delivered bytes.Buffer
+	first := true
+	sink := func(payload []byte) (int, error) {
+		if first {
+			first = false
+			_, _ = delivered.Write(payload[:2])
+			return 2, io.ErrClosedPipe
+		}
+		return delivered.Write(payload)
+	}
+	if _, err := pacer.write(context.Background(), frame, sink); err == nil {
+		t.Fatal("partial write error was lost")
+	}
+	if err := pacer.waitAndFlush(); err != nil {
+		t.Fatalf("waitAndFlush: %v", err)
+	}
+	if !bytes.Equal(delivered.Bytes(), frame) {
+		t.Fatalf("partial write was duplicated or lost: got %x want %x", delivered.Bytes(), frame)
+	}
+}
+
+type goldenHijackResponseWriter struct {
+	*httptest.ResponseRecorder
+	connection net.Conn
+}
+
+func (w *goldenHijackResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.connection, bufio.NewReadWriter(bufio.NewReader(w.connection), bufio.NewWriter(w.connection)), nil
+}
+
+func TestCountingResponseWriterOnlyUsesWebSocketPacerForWebSocketUpgrade(t *testing.T) {
+	tests := []struct {
+		name      string
+		websocket bool
+		wantPacer bool
+	}{
+		{name: "websocket", websocket: true, wantPacer: true},
+		{name: "other upgrade", websocket: false, wantPacer: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			peer, connection := net.Pipe()
+			defer peer.Close()
+			defer connection.Close()
+			gate := newGoldenResponseGate()
+			observer := newObserver(io.Discard, nil)
+			writer := &countingResponseWriter{
+				ResponseWriter: &goldenHijackResponseWriter{
+					ResponseRecorder: httptest.NewRecorder(), connection: connection,
+				},
+				observer: observer,
+				meta: requestEvidence{
+					transport: "websocket", method: http.MethodGet,
+					path: "/v1/responses", requestID: "request", connectionID: "connection",
+				},
+				context:          context.Background(),
+				pacer:            gate.newResponsePacer("upgrade-test"),
+				websocketUpgrade: test.websocket,
+			}
+			wrapped, _, err := writer.Hijack()
+			if err != nil {
+				t.Fatalf("Hijack: %v", err)
+			}
+			counted, ok := wrapped.(*countingConn)
+			if !ok {
+				t.Fatalf("Hijack returned %T, want *countingConn", wrapped)
+			}
+			if got := counted.websocketPacer != nil; got != test.wantPacer {
+				t.Fatalf("websocket pacer present = %t, want %t", got, test.wantPacer)
+			}
+		})
 	}
 }

--- a/cmd/subrouter-transport-observer/golden_websocket_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_websocket_pacing_test.go
@@ -8,9 +8,53 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 )
+
+type goldenWebSocketWrites struct {
+	mu     sync.Mutex
+	writes [][]byte
+	notify chan struct{}
+}
+
+func newGoldenWebSocketWrites() *goldenWebSocketWrites {
+	return &goldenWebSocketWrites{notify: make(chan struct{}, 1)}
+}
+
+func (w *goldenWebSocketWrites) write(payload []byte) (int, error) {
+	w.mu.Lock()
+	w.writes = append(w.writes, append([]byte(nil), payload...))
+	w.mu.Unlock()
+	select {
+	case w.notify <- struct{}{}:
+	default:
+	}
+	return len(payload), nil
+}
+
+func (w *goldenWebSocketWrites) snapshot() [][]byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([][]byte(nil), w.writes...)
+}
+
+func (w *goldenWebSocketWrites) waitForCount(t *testing.T, count int) {
+	t.Helper()
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	for {
+		if len(w.snapshot()) >= count {
+			return
+		}
+		select {
+		case <-w.notify:
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for %d WebSocket writes, got %d", count, len(w.snapshot()))
+		}
+	}
+}
 
 func TestGoldenWebSocketPacerKeepsFramesIntactWhileGateIsHeld(t *testing.T) {
 	gate := newGoldenResponseGate()
@@ -22,11 +66,7 @@ func TestGoldenWebSocketPacerKeepsFramesIntactWhileGateIsHeld(t *testing.T) {
 		t.Fatal("newGoldenWebSocketPacer returned nil")
 	}
 
-	var writes [][]byte
-	sink := func(payload []byte) (int, error) {
-		writes = append(writes, append([]byte(nil), payload...))
-		return len(payload), nil
-	}
+	writes := newGoldenWebSocketWrites()
 	frames := make([][]byte, 0, 128)
 	for index := 0; index < 128; index++ {
 		frame := []byte{0x81, 0x01, byte('a' + index%26)}
@@ -38,7 +78,7 @@ func TestGoldenWebSocketPacerKeepsFramesIntactWhileGateIsHeld(t *testing.T) {
 		if end > len(stream) {
 			end = len(stream)
 		}
-		if n, err := pacer.write(context.Background(), stream[offset:end], sink); err != nil {
+		if n, err := pacer.write(context.Background(), stream[offset:end], writes.write); err != nil {
 			t.Fatalf("write: %v", err)
 		} else if n != end-offset {
 			t.Fatalf("write count = %d, want %d", n, end-offset)
@@ -46,13 +86,11 @@ func TestGoldenWebSocketPacerKeepsFramesIntactWhileGateIsHeld(t *testing.T) {
 		offset = end
 	}
 
-	if len(writes) == 0 {
-		t.Fatal("pacer did not emit any complete frame while the stream was active")
-	}
-	if delay.elapsed == 0 {
+	writes.waitForCount(t, 1)
+	if delay.elapsedDuration() == 0 {
 		t.Fatal("pacer did not apply an interval between data frames")
 	}
-	for index, write := range writes {
+	for index, write := range writes.snapshot() {
 		if len(write)%3 != 0 {
 			t.Fatalf("write %d split a WebSocket frame: %d bytes", index, len(write))
 		}
@@ -68,7 +106,7 @@ func TestGoldenWebSocketPacerKeepsFramesIntactWhileGateIsHeld(t *testing.T) {
 		t.Fatalf("waitAndFlush: %v", err)
 	}
 	var delivered bytes.Buffer
-	for _, write := range writes {
+	for _, write := range writes.snapshot() {
 		_, _ = delivered.Write(write)
 	}
 	if !bytes.Equal(delivered.Bytes(), stream) {
@@ -141,8 +179,10 @@ func (delay *blockingObserverDelay) wait(
 	ctx context.Context,
 	_ <-chan struct{},
 	_ <-chan struct{},
+	wake <-chan struct{},
 	duration time.Duration,
-) error {
+) (bool, error) {
+	_ = duration
 	select {
 	case <-delay.started:
 	default:
@@ -150,9 +190,11 @@ func (delay *blockingObserverDelay) wait(
 	}
 	select {
 	case <-delay.release:
-		return nil
+		return false, nil
+	case <-wake:
+		return true, nil
 	case <-ctx.Done():
-		return ctx.Err()
+		return false, ctx.Err()
 	}
 }
 
@@ -221,29 +263,27 @@ func TestGoldenWebSocketPacerFlushesControlFramesBeforeGateRelease(t *testing.T)
 	base := gate.newResponsePacer("control-frame-test")
 	base.delay = &accumulatingObserverDelay{}
 	pacer := newGoldenWebSocketPacer(base)
-	var writes [][]byte
-	sink := func(payload []byte) (int, error) {
-		writes = append(writes, append([]byte(nil), payload...))
-		return len(payload), nil
-	}
+	writes := newGoldenWebSocketWrites()
 
 	// A control frame may arrive split across reads and after a held data frame.
 	// The complete data frame must be sent first to preserve wire order, then the
 	// control frame must be sent without waiting for the gate.
-	if _, err := pacer.write(context.Background(), []byte{0x81, 0x01, 'x'}, sink); err != nil {
+	if _, err := pacer.write(context.Background(), []byte{0x81, 0x01, 'x'}, writes.write); err != nil {
 		t.Fatalf("data write: %v", err)
 	}
-	if _, err := pacer.write(context.Background(), []byte{0x89}, sink); err != nil {
+	if _, err := pacer.write(context.Background(), []byte{0x89}, writes.write); err != nil {
 		t.Fatalf("partial control write: %v", err)
 	}
-	if len(writes) != 1 || !bytes.Equal(writes[0], []byte{0x81, 0x01, 'x'}) {
-		t.Fatalf("held data was not flushed before a control frame: %x", writes)
+	if len(writes.snapshot()) != 0 {
+		t.Fatalf("incomplete control frame changed the held tail: %x", writes.snapshot())
 	}
-	if _, err := pacer.write(context.Background(), []byte{0x00}, sink); err != nil {
+	if _, err := pacer.write(context.Background(), []byte{0x00}, writes.write); err != nil {
 		t.Fatalf("control write: %v", err)
 	}
-	if len(writes) != 2 || !bytes.Equal(writes[1], []byte{0x89, 0x00}) {
-		t.Fatalf("control frame was held behind the gate: %x", writes)
+	writes.waitForCount(t, 2)
+	gotWrites := writes.snapshot()
+	if !bytes.Equal(gotWrites[0], []byte{0x81, 0x01, 'x'}) || !bytes.Equal(gotWrites[1], []byte{0x89, 0x00}) {
+		t.Fatalf("control frame was held behind the gate: %x", gotWrites)
 	}
 
 	gate.releasePacing()
@@ -257,28 +297,24 @@ func TestGoldenWebSocketPacerKeepsCloseFrameInHeldTail(t *testing.T) {
 	base := gate.newResponsePacer("close-frame-test")
 	base.delay = &accumulatingObserverDelay{}
 	pacer := newGoldenWebSocketPacer(base)
-	var writes [][]byte
-	sink := func(payload []byte) (int, error) {
-		writes = append(writes, append([]byte(nil), payload...))
-		return len(payload), nil
-	}
+	writes := newGoldenWebSocketWrites()
 	stream := []byte{0x81, 0x01, 'x', 0x88, 0x00}
-	if _, err := pacer.write(context.Background(), stream, sink); err != nil {
+	if _, err := pacer.write(context.Background(), stream, writes.write); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	if len(writes) != 0 {
-		t.Fatalf("close/data tail was exposed before gate release: %x", writes)
+	if len(writes.snapshot()) != 0 {
+		t.Fatalf("close/data tail was exposed before gate release: %x", writes.snapshot())
 	}
 	gate.releasePacing()
 	if err := pacer.waitAndFlush(); err != nil {
 		t.Fatalf("waitAndFlush: %v", err)
 	}
 	var delivered bytes.Buffer
-	for _, write := range writes {
+	for _, write := range writes.snapshot() {
 		_, _ = delivered.Write(write)
 	}
 	if !bytes.Equal(delivered.Bytes(), stream) {
-		t.Fatalf("close frame was not released after gate release: %x", writes)
+		t.Fatalf("close frame was not released after gate release: %x", writes.snapshot())
 	}
 }
 
@@ -296,12 +332,12 @@ func TestGoldenWebSocketPacerDoesNotDelayQueuedPing(t *testing.T) {
 	if _, err := pacer.write(context.Background(), frames, sink); err != nil {
 		t.Fatalf("data write: %v", err)
 	}
-	beforePing := delay.elapsed
+	beforePing := delay.elapsedDuration()
 	if _, err := pacer.write(context.Background(), []byte{0x89, 0x00}, sink); err != nil {
 		t.Fatalf("ping write: %v", err)
 	}
-	if delay.elapsed != beforePing {
-		t.Fatalf("queued Ping added a pacing delay: before=%s after=%s", beforePing, delay.elapsed)
+	if afterPing := delay.elapsedDuration(); afterPing != beforePing {
+		t.Fatalf("queued Ping added a pacing delay: before=%s after=%s", beforePing, afterPing)
 	}
 	gate.releasePacing()
 	if err := pacer.waitAndFlush(); err != nil {
@@ -315,11 +351,7 @@ func TestGoldenWebSocketPacerDoesNotDelayControlFrameInSameWrite(t *testing.T) {
 	delay := &accumulatingObserverDelay{}
 	base.delay = delay
 	pacer := newGoldenWebSocketPacer(base)
-	var writes [][]byte
-	sink := func(payload []byte) (int, error) {
-		writes = append(writes, append([]byte(nil), payload...))
-		return len(payload), nil
-	}
+	writes := newGoldenWebSocketWrites()
 
 	// The ping is in the same read as enough data to cross the holdback. The
 	// pacer must inspect the complete batch before applying a data-frame delay.
@@ -328,14 +360,16 @@ func TestGoldenWebSocketPacerDoesNotDelayControlFrameInSameWrite(t *testing.T) {
 		stream = append(stream, 0x81, 0x01, byte('a'+index%26))
 	}
 	stream = append(stream, 0x89, 0x00)
-	if _, err := pacer.write(context.Background(), stream, sink); err != nil {
+	if _, err := pacer.write(context.Background(), stream, writes.write); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	if delay.elapsed != 0 {
-		t.Fatalf("same-write Ping added a pacing delay: %s", delay.elapsed)
+	writes.waitForCount(t, 101)
+	if elapsed := delay.elapsedDuration(); elapsed != 0 {
+		t.Fatalf("same-write Ping added a pacing delay: %s", elapsed)
 	}
-	if len(writes) != 101 || !bytes.Equal(writes[len(writes)-1], []byte{0x89, 0x00}) {
-		t.Fatalf("same-write Ping was not delivered promptly: %x", writes)
+	gotWrites := writes.snapshot()
+	if len(gotWrites) != 101 || !bytes.Equal(gotWrites[len(gotWrites)-1], []byte{0x89, 0x00}) {
+		t.Fatalf("same-write Ping was not delivered promptly: %x", gotWrites)
 	}
 
 	gate.releasePacing()
@@ -369,14 +403,14 @@ func TestGoldenWebSocketPacerRetainsPartialWriteProgress(t *testing.T) {
 		}
 		return delivered.Write(payload)
 	}
-	if _, err := pacer.write(context.Background(), frame, sink); err == nil {
+	if _, err := pacer.write(context.Background(), frame, sink); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := pacer.waitAndFlush(); err == nil {
 		t.Fatal("partial write error was lost")
 	}
-	if err := pacer.waitAndFlush(); err != nil {
-		t.Fatalf("waitAndFlush: %v", err)
-	}
-	if !bytes.Equal(delivered.Bytes(), frame) {
-		t.Fatalf("partial write was duplicated or lost: got %x want %x", delivered.Bytes(), frame)
+	if !bytes.Equal(delivered.Bytes(), frame[:2]) {
+		t.Fatalf("partial write was duplicated or lost: got %x want prefix %x", delivered.Bytes(), frame[:2])
 	}
 }
 

--- a/cmd/subrouter-transport-observer/golden_websocket_pacing_test.go
+++ b/cmd/subrouter-transport-observer/golden_websocket_pacing_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestGoldenWebSocketPacerKeepsFramesIntactWhileGateIsHeld(t *testing.T) {
@@ -111,6 +112,107 @@ func TestGoldenWebSocketFrameParserRejectsInvalidLength(t *testing.T) {
 	}
 	if err == io.EOF {
 		t.Fatal("parser reported an incomplete frame instead of invalid length")
+	}
+}
+
+func TestGoldenWebSocketFrameParserRejectsMalformedControlFrame(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		frame []byte
+	}{
+		{name: "fragmented ping", frame: []byte{0x09, 0x00}},
+		{name: "oversized ping", frame: []byte{0x89, 126, 0, 126}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			parser := goldenWebSocketFrameParser{}
+			if _, err := parser.append(test.frame); err == nil {
+				t.Fatal("parser accepted a malformed control frame")
+			}
+		})
+	}
+}
+
+type blockingObserverDelay struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (delay *blockingObserverDelay) wait(
+	ctx context.Context,
+	_ <-chan struct{},
+	_ <-chan struct{},
+	duration time.Duration,
+) error {
+	select {
+	case <-delay.started:
+	default:
+		close(delay.started)
+	}
+	select {
+	case <-delay.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestGoldenWebSocketPacerDoesNotBlockReadsDuringPacingDelay(t *testing.T) {
+	gate := newGoldenResponseGate()
+	base := gate.newResponsePacer("read-ahead-test")
+	delay := &blockingObserverDelay{started: make(chan struct{}), release: make(chan struct{})}
+	base.delay = delay
+	pacer := newGoldenWebSocketPacer(base)
+	controlWritten := make(chan struct{}, 1)
+	sink := func(payload []byte) (int, error) {
+		if bytes.Equal(payload, []byte{0x89, 0x00}) {
+			controlWritten <- struct{}{}
+		}
+		return len(payload), nil
+	}
+	data := make([]byte, 0, 100*3)
+	for index := 0; index < 100; index++ {
+		data = append(data, 0x81, 0x01, byte('a'+index%26))
+	}
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := pacer.write(context.Background(), data, sink)
+		firstDone <- err
+	}()
+	select {
+	case <-delay.started:
+	case <-time.After(time.Second):
+		t.Fatal("pacer did not enter a data pacing delay")
+	}
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := pacer.write(context.Background(), []byte{0x89, 0x00}, sink)
+		secondDone <- err
+	}()
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			t.Fatalf("control write: %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("control write blocked behind a pacing interval")
+	}
+	select {
+	case <-controlWritten:
+	case <-time.After(time.Second):
+		t.Fatal("control frame was not delivered while data pacing was held")
+	}
+	close(delay.release)
+	select {
+	case err := <-firstDone:
+		if err != nil {
+			t.Fatalf("data write: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("data write did not finish after pacing release")
+	}
+	gate.releasePacing()
+	if err := pacer.waitAndFlush(); err != nil {
+		t.Fatalf("waitAndFlush: %v", err)
 	}
 }
 

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -852,27 +852,26 @@ func (c *countingConn) Write(p []byte) (int, error) {
 }
 
 func (c *countingConn) Close() error {
+	var pacingErr error
 	if c.websocketPacer != nil {
 		if !c.websocketPacer.hasPayload() {
 			c.websocketPacer.releaseRequest()
 		}
-		if err := c.websocketPacer.waitAndFlush(); err != nil {
-			_ = c.Conn.Close()
-			return err
-		}
+		pacingErr = c.websocketPacer.waitAndFlush()
 	} else if c.pacer != nil {
 		if !c.pacer.hasPayload() {
 			c.pacer.releaseRequest()
 		}
-		if err := c.pacer.waitAndFlush(); err != nil {
-			_ = c.Conn.Close()
-			return err
-		}
+		pacingErr = c.pacer.waitAndFlush()
 	}
 	if c.closed.CompareAndSwap(false, true) {
 		c.observer.emit(transportEvent{Kind: "connection_closed", ConnectionID: c.meta.connectionID})
 	}
-	return c.Conn.Close()
+	closeErr := c.Conn.Close()
+	if pacingErr != nil {
+		return pacingErr
+	}
+	return closeErr
 }
 
 func newObserverHandler(upstream *url.URL, events io.Writer) http.Handler {

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -139,6 +139,7 @@ type goldenResponsePacer struct {
 	requestReleased    chan struct{}
 	releaseRequestOnce sync.Once
 	superseded         atomic.Bool
+	payloadSeen        atomic.Bool
 	mu                 sync.Mutex
 	started            bool
 	pending            []byte
@@ -182,6 +183,7 @@ func (p *goldenResponsePacer) write(ctx context.Context, payload []byte, write f
 	if p == nil || len(payload) == 0 {
 		return write(payload)
 	}
+	p.payloadSeen.Store(true)
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.sink = write
@@ -289,7 +291,7 @@ func (p *goldenResponsePacer) hasPayload() bool {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.started || len(p.pending) > 0
+	return p.payloadSeen.Load() || p.started || len(p.pending) > 0
 }
 
 func (p *goldenResponsePacer) waitAndFlush() error {
@@ -662,11 +664,12 @@ func (r *countingReadCloser) Read(p []byte) (int, error) {
 
 type countingResponseWriter struct {
 	http.ResponseWriter
-	observer   *observer
-	meta       requestEvidence
-	statusCode int
-	context    context.Context
-	pacer      *goldenResponsePacer
+	observer         *observer
+	meta             requestEvidence
+	statusCode       int
+	context          context.Context
+	pacer            *goldenResponsePacer
+	websocketUpgrade bool
 }
 
 func (w *countingResponseWriter) WriteHeader(statusCode int) {
@@ -737,16 +740,24 @@ func (w *countingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	w.recordFinalStatus(http.StatusSwitchingProtocols)
 	// ReverseProxy writes the HTTP 101 control response through buffered. The
 	// wrapped connection sees only post-handshake WebSocket frame bytes.
-	return &countingConn{Conn: connection, observer: w.observer, meta: w.meta, context: w.context, pacer: w.pacer}, buffered, nil
+	var websocketPacer *goldenWebSocketPacer
+	if w.websocketUpgrade {
+		websocketPacer = newGoldenWebSocketPacer(w.pacer)
+	}
+	return &countingConn{
+		Conn: connection, observer: w.observer, meta: w.meta, context: w.context,
+		pacer: w.pacer, websocketPacer: websocketPacer,
+	}, buffered, nil
 }
 
 type countingConn struct {
 	net.Conn
-	observer *observer
-	meta     requestEvidence
-	context  context.Context
-	pacer    *goldenResponsePacer
-	closed   atomic.Bool
+	observer       *observer
+	meta           requestEvidence
+	context        context.Context
+	pacer          *goldenResponsePacer
+	websocketPacer *goldenWebSocketPacer
+	closed         atomic.Bool
 }
 
 type countingUpstreamConn struct {
@@ -824,7 +835,7 @@ func (c *countingConn) Read(p []byte) (int, error) {
 }
 
 func (c *countingConn) Write(p []byte) (int, error) {
-	return c.pacer.write(c.context, p, func(chunk []byte) (int, error) {
+	write := func(chunk []byte) (int, error) {
 		n, err := c.Conn.Write(chunk)
 		if n > 0 {
 			event := c.meta.event("response_chunk")
@@ -833,11 +844,23 @@ func (c *countingConn) Write(p []byte) (int, error) {
 			c.observer.emit(event)
 		}
 		return n, err
-	})
+	}
+	if c.websocketPacer != nil {
+		return c.websocketPacer.write(c.context, p, write)
+	}
+	return c.pacer.write(c.context, p, write)
 }
 
 func (c *countingConn) Close() error {
-	if c.pacer != nil {
+	if c.websocketPacer != nil {
+		if !c.websocketPacer.hasPayload() {
+			c.websocketPacer.releaseRequest()
+		}
+		if err := c.websocketPacer.waitAndFlush(); err != nil {
+			_ = c.Conn.Close()
+			return err
+		}
+	} else if c.pacer != nil {
 		if !c.pacer.hasPayload() {
 			c.pacer.releaseRequest()
 		}
@@ -961,6 +984,7 @@ func newObserverHandlerWithObserverAndGate(upstream *url.URL, observation *obser
 		responseWriter := &countingResponseWriter{
 			ResponseWriter: w, observer: observation, meta: meta,
 			context: request.Context(), pacer: responsePacer,
+			websocketUpgrade: meta.transport == "websocket",
 		}
 		proxy.ServeHTTP(responseWriter, request)
 		if responsePacer != nil {

--- a/cmd/subrouter-transport-observer/main.go
+++ b/cmd/subrouter-transport-observer/main.go
@@ -39,7 +39,7 @@ const (
 )
 
 type observerDelay interface {
-	wait(context.Context, <-chan struct{}, <-chan struct{}, time.Duration) error
+	wait(context.Context, <-chan struct{}, <-chan struct{}, <-chan struct{}, time.Duration) (bool, error)
 }
 
 type timerObserverDelay struct{}
@@ -48,19 +48,22 @@ func (timerObserverDelay) wait(
 	ctx context.Context,
 	gateReleased <-chan struct{},
 	requestReleased <-chan struct{},
+	wake <-chan struct{},
 	duration time.Duration,
-) error {
+) (bool, error) {
 	timer := time.NewTimer(duration)
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return false, ctx.Err()
 	case <-gateReleased:
-		return nil
+		return false, nil
 	case <-requestReleased:
-		return nil
+		return false, nil
+	case <-wake:
+		return true, nil
 	case <-timer.C:
-		return nil
+		return false, nil
 	}
 }
 
@@ -235,7 +238,7 @@ func (p *goldenResponsePacer) writePacedLocked(ctx context.Context, payload []by
 			return total, nil
 		}
 		if p.started {
-			if err := p.delay.wait(ctx, p.gateReleased, p.requestReleased, p.interval); err != nil {
+			if _, err := p.delay.wait(ctx, p.gateReleased, p.requestReleased, nil, p.interval); err != nil {
 				return total, err
 			}
 			if p.isReleased() {


### PR DESCRIPTION
## Summary
- preserve complete WebSocket frames while the deployment continuity gate is held
- flush Ping/Pong control frames promptly and keep Close frames gated
- bound frame buffering, handle partial writes, and keep non-WebSocket upgrades on generic pacing

## Verification
- `go test ./cmd/subrouter-transport-observer -count=1`
- `go test -race ./cmd/subrouter-transport-observer -run 'TestGoldenWebSocket|TestCountingResponseWriter|TestGoldenObserver(HoldsRealResponseUntilGateRelease|ResumeWaitReleasesResponsePacing|KeepsUpstreamEvidenceRequestScopedOnPooledConnections)$' -count=1`\n- `go vet ./cmd/subrouter-transport-observer`\n- local autoreview clean\n\nThis is a maintainer continuity-harness fix. It does not rewrite or squash upstream contributor history.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790793878&installation_model_id=21920&pr_number=291&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F291&signature=119797a0a6bb50b85d10bc0d9f54cf479ba070c7500ac097dd673adce5da4029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WebSocket frame pacing in the continuity observer so complete frames are held until gate release and control frames are flushed immediately.

- Adds a WebSocket frame parser that reassembles complete frames without touching payloads.
- Routes WebSocket upgrade connections through a dedicated pacer; other upgrades keep generic pacing.
- Decouples pacing from upstream reads: writes enqueue and a writer goroutine owns delivery.
- Flushes Ping/Pong control frames, including queued and same-write ones; keeps Close frames gated with data.
- Bounds frame buffering, rejects malformed or oversized frames, retains partial write progress, and emits closed events on truncation.

<sup>Written for commit 65495a5cfd7d979f7f1ef1c16d7a38a62894d2e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added frame-aware pacing for WebSocket responses.
  - Preserves complete frames and wire order during delayed delivery.
  - Allows ping and pong control frames to flush promptly while data remains paced.
  - Adds safeguards for malformed, oversized, incomplete, or excessively buffered frames.

- **Bug Fixes**
  - Improves handling of partial writes and connection-close cleanup.
  - Applies WebSocket pacing only to actual WebSocket upgrades.

- **Tests**
  - Added coverage for fragmented frames, control-frame ordering, size limits, partial writes, and upgrade detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->