### PR TITLE
security: publish packages only from verified release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Validate release workflow
         run: scripts/test-release-workflow.sh
 
+      - name: Validate release security boundary
+        run: scripts/test-release-security.sh
+
+      - name: Test release package manifest
+        run: python3 scripts/test_release_package.py
+
       - name: Build
         run: go build ./...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Validate release workflow
+        run: scripts/test-release-workflow.sh
+
       - name: Build
         run: go build ./...
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Verify immutable release source
         id: context
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -119,6 +121,8 @@ jobs:
 
       - name: Verify immutable release source
         id: context
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -210,6 +214,7 @@ jobs:
       - name: Revalidate immutable release source
         env:
           EXPECTED_SOURCE_COMMIT: ${{ needs.build.outputs.source_commit }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           source_commit="$(scripts/verify-release-context.sh)"
@@ -252,6 +257,7 @@ jobs:
       - name: Revalidate immutable release source
         env:
           EXPECTED_SOURCE_COMMIT: ${{ needs.package-build.outputs.source_commit }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           source_commit="$(scripts/verify-release-context.sh)"
@@ -321,6 +327,7 @@ jobs:
       - name: Revalidate immutable release source
         env:
           EXPECTED_SOURCE_COMMIT: ${{ needs.package-build.outputs.source_commit }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           source_commit="$(scripts/verify-release-context.sh)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,14 @@
 name: Release
 
-# A pushed tag builds and tests, then publishes the immutable binaries consumed
-# by protected GCP deploys. The legacy pre-front updater reads the same release.
-# npm/PyPI are not published on a tag; they are manual opt-in only through the
-# workflow_dispatch toggles below.
+# Only a protected version tag can enter this workflow. The source commit is
+# revalidated against the live tag and protected main in every publishing job.
+# Package publishing is automatic only when package metadata matches the tag;
+# npm and PyPI environments provide the human approval boundary.
 
 on:
   push:
     tags:
       - "v*"
-  workflow_dispatch:
-    inputs:
-      publish_npm:
-        description: "Also publish to npm (manual opt-in)"
-        required: true
-        type: boolean
-        default: false
-      publish_pypi:
-        description: "Also publish to PyPI (manual opt-in)"
-        required: true
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -38,8 +26,9 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.version.outputs.version }}
-      source_commit: ${{ steps.version.outputs.source_commit }}
+      version: ${{ steps.context.outputs.version }}
+      source_commit: ${{ steps.context.outputs.source_commit }}
+      artifact_id: ${{ steps.upload-release.outputs.artifact-id }}
     permissions:
       contents: read
       id-token: write
@@ -49,50 +38,32 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Verify immutable release source
+        id: context
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_commit="$(scripts/verify-release-context.sh)"
+          printf 'source_commit=%s\n' "${source_commit}" >>"${GITHUB_OUTPUT}"
+          printf 'version=%s\n' "${GITHUB_REF_NAME#v}" >>"${GITHUB_OUTPUT}"
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
-      - name: Determine release version
-        id: version
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || {
-              echo "release tag must be versioned, for example v0.1.52" >&2
-              exit 1
-            }
-            version="${GITHUB_REF_NAME#v}"
-          else
-            version="$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
-          fi
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
-          source_commit="$(git rev-parse "${GITHUB_REF}^{commit}")"
-          echo "source_commit=${source_commit}" >> "${GITHUB_OUTPUT}"
-
-      - name: Require release commit on protected main
-        env:
-          SOURCE_COMMIT: ${{ steps.version.outputs.source_commit }}
-        run: |
-          set -euo pipefail
-          git fetch --no-tags origin main
-          git merge-base --is-ancestor "${SOURCE_COMMIT}" origin/main || {
-            echo "refusing to release a tag whose commit is not on origin/main" >&2
-            exit 1
-          }
-
       - name: Test Go packages
         run: CGO_ENABLED=0 go test ./...
 
       - name: Build Go release binaries
-        run: scripts/build-release.sh "${{ steps.version.outputs.version }}"
+        run: scripts/build-release.sh "${{ steps.context.outputs.version }}"
 
       - name: Copy deployment helpers into release assets
         env:
-          SOURCE_COMMIT: ${{ steps.version.outputs.source_commit }}
+          SOURCE_COMMIT: ${{ steps.context.outputs.source_commit }}
         run: |
           set -euo pipefail
           cp install.sh dist/release/install.sh
@@ -117,10 +88,103 @@ jobs:
           subject-path: dist/release/*
 
       - name: Upload Go release artifacts
+        id: upload-release
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: release-assets
           path: dist/release/*
+          if-no-files-found: error
+
+  package-build:
+    name: Prepare package artifacts
+    if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+    runs-on: ubuntu-latest
+    outputs:
+      publishable: ${{ steps.versions.outputs.publishable }}
+      version: ${{ steps.context.outputs.version }}
+      source_commit: ${{ steps.context.outputs.source_commit }}
+      artifact_id: ${{ steps.upload-packages.outputs.artifact-id }}
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Verify immutable release source
+        id: context
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_commit="$(scripts/verify-release-context.sh)"
+          printf 'source_commit=%s\n' "${source_commit}" >>"${GITHUB_OUTPUT}"
+          printf 'version=%s\n' "${GITHUB_REF_NAME#v}" >>"${GITHUB_OUTPUT}"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Require package versions to match the release tag
+        id: versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_version="${GITHUB_REF_NAME#v}"
+          npm_version="$(node -p "require('./package.json').version")"
+          python_version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          if [[ "${release_version}" != "${npm_version}" ]] || [[ "${release_version}" != "${python_version}" ]]; then
+            echo "::notice title=Package publishing skipped::Tag ${GITHUB_REF_NAME} does not match npm ${npm_version} and Python ${python_version}."
+            echo "publishable=false" >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          echo "publishable=true" >>"${GITHUB_OUTPUT}"
+
+      - name: Build npm package without lifecycle scripts
+        if: ${{ steps.versions.outputs.publishable == 'true' }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist/packages/npm
+          npm pack --ignore-scripts --pack-destination dist/packages/npm
+
+      - name: Build Python packages with pinned tools
+        if: ${{ steps.versions.outputs.publishable == 'true' }}
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check --no-cache-dir \
+            "build==1.6.0" "hatchling==1.32.0" "twine==7.0.0"
+          mkdir -p dist/packages/python
+          python -m build --no-isolation --outdir dist/packages/python
+          python -m twine check dist/packages/python/*.tar.gz dist/packages/python/*.whl
+
+      - name: Bind package artifacts to the release source
+        if: ${{ steps.versions.outputs.publishable == 'true' }}
+        env:
+          SOURCE_COMMIT: ${{ steps.context.outputs.source_commit }}
+          VERSION: ${{ steps.context.outputs.version }}
+        run: |
+          python3 scripts/release_package.py create \
+            --tag "${GITHUB_REF_NAME}" \
+            --source-commit "${SOURCE_COMMIT}" \
+            --version "${VERSION}" \
+            --directory dist/packages
+
+      - name: Upload package artifacts
+        id: upload-packages
+        if: ${{ steps.versions.outputs.publishable == 'true' }}
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: release-packages
+          path: dist/packages
           if-no-files-found: error
 
   github-release:
@@ -134,27 +198,41 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Revalidate immutable release source
+        env:
+          EXPECTED_SOURCE_COMMIT: ${{ needs.build.outputs.source_commit }}
+        run: |
+          set -euo pipefail
+          source_commit="$(scripts/verify-release-context.sh)"
+          [[ "${source_commit}" == "${EXPECTED_SOURCE_COMMIT}" ]] || {
+            echo "release source changed between build and publish" >&2
+            exit 1
+          }
 
       - name: Download Go release artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
-          name: release-assets
+          artifact-ids: ${{ needs.build.outputs.artifact_id }}
           path: dist/release
 
       - name: Stage, verify, and publish immutable GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          TAG_NAME: v${{ needs.build.outputs.version }}
+          TAG_NAME: ${{ github.ref_name }}
           SOURCE_COMMIT: ${{ needs.build.outputs.source_commit }}
         run: bash scripts/publish-github-release.sh dist/release
 
-  # Manual opt-in only. These never run on a tag push; trigger this workflow via
-  # the Actions "Run workflow" button with the toggle enabled to publish.
   npm-publish:
-    name: Publish npm package (manual)
+    name: Publish npm package
+    needs: package-build
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_npm }}
+    if: ${{ github.event_name == 'push' && github.ref_type == 'tag' && needs.package-build.outputs.publishable == 'true' }}
     environment: npm
     permissions:
       contents: read
@@ -162,6 +240,38 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Revalidate immutable release source
+        env:
+          EXPECTED_SOURCE_COMMIT: ${{ needs.package-build.outputs.source_commit }}
+        run: |
+          set -euo pipefail
+          source_commit="$(scripts/verify-release-context.sh)"
+          [[ "${source_commit}" == "${EXPECTED_SOURCE_COMMIT}" ]] || {
+            echo "package source changed between build and publish" >&2
+            exit 1
+          }
+
+      - name: Download package artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          artifact-ids: ${{ needs.package-build.outputs.artifact_id }}
+          path: dist/packages
+
+      - name: Verify package artifact provenance
+        env:
+          SOURCE_COMMIT: ${{ needs.package-build.outputs.source_commit }}
+          VERSION: ${{ needs.package-build.outputs.version }}
+        run: |
+          python3 scripts/release_package.py verify \
+            --tag "${GITHUB_REF_NAME}" \
+            --source-commit "${SOURCE_COMMIT}" \
+            --version "${VERSION}" \
+            --directory dist/packages
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -169,13 +279,23 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Publish to npm
-        run: npm publish --access public
+      - name: Publish verified npm package
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          packages=(dist/packages/npm/*.tgz)
+          (( ${#packages[@]} == 1 )) || {
+            echo "expected exactly one verified npm tarball" >&2
+            exit 1
+          }
+          npm publish "${packages[0]}" --access public --provenance --ignore-scripts
 
   pypi-publish:
-    name: Publish PyPI package (manual)
+    name: Publish PyPI package
+    needs: package-build
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_pypi }}
+    if: ${{ github.event_name == 'push' && github.ref_type == 'tag' && needs.package-build.outputs.publishable == 'true' }}
     environment: pypi
     permissions:
       contents: read
@@ -183,17 +303,45 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
-      - name: Build Python package
+      - name: Revalidate immutable release source
+        env:
+          EXPECTED_SOURCE_COMMIT: ${{ needs.package-build.outputs.source_commit }}
         run: |
-          python -m pip install --upgrade build twine
-          python -m build
-          python -m twine check dist/subrouter-*.tar.gz dist/subrouter-*.whl
+          set -euo pipefail
+          source_commit="$(scripts/verify-release-context.sh)"
+          [[ "${source_commit}" == "${EXPECTED_SOURCE_COMMIT}" ]] || {
+            echo "package source changed between build and publish" >&2
+            exit 1
+          }
 
-      - name: Publish to PyPI
+      - name: Download package artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          artifact-ids: ${{ needs.package-build.outputs.artifact_id }}
+          path: dist/packages
+
+      - name: Verify package artifact provenance
+        env:
+          SOURCE_COMMIT: ${{ needs.package-build.outputs.source_commit }}
+          VERSION: ${{ needs.package-build.outputs.version }}
+        run: |
+          python3 scripts/release_package.py verify \
+            --tag "${GITHUB_REF_NAME}" \
+            --source-commit "${SOURCE_COMMIT}" \
+            --version "${VERSION}" \
+            --directory dist/packages
+
+      - name: Publish verified Python packages
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: dist/packages/python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,12 @@ jobs:
       attestations: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -103,19 +103,21 @@ jobs:
             >dist/release/SOURCE_PROVENANCE.json
           (
             cd dist/release
+            checksum_tmp="$(mktemp)"
             find . -maxdepth 1 -type f ! -name SHA256SUMS -printf '%f\n' \
               | LC_ALL=C sort \
-              | xargs sha256sum >SHA256SUMS
+              | xargs sha256sum >"${checksum_tmp}"
+            mv "${checksum_tmp}" SHA256SUMS
             sha256sum --check SHA256SUMS
           )
 
       - name: Attest complete release asset set
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
           subject-path: dist/release/*
 
       - name: Upload Go release artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: release-assets
           path: dist/release/*
@@ -131,10 +133,10 @@ jobs:
       attestations: read
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download Go release artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: release-assets
           path: dist/release
@@ -159,10 +161,10 @@ jobs:
       id-token: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -180,10 +182,10 @@ jobs:
       id-token: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -194,4 +196,4 @@ jobs:
           python -m twine check dist/subrouter-*.tar.gz dist/subrouter-*.whl
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 # Only a protected version tag can enter this workflow. The source commit is
 # revalidated against the live tag and protected main in every publishing job.
 # Package publishing is automatic only when package metadata matches the tag;
-# npm and PyPI environments provide the human approval boundary.
+# the npm and PyPI environments must provide the human approval boundary.
 
 on:
   push:
@@ -54,12 +54,15 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Test Go packages
         run: CGO_ENABLED=0 go test ./...
 
       - name: Build Go release binaries
-        run: scripts/build-release.sh "${{ steps.context.outputs.version }}"
+        env:
+          VERSION: ${{ steps.context.outputs.version }}
+        run: scripts/build-release.sh "${VERSION}"
 
       - name: Copy deployment helpers into release assets
         env:
@@ -128,6 +131,7 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -278,6 +282,7 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Publish verified npm package
         shell: bash

--- a/scripts/release_package.py
+++ b/scripts/release_package.py
@@ -173,7 +173,7 @@ def verify_npm(path: Path, version: str) -> None:
             data = json.loads(stream.read(1024 * 1024), object_pairs_hook=_reject_duplicate_keys)
     except (OSError, tarfile.TarError, UnicodeDecodeError, json.JSONDecodeError) as error:
         fail(f"invalid npm archive {path}: {error}")
-    if data.get("name") != "subrouter" or data.get("version") != version:
+    if not isinstance(data, dict) or data.get("name") != "subrouter" or data.get("version") != version:
         fail(f"npm metadata does not match subrouter {version}: {path}")
 
 

--- a/scripts/release_package.py
+++ b/scripts/release_package.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Create and verify the package bundle passed between release jobs.
+
+The bundle carries a small, deterministic manifest. Publishers verify both the
+manifest and the package metadata before they receive an OIDC token. No
+network access is needed for verification.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Any, Iterable, Mapping, NoReturn
+
+
+MANIFEST_NAME = "PACKAGE_PROVENANCE.json"
+SCHEMA = "subrouter.release-packages/v1"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[.-][0-9A-Za-z.-]+)?$")
+
+
+class ManifestError(ValueError):
+    """Raised when a release package bundle is not self-consistent."""
+
+
+def fail(message: str) -> NoReturn:
+    raise ManifestError(message)
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            fail(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as stream:
+            return json.load(stream, object_pairs_hook=_reject_duplicate_keys)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        fail(f"cannot read JSON {path}: {error}")
+
+
+def sha256(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    try:
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+                size += len(chunk)
+    except OSError as error:
+        fail(f"cannot read package file {path}: {error}")
+    return digest.hexdigest(), size
+
+
+def package_files(root: Path) -> list[Path]:
+    if not root.is_dir():
+        fail(f"package directory is missing: {root}")
+    files: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if path.name == MANIFEST_NAME and path.parent == root:
+            continue
+        if path.is_symlink():
+            fail(f"package bundle contains a symlink: {path}")
+        if path.is_file():
+            relative = path.relative_to(root)
+            if any(part in ("", ".", "..") for part in relative.parts):
+                fail(f"invalid package path: {relative}")
+            files.append(path)
+    if not files:
+        fail("package bundle is empty")
+    return files
+
+
+def validate_identity(tag: str, source_commit: str, version: str) -> None:
+    if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+(?:[.-][0-9A-Za-z.-]+)?", tag):
+        fail(f"invalid release tag: {tag}")
+    if not SHA_RE.fullmatch(source_commit):
+        fail("source commit must be a full lowercase SHA")
+    if not VERSION_RE.fullmatch(version):
+        fail(f"invalid package version: {version}")
+    if tag[1:] != version:
+        fail(f"tag {tag} does not match package version {version}")
+
+
+def relative_name(path: Path, root: Path) -> str:
+    value = path.relative_to(root).as_posix()
+    if value.startswith("/") or ".." in Path(value).parts:
+        fail(f"invalid package path: {value}")
+    return value
+
+
+def manifest_for(root: Path, tag: str, source_commit: str, version: str) -> dict[str, Any]:
+    validate_identity(tag, source_commit, version)
+    files = package_files(root)
+    entries = []
+    for path in files:
+        digest, size = sha256(path)
+        entries.append({"name": relative_name(path, root), "sha256": digest, "size": size})
+    entries.sort(key=lambda entry: entry["name"])
+    return {
+        "schema": SCHEMA,
+        "tag": tag,
+        "source_commit": source_commit,
+        "version": version,
+        "files": entries,
+    }
+
+
+def write_manifest(root: Path, manifest: Mapping[str, Any]) -> None:
+    destination = root / MANIFEST_NAME
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=root, prefix=f".{MANIFEST_NAME}.", delete=False
+        ) as stream:
+            json.dump(manifest, stream, sort_keys=True, separators=(",", ":"))
+            stream.write("\n")
+            temporary = Path(stream.name)
+        os.replace(temporary, destination)
+    except OSError as error:
+        try:
+            temporary.unlink(missing_ok=True)
+        except (NameError, OSError):
+            pass
+        fail(f"cannot write package manifest: {error}")
+
+
+def _archive_member_names(names: Iterable[str]) -> None:
+    for name in names:
+        path = Path(name)
+        if path.is_absolute() or ".." in path.parts:
+            fail(f"archive contains an unsafe path: {name}")
+
+
+def _metadata_version(lines: Iterable[str], archive: Path) -> tuple[str | None, str | None]:
+    name: str | None = None
+    version: str | None = None
+    for line in lines:
+        key, separator, value = line.partition(":")
+        if not separator:
+            continue
+        if key.lower() == "name":
+            name = value.strip()
+        elif key.lower() == "version":
+            version = value.strip()
+    if name is None or version is None:
+        fail(f"package metadata is incomplete in {archive}")
+    return name, version
+
+
+def verify_npm(path: Path, version: str) -> None:
+    try:
+        with tarfile.open(path, mode="r:gz") as archive:
+            _archive_member_names(member.name for member in archive.getmembers())
+            members = [member for member in archive.getmembers() if member.name == "package/package.json"]
+            if len(members) != 1 or not members[0].isfile():
+                fail(f"npm archive has no unique package/package.json: {path}")
+            stream = archive.extractfile(members[0])
+            if stream is None:
+                fail(f"cannot read npm metadata: {path}")
+            data = json.loads(stream.read(1024 * 1024), object_pairs_hook=_reject_duplicate_keys)
+    except (OSError, tarfile.TarError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        fail(f"invalid npm archive {path}: {error}")
+    if data.get("name") != "subrouter" or data.get("version") != version:
+        fail(f"npm metadata does not match subrouter {version}: {path}")
+
+
+def verify_python_archive(path: Path, version: str) -> None:
+    if path.suffix == ".whl":
+        try:
+            with zipfile.ZipFile(path) as archive:
+                _archive_member_names(archive.namelist())
+                metadata = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+                if len(metadata) != 1:
+                    fail(f"wheel has no unique dist-info/METADATA: {path}")
+                lines = archive.read(metadata[0]).decode("utf-8").splitlines()
+        except (OSError, zipfile.BadZipFile, UnicodeDecodeError) as error:
+            fail(f"invalid wheel {path}: {error}")
+    else:
+        try:
+            with tarfile.open(path, mode="r:gz") as archive:
+                _archive_member_names(member.name for member in archive.getmembers())
+                metadata = [member for member in archive.getmembers() if member.name.endswith("/PKG-INFO")]
+                if len(metadata) != 1 or not metadata[0].isfile():
+                    fail(f"source archive has no unique PKG-INFO: {path}")
+                stream = archive.extractfile(metadata[0])
+                if stream is None:
+                    fail(f"cannot read source metadata: {path}")
+                lines = stream.read(1024 * 1024).decode("utf-8").splitlines()
+        except (OSError, tarfile.TarError, UnicodeDecodeError) as error:
+            fail(f"invalid source archive {path}: {error}")
+    name, actual_version = _metadata_version(lines, path)
+    if name != "subrouter" or actual_version != version:
+        fail(f"Python metadata does not match subrouter {version}: {path}")
+
+
+def validate_manifest(root: Path, expected_tag: str, expected_commit: str, expected_version: str) -> None:
+    validate_identity(expected_tag, expected_commit, expected_version)
+    manifest_path = root / MANIFEST_NAME
+    value = load_json(manifest_path)
+    if not isinstance(value, dict):
+        fail("package manifest must be an object")
+    required = {"schema", "tag", "source_commit", "version", "files"}
+    if set(value) != required:
+        fail(f"package manifest keys must be exactly {sorted(required)}")
+    if value["schema"] != SCHEMA:
+        fail("unsupported package manifest schema")
+    if value["tag"] != expected_tag or value["source_commit"] != expected_commit or value["version"] != expected_version:
+        fail("package manifest identity does not match the release context")
+    entries = value["files"]
+    if not isinstance(entries, list) or not entries:
+        fail("package manifest files must be a non-empty list")
+
+    expected: dict[str, tuple[str, int]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict) or set(entry) != {"name", "sha256", "size"}:
+            fail("package manifest contains a malformed file entry")
+        name = entry["name"]
+        digest = entry["sha256"]
+        size = entry["size"]
+        if not isinstance(name, str) or not name or Path(name).is_absolute() or ".." in Path(name).parts:
+            fail(f"package manifest contains an unsafe path: {name}")
+        if not (name.startswith("npm/") or name.startswith("python/")):
+            fail(f"package manifest contains an unexpected path: {name}")
+        if name in expected:
+            fail(f"package manifest contains duplicate file: {name}")
+        if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+            fail(f"invalid SHA-256 for {name}")
+        if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+            fail(f"invalid size for {name}")
+        expected[name] = (digest, size)
+
+    actual_paths = {relative_name(path, root): path for path in package_files(root)}
+    if set(expected) != set(actual_paths):
+        missing = sorted(set(expected) - set(actual_paths))
+        extra = sorted(set(actual_paths) - set(expected))
+        fail(f"package file set changed, missing={missing}, extra={extra}")
+    for name, path in actual_paths.items():
+        actual_digest, actual_size = sha256(path)
+        expected_digest, expected_size = expected[name]
+        if (actual_digest, actual_size) != (expected_digest, expected_size):
+            fail(f"package digest or size mismatch: {name}")
+
+    npm_files = [path for name, path in actual_paths.items() if name.startswith("npm/") and name.endswith(".tgz")]
+    wheel_files = [path for name, path in actual_paths.items() if name.startswith("python/") and name.endswith(".whl")]
+    source_files = [path for name, path in actual_paths.items() if name.startswith("python/") and name.endswith(".tar.gz")]
+    if len(npm_files) != 1 or len(wheel_files) != 1 or len(source_files) != 1:
+        fail("package bundle must contain exactly one npm tarball, wheel, and source archive")
+    verify_npm(npm_files[0], expected_version)
+    verify_python_archive(wheel_files[0], expected_version)
+    verify_python_archive(source_files[0], expected_version)
+
+
+def command_create(args: argparse.Namespace) -> None:
+    root = Path(args.directory).resolve()
+    manifest = manifest_for(root, args.tag, args.source_commit, args.version)
+    write_manifest(root, manifest)
+    validate_manifest(root, args.tag, args.source_commit, args.version)
+
+
+def command_verify(args: argparse.Namespace) -> None:
+    validate_manifest(Path(args.directory).resolve(), args.tag, args.source_commit, args.version)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    subparsers = result.add_subparsers(dest="command", required=True)
+    for command, handler in (("create", command_create), ("verify", command_verify)):
+        subparser = subparsers.add_parser(command)
+        subparser.add_argument("--tag", required=True)
+        subparser.add_argument("--source-commit", required=True)
+        subparser.add_argument("--version", required=True)
+        subparser.add_argument("--directory", required=True)
+        subparser.set_defaults(handler=handler)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = parser().parse_args(argv)
+        args.handler(args)
+    except ManifestError as error:
+        print(f"release package check: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-release-security.sh
+++ b/scripts/test-release-security.sh
@@ -87,12 +87,59 @@ PY
 "${root}/scripts/test-release-workflow.sh" "${workflow}"
 
 # Verify that the security gate catches a reintroduced manual trigger.
-bad_workflow="$(mktemp)"
-trap 'rm -f "${bad_workflow}"' EXIT
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+bad_workflow="${tmp_dir}/manual-trigger.yml"
 cp "${workflow}" "${bad_workflow}"
 printf '\nworkflow_dispatch:\n' >>"${bad_workflow}"
 if "${BASH_SOURCE[0]}" "${bad_workflow}" >/dev/null 2>&1; then
   fail "manual-trigger regression fixture unexpectedly passed"
+fi
+
+# Exercise the source helper against a local remote. A detached commit and a
+# moved tag must both fail, even when the caller supplies the old event SHA.
+remote="${tmp_dir}/remote.git"
+checkout="${tmp_dir}/checkout"
+git init --bare "${remote}" >/dev/null
+git clone -q "${remote}" "${checkout}"
+git -C "${checkout}" config user.name "release-security-test"
+git -C "${checkout}" config user.email "release-security-test@example.invalid"
+git -C "${checkout}" config commit.gpgsign false
+git -C "${checkout}" config tag.gpgsign false
+printf 'base\n' >"${checkout}/marker"
+git -C "${checkout}" add marker
+git -C "${checkout}" commit -qm base
+git -C "${checkout}" branch -M main
+git -C "${checkout}" push -q origin main
+git -C "${checkout}" tag v1.2.3
+git -C "${checkout}" push -q origin refs/tags/v1.2.3
+base_sha="$(git -C "${checkout}" rev-parse HEAD)"
+if ! (cd "${checkout}" && env GIT_TERMINAL_PROMPT=0 GITHUB_EVENT_NAME=push GITHUB_REF_PROTECTED=true GITHUB_SHA="${base_sha}" GITHUB_REF=refs/tags/v1.2.3 GITHUB_REF_NAME=v1.2.3 GITHUB_REF_TYPE=tag "${root}/scripts/verify-release-context.sh" >"${tmp_dir}/context.out"); then
+  fail "valid protected-main tag was rejected"
+fi
+[[ "$(<"${tmp_dir}/context.out")" == "${base_sha}" ]] || fail "source helper returned the wrong commit"
+if (cd "${checkout}" && env GIT_TERMINAL_PROMPT=0 GITHUB_EVENT_NAME=push GITHUB_REF_PROTECTED=false GITHUB_SHA="${base_sha}" GITHUB_REF=refs/tags/v1.2.3 GITHUB_REF_NAME=v1.2.3 GITHUB_REF_TYPE=tag "${root}/scripts/verify-release-context.sh" >/dev/null 2>&1); then
+  fail "unprotected tag context passed the source helper"
+fi
+
+git -C "${checkout}" checkout -qb untrusted
+printf 'untrusted\n' >>"${checkout}/marker"
+git -C "${checkout}" commit -qam untrusted
+git -C "${checkout}" tag v1.2.4
+git -C "${checkout}" push -q origin untrusted refs/tags/v1.2.4
+untrusted_sha="$(git -C "${checkout}" rev-parse HEAD)"
+if (cd "${checkout}" && env GIT_TERMINAL_PROMPT=0 GITHUB_EVENT_NAME=push GITHUB_REF_PROTECTED=true GITHUB_SHA="${untrusted_sha}" GITHUB_REF=refs/tags/v1.2.4 GITHUB_REF_NAME=v1.2.4 GITHUB_REF_TYPE=tag "${root}/scripts/verify-release-context.sh" >/dev/null 2>&1); then
+  fail "tag outside protected main passed the source helper"
+fi
+
+git -C "${checkout}" checkout -q "${base_sha}"
+git -C "${checkout}" tag -f v1.2.3 "${untrusted_sha}" >/dev/null
+git -C "${checkout}" push -q --force origin refs/tags/v1.2.3
+if (cd "${checkout}" && env GIT_TERMINAL_PROMPT=0 GITHUB_EVENT_NAME=push GITHUB_REF_PROTECTED=true GITHUB_SHA="${base_sha}" GITHUB_REF=refs/tags/v1.2.3 GITHUB_REF_NAME=v1.2.3 GITHUB_REF_TYPE=tag "${root}/scripts/verify-release-context.sh" >/dev/null 2>&1); then
+  fail "moved release tag passed the source helper"
 fi
 
 echo "release security check: passed"

--- a/scripts/test-release-security.sh
+++ b/scripts/test-release-security.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workflow="${1:-${root}/.github/workflows/release.yml}"
+
+fail() {
+  echo "release security check: $*" >&2
+  exit 1
+}
+
+[[ -f "${workflow}" ]] || fail "workflow is missing: ${workflow}"
+
+# Keep structural assertions in Python so indentation and quoted YAML do not
+# make the checks depend on fragile grep ranges.
+python3 - "${workflow}" <<'PY'
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+workflow = Path(sys.argv[1])
+text = workflow.read_text(encoding="utf-8")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"release security check: {message}")
+
+
+if re.search(r"(?m)^\s*workflow_dispatch\s*:", text):
+    fail("secret-bearing release workflow must not expose workflow_dispatch")
+if not re.search(r'''(?ms)^on:\s*\n\s+push:\s*\n\s+tags:\s*\n\s+-\s+["']v\*["']\s*$''', text):
+    fail("release trigger must be a v* tag push")
+if "github.event.inputs" in text or "inputs.publish_npm" in text or "inputs.publish_pypi" in text:
+    fail("manual publish inputs remain in the release workflow")
+
+
+def job_block(name: str) -> str:
+    match = re.search(rf"(?ms)^  {re.escape(name)}:\s*\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\s*$|\Z)", text)
+    if not match:
+        fail(f"job {name} is missing")
+    return match.group("body")
+
+
+build = job_block("build")
+package_build = job_block("package-build")
+github_release = job_block("github-release")
+npm = job_block("npm-publish")
+pypi = job_block("pypi-publish")
+
+for name, block in (("build", build), ("package-build", package_build), ("github-release", github_release), ("npm-publish", npm), ("pypi-publish", pypi)):
+    if "github.event_name == 'push'" not in block or "github.ref_type == 'tag'" not in block:
+        fail(f"{name} is not restricted to a tag push")
+    if "persist-credentials: false" not in block:
+        fail(f"{name} checkout must disable persisted credentials")
+    if "scripts/verify-release-context.sh" not in block:
+        fail(f"{name} does not verify the event tag and protected-main ancestry")
+
+if "contents: write" not in github_release:
+    fail("github-release must retain contents: write for the immutable release")
+for name, block in (("npm-publish", npm), ("pypi-publish", pypi)):
+    environment = "npm" if name == "npm-publish" else "pypi"
+    if f"environment: {environment}" not in block:
+        fail(f"{name} must use its protected environment")
+    if "id-token: write" not in block or "contents: read" not in block:
+        fail(f"{name} must request only read contents and OIDC identity")
+    if re.search(r"(?m)^\s+(?:contents|actions|packages|deployments):\s+write\s*$", block):
+        fail(f"{name} requests an unnecessary write permission")
+    if "needs.package-build.outputs.publishable == 'true'" not in block:
+        fail(f"{name} is not gated by the package version/source gate")
+    if "scripts/release_package.py verify" not in block:
+        fail(f"{name} does not verify the immutable package artifact manifest")
+if "npm publish" not in npm or "--provenance" not in npm:
+    fail("npm publishing must use a verified tarball and npm provenance")
+if "packages-dir:" not in pypi or "dist/packages/python" not in pypi:
+    fail("PyPI publishing must consume the verified Python artifact directory")
+if "actions/checkout@" not in text or "ref: ${{ github.sha }}" not in text:
+    fail("every checkout must bind to the event commit")
+if "artifact_id" not in text or "artifact-ids:" not in text:
+    fail("publish jobs must download artifacts from this exact workflow run")
+if "source_commit" not in package_build or "source_commit" not in github_release:
+    fail("release jobs must carry the verified source commit")
+PY
+
+# The pin validator also runs actionlint and rejects mutable action refs.
+"${root}/scripts/test-release-workflow.sh" "${workflow}"
+
+# Verify that the security gate catches a reintroduced manual trigger.
+bad_workflow="$(mktemp)"
+trap 'rm -f "${bad_workflow}"' EXIT
+cp "${workflow}" "${bad_workflow}"
+printf '\nworkflow_dispatch:\n' >>"${bad_workflow}"
+if "${BASH_SOURCE[0]}" "${bad_workflow}" >/dev/null 2>&1; then
+  fail "manual-trigger regression fixture unexpectedly passed"
+fi
+
+echo "release security check: passed"

--- a/scripts/test-release-security.sh
+++ b/scripts/test-release-security.sh
@@ -13,7 +13,7 @@ fail() {
 
 # Keep structural assertions in Python so indentation and quoted YAML do not
 # make the checks depend on fragile grep ranges.
-python3 - "${workflow}" <<'PY'
+python3 - "${workflow}" "${root}/scripts/verify-release-context.sh" <<'PY'
 from __future__ import annotations
 
 import re
@@ -22,6 +22,7 @@ from pathlib import Path
 
 workflow = Path(sys.argv[1])
 text = workflow.read_text(encoding="utf-8")
+helper = Path(sys.argv[2])
 
 
 def fail(message: str) -> None:
@@ -34,6 +35,10 @@ if not re.search(r'''(?ms)^on:\s*\n\s+push:\s*\n\s+tags:\s*\n\s+-\s+["']v\*["']\
     fail("release trigger must be a v* tag push")
 if "github.event.inputs" in text or "inputs.publish_npm" in text or "inputs.publish_pypi" in text:
     fail("manual publish inputs remain in the release workflow")
+
+helper_text = helper.read_text(encoding="utf-8")
+if "GITHUB_TOKEN" not in helper_text or "http.extraheader" not in helper_text:
+    fail("source verification must use a temporary authenticated fetch header")
 
 
 def job_block(name: str) -> str:
@@ -56,6 +61,8 @@ for name, block in (("build", build), ("package-build", package_build), ("github
         fail(f"{name} checkout must disable persisted credentials")
     if "scripts/verify-release-context.sh" not in block:
         fail(f"{name} does not verify the event tag and protected-main ancestry")
+    if "GITHUB_TOKEN: ${{ github.token }}" not in block:
+        fail(f"{name} does not provide a token for private-repository ref verification")
 
 if "contents: write" not in github_release:
     fail("github-release must retain contents: write for the immutable release")
@@ -117,11 +124,11 @@ git -C "${checkout}" push -q origin main
 git -C "${checkout}" tag v1.2.3
 git -C "${checkout}" push -q origin refs/tags/v1.2.3
 base_sha="$(git -C "${checkout}" rev-parse HEAD)"
-if ! (cd "${checkout}" && env GIT_TERMINAL_PROMPT=0 GITHUB_EVENT_NAME=push GITHUB_REF_PROTECTED=true GITHUB_SHA="${base_sha}" GITHUB_REF=refs/tags/v1.2.3 GITHUB_REF_NAME=v1.2.3 GITHUB_REF_TYPE=tag "${root}/scripts/verify-release-context.sh" >"${tmp_dir}/context.out"); then
+if ! (cd "${checkout}" && env GIT_TERMINAL_PROMPT=0 GITHUB_TOKEN=test-token GITHUB_EVENT_NAME=push GITHUB_REF_PROTECTED=true GITHUB_SHA="${base_sha}" GITHUB_REF=refs/tags/v1.2.3 GITHUB_REF_NAME=v1.2.3 GITHUB_REF_TYPE=tag "${root}/scripts/verify-release-context.sh" >"${tmp_dir}/context.out"); then
   fail "valid protected-main tag was rejected"
 fi
 [[ "$(<"${tmp_dir}/context.out")" == "${base_sha}" ]] || fail "source helper returned the wrong commit"
-if (cd "${checkout}" && env GIT_TERMINAL_PROMPT=0 GITHUB_EVENT_NAME=push GITHUB_REF_PROTECTED=false GITHUB_SHA="${base_sha}" GITHUB_REF=refs/tags/v1.2.3 GITHUB_REF_NAME=v1.2.3 GITHUB_REF_TYPE=tag "${root}/scripts/verify-release-context.sh" >/dev/null 2>&1); then
+if (cd "${checkout}" && env GIT_TERMINAL_PROMPT=0 GITHUB_TOKEN=test-token GITHUB_EVENT_NAME=push GITHUB_REF_PROTECTED=false GITHUB_SHA="${base_sha}" GITHUB_REF=refs/tags/v1.2.3 GITHUB_REF_NAME=v1.2.3 GITHUB_REF_TYPE=tag "${root}/scripts/verify-release-context.sh" >/dev/null 2>&1); then
   fail "unprotected tag context passed the source helper"
 fi
 
@@ -131,14 +138,14 @@ git -C "${checkout}" commit -qam untrusted
 git -C "${checkout}" tag v1.2.4
 git -C "${checkout}" push -q origin untrusted refs/tags/v1.2.4
 untrusted_sha="$(git -C "${checkout}" rev-parse HEAD)"
-if (cd "${checkout}" && env GIT_TERMINAL_PROMPT=0 GITHUB_EVENT_NAME=push GITHUB_REF_PROTECTED=true GITHUB_SHA="${untrusted_sha}" GITHUB_REF=refs/tags/v1.2.4 GITHUB_REF_NAME=v1.2.4 GITHUB_REF_TYPE=tag "${root}/scripts/verify-release-context.sh" >/dev/null 2>&1); then
+if (cd "${checkout}" && env GIT_TERMINAL_PROMPT=0 GITHUB_TOKEN=test-token GITHUB_EVENT_NAME=push GITHUB_REF_PROTECTED=true GITHUB_SHA="${untrusted_sha}" GITHUB_REF=refs/tags/v1.2.4 GITHUB_REF_NAME=v1.2.4 GITHUB_REF_TYPE=tag "${root}/scripts/verify-release-context.sh" >/dev/null 2>&1); then
   fail "tag outside protected main passed the source helper"
 fi
 
 git -C "${checkout}" checkout -q "${base_sha}"
 git -C "${checkout}" tag -f v1.2.3 "${untrusted_sha}" >/dev/null
 git -C "${checkout}" push -q --force origin refs/tags/v1.2.3
-if (cd "${checkout}" && env GIT_TERMINAL_PROMPT=0 GITHUB_EVENT_NAME=push GITHUB_REF_PROTECTED=true GITHUB_SHA="${base_sha}" GITHUB_REF=refs/tags/v1.2.3 GITHUB_REF_NAME=v1.2.3 GITHUB_REF_TYPE=tag "${root}/scripts/verify-release-context.sh" >/dev/null 2>&1); then
+if (cd "${checkout}" && env GIT_TERMINAL_PROMPT=0 GITHUB_TOKEN=test-token GITHUB_EVENT_NAME=push GITHUB_REF_PROTECTED=true GITHUB_SHA="${base_sha}" GITHUB_REF=refs/tags/v1.2.3 GITHUB_REF_NAME=v1.2.3 GITHUB_REF_TYPE=tag "${root}/scripts/verify-release-context.sh" >/dev/null 2>&1); then
   fail "moved release tag passed the source helper"
 fi
 

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workflow="${1:-${root}/.github/workflows/release.yml}"
+expected_pypi_revision="dc37677b2e1c63e2034f94d8a5b11f265b73ba33"
+# Upstream actionlint v1.7.8. It supports the Go 1.24 toolchain used by CI;
+# the commit pin keeps the linter itself stable.
+actionlint_revision="e7d448ef7507c20fc4c88a95d0c448b848cd6127"
+
+fail() {
+  echo "release workflow check: $*" >&2
+  exit 1
+}
+
+[[ -f "${workflow}" ]] || fail "workflow is missing: ${workflow}"
+
+uses_count=0
+pypi_count=0
+while IFS=$'\t' read -r line_number action_ref; do
+  [[ -n "${action_ref}" ]] || continue
+  uses_count=$((uses_count + 1))
+  [[ "${action_ref}" =~ ^[^@[:space:]]+@[0-9a-f]{40}$ ]] || {
+    fail "${workflow}:${line_number} uses a mutable or malformed action ref: ${action_ref}"
+  }
+  if [[ "${action_ref}" == "pypa/gh-action-pypi-publish@${expected_pypi_revision}" ]]; then
+    pypi_count=$((pypi_count + 1))
+  fi
+done < <(
+  awk '
+    /^[[:space:]]*uses:[[:space:]]*/ {
+      value = $0
+      sub(/^[[:space:]]*uses:[[:space:]]*/, "", value)
+      sub(/[[:space:]]+#.*$/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      printf "%d\t%s\n", NR, value
+    }
+  ' "${workflow}"
+)
+
+(( uses_count > 0 )) || fail "no action references found"
+(( pypi_count == 1 )) || {
+  fail "expected exactly one PyPI publisher pinned to ${expected_pypi_revision}, found ${pypi_count}"
+}
+
+if [[ -n "${ACTIONLINT_BIN:-}" ]]; then
+  "${ACTIONLINT_BIN}" "${workflow}"
+elif command -v actionlint >/dev/null 2>&1; then
+  actionlint "${workflow}"
+elif command -v go >/dev/null 2>&1; then
+  go run "github.com/rhysd/actionlint/cmd/actionlint@${actionlint_revision}" "${workflow}"
+else
+  fail "actionlint or Go is required"
+fi
+
+echo "release workflow check: passed"

--- a/scripts/test_release_package.py
+++ b/scripts/test_release_package.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Behavior tests for the release package manifest boundary."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from io import BytesIO
+from pathlib import Path
+
+import release_package
+
+
+TAG = "v1.2.3"
+VERSION = "1.2.3"
+COMMIT = "0123456789abcdef0123456789abcdef01234567"
+
+
+def write_npm_archive(path: Path) -> None:
+    payload = json.dumps({"name": "subrouter", "version": VERSION}, separators=(",", ":")).encode()
+    info = tarfile.TarInfo("package/package.json")
+    info.size = len(payload)
+    with tarfile.open(path, "w:gz") as archive:
+        archive.addfile(info, BytesIO(payload))
+
+
+def write_source_archive(path: Path) -> None:
+    payload = f"Metadata-Version: 2.1\nName: subrouter\nVersion: {VERSION}\n".encode()
+    info = tarfile.TarInfo(f"subrouter-{VERSION}/PKG-INFO")
+    info.size = len(payload)
+    with tarfile.open(path, "w:gz") as archive:
+        archive.addfile(info, BytesIO(payload))
+
+
+def write_wheel(path: Path) -> None:
+    metadata = f"Metadata-Version: 2.1\nName: subrouter\nVersion: {VERSION}\n".encode()
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(f"subrouter-{VERSION}.dist-info/METADATA", metadata)
+
+
+class ReleasePackageTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        (self.root / "npm").mkdir()
+        (self.root / "python").mkdir()
+        write_npm_archive(self.root / "npm" / f"subrouter-{VERSION}.tgz")
+        write_wheel(self.root / "python" / f"subrouter-{VERSION}-py3-none-any.whl")
+        write_source_archive(self.root / "python" / f"subrouter-{VERSION}.tar.gz")
+        manifest = release_package.manifest_for(self.root, TAG, COMMIT, VERSION)
+        release_package.write_manifest(self.root, manifest)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_valid_bundle_round_trips(self) -> None:
+        release_package.validate_manifest(self.root, TAG, COMMIT, VERSION)
+
+    def test_modified_package_is_rejected(self) -> None:
+        with (self.root / "npm" / f"subrouter-{VERSION}.tgz").open("ab") as stream:
+            stream.write(b"tampered")
+        with self.assertRaises(release_package.ManifestError):
+            release_package.validate_manifest(self.root, TAG, COMMIT, VERSION)
+
+    def test_extra_file_is_rejected(self) -> None:
+        (self.root / "python" / "unexpected.txt").write_text("unexpected", encoding="utf-8")
+        with self.assertRaises(release_package.ManifestError):
+            release_package.validate_manifest(self.root, TAG, COMMIT, VERSION)
+
+    def test_identity_mismatch_is_rejected(self) -> None:
+        with self.assertRaises(release_package.ManifestError):
+            release_package.validate_manifest(self.root, TAG, COMMIT, "1.2.4")
+
+    def test_duplicate_manifest_key_is_rejected(self) -> None:
+        (self.root / release_package.MANIFEST_NAME).write_text(
+            '{"schema":"subrouter.release-packages/v1","schema":"duplicate"}\n', encoding="utf-8"
+        )
+        with self.assertRaises(release_package.ManifestError):
+            release_package.validate_manifest(self.root, TAG, COMMIT, VERSION)
+
+    def test_create_command_writes_deterministic_manifest(self) -> None:
+        first = (self.root / release_package.MANIFEST_NAME).read_bytes()
+        manifest = release_package.manifest_for(self.root, TAG, COMMIT, VERSION)
+        release_package.write_manifest(self.root, manifest)
+        self.assertEqual(first, (self.root / release_package.MANIFEST_NAME).read_bytes())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/verify-release-context.sh
+++ b/scripts/verify-release-context.sh
@@ -7,13 +7,15 @@ set -euo pipefail
 : "${GITHUB_REF:?GITHUB_REF is required}"
 : "${GITHUB_REF_NAME:?GITHUB_REF_NAME is required}"
 : "${GITHUB_REF_TYPE:?GITHUB_REF_TYPE is required}"
+: "${GITHUB_EVENT_NAME:?GITHUB_EVENT_NAME is required}"
+: "${GITHUB_REF_PROTECTED:?GITHUB_REF_PROTECTED is required}"
 
 [[ "${GITHUB_SHA}" =~ ^[0-9a-f]{40}$ ]] || {
   echo "GITHUB_SHA is not a full lowercase commit SHA" >&2
   exit 1
 }
-[[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF}" == "refs/tags/${GITHUB_REF_NAME}" ]] || {
-  echo "release jobs require a tag push" >&2
+[[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF}" == "refs/tags/${GITHUB_REF_NAME}" && "${GITHUB_REF_PROTECTED}" == "true" ]] || {
+  echo "release jobs require a protected tag push" >&2
   exit 1
 }
 [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || {

--- a/scripts/verify-release-context.sh
+++ b/scripts/verify-release-context.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate the immutable source context used by every publishing job. The
+# caller must check out GITHUB_SHA before invoking this helper.
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+: "${GITHUB_REF:?GITHUB_REF is required}"
+: "${GITHUB_REF_NAME:?GITHUB_REF_NAME is required}"
+: "${GITHUB_REF_TYPE:?GITHUB_REF_TYPE is required}"
+
+[[ "${GITHUB_SHA}" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "GITHUB_SHA is not a full lowercase commit SHA" >&2
+  exit 1
+}
+[[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF}" == "refs/tags/${GITHUB_REF_NAME}" ]] || {
+  echo "release jobs require a tag push" >&2
+  exit 1
+}
+[[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || {
+  echo "release tag must be versioned, for example v0.1.52" >&2
+  exit 1
+}
+
+head_sha="$(git rev-parse 'HEAD^{commit}')"
+[[ "${head_sha}" == "${GITHUB_SHA}" ]] || {
+  echo "checked out commit ${head_sha} does not match the event commit ${GITHUB_SHA}" >&2
+  exit 1
+}
+
+# Fetch the event tag explicitly and force-update only this local ref. This
+# catches a tag movement between the webhook and the checkout. Protected tag
+# rulesets are still required, because this check cannot prevent a race after
+# it completes.
+git fetch --force --no-tags origin \
+  "+refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}" >/dev/null
+tag_sha="$(git rev-parse "refs/tags/${GITHUB_REF_NAME}^{commit}")"
+[[ "${tag_sha}" == "${GITHUB_SHA}" ]] || {
+  echo "tag ${GITHUB_REF_NAME} now resolves to ${tag_sha}, expected ${GITHUB_SHA}" >&2
+  exit 1
+}
+
+git fetch --no-tags origin main >/dev/null
+main_sha="$(git rev-parse 'origin/main^{commit}')"
+git merge-base --is-ancestor "${GITHUB_SHA}" "${main_sha}" || {
+  echo "release tag ${GITHUB_REF_NAME} is not an ancestor of protected main" >&2
+  exit 1
+}
+
+printf '%s\n' "${GITHUB_SHA}"

--- a/scripts/verify-release-context.sh
+++ b/scripts/verify-release-context.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 : "${GITHUB_REF_TYPE:?GITHUB_REF_TYPE is required}"
 : "${GITHUB_EVENT_NAME:?GITHUB_EVENT_NAME is required}"
 : "${GITHUB_REF_PROTECTED:?GITHUB_REF_PROTECTED is required}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required for authenticated ref verification}"
 
 [[ "${GITHUB_SHA}" =~ ^[0-9a-f]{40}$ ]] || {
   echo "GITHUB_SHA is not a full lowercase commit SHA" >&2
@@ -29,11 +30,21 @@ head_sha="$(git rev-parse 'HEAD^{commit}')"
   exit 1
 }
 
+# Keep the token in the process environment instead of a command argument or
+# persisted Git config. Public repositories also use the authenticated path so
+# the same helper works when a repository is made private.
+fetch_authenticated() {
+  GIT_CONFIG_COUNT=1 \
+  GIT_CONFIG_KEY_0=http.extraheader \
+  GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${GITHUB_TOKEN}" \
+    git fetch "$@"
+}
+
 # Fetch the event tag explicitly and force-update only this local ref. This
 # catches a tag movement between the webhook and the checkout. Protected tag
 # rulesets are still required, because this check cannot prevent a race after
 # it completes.
-git fetch --force --no-tags origin \
+fetch_authenticated --force --no-tags origin \
   "+refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}" >/dev/null
 tag_sha="$(git rev-parse "refs/tags/${GITHUB_REF_NAME}^{commit}")"
 [[ "${tag_sha}" == "${GITHUB_SHA}" ]] || {
@@ -41,7 +52,7 @@ tag_sha="$(git rev-parse "refs/tags/${GITHUB_REF_NAME}^{commit}")"
   exit 1
 }
 
-git fetch --no-tags origin main >/dev/null
+fetch_authenticated --no-tags origin main >/dev/null
 main_sha="$(git rev-parse 'origin/main^{commit}')"
 git merge-base --is-ancestor "${GITHUB_SHA}" "${main_sha}" || {
   echo "release tag ${GITHUB_REF_NAME} is not an ancestor of protected main" >&2


### PR DESCRIPTION
## Summary

Remove the secret-bearing `workflow_dispatch` path from the release workflow. Package publication now runs only from a protected `v*` tag push, after the event commit is checked out and revalidated against the live tag and `origin/main`.

Build npm and Python distributions in a separate tag-only job. A deterministic, hash-bound manifest ties every package file to the tag, source commit, version, and package metadata. Publisher jobs download the artifact by the current run's immutable artifact ID, verify the manifest, and then use least-privilege OIDC in the `npm` and `pypi` environments. npm publishes with provenance and lifecycle scripts disabled. Release action refs remain full commit SHAs and caches are disabled for release builds.

The package job reports a notice and skips publication when the tag does not match both package versions. This preserves binary releases while preventing a mismatched package from being published. Current repository metadata is `0.1.33`, while binary tags have advanced beyond that; a future package release must bump both metadata files before tagging.

## Verification

- `scripts/test-release-workflow.sh`
- `scripts/test-release-security.sh`
- `python3 scripts/test_release_package.py` (6 tests)
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `shellcheck scripts/*.sh`
- `uvx --from zizmor zizmor .github/workflows/release.yml` (no findings)
- `go test ./...` (pre-existing flaky `TestGoldenLocalMacHarnessOrchestratesAllModesWithoutContentEvidence`, `process_sampling_gap`; other packages passed)

## Required repository settings

Configure the existing `npm` and `pypi` environments with required reviewers, no self-review, no administrator bypass, and the protected release-tag policy. The workflow cannot enforce those repository settings from YAML.

This PR is stacked on the action-pin PR and should be retargeted to `main` after that PR merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the secret-bearing `workflow_dispatch` trigger from the release workflow so npm and PyPI packages are published only from protected `v*` tag pushes, and every publishing job revalidates the checkout against the live tag and `origin/main` before acting.

**Refactors**
- Builds npm and Python distributions in a new `package-build` job and binds each file to a deterministic, hash-bound manifest.
- Publisher jobs download artifacts by the run's immutable artifact ID, verify the manifest and package metadata, then publish with least-privilege OIDC in the `npm` and `pypi` environments.
- Source verification uses a temporary authenticated fetch header so the live tag and `origin/main` checks also work in private repositories.
- npm publishes with provenance and lifecycle scripts disabled; release action refs remain full commit SHAs and caches are disabled.
- Publishing is skipped with a notice when the tag does not match both package versions; current repository metadata is `0.1.33`, so a future package release must bump both metadata files before tagging.

**Migration**
- Configure the existing `npm` and `pypi` environments with required reviewers, no self-review, and no administrator bypass.
- Enable the protected release-tag policy; the workflow cannot enforce these repository settings from YAML.

<sup>Written for commit 3e761384687b5ca8853f7f45c684a1bd1cfb7ac3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

