### PR TITLE
fix: classify external-fork CLA recheck failures

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -2,8 +2,12 @@
 
 `cla-recheck-auth.sh` is the read-only admission step for an exact `recheck`
 comment. The caller must provide the event comment ID, body, author ID, login,
-and creation timestamp through environment variables and grant only `issues:read`
-and `pull-requests:read`.
+and creation timestamp through environment variables. The caller needs
+`issues:read` and `pull-requests:read`. The collaborator permission endpoint
+also needs repository Metadata read. GitHub Actions supplies that metadata
+permission implicitly for `GITHUB_TOKEN`; a caller that supplies a different
+token must grant Metadata read explicitly. No Administration or write
+permission is needed.
 
 The script re-reads the issue, live Pull Request, comment, and collaborator
 permission through bounded GitHub API requests. It accepts only an open,

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,22 @@
+# CLA recheck authorizer
+
+`cla-recheck-auth.sh` is the read-only admission step for an exact `recheck`
+comment. The caller must provide the event comment ID, body, author ID, login,
+and creation timestamp through environment variables and grant only `issues:read`
+and `pull-requests:read`.
+
+The script re-reads the issue, live Pull Request, comment, and collaborator
+permission through bounded GitHub API requests. It accepts only an open,
+unmerged Pull Request targeting `main`, an unchanged human comment, and a live
+`admin` or `maintain` role. It never writes a comment, check, ledger, or source
+file.
+
+Each request is retried at most three times. A validated 404 or a changed
+comment is `unauthorized` with `check_action=preserve`. A temporary API,
+transport, or rate-limit failure is `retry` with `check_action=preserve`; the
+caller must leave any existing required check untouched and run again later.
+Malformed or incomplete responses are `error` with `check_action=fail`.
+
+The workflow must execute this file from a trusted default-branch revision. It
+must not check out or execute Pull Request head content in a
+`pull_request_target` job.

