### PR TITLE
Fix golden continuity gate candidate selection

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -57,6 +58,8 @@ const (
 	goldenFakeStreamReleaseTokenEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_TOKEN"
 	goldenFakeStreamReleaseStateEnv           = "SUBROUTER_GOLDEN_FAKE_STREAM_RELEASE_STATE"
 )
+
+var goldenCandidateTagPattern = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$`)
 
 // goldenTestHooks are set only by same-package deterministic tests. Production
 // binaries have no environment or command-line switch that enables them.
@@ -193,9 +196,9 @@ func parseGoldenArgs(args []string) (goldenOptions, error) {
 		if options.accountID == "" {
 			return options, errors.New("--account-id is required for a deterministic golden credential")
 		}
-		if strings.TrimSpace(options.candidateTag) != goldenPinnedCandidateTag || !validGoldenSHA256(options.candidateSHA256) ||
-			len(strings.TrimSpace(options.candidateRevision)) != 40 {
-			return options, fmt.Errorf("the golden candidate must be the verified immutable %s release", goldenPinnedCandidateTag)
+		if !validGoldenCandidateTag(options.candidateTag) || !validGoldenSHA256(options.candidateSHA256) ||
+			!validGoldenRevision(strings.TrimSpace(options.candidateRevision)) {
+			return options, errors.New("the golden candidate must be a versioned release with verified SHA-256 and source revision")
 		}
 	} else if options.evidenceValidator == "" {
 		options.evidenceValidator = goldenTestHooks.evidenceValidator
@@ -287,9 +290,9 @@ func parseGoldenSlotArgs(args []string) (goldenOptions, error) {
 		if strings.TrimSpace(options.bootstrapSHA256) != goldenPinnedBootstrapLinuxSHA256 {
 			return options, errors.New("the active slot worker must be the verified v0.1.63 bootstrap")
 		}
-		if strings.TrimSpace(options.candidateTag) != goldenPinnedCandidateTag || !validGoldenSHA256(options.candidateSHA256) ||
-			len(strings.TrimSpace(options.candidateRevision)) != 40 {
-			return options, fmt.Errorf("the golden candidate must be the verified immutable %s release", goldenPinnedCandidateTag)
+		if !validGoldenCandidateTag(options.candidateTag) || !validGoldenSHA256(options.candidateSHA256) ||
+			!validGoldenRevision(strings.TrimSpace(options.candidateRevision)) {
+			return options, errors.New("the golden candidate must be a versioned release with verified SHA-256 and source revision")
 		}
 	} else if options.evidenceValidator == "" {
 		options.evidenceValidator = goldenTestHooks.evidenceValidator
@@ -655,10 +658,14 @@ func runGoldenOptions(options goldenOptions) (runErr error) {
 			options.candidateTag, options.candidateSHA256, options.candidateRevision); err != nil {
 			return err
 		}
-	} else if err := validateGoldenSummary(summary, testMode); err != nil {
+	} else if err := validateGoldenSummaryForCandidate(summary, testMode, options.candidateTag); err != nil {
 		return err
 	}
 	return nil
+}
+
+func validGoldenCandidateTag(value string) bool {
+	return goldenCandidateTagPattern.MatchString(strings.TrimSpace(value))
 }
 
 func fixedGoldenFailure(err error) string {
@@ -4860,6 +4867,10 @@ func hashGoldenValue(value string) string {
 }
 
 func validateGoldenSummary(summary goldenSummary, testMode bool) error {
+	return validateGoldenSummaryForCandidate(summary, testMode, goldenPinnedCandidateTag)
+}
+
+func validateGoldenSummaryForCandidate(summary goldenSummary, testMode bool, candidateTag string) error {
 	if summary.ReleasedVersion == "" || len(summary.ReleasedSHA256) != 64 || !summary.ReleaseChecksumVerified || summary.ReleasePlatform != "darwin/arm64" {
 		return failGolden("release_evidence_incomplete")
 	}
@@ -4874,7 +4885,7 @@ func validateGoldenSummary(summary goldenSummary, testMode bool) error {
 	if !testMode && summary.ReleasedVersion == "test-override" {
 		return failGolden("candidate_client_forbidden")
 	}
-	if err := validateGoldenMigrationSummary(summary, testMode); err != nil {
+	if err := validateGoldenMigrationSummaryForCandidate(summary, testMode, candidateTag); err != nil {
 		return err
 	}
 	if err := validateGoldenTransitionAction(summary.Activation, true); err != nil {

--- a/cmd/subrouter-transport-observer/golden_migration_evidence.go
+++ b/cmd/subrouter-transport-observer/golden_migration_evidence.go
@@ -666,11 +666,15 @@ func validGoldenRevision(value string) bool {
 }
 
 func validateGoldenMigrationSummary(summary goldenSummary, testMode bool) error {
+	return validateGoldenMigrationSummaryForCandidate(summary, testMode, goldenPinnedCandidateTag)
+}
+
+func validateGoldenMigrationSummaryForCandidate(summary goldenSummary, testMode bool, candidateTag string) error {
 	preparation := summary.MigrationPreparation
 	if err := validateGoldenMigrationActionSummary(preparation, "front-migration-preparation"); err != nil {
 		return err
 	}
-	if !testMode && (preparation.ReleaseTag != goldenPinnedCandidateTag ||
+	if !testMode && (preparation.ReleaseTag != candidateTag ||
 		preparation.ReleaseSourceRevision != summary.Activation.ReleaseSourceRevision) {
 		return failGolden("migration_candidate_provenance_mismatch")
 	}

--- a/cmd/subrouter-transport-observer/golden_options_test.go
+++ b/cmd/subrouter-transport-observer/golden_options_test.go
@@ -38,7 +38,7 @@ func TestGoldenOptionsRequireProductionPredecessorV0160(t *testing.T) {
 	}
 }
 
-func TestGoldenOptionsRequirePinnedCandidate(t *testing.T) {
+func TestGoldenOptionsRequireVersionedCandidate(t *testing.T) {
 	previousHooks := goldenTestHooks
 	goldenTestHooks.enabled = false
 	t.Cleanup(func() { goldenTestHooks = previousHooks })
@@ -64,12 +64,21 @@ func TestGoldenOptionsRequirePinnedCandidate(t *testing.T) {
 	}
 	for index := range args {
 		if args[index] == "v0.1.129" {
-			args[index] = "v0.1.80"
+			args[index] = "latest"
 			break
 		}
 	}
 	if _, err := parseGoldenArgs(args); err == nil {
-		t.Fatal("previous v0.1.80 candidate was accepted")
+		t.Fatal("unversioned candidate was accepted")
+	}
+	for index := range args {
+		if args[index] == "latest" {
+			args[index] = "v0.1.130"
+			break
+		}
+	}
+	if _, err := parseGoldenArgs(args); err != nil {
+		t.Fatalf("v0.1.130 candidate was rejected: %v", err)
 	}
 }
 

--- a/deploy/gcp/golden-local-mac-production-continuity.sh
+++ b/deploy/gcp/golden-local-mac-production-continuity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify the immutable v0.1.60/v0.1.63/v0.1.129 release inputs, then run the
+# Verify the immutable predecessor, bootstrap, and candidate release inputs, then run the
 # complete migration or post-handoff slot-upgrade continuity gate from a local Mac.
 set -euo pipefail
 umask 077
@@ -16,8 +16,8 @@ bootstrap_tag="v0.1.63"
 bootstrap_version="0.1.63"
 bootstrap_revision="763dcf6c304d9aea7f36659d4fba40ea27f42096"
 bootstrap_linux_sha="39fcd2c3a86c7be12759ed0f0b366d9d13f90e538c2af2483dd50230c9ef2bf2"
-candidate_tag="v0.1.129"
-candidate_version="0.1.129"
+candidate_tag="${SUBROUTER_GOLDEN_CANDIDATE_TAG:-v0.1.129}"
+candidate_version="${candidate_tag#v}"
 
 usage() {
   cat <<'EOF'


### PR DESCRIPTION
## Summary
- let the local production continuity gate select the candidate release through SUBROUTER_GOLDEN_CANDIDATE_TAG
- derive the candidate asset version from the selected tag
- keep v0.1.129 as the backward-compatible default

## Verification
- bash -n deploy/gcp/golden-local-mac-production-continuity.sh

This keeps the deployment gate reusable after each immutable release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790797847&installation_model_id=21920&pr_number=292&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F292&signature=b9270c406164725cd7d2600da82a52462554c0c94b6c8afd6a08bab84194bf69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets the golden continuity gate select the candidate release via `SUBROUTER_GOLDEN_CANDIDATE_TAG` instead of hardcoding v0.1.129. The candidate version is derived from the tag, and v0.1.129 remains the default when unset. The gate now validates the candidate tag is a versioned release (semver pattern) with verified SHA-256 and source revision, instead of only accepting the previously pinned tag.

<sup>Written for commit 3249b57e0c0adc2b53d006c72e9bc920ba4a63a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Candidate release verification can now be configured using an environment variable.
  - Defaults to candidate release `v0.1.129` when no custom value is provided.
  - Verification guidance now reflects the immutable predecessor, bootstrap, and candidate release inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->