--- a/.github/scripts/cla-recheck-auth.sh
+++ b/.github/scripts/cla-recheck-auth.sh
@@ -217,9 +217,10 @@ fi
 if ! jq -e '
   has("merged_at") and
   (.merged_at == null or
-   (.merged_at | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$")))
+   (.merged_at | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$"))) and
+  (.state == "closed" or (.state == "open" and .merged_at == null))
 ' <<<"${api_body}" >/dev/null 2>&1; then
-  fail_input 'GitHub returned an invalid merged_at value for the live pull request.'
+  fail_input 'GitHub returned an inconsistent merged_at value for the live pull request.'
 fi
 if ! jq -e --arg repo "${GH_REPO}" '
   def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991;

--- a/.github/scripts/cla-recheck-auth.sh
+++ b/.github/scripts/cla-recheck-auth.sh
@@ -162,6 +162,16 @@ require_inputs() {
 
 require_inputs
 
+validate_state() {
+  local resource="$1"
+  if ! jq -e '
+    type == "object" and
+    (.state | type == "string" and (. == "open" or . == "closed"))
+  ' <<<"${api_body}" >/dev/null 2>&1; then
+    fail_input "GitHub returned an invalid ${resource} pull request state."
+  fi
+}
+
 # Read the issue resource first. It uses the issue read permission and remains
 # available for fork Pull Requests when the Pulls endpoint is temporarily
 # unavailable. It proves that this exact issue is still an open Pull Request.
@@ -175,10 +185,8 @@ if ! jq -e --arg pr "${PR_NUMBER}" '
 ' <<<"${api_body}" >/dev/null 2>&1; then
   fail_input 'GitHub returned malformed pull request issue data.'
 fi
-if ! jq -e '.state | type == "string"' <<<"${api_body}" >/dev/null 2>&1; then
-  fail_input 'GitHub returned an invalid pull request state.'
-fi
-if jq -e '.state != "open"' <<<"${api_body}" >/dev/null 2>&1; then
+validate_state issue
+if jq -e '.state == "closed"' <<<"${api_body}" >/dev/null 2>&1; then
   finish unauthorized preserve 'CLA recheck ignored: the pull request is no longer open.' 0
 fi
 if ! jq -e --arg repo "${GH_REPO}" --arg pr "${PR_NUMBER}" '
@@ -202,10 +210,8 @@ if ! jq -e --arg pr "${PR_NUMBER}" '
 ' <<<"${api_body}" >/dev/null 2>&1; then
   fail_input 'GitHub returned malformed live pull request identity data.'
 fi
-if ! jq -e '.state | type == "string"' <<<"${api_body}" >/dev/null 2>&1; then
-  fail_input 'GitHub returned an invalid live pull request state.'
-fi
-if jq -e '.state != "open"' <<<"${api_body}" >/dev/null 2>&1; then
+validate_state pull request
+if jq -e '.state == "closed"' <<<"${api_body}" >/dev/null 2>&1; then
   finish unauthorized preserve 'CLA recheck ignored: the pull request is no longer open.' 0
 fi
 if ! jq -e '

--- a/.github/scripts/cla-recheck-auth.sh
+++ b/.github/scripts/cla-recheck-auth.sh
@@ -175,6 +175,9 @@ if ! jq -e --arg pr "${PR_NUMBER}" '
 ' <<<"${api_body}" >/dev/null 2>&1; then
   fail_input 'GitHub returned malformed pull request issue data.'
 fi
+if ! jq -e '.state | type == "string"' <<<"${api_body}" >/dev/null 2>&1; then
+  fail_input 'GitHub returned an invalid pull request state.'
+fi
 if jq -e '.state != "open"' <<<"${api_body}" >/dev/null 2>&1; then
   finish unauthorized preserve 'CLA recheck ignored: the pull request is no longer open.' 0
 fi
@@ -199,8 +202,18 @@ if ! jq -e --arg pr "${PR_NUMBER}" '
 ' <<<"${api_body}" >/dev/null 2>&1; then
   fail_input 'GitHub returned malformed live pull request identity data.'
 fi
-if jq -e '.state != "open" or .merged_at != null' <<<"${api_body}" >/dev/null 2>&1; then
+if ! jq -e '.state | type == "string"' <<<"${api_body}" >/dev/null 2>&1; then
+  fail_input 'GitHub returned an invalid live pull request state.'
+fi
+if jq -e '.state != "open"' <<<"${api_body}" >/dev/null 2>&1; then
   finish unauthorized preserve 'CLA recheck ignored: the pull request is no longer open.' 0
+fi
+if ! jq -e '
+  has("merged_at") and
+  (.merged_at == null or
+   (.merged_at | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$")))
+' <<<"${api_body}" >/dev/null 2>&1; then
+  fail_input 'GitHub returned an invalid merged_at value for the live pull request.'
 fi
 if ! jq -e --arg repo "${GH_REPO}" '
   def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991;

--- a/.github/scripts/cla-recheck-auth.sh
+++ b/.github/scripts/cla-recheck-auth.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# Authenticate the exact `recheck` comment without granting a writer token.
+# The caller treats `retry` as a no-op and retries after the API recovers.
+set -euo pipefail
+
+readonly EXPECTED_REPOSITORY='manaflow-ai/subrouter'
+readonly MAX_RESPONSE_BYTES=262144
+readonly MAX_TOTAL_BYTES=2000000
+readonly MAX_ATTEMPTS=3
+readonly MAX_SAFE_INTEGER=9007199254740991
+readonly RETRY_DELAY_SECONDS="${CLA_RECHECK_RETRY_DELAY_SECONDS:-1}"
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+authorized=false
+decision=error
+check_action=fail
+api_total_bytes=0
+raw_file="$(mktemp)"
+trap 'rm -f -- "${raw_file}"' EXIT
+
+emit() {
+  printf 'authorized=%s\ndecision=%s\ncheck_action=%s\n' \
+    "${authorized}" "${decision}" "${check_action}" >>"${GITHUB_OUTPUT}"
+}
+
+finish() {
+  decision="$1"
+  check_action="$2"
+  emit
+  printf '%s\n' "$3"
+  [[ "$4" == 0 ]] || exit "$4"
+  exit 0
+}
+
+fail_input() {
+  authorized=false
+  decision=error
+  check_action=fail
+  emit
+  echo "::error title=CLA recheck policy::$1" >&2
+  exit 1
+}
+
+retry_later() {
+  authorized=false
+  decision=retry
+  check_action=preserve
+  emit
+  echo "::warning title=CLA recheck retry::$1" >&2
+  exit 1
+}
+
+is_safe_id() {
+  local value="${1:-}"
+  [[ "$value" =~ ^[1-9][0-9]*$ ]] || return 1
+  (( ${#value} <= 16 )) || return 1
+  (( ${#value} != 16 || value <= MAX_SAFE_INTEGER ))
+}
+
+is_safe_login() {
+  [[ "${1:-}" =~ ^[A-Za-z0-9][A-Za-z0-9-]{0,38}$ ]]
+}
+
+is_timestamp() {
+  [[ "${1:-}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}
+
+is_valid_not_found() {
+  local body="${1:-}"
+  jq -e 'type == "object" and ((.status == 404) or (.status == "404")) and (.message | type == "string" and length > 0)' \
+    <<<"${body}" >/dev/null 2>&1
+}
+
+extract_http_body() {
+  awk '
+    BEGIN { in_headers = 0; body_started = 0; body = "" }
+    {
+      sub(/\r$/, "")
+      if ($0 ~ /^HTTP\/[0-9.]+[[:space:]][0-9][0-9][0-9]([[:space:]]|$)/) {
+        in_headers = 1
+        body_started = 0
+        body = ""
+        next
+      }
+      if (in_headers && $0 == "") {
+        in_headers = 0
+        body_started = 1
+        next
+      }
+      if (body_started) body = body $0 "\n"
+    }
+    END { printf "%s", body }
+  ' "${raw_file}"
+}
+
+read_response() {
+  local endpoint="$1"
+  local attempt raw_bytes command_status http_status response_body
+  api_kind=retry
+  api_body=""
+
+  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    : >"${raw_file}"
+    set +e
+    (
+      # `ulimit -f` is a pre-parser bound. The extra block permits the limit
+      # check below to distinguish an exact-bound response from an overflow.
+      ulimit -f $(( (MAX_RESPONSE_BYTES + 511) / 512 + 1 ))
+      gh api --method GET --include \
+        --header 'Accept: application/vnd.github+json' \
+        --header 'X-GitHub-Api-Version: 2022-11-28' \
+        "${endpoint}" >"${raw_file}" 2>/dev/null
+    )
+    command_status=$?
+    set -e
+
+    raw_bytes="$(LC_ALL=C wc -c <"${raw_file}" | tr -d '[:space:]')"
+    if ! [[ "${raw_bytes}" =~ ^[0-9]+$ ]] || (( raw_bytes > MAX_RESPONSE_BYTES )); then
+      api_kind=retry
+    else
+      api_total_bytes=$((api_total_bytes + raw_bytes))
+      if (( api_total_bytes > MAX_TOTAL_BYTES )); then
+        api_kind=retry
+      else
+        http_status="$(awk '/^HTTP\// { gsub("\r", "", $2); code=$2 } END { print code }' "${raw_file}")"
+        if [[ -z "${http_status}" ]]; then
+          http_status=200
+          response_body="$(<"${raw_file}")"
+        else
+          response_body="$(extract_http_body)"
+        fi
+        api_body="${response_body}"
+        if [[ "${http_status}" == 404 ]] && is_valid_not_found "${response_body}"; then
+          api_kind=not_found
+          return 2
+        elif (( command_status == 0 )) && [[ "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
+          api_kind=ok
+          return 0
+        else
+          api_kind=retry
+        fi
+      fi
+    fi
+    if (( attempt < MAX_ATTEMPTS )); then
+      sleep "${RETRY_DELAY_SECONDS}"
+    fi
+  done
+  return 1
+}
+
+require_inputs() {
+  [[ "${GH_REPO:-}" == "${EXPECTED_REPOSITORY}" ]] || fail_input 'The helper is not running in the canonical repository.'
+  [[ "${COMMENT_BODY:-}" == 'recheck' ]] || fail_input 'The comment is not the exact recheck command.'
+  is_safe_id "${PR_NUMBER:-}" || fail_input 'The pull request number is invalid.'
+  is_safe_id "${COMMENT_ID:-}" || fail_input 'The comment ID is invalid.'
+  is_safe_id "${COMMENT_USER_ID:-}" || fail_input 'The commenter ID is invalid.'
+  is_safe_login "${COMMENT_USER_LOGIN:-}" || fail_input 'The commenter login is invalid.'
+  [[ "${COMMENT_USER_TYPE:-User}" == User ]] || fail_input 'The commenter is not an authenticated human user.'
+  is_timestamp "${COMMENT_CREATED_AT:-}" || fail_input 'The comment timestamp is invalid.'
+}
+
+require_inputs
+
+# Read the issue resource first. It uses the issue read permission and remains
+# available for fork Pull Requests when the Pulls endpoint is temporarily
+# unavailable. It proves that this exact issue is still an open Pull Request.
+if ! read_response "repos/${GH_REPO}/issues/${PR_NUMBER}"; then
+  [[ "${api_kind}" == not_found ]] && finish unauthorized preserve 'CLA recheck ignored: the pull request no longer exists or is closed.' 0
+  retry_later 'GitHub could not read the pull request issue after bounded retries.'
+fi
+if ! jq -e --arg pr "${PR_NUMBER}" '
+  def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991;
+  type == "object" and (.number | safe_id and tostring == $pr)
+' <<<"${api_body}" >/dev/null 2>&1; then
+  fail_input 'GitHub returned malformed pull request issue data.'
+fi
+if jq -e '.state != "open"' <<<"${api_body}" >/dev/null 2>&1; then
+  finish unauthorized preserve 'CLA recheck ignored: the pull request is no longer open.' 0
+fi
+if ! jq -e --arg repo "${GH_REPO}" --arg pr "${PR_NUMBER}" '
+  (.state | type == "string") and
+  (.pull_request | type == "object") and
+  .pull_request.url == ("https://api.github.com/repos/" + $repo + "/pulls/" + $pr)
+' <<<"${api_body}" >/dev/null 2>&1; then
+  fail_input 'GitHub returned incomplete pull request issue data.'
+fi
+
+# The Pulls resource is the authoritative base/head identity. A validated
+# issue response is not enough to authorize a privileged refresh. If this read
+# remains unavailable, preserve any existing check and ask for a later retry.
+if ! read_response "repos/${GH_REPO}/pulls/${PR_NUMBER}"; then
+  [[ "${api_kind}" == not_found ]] && finish unauthorized preserve 'CLA recheck ignored: the pull request no longer exists.' 0
+  retry_later 'GitHub could not read the live pull request identity after bounded retries.'
+fi
+if ! jq -e --arg pr "${PR_NUMBER}" '
+  def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991;
+  type == "object" and (.number | safe_id and tostring == $pr)
+' <<<"${api_body}" >/dev/null 2>&1; then
+  fail_input 'GitHub returned malformed live pull request identity data.'
+fi
+if jq -e '.state != "open" or .merged_at != null' <<<"${api_body}" >/dev/null 2>&1; then
+  finish unauthorized preserve 'CLA recheck ignored: the pull request is no longer open.' 0
+fi
+if ! jq -e --arg repo "${GH_REPO}" '
+  def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991;
+  (.base | type == "object") and .base.ref == "main" and
+  (.base.repo | type == "object") and
+  ((.base.repo.full_name | type == "string") and (.base.repo.full_name | ascii_downcase) == ($repo | ascii_downcase)) and
+  (.base.repo.id | safe_id) and
+  (.head | type == "object") and (.head.sha | type == "string" and test("^[0-9a-fA-F]{40}$")) and
+  (.head.repo | type == "object") and (.head.repo.id | safe_id) and
+  (.user | type == "object") and (.user.id | safe_id)
+' <<<"${api_body}" >/dev/null 2>&1; then
+  if jq -e --arg repo "${GH_REPO}" '
+    type == "object" and
+    ((.base | type == "object") and
+      ((.base.ref | type == "string") and .base.ref != "main" or
+       (.base.repo | type == "object") and
+       (.base.repo.full_name | type == "string") and
+       (.base.repo.full_name | ascii_downcase) != ($repo | ascii_downcase)))
+  ' <<<"${api_body}" >/dev/null 2>&1; then
+    finish unauthorized preserve 'CLA recheck ignored: the pull request no longer targets main.' 0
+  fi
+  fail_input 'GitHub returned incomplete live pull request identity data.'
+fi
+
+# Confirm the event comment is still the exact, unedited snapshot. A validated
+# 404 or an immutable mismatch is ordinary unauthorized input. Other failures
+# retain the explicit retry state.
+if ! read_response "repos/${GH_REPO}/issues/comments/${COMMENT_ID}"; then
+  [[ "${api_kind}" == not_found ]] && finish unauthorized preserve 'CLA recheck ignored: the command comment was deleted.' 0
+  retry_later 'GitHub could not read the live recheck comment after bounded retries.'
+fi
+if ! jq -e --arg id "${COMMENT_ID}" --arg body "${COMMENT_BODY}" --arg user_id "${COMMENT_USER_ID}" \
+          --arg login "${COMMENT_USER_LOGIN}" --arg issue_url "https://api.github.com/repos/${GH_REPO}/issues/${PR_NUMBER}" \
+          --arg created "${COMMENT_CREATED_AT}" '
+  type == "object" and (.id | type == "number" and floor == . and tostring == $id) and
+  .body == $body and (.user | type == "object") and
+  (.user.id | type == "number" and floor == . and tostring == $user_id) and
+  (.user.login | type == "string" and ascii_downcase == ($login | ascii_downcase)) and
+  .user.type == "User" and .issue_url == $issue_url and
+  (.created_at | type == "string" and . == $created) and .updated_at == .created_at
+' <<<"${api_body}" >/dev/null 2>&1; then
+  if jq -e 'type == "object" and (.id | type == "number") and (.body | type == "string") and (.user | type == "object")' <<<"${api_body}" >/dev/null 2>&1; then
+    finish unauthorized preserve 'CLA recheck ignored: the command comment changed after delivery.' 0
+  fi
+  fail_input 'GitHub returned malformed live recheck comment data.'
+fi
+
+# A 404 from the collaborator permission endpoint is a validated ordinary
+# denial. Do not turn it into an infrastructure failure.
+if ! read_response "repos/${GH_REPO}/collaborators/${COMMENT_USER_LOGIN}/permission"; then
+  [[ "${api_kind}" == not_found ]] && finish unauthorized preserve 'CLA recheck ignored: requester is not an admin or maintainer.' 0
+  retry_later 'GitHub could not verify the requester permission after bounded retries.'
+fi
+if ! jq -e --arg id "${COMMENT_USER_ID}" '
+  type == "object" and (.user | type == "object") and
+  (.user.id | type == "number" and floor == . and tostring == $id) and
+  (.permission | type == "string") and
+  ((.role_name // "") | type == "string")
+' <<<"${api_body}" >/dev/null 2>&1; then
+  fail_input 'GitHub returned malformed requester permission data.'
+fi
+role_name="$(jq -r '.role_name // .permission' <<<"${api_body}")"
+case "${role_name}" in
+  admin|maintain)
+    finish authorized refresh 'CLA recheck requester has live admin or maintainer permission.' 0
+    ;;
+  push|write|none|read|pull|triage)
+    finish unauthorized preserve 'CLA recheck ignored: requester is not an admin or maintainer.' 0
+    ;;
+  *)
+    retry_later 'GitHub returned an unknown requester permission role.'
+    ;;
+esac

--- a/tests/test_cla_recheck_auth.sh
+++ b/tests/test_cla_recheck_auth.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Behavior tests for the read-only recheck authorizer.
+# The fixtures model an external-fork Pull Request and an already-green CLA
+# check. They exercise API responses through a fake `gh` command, not workflow
+# source text.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT_DIR/.github/scripts/cla-recheck-auth.sh"
+readonly PR_NUMBER=301
+readonly COMMENT_ID=900
+readonly COMMENT_AUTHOR_ID=25807
+readonly COMMENT_AUTHOR_LOGIN=danielraffel
+readonly COMMENT_BODY=recheck
+readonly COMMENT_CREATED_AT=2026-09-02T03:42:16Z
+
+command -v jq >/dev/null
+test -x "$SCRIPT"
+
+api_calls=()
+pull_attempts=0
+
+fake_gh() {
+  local endpoint="${!#}"
+  local method=GET
+  local arg
+  for arg in "$@"; do
+    [[ "$arg" == POST ]] && method=POST
+  done
+  [[ "$method" == GET ]] || {
+    echo "unexpected write method: $method" >&2
+    return 97
+  }
+  api_calls+=("$endpoint")
+
+  case "$FAKE_MODE:$endpoint" in
+    external-fork:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    external-fork:repos/manaflow-ai/subrouter/pulls/301)
+      pull_attempts=$((pull_attempts + 1))
+      if (( pull_attempts < 3 )); then
+        printf 'HTTP/2 503\r\ncontent-type: application/json\r\n\r\n{"message":"temporary upstream failure"}\n'
+        return 1
+      fi
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",merged_at:null,user:{id:25807,login:"danielraffel"},base:{ref:"main",repo:{id:1228491972,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"danielraffel/subrouter"}}}'
+      ;;
+    external-fork:repos/manaflow-ai/subrouter/issues/comments/900)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc --arg created "$COMMENT_CREATED_AT" '{id:900,body:"recheck",user:{id:25807,login:"danielraffel",type:"User"},issue_url:"https://api.github.com/repos/manaflow-ai/subrouter/issues/301",created_at:$created,updated_at:$created}'
+      ;;
+    external-fork:repos/manaflow-ai/subrouter/collaborators/danielraffel/permission)
+      printf 'HTTP/2 404\r\ncontent-type: application/json\r\n\r\n{"message":"Not Found","status":404}\n'
+      return 1
+      ;;
+    transport-error:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    transport-error:repos/manaflow-ai/subrouter/pulls/301)
+      printf 'HTTP/2 503\r\ncontent-type: application/json\r\n\r\n{"message":"service unavailable"}\n'
+      return 1
+      ;;
+    authorized:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    authorized:repos/manaflow-ai/subrouter/pulls/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",merged_at:null,user:{id:25807,login:"danielraffel"},base:{ref:"main",repo:{id:1228491972,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"danielraffel/subrouter"}}}'
+      ;;
+    authorized:repos/manaflow-ai/subrouter/issues/comments/900)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc --arg created "$COMMENT_CREATED_AT" '{id:900,body:"recheck",user:{id:25807,login:"danielraffel",type:"User"},issue_url:"https://api.github.com/repos/manaflow-ai/subrouter/issues/301",created_at:$created,updated_at:$created}'
+      ;;
+    authorized:repos/manaflow-ai/subrouter/collaborators/danielraffel/permission)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{user:{id:25807,login:"danielraffel"},permission:"maintain",role_name:"maintain"}'
+      ;;
+    malformed:*)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n{"unexpected":true}\n'
+      ;;
+    *)
+      echo "fixture endpoint missing for $FAKE_MODE:$endpoint" >&2
+      return 98
+      ;;
+  esac
+}
+
+gh() { fake_gh "$@"; }
+export -f fake_gh gh
+
+run_case() {
+  local mode="$1" expected_status="$2" expected_decision="$3" expected_action="$4"
+  local work status
+  work="$(mktemp -d)"
+  export FAKE_MODE="$mode" pull_attempts=0
+  export GH_REPO=manaflow-ai/subrouter PR_NUMBER COMMENT_ID COMMENT_BODY
+  export COMMENT_USER_ID="$COMMENT_AUTHOR_ID" COMMENT_USER_LOGIN="$COMMENT_AUTHOR_LOGIN"
+  export GITHUB_OUTPUT="$work/output.env"
+  export CLA_RECHECK_RETRY_DELAY_SECONDS=0
+  : >"$GITHUB_OUTPUT"
+  set +e
+  (cd "$ROOT_DIR" && bash "$SCRIPT") >"$work/log" 2>&1
+  status="$?"
+  set -e
+  [[ "$status" == "$expected_status" ]] || { cat "$work/log" >&2; echo "case $mode status $status" >&2; return 1; }
+  grep -Fxq "authorized=false" "$GITHUB_OUTPUT" || grep -Fxq "authorized=true" "$GITHUB_OUTPUT"
+  grep -Fxq "decision=$expected_decision" "$GITHUB_OUTPUT" || { cat "$work/output.env" >&2; return 1; }
+  grep -Fxq "check_action=$expected_action" "$GITHUB_OUTPUT" || { cat "$work/output.env" >&2; return 1; }
+  if [[ "$mode" == external-fork ]]; then
+    [[ "$pull_attempts" == 3 ]] || { echo "external-fork did not retry pull API" >&2; return 1; }
+  fi
+  rm -rf "$work"
+}
+
+# Daniel's external-fork PR already has a durable CLA signature and a green
+# required check. A temporary Pulls API failure must be retried, then a valid
+# non-collaborator response is an unauthorized no-op that preserves green.
+run_case external-fork 0 unauthorized preserve
+
+# Persistent API failure is a retry state, not an unauthorized denial and not a
+# new failure check. The caller can retry after GitHub recovers.
+run_case transport-error 1 retry preserve
+
+# A valid maintainer response admits the refresh path.
+run_case authorized 0 authorized refresh
+
+# Malformed API data is an explicit error and must never be treated as a
+# successful or unauthorized authorization.
+run_case malformed 1 error fail
+
+echo "CLA recheck authorization behavior tests passed"

--- a/tests/test_cla_recheck_auth.sh
+++ b/tests/test_cla_recheck_auth.sh
@@ -75,6 +75,18 @@ fake_gh() {
       printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
       jq -nc '{number:301,state:"open",merged_at:null,user:{id:25807,login:"danielraffel"},base:{ref:"main",repo:{id:1228491972,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:null}}'
       ;;
+    missing-state:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    missing-merged:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    missing-merged:repos/manaflow-ai/subrouter/pulls/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",user:{id:25807,login:"danielraffel"},base:{ref:"main",repo:{id:1228491972,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"danielraffel/subrouter"}}}'
+      ;;
     transport-error:repos/manaflow-ai/subrouter/issues/301)
       printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
       jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
@@ -154,6 +166,12 @@ run_case closed-404 0 unauthorized preserve
 # A current PR with a missing head repository is malformed identity data. It
 # must fail closed instead of being mistaken for an unrelated deleted fork.
 run_case current-null 1 error fail
+
+# Missing state is malformed, not a closed Pull Request denial.
+run_case missing-state 1 error fail
+
+# Missing merged_at must not be interpreted as an explicit unmerged state.
+run_case missing-merged 1 error fail
 
 # A valid maintainer response admits the refresh path.
 run_case authorized 0 authorized refresh

--- a/tests/test_cla_recheck_auth.sh
+++ b/tests/test_cla_recheck_auth.sh
@@ -39,8 +39,12 @@ fake_gh() {
       jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
       ;;
     external-fork:repos/manaflow-ai/subrouter/pulls/301)
-      pull_attempts=$((pull_attempts + 1))
-      if (( pull_attempts < 3 )); then
+      local attempt
+      attempt="$(<"${PULL_ATTEMPTS_FILE}")"
+      attempt=$((attempt + 1))
+      printf '%s\n' "$attempt" >"${PULL_ATTEMPTS_FILE}"
+      pull_attempts="$attempt"
+      if (( attempt < 3 )); then
         printf 'HTTP/2 503\r\ncontent-type: application/json\r\n\r\n{"message":"temporary upstream failure"}\n'
         return 1
       fi
@@ -54,6 +58,22 @@ fake_gh() {
     external-fork:repos/manaflow-ai/subrouter/collaborators/danielraffel/permission)
       printf 'HTTP/2 404\r\ncontent-type: application/json\r\n\r\n{"message":"Not Found","status":404}\n'
       return 1
+      ;;
+    closed-404:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    closed-404:repos/manaflow-ai/subrouter/pulls/301)
+      printf 'HTTP/2 404\r\ncontent-type: application/json\r\n\r\n{"message":"Not Found","status":404}\n'
+      return 1
+      ;;
+    current-null:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    current-null:repos/manaflow-ai/subrouter/pulls/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",merged_at:null,user:{id:25807,login:"danielraffel"},base:{ref:"main",repo:{id:1228491972,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:null}}'
       ;;
     transport-error:repos/manaflow-ai/subrouter/issues/301)
       printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
@@ -96,9 +116,11 @@ run_case() {
   local mode="$1" expected_status="$2" expected_decision="$3" expected_action="$4"
   local work status
   work="$(mktemp -d)"
-  export FAKE_MODE="$mode" pull_attempts=0
+  export FAKE_MODE="$mode" pull_attempts=0 PULL_ATTEMPTS_FILE="$work/pull-attempts"
+  printf '0\n' >"$PULL_ATTEMPTS_FILE"
   export GH_REPO=manaflow-ai/subrouter PR_NUMBER COMMENT_ID COMMENT_BODY
-  export COMMENT_USER_ID="$COMMENT_AUTHOR_ID" COMMENT_USER_LOGIN="$COMMENT_AUTHOR_LOGIN"
+  export COMMENT_USER_ID="$COMMENT_AUTHOR_ID" COMMENT_USER_LOGIN="$COMMENT_AUTHOR_LOGIN" \
+    COMMENT_USER_TYPE=User COMMENT_CREATED_AT
   export GITHUB_OUTPUT="$work/output.env"
   export CLA_RECHECK_RETRY_DELAY_SECONDS=0
   : >"$GITHUB_OUTPUT"
@@ -111,7 +133,7 @@ run_case() {
   grep -Fxq "decision=$expected_decision" "$GITHUB_OUTPUT" || { cat "$work/output.env" >&2; return 1; }
   grep -Fxq "check_action=$expected_action" "$GITHUB_OUTPUT" || { cat "$work/output.env" >&2; return 1; }
   if [[ "$mode" == external-fork ]]; then
-    [[ "$pull_attempts" == 3 ]] || { echo "external-fork did not retry pull API" >&2; return 1; }
+    [[ "$(<"$PULL_ATTEMPTS_FILE")" == 3 ]] || { echo "external-fork did not retry pull API" >&2; return 1; }
   fi
   rm -rf "$work"
 }
@@ -124,6 +146,14 @@ run_case external-fork 0 unauthorized preserve
 # Persistent API failure is a retry state, not an unauthorized denial and not a
 # new failure check. The caller can retry after GitHub recovers.
 run_case transport-error 1 retry preserve
+
+# A validated Pulls 404 means the PR disappeared between the issue and Pulls
+# reads. Preserve the existing check as an ordinary no-op.
+run_case closed-404 0 unauthorized preserve
+
+# A current PR with a missing head repository is malformed identity data. It
+# must fail closed instead of being mistaken for an unrelated deleted fork.
+run_case current-null 1 error fail
 
 # A valid maintainer response admits the refresh path.
 run_case authorized 0 authorized refresh

--- a/tests/test_cla_recheck_auth.sh
+++ b/tests/test_cla_recheck_auth.sh
@@ -79,6 +79,26 @@ fake_gh() {
       printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
       jq -nc '{number:301,pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
       ;;
+    unsupported-issue-state:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"pending",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    unsupported-pull-state:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    unsupported-pull-state:repos/manaflow-ai/subrouter/pulls/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"pending",merged_at:null,user:{id:25807,login:"danielraffel"},base:{ref:"main",repo:{id:1228491972,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"danielraffel/subrouter"}}}'
+      ;;
+    nonstring-state:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:42,pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    closed-state:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"closed",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
     missing-merged:repos/manaflow-ai/subrouter/issues/301)
       printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
       jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
@@ -169,6 +189,13 @@ run_case current-null 1 error fail
 
 # Missing state is malformed, not a closed Pull Request denial.
 run_case missing-state 1 error fail
+
+# Unsupported issue and Pulls state values are malformed, not closed Pull
+# Request denials. They must fail before any authorization decision.
+run_case unsupported-issue-state 1 error fail
+run_case unsupported-pull-state 1 error fail
+run_case nonstring-state 1 error fail
+run_case closed-state 0 unauthorized preserve
 
 # Missing merged_at must not be interpreted as an explicit unmerged state.
 run_case missing-merged 1 error fail

--- a/tests/test_cla_recheck_auth.sh
+++ b/tests/test_cla_recheck_auth.sh
@@ -131,6 +131,22 @@ fake_gh() {
       printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
       jq -nc '{user:{id:25807,login:"danielraffel"},permission:"maintain",role_name:"maintain"}'
       ;;
+    open-merged:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    open-merged:repos/manaflow-ai/subrouter/pulls/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",merged_at:"2026-09-02T03:42:16Z",user:{id:25807,login:"danielraffel"},base:{ref:"main",repo:{id:1228491972,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"danielraffel/subrouter"}}}'
+      ;;
+    open-merged:repos/manaflow-ai/subrouter/issues/comments/900)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc --arg created "$COMMENT_CREATED_AT" '{id:900,body:"recheck",user:{id:25807,login:"danielraffel",type:"User"},issue_url:"https://api.github.com/repos/manaflow-ai/subrouter/issues/301",created_at:$created,updated_at:$created}'
+      ;;
+    open-merged:repos/manaflow-ai/subrouter/collaborators/danielraffel/permission)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{user:{id:25807,login:"danielraffel"},permission:"maintain",role_name:"maintain"}'
+      ;;
     malformed:*)
       printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n{"unexpected":true}\n'
       ;;
@@ -202,6 +218,10 @@ run_case missing-merged 1 error fail
 
 # A valid maintainer response admits the refresh path.
 run_case authorized 0 authorized refresh
+
+# An open Pull Request with a non-null merged_at value is inconsistent and
+# must fail closed instead of authorizing a refresh.
+run_case open-merged 1 error fail
 
 # Malformed API data is an explicit error and must never be treated as a
 # successful or unauthorized authorization.


### PR DESCRIPTION
## Summary

- add a trusted, read-only CLA recheck authorizer for the follow-up workflow wiring
- retry bounded GitHub API transport and rate-limit failures without changing an existing required check
- classify validated 404 or changed comments as unauthorized no-ops, and malformed or incomplete responses as visible errors
- require complete live current-PR identity, including a non-null head repository
- add test-first external-fork, retry, 404, current-null, authorized, and malformed fixtures

This PR intentionally does not change `.github/workflows/cla.yml` or repository rulesets. The follow-up workflow PR must execute this file only from a trusted default-branch revision and must never check out pull request head content.

## Verification

- `tests/test_cla_recheck_auth.sh`
- `shellcheck .github/scripts/cla-recheck-auth.sh tests/test_cla_recheck_auth.sh`
- `bash -n .github/scripts/cla-recheck-auth.sh tests/test_cla_recheck_auth.sh`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only CLA recheck authorizer so external-fork `recheck` comments can be validated without a writer token or any change to the existing required check.

- `cla-recheck-auth.sh` re-reads the issue, PR, comment, and collaborator permission via bounded GitHub API calls, retrying transient failures up to three times.
- A validated 404 or a changed comment is an unauthorized no-op that preserves the existing check; temporary API/transport failures preserve the check and retry later; malformed, incomplete, or unsupported-state responses fail the check.
- Authorization requires an open, unmerged PR targeting main with a complete non-null head repository; a missing `merged_at` or a merge timestamp on an open PR fails the check.
- `README.md` documents the required environment variables and permissions: `issues:read`, `pull-requests:read`, plus Metadata read for non-`GITHUB_TOKEN` callers.
- `.github/workflows/cla.yml` and repository rulesets are intentionally untouched; the follow-up workflow must run this file from a trusted default-branch revision, never from PR head.
- Adds fixture-based tests covering external forks, retries, 404s, null head repos, merged and open-merged PRs, authorized maintainers, unsupported states, and malformed API responses.

<sup>Written for commit fa4300472b13fb2e8c6c9f84a8be2a248f354593. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for authorized pull request `recheck` comments, including pull request status, comment integrity, and maintainer permissions.
  * Added bounded retries and clear outcomes for authorized, unauthorized, transient, and invalid requests.

* **Documentation**
  * Documented configuration requirements, permissions, validation rules, retry behavior, and workflow security guidance.

* **Tests**
  * Added coverage for authorization, retries, missing or malformed data, unauthorized forks, and successful maintainer requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->