### PR TITLE
security: wire native CLA v3 enforcement and safe rechecks

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -2,8 +2,12 @@
 
 `cla-recheck-auth.sh` is the read-only admission step for an exact `recheck`
 comment. The caller must provide the event comment ID, body, author ID, login,
-and creation timestamp through environment variables and grant only `issues:read`
-and `pull-requests:read`.
+and creation timestamp through environment variables. The caller needs
+`issues:read` and `pull-requests:read`. The collaborator permission endpoint
+also needs repository Metadata read. GitHub Actions supplies that metadata
+permission implicitly for `GITHUB_TOKEN`; a caller that supplies a different
+token must grant Metadata read explicitly. No Administration or write
+permission is needed.
 
 The script re-reads the issue, live Pull Request, comment, and collaborator
 permission through bounded GitHub API requests. It accepts only an open,

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,22 @@
+# CLA recheck authorizer
+
+`cla-recheck-auth.sh` is the read-only admission step for an exact `recheck`
+comment. The caller must provide the event comment ID, body, author ID, login,
+and creation timestamp through environment variables and grant only `issues:read`
+and `pull-requests:read`.
+
+The script re-reads the issue, live Pull Request, comment, and collaborator
+permission through bounded GitHub API requests. It accepts only an open,
+unmerged Pull Request targeting `main`, an unchanged human comment, and a live
+`admin` or `maintain` role. It never writes a comment, check, ledger, or source
+file.
+
+Each request is retried at most three times. A validated 404 or a changed
+comment is `unauthorized` with `check_action=preserve`. A temporary API,
+transport, or rate-limit failure is `retry` with `check_action=preserve`; the
+caller must leave any existing required check untouched and run again later.
+Malformed or incomplete responses are `error` with `check_action=fail`.
+
+The workflow must execute this file from a trusted default-branch revision. It
+must not check out or execute Pull Request head content in a
+`pull_request_target` job.

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -24,3 +24,23 @@ Malformed or incomplete responses are `error` with `check_action=fail`.
 The workflow must execute this file from a trusted default-branch revision. It
 must not check out or execute Pull Request head content in a
 `pull_request_target` job.
+
+The workflow's only required status context is the native job `CLA Assistant
+v3`. The job name is produced by GitHub Actions, and the rerun helper binds the
+workflow path, workflow ID, run, job, app ID 15368, source head, target base,
+generation `v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af`, and canonical
+details URL before requesting a rerun. No Checks API check is created by a
+comment event.
+
+Signatures are written only by the maintained action at immutable SHA
+`212a0f2dd659b24b48a30ba35966e06dc41736af` to
+`cla-signatures:signatures/version2/cla.json`. That branch must remain protected
+against deletion, force-push, and non-linear history, with only the GitHub
+Actions writer bypass. The empty version 2 file is bootstrapped by an
+administrator before the `CLA Assistant v3` context is made required on `main`.
+
+`lock-merged-pr.sh` is the separate post-merge lock lane. It accepts only a
+canonical `pull_request_target` close event, rechecks the live merged Pull
+Request, grants no ledger or Actions write permission, and verifies the lock
+after the PUT. Its API capture is bounded before JSON parsing and it does not
+print response bodies.

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -30,7 +30,12 @@ v3`. The job name is produced by GitHub Actions, and the rerun helper binds the
 workflow path, workflow ID, run, job, app ID 15368, source head, target base,
 generation `v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af`, and canonical
 details URL before requesting a rerun. No Checks API check is created by a
-comment event.
+comment event. The issue-comment rerun lane accepts only workflow attempt 1, so
+rerunning that lane cannot recursively schedule another rerun. Repeated
+lifecycle events can leave multiple failed native checks for one head; the
+helper accepts those only when every same-name result is a completed failure
+and exactly one result is bound to the selected native job. Any successful or
+in-progress duplicate fails closed.
 
 Signatures are written only by the maintained action at immutable SHA
 `212a0f2dd659b24b48a30ba35966e06dc41736af` to

--- a/.github/scripts/cla-recheck-auth.sh
+++ b/.github/scripts/cla-recheck-auth.sh
@@ -217,9 +217,10 @@ fi
 if ! jq -e '
   has("merged_at") and
   (.merged_at == null or
-   (.merged_at | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$")))
+   (.merged_at | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$"))) and
+  (.state == "closed" or (.state == "open" and .merged_at == null))
 ' <<<"${api_body}" >/dev/null 2>&1; then
-  fail_input 'GitHub returned an invalid merged_at value for the live pull request.'
+  fail_input 'GitHub returned an inconsistent merged_at value for the live pull request.'
 fi
 if ! jq -e --arg repo "${GH_REPO}" '
   def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991;

--- a/.github/scripts/cla-recheck-auth.sh
+++ b/.github/scripts/cla-recheck-auth.sh
@@ -27,6 +27,11 @@ emit() {
 finish() {
   decision="$1"
   check_action="$2"
+  if [[ "${decision}" == authorized ]]; then
+    authorized=true
+  else
+    authorized=false
+  fi
   emit
   printf '%s\n' "$3"
   [[ "$4" == 0 ]] || exit "$4"
@@ -68,7 +73,11 @@ is_timestamp() {
 
 is_valid_not_found() {
   local body="${1:-}"
-  jq -e 'type == "object" and ((.status == 404) or (.status == "404")) and (.message | type == "string" and length > 0)' \
+  jq -e '
+    type == "object" and
+    (.message | type == "string" and length > 0) and
+    ((has("status") | not) or (.status == 404) or (.status == "404"))
+  ' \
     <<<"${body}" >/dev/null 2>&1
 }
 
@@ -210,7 +219,7 @@ if ! jq -e --arg pr "${PR_NUMBER}" '
 ' <<<"${api_body}" >/dev/null 2>&1; then
   fail_input 'GitHub returned malformed live pull request identity data.'
 fi
-validate_state pull request
+validate_state 'pull request'
 if jq -e '.state == "closed"' <<<"${api_body}" >/dev/null 2>&1; then
   finish unauthorized preserve 'CLA recheck ignored: the pull request is no longer open.' 0
 fi

--- a/.github/scripts/cla-recheck-auth.sh
+++ b/.github/scripts/cla-recheck-auth.sh
@@ -162,6 +162,16 @@ require_inputs() {
 
 require_inputs
 
+validate_state() {
+  local resource="$1"
+  if ! jq -e '
+    type == "object" and
+    (.state | type == "string" and (. == "open" or . == "closed"))
+  ' <<<"${api_body}" >/dev/null 2>&1; then
+    fail_input "GitHub returned an invalid ${resource} pull request state."
+  fi
+}
+
 # Read the issue resource first. It uses the issue read permission and remains
 # available for fork Pull Requests when the Pulls endpoint is temporarily
 # unavailable. It proves that this exact issue is still an open Pull Request.
@@ -175,10 +185,8 @@ if ! jq -e --arg pr "${PR_NUMBER}" '
 ' <<<"${api_body}" >/dev/null 2>&1; then
   fail_input 'GitHub returned malformed pull request issue data.'
 fi
-if ! jq -e '.state | type == "string"' <<<"${api_body}" >/dev/null 2>&1; then
-  fail_input 'GitHub returned an invalid pull request state.'
-fi
-if jq -e '.state != "open"' <<<"${api_body}" >/dev/null 2>&1; then
+validate_state issue
+if jq -e '.state == "closed"' <<<"${api_body}" >/dev/null 2>&1; then
   finish unauthorized preserve 'CLA recheck ignored: the pull request is no longer open.' 0
 fi
 if ! jq -e --arg repo "${GH_REPO}" --arg pr "${PR_NUMBER}" '
@@ -202,10 +210,8 @@ if ! jq -e --arg pr "${PR_NUMBER}" '
 ' <<<"${api_body}" >/dev/null 2>&1; then
   fail_input 'GitHub returned malformed live pull request identity data.'
 fi
-if ! jq -e '.state | type == "string"' <<<"${api_body}" >/dev/null 2>&1; then
-  fail_input 'GitHub returned an invalid live pull request state.'
-fi
-if jq -e '.state != "open"' <<<"${api_body}" >/dev/null 2>&1; then
+validate_state pull request
+if jq -e '.state == "closed"' <<<"${api_body}" >/dev/null 2>&1; then
   finish unauthorized preserve 'CLA recheck ignored: the pull request is no longer open.' 0
 fi
 if ! jq -e '

--- a/.github/scripts/cla-recheck-auth.sh
+++ b/.github/scripts/cla-recheck-auth.sh
@@ -175,6 +175,9 @@ if ! jq -e --arg pr "${PR_NUMBER}" '
 ' <<<"${api_body}" >/dev/null 2>&1; then
   fail_input 'GitHub returned malformed pull request issue data.'
 fi
+if ! jq -e '.state | type == "string"' <<<"${api_body}" >/dev/null 2>&1; then
+  fail_input 'GitHub returned an invalid pull request state.'
+fi
 if jq -e '.state != "open"' <<<"${api_body}" >/dev/null 2>&1; then
   finish unauthorized preserve 'CLA recheck ignored: the pull request is no longer open.' 0
 fi
@@ -199,8 +202,18 @@ if ! jq -e --arg pr "${PR_NUMBER}" '
 ' <<<"${api_body}" >/dev/null 2>&1; then
   fail_input 'GitHub returned malformed live pull request identity data.'
 fi
-if jq -e '.state != "open" or .merged_at != null' <<<"${api_body}" >/dev/null 2>&1; then
+if ! jq -e '.state | type == "string"' <<<"${api_body}" >/dev/null 2>&1; then
+  fail_input 'GitHub returned an invalid live pull request state.'
+fi
+if jq -e '.state != "open"' <<<"${api_body}" >/dev/null 2>&1; then
   finish unauthorized preserve 'CLA recheck ignored: the pull request is no longer open.' 0
+fi
+if ! jq -e '
+  has("merged_at") and
+  (.merged_at == null or
+   (.merged_at | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$")))
+' <<<"${api_body}" >/dev/null 2>&1; then
+  fail_input 'GitHub returned an invalid merged_at value for the live pull request.'
 fi
 if ! jq -e --arg repo "${GH_REPO}" '
   def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991;

--- a/.github/scripts/cla-recheck-auth.sh
+++ b/.github/scripts/cla-recheck-auth.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# Authenticate the exact `recheck` comment without granting a writer token.
+# The caller treats `retry` as a no-op and retries after the API recovers.
+set -euo pipefail
+
+readonly EXPECTED_REPOSITORY='manaflow-ai/subrouter'
+readonly MAX_RESPONSE_BYTES=262144
+readonly MAX_TOTAL_BYTES=2000000
+readonly MAX_ATTEMPTS=3
+readonly MAX_SAFE_INTEGER=9007199254740991
+readonly RETRY_DELAY_SECONDS="${CLA_RECHECK_RETRY_DELAY_SECONDS:-1}"
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+authorized=false
+decision=error
+check_action=fail
+api_total_bytes=0
+raw_file="$(mktemp)"
+trap 'rm -f -- "${raw_file}"' EXIT
+
+emit() {
+  printf 'authorized=%s\ndecision=%s\ncheck_action=%s\n' \
+    "${authorized}" "${decision}" "${check_action}" >>"${GITHUB_OUTPUT}"
+}
+
+finish() {
+  decision="$1"
+  check_action="$2"
+  emit
+  printf '%s\n' "$3"
+  [[ "$4" == 0 ]] || exit "$4"
+  exit 0
+}
+
+fail_input() {
+  authorized=false
+  decision=error
+  check_action=fail
+  emit
+  echo "::error title=CLA recheck policy::$1" >&2
+  exit 1
+}
+
+retry_later() {
+  authorized=false
+  decision=retry
+  check_action=preserve
+  emit
+  echo "::warning title=CLA recheck retry::$1" >&2
+  exit 1
+}
+
+is_safe_id() {
+  local value="${1:-}"
+  [[ "$value" =~ ^[1-9][0-9]*$ ]] || return 1
+  (( ${#value} <= 16 )) || return 1
+  (( ${#value} != 16 || value <= MAX_SAFE_INTEGER ))
+}
+
+is_safe_login() {
+  [[ "${1:-}" =~ ^[A-Za-z0-9][A-Za-z0-9-]{0,38}$ ]]
+}
+
+is_timestamp() {
+  [[ "${1:-}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}
+
+is_valid_not_found() {
+  local body="${1:-}"
+  jq -e 'type == "object" and ((.status == 404) or (.status == "404")) and (.message | type == "string" and length > 0)' \
+    <<<"${body}" >/dev/null 2>&1
+}
+
+extract_http_body() {
+  awk '
+    BEGIN { in_headers = 0; body_started = 0; body = "" }
+    {
+      sub(/\r$/, "")
+      if ($0 ~ /^HTTP\/[0-9.]+[[:space:]][0-9][0-9][0-9]([[:space:]]|$)/) {
+        in_headers = 1
+        body_started = 0
+        body = ""
+        next
+      }
+      if (in_headers && $0 == "") {
+        in_headers = 0
+        body_started = 1
+        next
+      }
+      if (body_started) body = body $0 "\n"
+    }
+    END { printf "%s", body }
+  ' "${raw_file}"
+}
+
+read_response() {
+  local endpoint="$1"
+  local attempt raw_bytes command_status http_status response_body
+  api_kind=retry
+  api_body=""
+
+  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    : >"${raw_file}"
+    set +e
+    (
+      # `ulimit -f` is a pre-parser bound. The extra block permits the limit
+      # check below to distinguish an exact-bound response from an overflow.
+      ulimit -f $(( (MAX_RESPONSE_BYTES + 511) / 512 + 1 ))
+      gh api --method GET --include \
+        --header 'Accept: application/vnd.github+json' \
+        --header 'X-GitHub-Api-Version: 2022-11-28' \
+        "${endpoint}" >"${raw_file}" 2>/dev/null
+    )
+    command_status=$?
+    set -e
+
+    raw_bytes="$(LC_ALL=C wc -c <"${raw_file}" | tr -d '[:space:]')"
+    if ! [[ "${raw_bytes}" =~ ^[0-9]+$ ]] || (( raw_bytes > MAX_RESPONSE_BYTES )); then
+      api_kind=retry
+    else
+      api_total_bytes=$((api_total_bytes + raw_bytes))
+      if (( api_total_bytes > MAX_TOTAL_BYTES )); then
+        api_kind=retry
+      else
+        http_status="$(awk '/^HTTP\// { gsub("\r", "", $2); code=$2 } END { print code }' "${raw_file}")"
+        if [[ -z "${http_status}" ]]; then
+          http_status=200
+          response_body="$(<"${raw_file}")"
+        else
+          response_body="$(extract_http_body)"
+        fi
+        api_body="${response_body}"
+        if [[ "${http_status}" == 404 ]] && is_valid_not_found "${response_body}"; then
+          api_kind=not_found
+          return 2
+        elif (( command_status == 0 )) && [[ "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
+          api_kind=ok
+          return 0
+        else
+          api_kind=retry
+        fi
+      fi
+    fi
+    if (( attempt < MAX_ATTEMPTS )); then
+      sleep "${RETRY_DELAY_SECONDS}"
+    fi
+  done
+  return 1
+}
+
+require_inputs() {
+  [[ "${GH_REPO:-}" == "${EXPECTED_REPOSITORY}" ]] || fail_input 'The helper is not running in the canonical repository.'
+  [[ "${COMMENT_BODY:-}" == 'recheck' ]] || fail_input 'The comment is not the exact recheck command.'
+  is_safe_id "${PR_NUMBER:-}" || fail_input 'The pull request number is invalid.'
+  is_safe_id "${COMMENT_ID:-}" || fail_input 'The comment ID is invalid.'
+  is_safe_id "${COMMENT_USER_ID:-}" || fail_input 'The commenter ID is invalid.'
+  is_safe_login "${COMMENT_USER_LOGIN:-}" || fail_input 'The commenter login is invalid.'
+  [[ "${COMMENT_USER_TYPE:-User}" == User ]] || fail_input 'The commenter is not an authenticated human user.'
+  is_timestamp "${COMMENT_CREATED_AT:-}" || fail_input 'The comment timestamp is invalid.'
+}
+
+require_inputs
+
+# Read the issue resource first. It uses the issue read permission and remains
+# available for fork Pull Requests when the Pulls endpoint is temporarily
+# unavailable. It proves that this exact issue is still an open Pull Request.
+if ! read_response "repos/${GH_REPO}/issues/${PR_NUMBER}"; then
+  [[ "${api_kind}" == not_found ]] && finish unauthorized preserve 'CLA recheck ignored: the pull request no longer exists or is closed.' 0
+  retry_later 'GitHub could not read the pull request issue after bounded retries.'
+fi
+if ! jq -e --arg pr "${PR_NUMBER}" '
+  def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991;
+  type == "object" and (.number | safe_id and tostring == $pr)
+' <<<"${api_body}" >/dev/null 2>&1; then
+  fail_input 'GitHub returned malformed pull request issue data.'
+fi
+if jq -e '.state != "open"' <<<"${api_body}" >/dev/null 2>&1; then
+  finish unauthorized preserve 'CLA recheck ignored: the pull request is no longer open.' 0
+fi
+if ! jq -e --arg repo "${GH_REPO}" --arg pr "${PR_NUMBER}" '
+  (.state | type == "string") and
+  (.pull_request | type == "object") and
+  .pull_request.url == ("https://api.github.com/repos/" + $repo + "/pulls/" + $pr)
+' <<<"${api_body}" >/dev/null 2>&1; then
+  fail_input 'GitHub returned incomplete pull request issue data.'
+fi
+
+# The Pulls resource is the authoritative base/head identity. A validated
+# issue response is not enough to authorize a privileged refresh. If this read
+# remains unavailable, preserve any existing check and ask for a later retry.
+if ! read_response "repos/${GH_REPO}/pulls/${PR_NUMBER}"; then
+  [[ "${api_kind}" == not_found ]] && finish unauthorized preserve 'CLA recheck ignored: the pull request no longer exists.' 0
+  retry_later 'GitHub could not read the live pull request identity after bounded retries.'
+fi
+if ! jq -e --arg pr "${PR_NUMBER}" '
+  def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991;
+  type == "object" and (.number | safe_id and tostring == $pr)
+' <<<"${api_body}" >/dev/null 2>&1; then
+  fail_input 'GitHub returned malformed live pull request identity data.'
+fi
+if jq -e '.state != "open" or .merged_at != null' <<<"${api_body}" >/dev/null 2>&1; then
+  finish unauthorized preserve 'CLA recheck ignored: the pull request is no longer open.' 0
+fi
+if ! jq -e --arg repo "${GH_REPO}" '
+  def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991;
+  (.base | type == "object") and .base.ref == "main" and
+  (.base.repo | type == "object") and
+  ((.base.repo.full_name | type == "string") and (.base.repo.full_name | ascii_downcase) == ($repo | ascii_downcase)) and
+  (.base.repo.id | safe_id) and
+  (.head | type == "object") and (.head.sha | type == "string" and test("^[0-9a-fA-F]{40}$")) and
+  (.head.repo | type == "object") and (.head.repo.id | safe_id) and
+  (.user | type == "object") and (.user.id | safe_id)
+' <<<"${api_body}" >/dev/null 2>&1; then
+  if jq -e --arg repo "${GH_REPO}" '
+    type == "object" and
+    ((.base | type == "object") and
+      ((.base.ref | type == "string") and .base.ref != "main" or
+       (.base.repo | type == "object") and
+       (.base.repo.full_name | type == "string") and
+       (.base.repo.full_name | ascii_downcase) != ($repo | ascii_downcase)))
+  ' <<<"${api_body}" >/dev/null 2>&1; then
+    finish unauthorized preserve 'CLA recheck ignored: the pull request no longer targets main.' 0
+  fi
+  fail_input 'GitHub returned incomplete live pull request identity data.'
+fi
+
+# Confirm the event comment is still the exact, unedited snapshot. A validated
+# 404 or an immutable mismatch is ordinary unauthorized input. Other failures
+# retain the explicit retry state.
+if ! read_response "repos/${GH_REPO}/issues/comments/${COMMENT_ID}"; then
+  [[ "${api_kind}" == not_found ]] && finish unauthorized preserve 'CLA recheck ignored: the command comment was deleted.' 0
+  retry_later 'GitHub could not read the live recheck comment after bounded retries.'
+fi
+if ! jq -e --arg id "${COMMENT_ID}" --arg body "${COMMENT_BODY}" --arg user_id "${COMMENT_USER_ID}" \
+          --arg login "${COMMENT_USER_LOGIN}" --arg issue_url "https://api.github.com/repos/${GH_REPO}/issues/${PR_NUMBER}" \
+          --arg created "${COMMENT_CREATED_AT}" '
+  type == "object" and (.id | type == "number" and floor == . and tostring == $id) and
+  .body == $body and (.user | type == "object") and
+  (.user.id | type == "number" and floor == . and tostring == $user_id) and
+  (.user.login | type == "string" and ascii_downcase == ($login | ascii_downcase)) and
+  .user.type == "User" and .issue_url == $issue_url and
+  (.created_at | type == "string" and . == $created) and .updated_at == .created_at
+' <<<"${api_body}" >/dev/null 2>&1; then
+  if jq -e 'type == "object" and (.id | type == "number") and (.body | type == "string") and (.user | type == "object")' <<<"${api_body}" >/dev/null 2>&1; then
+    finish unauthorized preserve 'CLA recheck ignored: the command comment changed after delivery.' 0
+  fi
+  fail_input 'GitHub returned malformed live recheck comment data.'
+fi
+
+# A 404 from the collaborator permission endpoint is a validated ordinary
+# denial. Do not turn it into an infrastructure failure.
+if ! read_response "repos/${GH_REPO}/collaborators/${COMMENT_USER_LOGIN}/permission"; then
+  [[ "${api_kind}" == not_found ]] && finish unauthorized preserve 'CLA recheck ignored: requester is not an admin or maintainer.' 0
+  retry_later 'GitHub could not verify the requester permission after bounded retries.'
+fi
+if ! jq -e --arg id "${COMMENT_USER_ID}" '
+  type == "object" and (.user | type == "object") and
+  (.user.id | type == "number" and floor == . and tostring == $id) and
+  (.permission | type == "string") and
+  ((.role_name // "") | type == "string")
+' <<<"${api_body}" >/dev/null 2>&1; then
+  fail_input 'GitHub returned malformed requester permission data.'
+fi
+role_name="$(jq -r '.role_name // .permission' <<<"${api_body}")"
+case "${role_name}" in
+  admin|maintain)
+    finish authorized refresh 'CLA recheck requester has live admin or maintainer permission.' 0
+    ;;
+  push|write|none|read|pull|triage)
+    finish unauthorized preserve 'CLA recheck ignored: requester is not an admin or maintainer.' 0
+    ;;
+  *)
+    retry_later 'GitHub returned an unknown requester permission role.'
+    ;;
+esac

--- a/.github/scripts/lock-merged-pr.sh
+++ b/.github/scripts/lock-merged-pr.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Lock one verified merged Pull Request. This file is checked out from the
+# trusted workflow revision and never from a Pull Request head.
+set -euo pipefail
+
+readonly EXPECTED_REPOSITORY='manaflow-ai/subrouter'
+readonly MAX_RESPONSE_BYTES=262144
+readonly MAX_TOTAL_BYTES=2000000
+readonly MAX_SAFE_INTEGER=9007199254740991
+
+fail() {
+  echo "::error title=CLA lock policy::$1" >&2
+  exit 1
+}
+
+is_safe_id() {
+  local value="${1:-}"
+  [[ "${value}" =~ ^[1-9][0-9]*$ ]] || return 1
+  (( ${#value} <= 16 )) || return 1
+  (( ${#value} != 16 || value <= MAX_SAFE_INTEGER ))
+}
+
+is_safe_text() {
+  local value="${1:-}"
+  [[ -n "${value}" && "${value}" != *$'\n'* && "${value}" != *$'\r'* ]]
+}
+
+is_sha() {
+  [[ "${1:-}" =~ ^[0-9a-fA-F]{40}$ ]]
+}
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${GH_REPO:?GH_REPO is required}"
+: "${PR_NUMBER:?PR_NUMBER is required}"
+
+[[ "${GH_REPO}" == "${EXPECTED_REPOSITORY}" ]] || fail 'The workflow is not running in the canonical repository.'
+is_safe_id "${PR_NUMBER}" || fail 'The Pull Request number is invalid.'
+is_safe_id "${CANONICAL_REPOSITORY_ID:-}" || fail 'The canonical repository ID is invalid.'
+[[ "${EVENT_NAME:-}" == pull_request_target && "${EVENT_ACTION:-}" == closed ]] || fail 'The event is not a closed Pull Request event.'
+[[ "${EVENT_PR_STATE:-}" == closed && "${EVENT_PR_MERGED:-}" == true ]] || fail 'The event does not describe a merged Pull Request.'
+[[ "${EVENT_PR_NUMBER:-}" == "${PR_NUMBER}" ]] || fail 'The event Pull Request number changed.'
+[[ "${EVENT_REPOSITORY:-}" == "${EXPECTED_REPOSITORY}" ]] || fail 'The event repository is not canonical.'
+is_safe_id "${EVENT_REPOSITORY_ID:-}" || fail 'The event repository ID is invalid.'
+[[ "${EVENT_REPOSITORY_ID}" == "${CANONICAL_REPOSITORY_ID}" ]] || fail 'The event repository ID changed.'
+[[ "${EVENT_BASE_REF:-}" == main && "${EVENT_BASE_REPOSITORY:-}" == "${EXPECTED_REPOSITORY}" ]] || fail 'The event base is not canonical main.'
+is_safe_id "${EVENT_BASE_REPOSITORY_ID:-}" || fail 'The event base repository ID is invalid.'
+[[ "${EVENT_BASE_REPOSITORY_ID}" == "${CANONICAL_REPOSITORY_ID}" ]] || fail 'The event base repository ID changed.'
+is_safe_text "${EVENT_OPENER_LOGIN:-}" || fail 'The event opener login is invalid.'
+is_safe_id "${EVENT_OPENER_ID:-}" || fail 'The event opener ID is invalid.'
+
+API_FILE="$(mktemp)"
+LOCK_FILE="$(mktemp)"
+readonly API_FILE LOCK_FILE
+trap 'rm -f -- "${API_FILE}" "${LOCK_FILE}"' EXIT
+api_total_bytes=0
+api_status=''
+api_body=''
+
+api_request() {
+  local method="$1" endpoint="$2" raw_bytes command_status first_line
+  : >"${API_FILE}"
+  set +e
+  (
+    # The file limit is a pre-parser bound. The byte count below also rejects
+    # an exact overflow and protects the aggregate request budget.
+    ulimit -f $(( (MAX_RESPONSE_BYTES + 511) / 512 + 1 ))
+    if [[ "${method}" == PUT ]]; then
+      gh api --method PUT --include \
+        --header 'Accept: application/vnd.github+json' \
+        --header 'X-GitHub-Api-Version: 2022-11-28' \
+        "${endpoint}" --field lock_reason=resolved >"${API_FILE}" 2>/dev/null
+    else
+      gh api --method GET --include \
+        --header 'Accept: application/vnd.github+json' \
+        --header 'X-GitHub-Api-Version: 2022-11-28' \
+        "${endpoint}" >"${API_FILE}" 2>/dev/null
+    fi
+  )
+  command_status=$?
+  set -e
+  raw_bytes="$(LC_ALL=C wc -c <"${API_FILE}" | tr -d '[:space:]')"
+  [[ "${raw_bytes}" =~ ^[0-9]+$ ]] || return 1
+  (( raw_bytes <= MAX_RESPONSE_BYTES )) || return 2
+  api_total_bytes=$((api_total_bytes + raw_bytes))
+  (( api_total_bytes <= MAX_TOTAL_BYTES )) || return 2
+
+  IFS= read -r first_line <"${API_FILE}" || true
+  if [[ "${first_line}" =~ ^HTTP/[0-9.]+[[:space:]]+[0-9]{3}([[:space:]]|$) ]]; then
+    api_status="$(awk '/^HTTP\// { gsub("\r", "", $2); code=$2 } END { print code }' "${API_FILE}")"
+    api_body="$(awk 'BEGIN { body=0 } { sub(/\r$/, "") } body { print; next } /^$/ { body=1 }' "${API_FILE}")"
+  else
+    api_status=200
+    api_body="$(<"${API_FILE}")"
+  fi
+  [[ "${api_status}" =~ ^[0-9]{3}$ ]] || return 1
+  (( command_status == 0 )) || return 1
+  [[ "${api_status}" =~ ^2[0-9][0-9]$ ]]
+}
+
+api_get() { api_request GET "$1"; }
+
+validate_live_pr() {
+  local json="$1" expected_base_ref expected_base_repo expected_base_id expected_opener_login expected_opener_id
+  jq -e --arg repo "${EXPECTED_REPOSITORY}" --arg pr "${PR_NUMBER}" '
+    def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991;
+    def text: type == "string" and length > 0 and test("^[^\\r\\n]+$");
+    type == "object" and (.number | safe_id and tostring == $pr) and
+    .state == "closed" and (.merged_at | type == "string" and length > 0) and
+    (.base | type == "object" and .ref == "main" and (.repo | type == "object")) and
+    .base.repo.full_name == $repo and (.base.repo.id | safe_id) and
+    (.head | type == "object") and (.head.ref | text) and (.head.sha | type == "string" and test("^[0-9a-fA-F]{40}$")) and
+    (if .head.repo == null then true else
+      (.head.repo | type == "object" and (.full_name | text) and (.id | safe_id))
+    end) and
+    (.user | type == "object" and (.login | text) and (.id | safe_id))
+  ' <<<"${json}" >/dev/null 2>&1 || return 1
+  expected_base_ref="$(jq -er '.base.ref | strings' <<<"${json}")"
+  expected_base_repo="$(jq -er '.base.repo.full_name | strings' <<<"${json}")"
+  expected_base_id="$(jq -er '.base.repo.id | numbers | tostring' <<<"${json}")"
+  expected_opener_login="$(jq -er '.user.login | strings' <<<"${json}")"
+  expected_opener_id="$(jq -er '.user.id | numbers | tostring' <<<"${json}")"
+  [[ "${expected_base_ref}" == "${EVENT_BASE_REF}" &&
+     "${expected_base_repo}" == "${EVENT_BASE_REPOSITORY}" &&
+     "${expected_base_id}" == "${EVENT_BASE_REPOSITORY_ID}" &&
+     "${expected_opener_login,,}" == "${EVENT_OPENER_LOGIN,,}" &&
+     "${expected_opener_id}" == "${EVENT_OPENER_ID}" ]]
+}
+
+pr_endpoint="repos/${GH_REPO}/pulls/${PR_NUMBER}"
+api_get "${pr_endpoint}" || fail 'Could not read the live merged Pull Request.'
+live_pr="${api_body}"
+validate_live_pr "${live_pr}" || fail 'The live merged Pull Request identity changed.'
+
+issue_endpoint="repos/${GH_REPO}/issues/${PR_NUMBER}"
+lock_endpoint="${issue_endpoint}/lock"
+api_get "${issue_endpoint}" || fail 'Could not read the Pull Request lock state.'
+jq -e 'type == "object" and (.locked | type == "boolean")' <<<"${api_body}" >/dev/null 2>&1 || fail 'GitHub returned an invalid lock state.'
+locked="$(jq -er '.locked | tostring' <<<"${api_body}")"
+if [[ "${locked}" == true ]]; then
+  api_get "${pr_endpoint}" || fail 'Could not re-read the merged Pull Request.'
+  validate_live_pr "${api_body}" || fail 'The already-locked Pull Request identity changed.'
+  echo "Pull Request ${PR_NUMBER} is already locked."
+  exit 0
+fi
+[[ "${locked}" == false ]] || fail 'GitHub returned an unknown lock state.'
+
+api_request PUT "${lock_endpoint}" || fail "Could not lock Pull Request ${PR_NUMBER}."
+[[ "${api_status}" == 204 ]] || fail "GitHub returned HTTP ${api_status} while locking Pull Request ${PR_NUMBER}."
+
+api_get "${issue_endpoint}" || fail 'Could not verify the Pull Request lock state.'
+jq -e '.locked == true' <<<"${api_body}" >/dev/null 2>&1 || fail 'GitHub did not report the Pull Request as locked.'
+api_get "${pr_endpoint}" || fail 'Could not verify the merged Pull Request identity after locking.'
+validate_live_pr "${api_body}" || fail 'The Pull Request identity changed after locking; retain the lock for administrator review.'
+echo "Locked merged Pull Request ${PR_NUMBER}."

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -28,7 +28,7 @@ fail() {
 }
 
 no_op() {
-  [[ "${WRITER_POLICY_RESULT:-}" == true ]] ||
+  [[ "${WRITER_RESULT:-}" == success && "${WRITER_POLICY_RESULT:-}" == true ]] ||
     fail "A no-op rerun decision requires the writer's explicit all-signed policy result."
   echo "CLA rerun not needed: ${1}"
   exit 0
@@ -174,15 +174,19 @@ require_inputs() {
     true|false) ;;
     *) fail "The writer returned an invalid CLA policy result." ;;
   esac
-  case "${WRITER_RESULT:-}" in
-    success) ;;
-    *) fail "The writer job did not complete successfully." ;;
+  case "${COMMENT_BODY:-}" in
+    "$SIGN_PHRASE")
+      [[ "${WRITER_RESULT:-}" == success ]] || fail "The writer job did not complete successfully."
+      [[ "${WRITER_POLICY_RESULT:-}" == true ]] || fail "The writer did not confirm an all-signed policy."
+      ;;
+    recheck)
+      [[ "${RECHECK_DECISION:-}" == authorized ]] || fail "The recheck was not authorized by the live read-only gate."
+      case "${WRITER_RESULT:-}" in
+        success|failure|cancelled|skipped) ;;
+        *) fail "The writer result is invalid for an authorized recheck." ;;
+      esac
+      ;;
   esac
-  if [[ "${COMMENT_BODY:-}" == "$SIGN_PHRASE" &&
-        "${SIGNATURE_RECORDED:-}" != true &&
-        "${WRITER_POLICY_RESULT:-}" != true ]]; then
-    fail "The signing comment did not produce a persisted signature or an all-signed policy result."
-  fi
   [[ "${CLA_GENERATION:-}" == "$EXPECTED_GENERATION" ]] || fail "The CLA generation is not the reviewed action release."
   is_sha "${WORKFLOW_SHA:-}" || fail "The trusted workflow revision is invalid."
   [[ "${WORKFLOW_PATH:-}" == "$EXPECTED_WORKFLOW_PATH" ]] || fail "The trusted workflow path is invalid."

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -1,0 +1,597 @@
+#!/usr/bin/env bash
+# Re-run the native CLA policy job after an authenticated CLA issue comment.
+# The workflow checks this file out at an immutable workflow SHA.
+set -euo pipefail
+
+readonly SIGN_PHRASE='I have read the CLA Document v2.2 and I hereby sign the CLA'
+readonly EXPECTED_REPOSITORY='manaflow-ai/subrouter'
+readonly EXPECTED_WORKFLOW_PATH='.github/workflows/cla.yml'
+readonly EXPECTED_ASSISTANT_JOB='CLA Assistant v3'
+readonly EXPECTED_WRITER_JOB='CLA ledger writer'
+readonly EXPECTED_GATE_JOB='Validate CLA trigger'
+readonly EXPECTED_APP_ID=15368
+readonly EXPECTED_APP_SLUG='github-actions'
+readonly EXPECTED_GENERATION='v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af'
+readonly SIGNATURES_BRANCH='cla-signatures'
+readonly SIGNATURES_PATH='signatures/version2/cla.json'
+readonly MAX_PAGE_BYTES=1048576
+readonly MAX_TOTAL_BYTES=10000000
+readonly MAX_PAGES=10
+readonly MAX_MATCHING_RUNS=100
+readonly MAX_FALLBACK_RUNS=1000
+readonly MAX_LEDGER_BYTES=1000000
+readonly MAX_LEDGER_SIGNATURES=10000
+
+fail() {
+  echo "::error title=CLA rerun policy::${1}" >&2
+  exit 1
+}
+
+no_op() {
+  [[ "${WRITER_POLICY_RESULT:-}" == true ]] ||
+    fail "A no-op rerun decision requires the writer's explicit all-signed policy result."
+  echo "CLA rerun not needed: ${1}"
+  exit 0
+}
+
+is_safe_id() {
+  local value="${1:-}"
+  [[ "$value" =~ ^[1-9][0-9]*$ ]] || return 1
+  (( $(printf '%s' "$value" | wc -c) <= 16 )) || return 1
+  if (( $(printf '%s' "$value" | wc -c) == 16 )); then
+    (( value <= 9007199254740991 )) || return 1
+  fi
+}
+
+is_sha() {
+  [[ "${1:-}" =~ ^[0-9a-fA-F]{40}$ ]]
+}
+
+is_timestamp() {
+  [[ "${1:-}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}
+
+is_safe_text() {
+  local value="${1:-}"
+  [[ -n "$value" && "$value" != *$'\n'* && "$value" != *$'\r'* ]]
+}
+
+# Capture the complete API response in a bounded file before jq sees it.
+# ulimit -f prevents a maliciously large response from filling the runner.
+api_total_bytes=0
+declare -a CLA_TEMP_FILES=()
+cleanup_temp_files() {
+  local file
+  for file in "${CLA_TEMP_FILES[@]}"; do
+    rm -f -- "$file"
+  done
+}
+api_file="$(mktemp)"
+CLA_TEMP_FILES+=("$api_file")
+trap cleanup_temp_files EXIT
+api_http_status=''
+api_body=''
+api_has_next=false
+api_request() {
+  local method="$1"
+  local endpoint="$2"
+  local raw_bytes http_status response_body first_line has_headers=false
+  case "$method" in
+    GET|POST) ;;
+    *) return 1 ;;
+  esac
+  : >"$api_file"
+  set +e
+  (
+    ulimit -f 2049
+    gh api --method "$method" \
+      --header 'Accept: application/vnd.github+json' \
+      --header 'X-GitHub-Api-Version: 2022-11-28' \
+      --include --silent "$endpoint" >"$api_file" 2>/dev/null
+  )
+  local producer_status="$?"
+  set -e
+  raw_bytes="$(LC_ALL=C wc -c <"$api_file" | tr -d '[:space:]')"
+  [[ "$raw_bytes" =~ ^[0-9]+$ ]] || return 1
+  (( raw_bytes <= MAX_PAGE_BYTES )) || return 2
+  api_total_bytes=$((api_total_bytes + raw_bytes))
+  (( api_total_bytes <= MAX_TOTAL_BYTES )) || return 2
+  IFS= read -r first_line <"$api_file" || true
+  if [[ "$first_line" =~ ^HTTP/[0-9.]+[[:space:]]+[0-9]{3}([[:space:]]|$) ]]; then
+    has_headers=true
+    http_status="$(awk '/^HTTP\// { gsub("\r", "", $2); code=$2 } END { print code }' "$api_file")"
+    response_body="$(awk '
+      BEGIN { body=0 }
+      { sub(/\r$/, "") }
+      body { print; next }
+      /^$/ { body=1 }
+    ' "$api_file")"
+  else
+    http_status=200
+    response_body="$(<"$api_file")"
+  fi
+  [[ "$http_status" =~ ^[0-9]{3}$ ]] || return 1
+  api_http_status="$http_status"
+  api_body="$response_body"
+  api_has_next=false
+  if [[ "$has_headers" == true ]] && awk '
+    BEGIN { in_headers=1; found=0 }
+    in_headers {
+      line=$0
+      sub(/\r$/, "", line)
+      if (line == "") { in_headers=0; next }
+      lower=tolower(line)
+      if (lower ~ /^link:[[:space:]]/ && lower ~ /rel="?next"?/) found=1
+    }
+    END { exit(found ? 0 : 1) }
+  ' "$api_file"; then
+    api_has_next=true
+  fi
+  (( producer_status == 0 )) || return 1
+  [[ "$http_status" =~ ^2[0-9][0-9]$ ]]
+}
+
+api_get() { api_request GET "$1"; }
+api_post() { api_request POST "$1"; }
+
+is_valid_not_found() {
+  [[ "$api_http_status" == 404 ]] || return 1
+  # GitHub can return an empty body for a validated 404, especially when the
+  # resource was deleted between the event and this read. Accept that wire
+  # shape, and accept a JSON error only when its status and message are
+  # internally consistent. Any other body stays an infrastructure error.
+  if [[ -z "${api_body//[[:space:]]/}" ]]; then
+    return 0
+  fi
+  jq -e 'type == "object" and ((.status == 404) or (.status == "404")) and (.message | type == "string" and length > 0)' \
+    <<<"$api_body" >/dev/null 2>&1
+}
+
+require_inputs() {
+  [[ "${GH_REPO:-}" == "$EXPECTED_REPOSITORY" ]] || fail "The helper is not running in the canonical repository."
+  [[ "${EVENT_NAME:-}" == issue_comment ]] || fail "The helper received an unexpected event."
+  is_safe_id "${ISSUE_NUMBER:-}" || fail "The issue number is invalid."
+  [[ "${PR_NUMBER:-}" == "${ISSUE_NUMBER:-}" ]] || fail "The issue and pull request numbers differ."
+  is_safe_id "${COMMENT_ID:-}" || fail "The comment ID is invalid."
+  is_safe_id "${COMMENT_AUTHOR_ID:-}" || fail "The comment author ID is invalid."
+  is_timestamp "${COMMENT_CREATED_AT:-}" || fail "The comment timestamp is invalid."
+  is_safe_text "${COMMENT_AUTHOR_LOGIN:-}" || fail "The comment author login is invalid."
+  [[ "${COMMENT_AUTHOR_TYPE:-}" == User ]] || fail "The comment author is not a human user."
+  [[ "${COMMENT_AUTHOR_LOGIN,,}" != *"[bot]" ]] || fail "Bot comments cannot trigger a CLA rerun."
+  case "${COMMENT_AUTHOR_ASSOCIATION:-}" in
+    OWNER|MEMBER|COLLABORATOR|CONTRIBUTOR|FIRST_TIME_CONTRIBUTOR|FIRST_TIMER|NONE) ;;
+    *) fail "The comment author association is invalid." ;;
+  esac
+  case "${COMMENT_BODY:-}" in
+    "$SIGN_PHRASE"|recheck) ;;
+    *) fail "The comment is not an accepted CLA command." ;;
+  esac
+  case "${SIGNATURE_RECORDED:-}" in
+    true|false|'') ;;
+    *) fail "The writer returned an invalid signature result." ;;
+  esac
+  case "${WRITER_POLICY_RESULT:-}" in
+    true|false) ;;
+    *) fail "The writer returned an invalid CLA policy result." ;;
+  esac
+  case "${WRITER_RESULT:-}" in
+    success) ;;
+    *) fail "The writer job did not complete successfully." ;;
+  esac
+  if [[ "${COMMENT_BODY:-}" == "$SIGN_PHRASE" &&
+        "${SIGNATURE_RECORDED:-}" != true &&
+        "${WRITER_POLICY_RESULT:-}" != true ]]; then
+    fail "The signing comment did not produce a persisted signature or an all-signed policy result."
+  fi
+  [[ "${CLA_GENERATION:-}" == "$EXPECTED_GENERATION" ]] || fail "The CLA generation is not the reviewed action release."
+  is_sha "${WORKFLOW_SHA:-}" || fail "The trusted workflow revision is invalid."
+  [[ "${WORKFLOW_PATH:-}" == "$EXPECTED_WORKFLOW_PATH" ]] || fail "The trusted workflow path is invalid."
+  [[ "${TARGET_EVENT:-}" == pull_request_target && "${TARGET_BASE_REF:-}" == main ]] ||
+    fail "The target workflow contract is invalid."
+  checked_out_sha="$(git rev-parse HEAD 2>/dev/null)" || fail "The trusted checkout cannot be verified."
+  [[ "$checked_out_sha" == "${WORKFLOW_SHA:-}" ]] || fail "The checkout is not the immutable workflow revision."
+  [[ -f .github/scripts/rerun-failed-cla.sh ]] || fail "The trusted rerun helper is missing."
+}
+
+read_issue() {
+  api_get "repos/${GH_REPO}/issues/${PR_NUMBER}" || fail "Could not read the pull request issue."
+  local issue_json="$api_body"
+  jq -e --arg repo "${GH_REPO}" --arg pr "${PR_NUMBER}" '
+    type == "object" and .state == "open" and
+    (.number | type == "number" and floor == . and . > 0 and (tostring == $pr)) and
+    (.pull_request | type == "object") and
+    .pull_request.url == ("https://api.github.com/repos/" + $repo + "/pulls/" + $pr)
+  ' <<<"$issue_json" >/dev/null 2>&1 || fail "The issue is not the exact open pull request."
+}
+
+read_comment() {
+  if ! api_get "repos/${GH_REPO}/issues/comments/${COMMENT_ID}"; then
+    if is_valid_not_found; then
+      # Deletion is a validated race, not an infrastructure error. Defer the
+      # no-op decision until after the collision and run scans. A writer that
+      # did not prove all-signed must still rerun the native check, even when
+      # its original comment disappeared.
+      echo "The authenticated comment was deleted after the writer completed."
+      return 0
+    fi
+    fail "Could not read the authenticated comment."
+  fi
+  local comment_json="$api_body"
+  local issue_url="https://api.github.com/repos/${GH_REPO}/issues/${PR_NUMBER}"
+  # Validate the response shape separately from the immutable snapshot
+  # comparison. This keeps malformed or partial API data fail-closed while a
+  # genuine edit is classified as the same bounded race as a validated 404.
+  jq -e '
+    type == "object" and
+    (.id | type == "number" and floor == . and . > 0) and
+    (.issue_url | type == "string" and length > 0) and
+    (.body | type == "string") and
+    (.user | type == "object") and
+    (.user.id | type == "number" and floor == . and . > 0) and
+    (.user.login | type == "string" and length > 0) and
+    (.user.type | type == "string" and length > 0) and
+    (.created_at | type == "string" and length > 0) and
+    (.updated_at | type == "string" and length > 0)
+  ' <<<"$comment_json" >/dev/null 2>&1 || fail "The authenticated comment response is malformed."
+  if jq -e --arg issue_url "$issue_url" \
+    --arg body "${COMMENT_BODY}" --arg author_id "${COMMENT_AUTHOR_ID}" \
+    --arg author_login "${COMMENT_AUTHOR_LOGIN}" --arg author_type "${COMMENT_AUTHOR_TYPE}" \
+    --arg created_at "${COMMENT_CREATED_AT}" --arg comment_id "${COMMENT_ID}" '
+      (.id | tostring) == $comment_id and
+      .issue_url == $issue_url and .body == $body and
+      (.user.id | tostring) == $author_id and
+      (.user.login | ascii_downcase) == ($author_login | ascii_downcase) and
+      .user.type == $author_type and .created_at == $created_at and .updated_at == .created_at
+    ' <<<"$comment_json" >/dev/null 2>&1; then
+    return 0
+  fi
+  # The immutable event snapshot changed after the writer ran. Continue to
+  # the exact-head collision/run checks so a false writer policy cannot leave
+  # an inherited green required check untouched. A true all-signed policy may
+  # safely no-op later when no failed native run exists.
+  echo "The authenticated comment changed after the writer completed."
+}
+
+read_pr() {
+  api_get "repos/${GH_REPO}/pulls/${PR_NUMBER}" || fail "Could not read the live pull request."
+  PR_JSON="$api_body"
+  jq -e --arg repo "${GH_REPO}" --arg pr "${PR_NUMBER}" --arg base "${TARGET_BASE_REF}" '
+    def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991;
+    type == "object" and
+    (.number | safe_id and (tostring == $pr)) and .state == "open" and .merged_at == null and
+    (.base | type == "object") and .base.ref == $base and
+    (.base.repo | type == "object") and .base.repo.full_name == $repo and (.base.repo.id | safe_id) and
+    (.head | type == "object") and
+    (.head.ref | type == "string" and length > 0 and test("^[^\\r\\n]+$")) and
+    (.head.sha | type == "string" and test("^[0-9a-fA-F]{40}$")) and
+    (.head.repo | type == "object") and
+    (.head.repo.full_name | type == "string" and test("^[^/[:space:]]+/[^/[:space:]]+$")) and
+    (.head.repo.id | safe_id) and
+    (.user | type == "object") and (.user.id | safe_id) and
+    (.user.login | type == "string" and test("^[A-Za-z0-9][A-Za-z0-9-]{0,38}$"))
+  ' <<<"$PR_JSON" >/dev/null 2>&1 || fail "The live pull request identity is invalid."
+  HEAD_SHA="$(jq -er '.head.sha | strings' <<<"$PR_JSON")"
+  HEAD_REF="$(jq -er '.head.ref | strings' <<<"$PR_JSON")"
+  BASE_REPO_ID="$(jq -er '.base.repo.id | numbers | tostring' <<<"$PR_JSON")"
+  PR_AUTHOR_ID="$(jq -er '.user.id | numbers | tostring' <<<"$PR_JSON")"
+  HEAD_REPO="$(jq -r 'if .head.repo == null then "" else (.head.repo.full_name // "") end' <<<"$PR_JSON")"
+  HEAD_REPO_ID="$(jq -r 'if .head.repo == null then "" else (.head.repo.id // "") end' <<<"$PR_JSON")"
+  if [[ -n "$HEAD_REPO" || -n "$HEAD_REPO_ID" ]]; then
+    [[ "$HEAD_REPO" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || fail "The live head repository name is invalid."
+    is_safe_id "$HEAD_REPO_ID" || fail "The live head repository ID is invalid."
+  fi
+  if [[ "${COMMENT_BODY}" == recheck && "${COMMENT_AUTHOR_ID}" != "$PR_AUTHOR_ID" ]]; then
+    case "${COMMENT_AUTHOR_ASSOCIATION}" in
+      OWNER|MEMBER|COLLABORATOR) ;;
+      *) fail "Only the pull request author or a trusted repository participant may request a rerun." ;;
+    esac
+  fi
+}
+
+validate_signature() {
+  [[ "${COMMENT_BODY}" == "$SIGN_PHRASE" ]] || return 0
+  api_get "repos/${GH_REPO}/contents/$SIGNATURES_PATH?ref=$SIGNATURES_BRANCH" ||
+    fail "Could not read the protected signature ledger."
+  local response="$api_body" content compact decoded encoded decoded_size
+  jq -e 'type == "object" and .type == "file" and .encoding == "base64" and (.content | type == "string")' \
+    <<<"$response" >/dev/null 2>&1 || fail "The signature ledger response is malformed."
+  content="$(jq -er '.content | strings' <<<"$response")" || fail "The signature ledger content is invalid."
+  compact="$(printf '%s' "$content" | tr -d '[:space:]')"
+  [[ "$compact" =~ ^[A-Za-z0-9+/]+={0,2}$ ]] || fail "The signature ledger is not valid base64."
+  encoded="$(printf '%s' "$compact" | wc -c | tr -d '[:space:]')"
+  if ! [[ "$encoded" =~ ^[0-9]+$ ]] || (( encoded % 4 != 0 )); then
+    fail "The signature ledger encoding is invalid."
+  fi
+  (( encoded <= ((MAX_LEDGER_BYTES + 2) * 4 / 3 + 4) )) || fail "The signature ledger exceeds its size limit."
+  if base64 --decode </dev/null >/dev/null 2>&1; then
+    decoded="$(printf '%s' "$compact" | base64 --decode 2>/dev/null)" || fail "The signature ledger is not valid base64."
+  else
+    decoded="$(printf '%s' "$compact" | base64 -D 2>/dev/null)" || fail "The signature ledger is not valid base64."
+  fi
+  decoded_size="$(printf '%s' "$decoded" | wc -c | tr -d '[:space:]')"
+  if ! [[ "$decoded_size" =~ ^[0-9]+$ ]] || (( decoded_size > MAX_LEDGER_BYTES )); then
+    fail "The signature ledger exceeds its size limit."
+  fi
+  jq -e --arg login "${COMMENT_AUTHOR_LOGIN}" --arg author_id "${COMMENT_AUTHOR_ID}" \
+    --arg comment_id "${COMMENT_ID}" --arg created_at "${COMMENT_CREATED_AT}" \
+    --arg repo_id "$BASE_REPO_ID" --arg pr "${PR_NUMBER}" --argjson max "$MAX_LEDGER_SIGNATURES" '
+      type == "object" and (.signedContributors | type == "array" and length <= $max) and
+      any(.signedContributors[]?;
+        (.name | type == "string" and (ascii_downcase == ($login | ascii_downcase))) and
+        (.id | type == "number" and floor == . and . > 0 and . <= 9007199254740991 and tostring == $author_id) and
+        (.comment_id | type == "number" and floor == . and . > 0 and . <= 9007199254740991 and tostring == $comment_id) and
+        (.created_at | type == "string" and . == $created_at) and
+        (.repoId | type == "number" and floor == . and . > 0 and . <= 9007199254740991 and tostring == $repo_id) and
+        (.pullRequestNo | type == "number" and floor == . and . > 0 and . <= 9007199254740991 and tostring == $pr)
+      )
+    ' <<<"$decoded" >/dev/null 2>&1 || fail "The authenticated signature was not persisted by the CLA action."
+}
+
+validate_unique_head() {
+  local pages_file
+  pages_file="$(mktemp)"
+  CLA_TEMP_FILES+=("$pages_file")
+  : >"$pages_file"
+  local page count
+  for ((page = 1; page <= MAX_PAGES; page++)); do
+    api_get "repos/${GH_REPO}/pulls?state=open&base=${TARGET_BASE_REF}&per_page=100&page=$page" ||
+      fail "Could not enumerate open pull requests."
+    local page_json="$api_body"
+    jq -e '
+      def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991;
+      def safe_ref: type == "string" and length > 0 and test("^[^\\r\\n]+$");
+      def safe_sha: type == "string" and test("^[0-9a-fA-F]{40}$");
+      type == "array" and length <= 100 and all(.[];
+        type == "object" and (.number | safe_id) and .state == "open" and
+        (.base | type == "object") and (.base.ref | safe_ref) and
+        (.base.repo | type == "object") and (.base.repo.full_name | type == "string" and length > 0) and (.base.repo.id | safe_id) and
+        (.head | type == "object") and (.head.ref | safe_ref) and (.head.sha | safe_sha)
+      )
+    ' \
+      <<<"$page_json" >/dev/null 2>&1 || fail "The open pull request response is malformed."
+    count="$(jq -er 'length | numbers' <<<"$page_json")"
+    printf '%s\n' "$page_json" >>"$pages_file"
+    if (( count < 100 )) && [[ "$api_has_next" != true ]]; then break; fi
+    (( page < MAX_PAGES )) || fail "The open pull request result window is truncated."
+  done
+  local all_open matching current_count sibling_count
+  all_open="$(jq -s 'add' "$pages_file")" || fail "Could not combine open pull request pages."
+  matching="$(jq -r --arg sha "$HEAD_SHA" '[.[] | select((.head.sha | ascii_downcase) == ($sha | ascii_downcase))] | length' <<<"$all_open")"
+  current_count="$(jq -r --argjson pr "${PR_NUMBER}" --arg sha "$HEAD_SHA" '[.[] | select(.number == $pr and ((.head.sha | ascii_downcase) == ($sha | ascii_downcase)))] | length' <<<"$all_open")"
+  [[ "$matching" =~ ^[0-9]+$ && "$current_count" =~ ^[0-9]+$ ]] || fail "Could not count open pull request identities."
+  (( current_count == 1 )) || fail "The live pull request is missing from the open-head scan."
+  sibling_count=$((matching - current_count))
+  (( sibling_count == 0 )) || fail "The source head is shared by another open pull request."
+  echo "Open-head collision scan passed."
+}
+
+find_workflow() {
+  local pages_file
+  pages_file="$(mktemp)"
+  CLA_TEMP_FILES+=("$pages_file")
+  : >"$pages_file"
+  local page count
+  for ((page = 1; page <= MAX_PAGES; page++)); do
+    api_get "repos/${GH_REPO}/actions/workflows?per_page=100&page=$page" ||
+      fail "Could not enumerate repository workflows."
+    local page_json="$api_body"
+    jq -e 'def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991; type == "object" and (.workflows | type == "array" and length <= 100) and all(.workflows[]; type == "object" and (.id | safe_id) and (.path | type == "string" and length > 0 and test("^[^\\r\\n]+$")) and (.state | type == "string"))' \
+      <<<"$page_json" >/dev/null 2>&1 || fail "The workflow response is malformed."
+    count="$(jq -er '.workflows | length | numbers' <<<"$page_json")"
+    printf '%s\n' "$page_json" >>"$pages_file"
+    if (( count < 100 )) && [[ "$api_has_next" != true ]]; then break; fi
+    (( page < MAX_PAGES )) || fail "The workflow result window is truncated."
+  done
+  local all_workflows
+  all_workflows="$(jq -s '[.[].workflows[]]' "$pages_file")" || fail "Could not combine workflow pages."
+  WORKFLOW_ID="$(jq -r --arg path "$EXPECTED_WORKFLOW_PATH" '[.[] | select(.path == $path and .state == "active") | .id] | unique | if length == 1 then .[0] else empty end' <<<"$all_workflows")"
+  is_safe_id "$WORKFLOW_ID" || fail "The expected CLA workflow is not uniquely active."
+}
+
+find_failed_run() {
+  local pages_file
+  pages_file="$(mktemp)"
+  CLA_TEMP_FILES+=("$pages_file")
+  : >"$pages_file"
+  local page count
+  for ((page = 1; page <= MAX_PAGES; page++)); do
+    api_get "repos/${GH_REPO}/actions/workflows/$WORKFLOW_ID/runs?event=${TARGET_EVENT}&per_page=100&page=$page" ||
+      fail "Could not enumerate CLA workflow runs."
+    local page_json="$api_body"
+    jq -e '
+      def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991;
+      def safe_ref: type == "string" and length > 0 and test("^[^\\r\\n]+$");
+      def safe_sha: type == "string" and test("^[0-9a-fA-F]{40}$");
+      def safe_timestamp: type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$");
+      def valid_pr:
+        type == "object" and (.number | safe_id) and
+        (.base | type == "object") and (.base.ref | safe_ref) and (.base.repo | type == "object") and (.base.repo.id | safe_id) and
+        (.head | type == "object") and (.head.ref | safe_ref) and (.head.sha | safe_sha);
+      type == "object" and (.workflow_runs | type == "array" and length <= 100) and all(.workflow_runs[];
+        type == "object" and (.id | safe_id) and (.workflow_id | safe_id) and
+        (.path | type == "string" and length > 0 and test("^[^\\r\\n]+$")) and
+        (.event | type == "string" and length > 0 and test("^[^\\r\\n]+$")) and
+        (.status | type == "string" and length > 0 and test("^[^\\r\\n]+$")) and
+        (.conclusion == null or (.conclusion | type == "string" and length > 0 and test("^[^\\r\\n]+$"))) and
+        (.head_sha | safe_sha) and (.head_branch | safe_ref) and
+        (.created_at | safe_timestamp) and
+        (.pull_requests == null or (.pull_requests | type == "array" and all(.[]; valid_pr)))
+      )
+    ' \
+      <<<"$page_json" >/dev/null 2>&1 || fail "The workflow-run response is malformed."
+    count="$(jq -er '.workflow_runs | length | numbers' <<<"$page_json")"
+    printf '%s\n' "$page_json" >>"$pages_file"
+    if (( count < 100 )) && [[ "$api_has_next" != true ]]; then break; fi
+    (( page < MAX_PAGES )) || fail "The workflow-run result window is truncated."
+  done
+  local all_runs candidates candidate_count
+  all_runs="$(jq -s '[.[].workflow_runs[]]' "$pages_file")" || fail "Could not combine workflow-run pages."
+  candidates="$(jq -c --arg workflow_id "$WORKFLOW_ID" --arg path "$EXPECTED_WORKFLOW_PATH" --arg event "${TARGET_EVENT}" --arg sha "$HEAD_SHA" --arg head_ref "$HEAD_REF" --arg base "${TARGET_BASE_REF}" --arg repo "${GH_REPO}" --arg before "${COMMENT_CREATED_AT}" --argjson pr "${PR_NUMBER}" --argjson base_repo_id "$BASE_REPO_ID" '
+    def source_ok:
+      if .pull_requests == null or (.pull_requests | length) == 0 then
+        .head_sha == $sha and .head_branch == $head_ref
+      else any(.pull_requests[]?;
+        (.number | type == "number" and . == $pr) and
+        (.base.ref == $base) and (.base.repo.id | type == "number" and . == $base_repo_id) and
+        (.head.ref == $head_ref) and (.head.sha == $sha)
+      ) end;
+    [ .[] | select(
+      (.id | type == "number" and floor == . and . > 0) and
+      (.workflow_id | type == "number" and . == ($workflow_id | tonumber)) and
+      .path == $path and .event == $event and .status == "completed" and .conclusion == "failure" and
+      .head_sha == $sha and .head_branch == $head_ref and (.created_at | type == "string" and . <= $before) and
+      source_ok
+    ) ] | sort_by([.created_at, .id])
+  ' <<<"$all_runs")" || fail "Could not select exact failed CLA workflow runs."
+  candidate_count="$(jq -r 'length' <<<"$candidates")"
+  [[ "$candidate_count" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA workflow runs."
+  # Keep the normal selection set small. The API scan itself is bounded to
+  # MAX_FALLBACK_RUNS records, so a busy head cannot force an unbounded retry
+  # or make the helper choose an arbitrary run outside the reviewed window.
+  (( candidate_count <= MAX_FALLBACK_RUNS )) || fail "The exact source head has more than ${MAX_FALLBACK_RUNS} matching CLA workflow runs."
+  (( candidate_count <= MAX_MATCHING_RUNS )) || fail "The exact source head has more than ${MAX_MATCHING_RUNS} matching CLA workflow runs; retry after old runs expire."
+  if (( candidate_count == 0 )); then
+    if [[ "${WRITER_POLICY_RESULT:-}" == true ]]; then
+      no_op "no failed native CLA run exists for this exact source head"
+    fi
+    # A failed writer must never leave an earlier green required check as the
+    # only visible result. Native v3 is the sole check producer, so an
+    # administrator must start a fresh lifecycle run when no failed run can
+    # be safely rerun from this comment event.
+    fail "The writer did not confirm an all-signed policy and no failed native CLA run is available for a safe rerun."
+  fi
+  CANDIDATE_RUN_JSON="$(jq -c '.[-1]' <<<"$candidates")"
+  RUN_ID="$(jq -er '.id | numbers | tostring' <<<"$CANDIDATE_RUN_JSON")"
+  RUN_EXECUTION_SHA="$(jq -er '.head_sha | strings' <<<"$CANDIDATE_RUN_JSON")"
+}
+
+validate_run() {
+  local run_json="$1"
+  jq -e --arg run_id "$RUN_ID" --arg workflow_id "$WORKFLOW_ID" --arg path "$EXPECTED_WORKFLOW_PATH" --arg event "${TARGET_EVENT}" --arg sha "$HEAD_SHA" --arg head_ref "$HEAD_REF" --arg base "${TARGET_BASE_REF}" --arg repo "${GH_REPO}" --arg before "${COMMENT_CREATED_AT}" --argjson pr "${PR_NUMBER}" --argjson base_repo_id "$BASE_REPO_ID" '
+    def source_ok:
+      if .pull_requests == null or (.pull_requests | length) == 0 then .head_sha == $sha and .head_branch == $head_ref
+      else any(.pull_requests[]?; (.number | type == "number" and . == $pr) and .base.ref == $base and (.base.repo.id | type == "number" and . == $base_repo_id) and .head.ref == $head_ref and .head.sha == $sha) end;
+    type == "object" and (.id | type == "number" and floor == . and tostring == $run_id) and
+    (.workflow_id | type == "number" and . == ($workflow_id | tonumber)) and .path == $path and .event == $event and
+    .status == "completed" and .conclusion == "failure" and .head_sha == $sha and .head_branch == $head_ref and
+    (.created_at | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$") and . <= $before) and
+    .html_url == ("https://github.com/" + $repo + "/actions/runs/" + $run_id) and
+    (.pull_requests == null or (.pull_requests | type == "array")) and source_ok
+  ' <<<"$run_json" >/dev/null 2>&1 || fail "The selected workflow run is no longer exact."
+}
+
+fetch_jobs() {
+  local target_run="$1"
+  local pages_file
+  pages_file="$(mktemp)"
+  CLA_TEMP_FILES+=("$pages_file")
+  : >"$pages_file"
+  local page count
+  for ((page = 1; page <= MAX_PAGES; page++)); do
+    api_get "repos/${GH_REPO}/actions/runs/$target_run/jobs?per_page=100&page=$page" ||
+      fail "Could not enumerate jobs for the selected workflow run."
+    local page_json="$api_body"
+    jq -e 'def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991; type == "object" and (.jobs | type == "array" and length <= 100) and all(.jobs[]; type == "object" and (.id | safe_id) and (.run_id | safe_id) and (.name | type == "string" and length > 0 and test("^[^\\r\\n]+$")) and (.status | type == "string" and length > 0 and test("^[^\\r\\n]+$")) and (.conclusion | type == "string" and length > 0 and test("^[^\\r\\n]+$")) and (.head_sha | type == "string" and test("^[0-9a-fA-F]{40}$")) and (.steps | type == "array" and length <= 100))' \
+      <<<"$page_json" >/dev/null 2>&1 || fail "The workflow job response is malformed."
+    count="$(jq -er '.jobs | length | numbers' <<<"$page_json")"
+    printf '%s\n' "$page_json" >>"$pages_file"
+    if (( count < 100 )) && [[ "$api_has_next" != true ]]; then break; fi
+    (( page < MAX_PAGES )) || fail "The workflow job result window is truncated."
+  done
+  JOBS_JSON="$(jq -s '[.[].jobs[]]' "$pages_file")" || fail "Could not combine workflow job pages."
+}
+
+validate_jobs() {
+  local jobs_json="$1" failed_json invalid_count native_total native_fold_total native_failed
+  jq -e --arg run_id "$RUN_ID" --arg sha "$RUN_EXECUTION_SHA" '
+    type == "array" and length <= 1000 and all(.[];
+      (.id | type == "number" and floor == . and . > 0 and . <= 9007199254740991) and
+      (.run_id | type == "number" and floor == . and . > 0 and . <= 9007199254740991 and . == ($run_id | tonumber)) and
+      (.name | type == "string" and length > 0) and
+      (.status == "completed") and (.conclusion | type == "string") and
+      (.head_sha | type == "string" and (ascii_downcase == ($sha | ascii_downcase))) and
+      (.steps | type == "array")
+    )
+  ' <<<"$jobs_json" >/dev/null 2>&1 || fail "The selected run contains malformed jobs."
+  failed_json="$(jq -c '[.[] | select(.conclusion != "success" and .conclusion != "skipped")]' <<<"$jobs_json")"
+  invalid_count="$(jq -r '[.[] | select(.conclusion != "failure")] | length' <<<"$failed_json")"
+  (( invalid_count == 0 )) || fail "The selected run contains a cancelled or non-failure job."
+  jq -e --arg assistant "$EXPECTED_ASSISTANT_JOB" --arg writer "$EXPECTED_WRITER_JOB" --arg gate "$EXPECTED_GATE_JOB" 'all(.[]; .name == $assistant or .name == $writer or .name == $gate)' <<<"$failed_json" >/dev/null 2>&1 ||
+    fail "The selected run contains an unexpected failed job."
+  native_total="$(jq -r --arg name "$EXPECTED_ASSISTANT_JOB" '[.[] | select(.name == $name)] | length' <<<"$jobs_json")"
+  native_fold_total="$(jq -r --arg name "$EXPECTED_ASSISTANT_JOB" '[.[] | select((.name | ascii_downcase) == ($name | ascii_downcase))] | length' <<<"$jobs_json")"
+  native_failed="$(jq -r --arg name "$EXPECTED_ASSISTANT_JOB" '[.[] | select(.name == $name and .conclusion == "failure")] | length' <<<"$jobs_json")"
+  [[ "$native_total" =~ ^[0-9]+$ && "$native_fold_total" =~ ^[0-9]+$ && "$native_failed" =~ ^[0-9]+$ ]] || fail "Could not count native CLA jobs."
+  (( native_total == 1 && native_fold_total == 1 && native_failed == 1 )) || fail "The selected run does not contain exactly one failed native CLA job."
+  NATIVE_JOB_JSON="$(jq -c --arg name "$EXPECTED_ASSISTANT_JOB" --arg sha "$RUN_EXECUTION_SHA" --arg marker "CLA generation $EXPECTED_GENERATION" --arg run_id "$RUN_ID" --arg repo "${GH_REPO}" '[.[] | select(.name == $name and .conclusion == "failure" and ((.head_sha | ascii_downcase) == ($sha | ascii_downcase)) and .html_url == ("https://github.com/" + $repo + "/actions/runs/" + $run_id + "/job/" + (.id | tostring)) and ([.steps[] | select(.name == $marker and .status == "completed" and .conclusion == "success")] | length == 1))] | if length == 1 then .[0] else empty end' <<<"$jobs_json")" ||
+    fail "Could not identify the exact failed native CLA job."
+  [[ -n "$NATIVE_JOB_JSON" ]] || fail "The native job has an old generation or non-canonical URL."
+  NATIVE_JOB_ID="$(jq -er '.id | numbers | tostring' <<<"$NATIVE_JOB_JSON")"
+  # Rerun the complete exact run. The native job consumes writer outputs, so
+  # rerunning the native job alone would reuse the old unsigned dependency.
+  RERUN_ENDPOINT="repos/${GH_REPO}/actions/runs/$RUN_ID/rerun"
+}
+
+validate_native_check() {
+  local pages_file
+  pages_file="$(mktemp)"
+  CLA_TEMP_FILES+=("$pages_file")
+  : >"$pages_file"
+  local page count
+  for ((page = 1; page <= MAX_PAGES; page++)); do
+    api_get "repos/${GH_REPO}/commits/$HEAD_SHA/check-runs?per_page=100&page=$page" ||
+      fail "Could not enumerate checks for the selected source head."
+    local page_json="$api_body"
+    jq -e 'def safe_id: type == "number" and floor == . and . > 0 and . <= 9007199254740991; def safe_details: . == null or (. | type == "string" and length > 0 and test("^https://[^[:space:]\\r\\n]+$")); type == "object" and (.check_runs | type == "array" and length <= 100) and all(.check_runs[]; type == "object" and (.id | safe_id) and (.name | type == "string" and length > 0 and test("^[^\\r\\n]+$")) and (.head_sha | type == "string" and test("^[0-9a-fA-F]{40}$")) and (.status | type == "string" and length > 0 and test("^[^\\r\\n]+$")) and (.conclusion == null or (.conclusion | type == "string" and length > 0 and test("^[^\\r\\n]+$"))) and (.app | type == "object" and (.id | safe_id) and (.slug | type == "string" and length > 0 and test("^[^\\r\\n]+$"))) and (.details_url | safe_details))' \
+      <<<"$page_json" >/dev/null 2>&1 || fail "The check-run response is malformed."
+    count="$(jq -er '.check_runs | length | numbers' <<<"$page_json")"
+    printf '%s\n' "$page_json" >>"$pages_file"
+    if (( count < 100 )) && [[ "$api_has_next" != true ]]; then break; fi
+    (( page < MAX_PAGES )) || fail "The check-run result window is truncated."
+  done
+  local all_checks canonical_url same_name_count matching_count
+  all_checks="$(jq -s '[.[].check_runs[]]' "$pages_file")" || fail "Could not combine check-run pages."
+  canonical_url="https://github.com/${GH_REPO}/actions/runs/$RUN_ID/job/$NATIVE_JOB_ID"
+  same_name_count="$(jq -r --arg name "$EXPECTED_ASSISTANT_JOB" --arg sha "$HEAD_SHA" --argjson app_id "$EXPECTED_APP_ID" --arg slug "$EXPECTED_APP_SLUG" '[.[] | select((.name | ascii_downcase) == ($name | ascii_downcase) and ((.head_sha | ascii_downcase) == ($sha | ascii_downcase)) and (.app.id | type == "number" and . == $app_id) and .app.slug == $slug)] | length' <<<"$all_checks")"
+  [[ "$same_name_count" =~ ^[0-9]+$ ]] || fail "Could not count same-name native CLA checks."
+  (( same_name_count <= MAX_FALLBACK_RUNS )) || fail "The source head has more than ${MAX_FALLBACK_RUNS} same-name native CLA checks."
+  (( same_name_count == 1 )) || fail "The source head has duplicate or ambiguous native CLA checks."
+  matching_count="$(jq -r --arg name "$EXPECTED_ASSISTANT_JOB" --arg sha "$HEAD_SHA" --arg url "$canonical_url" --argjson app_id "$EXPECTED_APP_ID" --arg slug "$EXPECTED_APP_SLUG" '[.[] | select(.name == $name and ((.head_sha | ascii_downcase) == ($sha | ascii_downcase)) and .status == "completed" and .conclusion == "failure" and (.app.id | type == "number" and . == $app_id) and .app.slug == $slug and .details_url == $url)] | length' <<<"$all_checks")"
+  [[ "$matching_count" =~ ^[0-9]+$ ]] || fail "Could not count native CLA checks."
+  (( matching_count == 1 )) || fail "The exact native CLA check is missing or colliding with another producer."
+  CHECK_ID="$(jq -er --arg name "$EXPECTED_ASSISTANT_JOB" --arg sha "$HEAD_SHA" --arg url "$canonical_url" --argjson app_id "$EXPECTED_APP_ID" --arg slug "$EXPECTED_APP_SLUG" '[.[] | select(.name == $name and .head_sha == $sha and .status == "completed" and .conclusion == "failure" and .app.id == $app_id and .app.slug == $slug and .details_url == $url) | .id] | if length == 1 then .[0] else empty end' <<<"$all_checks")"
+  is_safe_id "$CHECK_ID" || fail "The native CLA check ID is invalid."
+  api_get "repos/${GH_REPO}/check-runs/$CHECK_ID" || fail "Could not re-read the native CLA check."
+  jq -e --arg id "$CHECK_ID" --arg name "$EXPECTED_ASSISTANT_JOB" --arg sha "$HEAD_SHA" --arg url "$canonical_url" --argjson app_id "$EXPECTED_APP_ID" --arg slug "$EXPECTED_APP_SLUG" 'type == "object" and (.id | type == "number" and floor == . and tostring == $id) and .name == $name and ((.head_sha | ascii_downcase) == ($sha | ascii_downcase)) and .status == "completed" and .conclusion == "failure" and (.app.id | type == "number" and . == $app_id) and .app.slug == $slug and .details_url == $url' <<<"$api_body" >/dev/null 2>&1 ||
+    fail "The native CLA check changed or is not bound to the selected job."
+}
+
+final_recheck() {
+  read_pr
+  validate_unique_head
+  api_get "repos/${GH_REPO}/actions/runs/$RUN_ID" || fail "Could not re-read the selected run."
+  validate_run "$api_body"
+  fetch_jobs "$RUN_ID"
+  validate_jobs "$JOBS_JSON"
+  validate_native_check
+}
+
+require_inputs
+read_issue
+read_comment
+read_pr
+validate_signature
+validate_unique_head
+find_workflow
+find_failed_run
+api_get "repos/${GH_REPO}/actions/runs/$RUN_ID" || fail "Could not read the selected run."
+validate_run "$api_body"
+fetch_jobs "$RUN_ID"
+validate_jobs "$JOBS_JSON"
+api_get "repos/${GH_REPO}/actions/jobs/$NATIVE_JOB_ID" || fail "Could not read the selected native job."
+jq -e --arg id "$NATIVE_JOB_ID" --arg run_id "$RUN_ID" --arg name "$EXPECTED_ASSISTANT_JOB" --arg sha "$RUN_EXECUTION_SHA" --arg repo "${GH_REPO}" --arg marker "CLA generation $EXPECTED_GENERATION" 'type == "object" and (.id | type == "number" and floor == . and tostring == $id) and (.run_id | type == "number" and tostring == $run_id) and .name == $name and .status == "completed" and .conclusion == "failure" and ((.head_sha | ascii_downcase) == ($sha | ascii_downcase)) and .html_url == ("https://github.com/" + $repo + "/actions/runs/" + $run_id + "/job/" + $id) and ([.steps[] | select(.name == $marker and .status == "completed" and .conclusion == "success")] | length == 1)' <<<"$api_body" >/dev/null 2>&1 ||
+  fail "The selected native job no longer matches the exact failed job."
+validate_native_check
+final_recheck
+api_post "$RERUN_ENDPOINT" || fail "Could not rerun the exact native CLA workflow run."
+echo "Requested a full rerun of workflow run $RUN_ID for source head $HEAD_SHA."

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -150,6 +150,10 @@ is_valid_not_found() {
 require_inputs() {
   [[ "${GH_REPO:-}" == "$EXPECTED_REPOSITORY" ]] || fail "The helper is not running in the canonical repository."
   [[ "${EVENT_NAME:-}" == issue_comment ]] || fail "The helper received an unexpected event."
+  # A rerun of the issue-comment workflow reuses its original event payload.
+  # Refuse every attempt after the first so the rerun worker cannot schedule a
+  # new rerun of itself indefinitely.
+  [[ "${RUN_ATTEMPT:-}" == 1 ]] || fail "The issue-comment rerun helper only runs on the first workflow attempt."
   is_safe_id "${ISSUE_NUMBER:-}" || fail "The issue number is invalid."
   [[ "${PR_NUMBER:-}" == "${ISSUE_NUMBER:-}" ]] || fail "The issue and pull request numbers differ."
   is_safe_id "${COMMENT_ID:-}" || fail "The comment ID is invalid."
@@ -553,14 +557,22 @@ validate_native_check() {
     if (( count < 100 )) && [[ "$api_has_next" != true ]]; then break; fi
     (( page < MAX_PAGES )) || fail "The check-run result window is truncated."
   done
-  local all_checks canonical_url same_name_count matching_count
+  local all_checks canonical_url same_name_count same_name_nonfailure_count matching_count
   all_checks="$(jq -s '[.[].check_runs[]]' "$pages_file")" || fail "Could not combine check-run pages."
   canonical_url="https://github.com/${GH_REPO}/actions/runs/$RUN_ID/job/$NATIVE_JOB_ID"
   same_name_count="$(jq -r --arg name "$EXPECTED_ASSISTANT_JOB" --arg sha "$HEAD_SHA" --argjson app_id "$EXPECTED_APP_ID" --arg slug "$EXPECTED_APP_SLUG" '[.[] | select((.name | ascii_downcase) == ($name | ascii_downcase) and ((.head_sha | ascii_downcase) == ($sha | ascii_downcase)) and (.app.id | type == "number" and . == $app_id) and .app.slug == $slug)] | length' <<<"$all_checks")"
   [[ "$same_name_count" =~ ^[0-9]+$ ]] || fail "Could not count same-name native CLA checks."
   (( same_name_count <= MAX_FALLBACK_RUNS )) || fail "The source head has more than ${MAX_FALLBACK_RUNS} same-name native CLA checks."
-  (( same_name_count == 1 )) || fail "The source head has duplicate or ambiguous native CLA checks."
-  matching_count="$(jq -r --arg name "$EXPECTED_ASSISTANT_JOB" --arg sha "$HEAD_SHA" --arg url "$canonical_url" --argjson app_id "$EXPECTED_APP_ID" --arg slug "$EXPECTED_APP_SLUG" '[.[] | select(.name == $name and ((.head_sha | ascii_downcase) == ($sha | ascii_downcase)) and .status == "completed" and .conclusion == "failure" and (.app.id | type == "number" and . == $app_id) and .app.slug == $slug and .details_url == $url)] | length' <<<"$all_checks")"
+  (( same_name_count >= 1 )) || fail "The source head has no native CLA check."
+  # Repeated lifecycle events can legitimately leave several native checks for
+  # one head. They are safe to tolerate only when every same-name result is a
+  # completed failure. A successful or in-progress duplicate could satisfy
+  # branch protection while the selected writer result is stale, so fail
+  # closed instead of guessing which result GitHub will use.
+  same_name_nonfailure_count="$(jq -r --arg name "$EXPECTED_ASSISTANT_JOB" --arg sha "$HEAD_SHA" --argjson app_id "$EXPECTED_APP_ID" --arg slug "$EXPECTED_APP_SLUG" '[.[] | select((.name | ascii_downcase) == ($name | ascii_downcase) and ((.head_sha | ascii_downcase) == ($sha | ascii_downcase)) and (.app.id | type == "number" and . == $app_id) and .app.slug == $slug and (.status != "completed" or .conclusion != "failure"))] | length' <<<"$all_checks")"
+  [[ "$same_name_nonfailure_count" =~ ^[0-9]+$ ]] || fail "Could not validate same-name native CLA check conclusions."
+  (( same_name_nonfailure_count == 0 )) || fail "The source head has a successful or incomplete duplicate native CLA check."
+  matching_count="$(jq -r --arg name "$EXPECTED_ASSISTANT_JOB" --arg sha "$HEAD_SHA" --arg url "$canonical_url" --argjson app_id "$EXPECTED_APP_ID" --arg slug "$EXPECTED_APP_SLUG" '[.[] | select((.name | ascii_downcase) == ($name | ascii_downcase) and ((.head_sha | ascii_downcase) == ($sha | ascii_downcase)) and .status == "completed" and .conclusion == "failure" and (.app.id | type == "number" and . == $app_id) and .app.slug == $slug and .details_url == $url)] | length' <<<"$all_checks")"
   [[ "$matching_count" =~ ^[0-9]+$ ]] || fail "Could not count native CLA checks."
   (( matching_count == 1 )) || fail "The exact native CLA check is missing or colliding with another producer."
   CHECK_ID="$(jq -er --arg name "$EXPECTED_ASSISTANT_JOB" --arg sha "$HEAD_SHA" --arg url "$canonical_url" --argjson app_id "$EXPECTED_APP_ID" --arg slug "$EXPECTED_APP_SLUG" '[.[] | select(.name == $name and .head_sha == $sha and .status == "completed" and .conclusion == "failure" and .app.id == $app_id and .app.slug == $slug and .details_url == $url) | .id] | if length == 1 then .[0] else empty end' <<<"$all_checks")"

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -87,7 +87,7 @@ api_request() {
     gh api --method "$method" \
       --header 'Accept: application/vnd.github+json' \
       --header 'X-GitHub-Api-Version: 2022-11-28' \
-      --include --silent "$endpoint" >"$api_file" 2>/dev/null
+      --include "$endpoint" >"$api_file" 2>/dev/null
   )
   local producer_status="$?"
   set -e

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,4 @@
-name: "CLA Assistant v3"
+name: "CLA policy workflow"
 on:
   issue_comment:
     types: [created]
@@ -77,11 +77,14 @@ jobs:
       recheck_decision: ${{ steps.classify-recheck.outputs.decision || 'error' }}
     steps:
       - name: "Require GitHub-hosted runner"
-        if: runner.environment != 'github-hosted'
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
           set -euo pipefail
-          echo "::error title=CLA runner policy::CLA policy requires a GitHub-hosted runner."
-          exit 1
+          if [[ "${RUNNER_ENVIRONMENT}" != "github-hosted" ]]; then
+            echo "::error title=CLA runner policy::CLA policy requires a GitHub-hosted runner."
+            exit 1
+          fi
       - name: "Validate exact CLA trigger"
         id: validate-trigger
         env:
@@ -412,12 +415,14 @@ jobs:
                 *)
                   printf 'authorized=false\ndecision=error\n' >> "${GITHUB_OUTPUT}"
                   echo "::error title=CLA recheck policy::The authorization step returned an unknown decision." >&2
+                  exit 1
                   ;;
               esac
               ;;
             failure|cancelled|skipped|*)
               printf 'authorized=false\ndecision=error\n' >> "${GITHUB_OUTPUT}"
               echo "::error title=CLA recheck policy::The authorization step did not complete." >&2
+              exit 1
               ;;
           esac
 
@@ -461,11 +466,14 @@ jobs:
       comment_author_id: ${{ steps.signer-preflight.outputs.comment_author_id || '' }}
     steps:
       - name: "Require GitHub-hosted runner"
-        if: runner.environment != 'github-hosted'
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
           set -euo pipefail
-          echo "::error title=CLA runner policy::CLA policy requires a GitHub-hosted runner."
-          exit 1
+          if [[ "${RUNNER_ENVIRONMENT}" != "github-hosted" ]]; then
+            echo "::error title=CLA runner policy::CLA policy requires a GitHub-hosted runner."
+            exit 1
+          fi
       - name: "Authenticate exact CLA signer"
         id: signer-preflight
         # The maintained action reports an expected identity denial as a
@@ -539,9 +547,9 @@ jobs:
               ;;
           esac
 
-  CLAAssistant:
+  CLALedgerWriter:
     needs: [CLACommentGate, CLASignerGate]
-    name: "CLA Assistant writer"
+    name: "CLA ledger writer"
     if: >-
       always() &&
       github.repository == 'manaflow-ai/subrouter' &&
@@ -603,14 +611,18 @@ jobs:
       signature_recorded: ${{ steps.cla_action.outputs.signature_recorded || 'false' }}
       cla_passed: ${{ steps.cla_action.outputs.cla_passed || 'false' }}
       validated_head_sha: ${{ steps.cla_preflight.outputs.head_sha || '' }}
+      validated_base_sha: ${{ steps.cla_preflight.outputs.base_sha || '' }}
       recheck_decision: ${{ steps.recheck_auth.outputs.decision || '' }}
     steps:
       - name: "Require GitHub-hosted runner"
-        if: runner.environment != 'github-hosted'
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
           set -euo pipefail
-          echo "::error title=CLA runner policy::CLA policy requires a GitHub-hosted runner."
-          exit 1
+          if [[ "${RUNNER_ENVIRONMENT}" != "github-hosted" ]]; then
+            echo "::error title=CLA runner policy::CLA policy requires a GitHub-hosted runner."
+            exit 1
+          fi
       - name: "Require CLA admission gate"
         env:
           CLA_GATE_RESULT: ${{ needs.CLACommentGate.result || '' }}
@@ -849,8 +861,10 @@ jobs:
             exit 1
           fi
           echo "CLA preflight passed: ${commits} commits (maximum 1,000)."
-          echo "head_sha=${head_sha}" >> "${GITHUB_OUTPUT}"
-          echo "validated=true" >> "${GITHUB_OUTPUT}"
+          printf '%s\n' \
+            "head_sha=${head_sha}" \
+            "base_sha=${base_sha}" \
+            'validated=true' >> "${GITHUB_OUTPUT}"
 
       - name: "Revalidate recheck authorization before CLA write"
         id: recheck_auth
@@ -1526,1567 +1540,184 @@ jobs:
           # these numeric IDs only on authenticated Pull Request openers.
           allowlist-ids: '38676809,67667005'
 
-  CLAHeadCheckRefresh:
-    name: "Refresh CLA required check"
-    # Branch protection must require the Checks API context named exactly
-    # `CLA Assistant v3` from GitHub Actions app 15368. This job display name
-    # is only the producer implementation and is not the protected context.
-    needs: [CLACommentGate, CLASignerGate, CLAAssistant]
-    # issue_comment runs execute from the default branch and therefore cannot
-    # update a check attached to the contributor's head SHA. This worker is the
-    # sole producer of the required `CLA Assistant v3` check, for both lifecycle
-    # and authenticated comment events. It publishes a failed check when an
-    # admitted event or lifecycle writer dependency fails, so skipped or
-    # duplicate GitHub Actions job checks cannot mask an invalid CLA state.
-    # Exact commands from any authenticated human start this read-only worker,
-    # including unauthorized commands. A bounded phrase, identity, and open
-    # Pull Request predicate keeps arbitrary public comments out of the queue;
-    # the remaining availability cost is one bounded collision scan per exact
-    # command. The writer may find an identity already present in the ledger
-    # and perform no new row write; that idempotent
-    # declaration still represents a valid all-signed state. The maintained
-    # action accepts declarations only from newly-created
-    # comments. Editing or deleting a comment after its durable ledger entry is
-    # intentional and does not revoke the CLA; merged pull requests are locked
-    # so the comment evidence cannot be changed after merge.
-    # An internally consistent unauthorized signer or recheck result is a
-    # no-op only after the worker has completed its collision scan. Missing or
-    # inconsistent gate outputs must publish a failed required check.
+  # This no-permission job is the sole producer of the required
+  # `CLA Assistant v3` check context. It runs only for a lifecycle event on
+  # the exact source head. Issue comments never create a same-name check from
+  # the default branch; the rerun worker below replays this native job. Keep
+  # this job scheduled even when an admission dependency fails, so a failed
+  # writer cannot leave an inherited green required check untouched.
+  CLAAssistant:
+    name: "CLA Assistant v3"
+    needs: [CLACommentGate, CLALedgerWriter]
     if: >-
       always() &&
       github.repository == 'manaflow-ai/subrouter' &&
+      github.event_name == 'pull_request_target' &&
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'reopened' ||
+        github.event.action == 'synchronize' ||
+        github.event.action == 'edited' ||
+        github.event.action == 'ready_for_review'
+      )
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
+    timeout-minutes: 5
+    concurrency:
+      group: "cla-required-${{ github.repository }}-${{ github.event.pull_request.number }}"
+      cancel-in-progress: false
+    permissions: {}
+    steps:
+      - name: "Require GitHub-hosted runner"
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
+        run: |
+          set -euo pipefail
+          if [[ "${RUNNER_ENVIRONMENT}" != "github-hosted" ]]; then
+            echo "::error title=CLA runner policy::CLA policy requires a GitHub-hosted runner."
+            exit 1
+          fi
+
+      - name: "CLA generation v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af"
+        run: echo "CLA generation ${CLA_GENERATION}"
+
+      - name: "Publish exact CLA policy result"
+        env:
+          GATE_RESULT: ${{ needs.CLACommentGate.result || '' }}
+          GATE_ADMITTED: ${{ needs.CLACommentGate.outputs.admitted || '' }}
+          WRITER_RESULT: ${{ needs.CLALedgerWriter.result || '' }}
+          WRITER_POLICY_RESULT: ${{ needs.CLALedgerWriter.outputs.cla_passed || 'false' }}
+          WRITER_HEAD_SHA: ${{ needs.CLALedgerWriter.outputs.validated_head_sha || '' }}
+          WRITER_BASE_SHA: ${{ needs.CLALedgerWriter.outputs.validated_base_sha || '' }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          CLA_GENERATION: ${{ env.CLA_GENERATION }}
+        run: |
+          set -euo pipefail
+          is_sha() {
+            [[ "${1}" =~ ^[0-9a-fA-F]{40}$ ]]
+          }
+          if [[ "${GATE_RESULT}" != "success" || "${GATE_ADMITTED}" != "true" ]]; then
+            echo "::error title=CLA policy::The read-only admission gate did not pass."
+            exit 1
+          fi
+          [[ "${WRITER_RESULT}" == "success" ]] || {
+            echo "::error title=CLA policy::The ledger writer did not pass."
+            exit 1
+          }
+          [[ "${WRITER_POLICY_RESULT}" == "true" ]] || {
+            echo "::error title=CLA policy::The ledger writer did not confirm that every contributor is signed."
+            exit 1
+          }
+          if ! is_sha "${EVENT_HEAD_SHA}" || ! is_sha "${WRITER_HEAD_SHA}"; then
+            echo "::error title=CLA policy::The writer did not return a valid source head."
+            exit 1
+          fi
+          [[ "${WRITER_HEAD_SHA,,}" == "${EVENT_HEAD_SHA,,}" ]] || {
+            echo "::error title=CLA policy::The writer result is bound to a different source head."
+            exit 1
+          }
+          if ! is_sha "${EVENT_BASE_SHA}" || ! is_sha "${WRITER_BASE_SHA}"; then
+            echo "::error title=CLA policy::The writer did not return a valid target base."
+            exit 1
+          fi
+          [[ "${WRITER_BASE_SHA,,}" == "${EVENT_BASE_SHA,,}" ]] || {
+            echo "::error title=CLA policy::The writer result is bound to a different target base."
+            exit 1
+          }
+          [[ "${CLA_GENERATION}" == "v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af" ]] || {
+            echo "::error title=CLA policy::The policy generation is not the reviewed action release."
+            exit 1
+          }
+          echo "CLA Assistant v3 passed for source head ${EVENT_HEAD_SHA}."
+
+  # Issue comments run from the default branch. This job never executes
+  # contributor-controlled shell and never creates a same-name check. It
+  # validates the native failed job, run, and check through the immutable
+  # helper before requesting one exact rerun.
+  RerunFailedCLA:
+    name: "Rerun failed CLA check"
+    needs: [CLACommentGate, CLASignerGate, CLALedgerWriter]
+    if: >-
+      always() &&
+      github.repository == 'manaflow-ai/subrouter' &&
+      needs.CLACommentGate.result == 'success' &&
+      needs.CLACommentGate.outputs.admitted == 'true' &&
+      github.event_name == 'issue_comment' &&
+      github.event.action == 'created' &&
+      github.event.issue.state == 'open' &&
+      github.event.issue.pull_request &&
+      github.event.comment.user.type == 'User' &&
       (
         (
-          github.event_name == 'pull_request_target' &&
-          (
-            github.event.action == 'opened' ||
-            github.event.action == 'reopened' ||
-            github.event.action == 'synchronize' ||
-            github.event.action == 'edited' ||
-            github.event.action == 'ready_for_review'
-          )
+          github.event.comment.body == 'recheck' &&
+          needs.CLACommentGate.outputs.recheck_authorized == 'true' &&
+          needs.CLALedgerWriter.result == 'success'
         ) ||
         (
-          github.event_name == 'issue_comment' &&
-          github.event.action == 'created' &&
-          needs.CLACommentGate.result == 'success' &&
-          needs.CLACommentGate.outputs.admitted == 'true' &&
-          github.event.issue.pull_request &&
-          github.event.issue.state == 'open' &&
-          github.event.comment.user.type == 'User' &&
-          github.event.comment.user.id > 0 &&
+          github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
+          needs.CLASignerGate.result == 'success' &&
+          needs.CLASignerGate.outputs.signer_authorized == 'true' &&
+          needs.CLALedgerWriter.result == 'success' &&
           (
-            github.event.comment.body == 'recheck' ||
-            github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
+            needs.CLALedgerWriter.outputs.cla_passed == 'true' ||
+            needs.CLALedgerWriter.outputs.signature_recorded == 'true'
           )
         )
       )
     runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
-    timeout-minutes: 10
+    timeout-minutes: 15
     concurrency:
-      group: "cla-check-refresh-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}"
+      group: "cla-rerun-${{ github.repository }}-${{ github.event.issue.number }}"
       cancel-in-progress: false
     permissions:
-      # The worker updates one check run on one live PR head. It cannot alter
-      # source, signatures, comments, releases, or workflow configuration.
-      checks: write # Create or update the one exact-head required CLA check run.
-      issues: read # Revalidate the live declaration comment before the check write.
-      pull-requests: read # Revalidate the live Pull Request head and base identity.
-    outputs:
-      refreshed: ${{ steps.refresh-check.outputs.refreshed || 'false' }}
-      conclusion: ${{ steps.refresh-check.outputs.conclusion || 'failure' }}
-      decision: ${{ steps.refresh-check.outputs.decision || 'error' }}
-      head_sha: ${{ steps.refresh-check.outputs.head_sha || '' }}
+      actions: write
+      checks: read
+      contents: read
+      issues: read
+      pull-requests: read
     steps:
       - name: "Require GitHub-hosted runner"
-        if: runner.environment != 'github-hosted'
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
           set -euo pipefail
-          echo "::error title=CLA runner policy::CLA policy requires a GitHub-hosted runner."
-          exit 1
-      - name: "Validate exact head and declaration"
-        id: validate-refresh
+          if [[ "${RUNNER_ENVIRONMENT}" != "github-hosted" ]]; then
+            echo "::error title=CLA runner policy::CLA policy requires a GitHub-hosted runner."
+            exit 1
+          fi
+
+      - name: "Checkout trusted CLA rerun helper"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2, immutable
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/rerun-failed-cla.sh
+          sparse-checkout-cone-mode: false
+
+      - name: "Rerun exact failed native CLA job"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          WORKFLOW_SHA: ${{ github.workflow_sha || '' }}
-          REPOSITORY_ID: ${{ github.repository_id || '' }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || '' }}
           EVENT_NAME: ${{ github.event_name }}
-          EVENT_ACTION: ${{ github.event.action || '' }}
-          EVENT_PR_STATE: ${{ github.event.pull_request.state || '' }}
-          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
-          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
-          EVENT_BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name || '' }}
-          EVENT_BASE_REPOSITORY_ID: ${{ github.event.pull_request.base.repo.id || '' }}
-          EVENT_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
-          EVENT_HEAD_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || '' }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
-          EVENT_ISSUE_STATE: ${{ github.event.issue.state || '' }}
-          EVENT_COMMENT_ID: ${{ github.event.comment.id || '' }}
-          EVENT_COMMENT_BODY: ${{ github.event.comment.body || '' }}
-          EVENT_COMMENT_USER_ID: ${{ github.event.comment.user.id || '' }}
-          EVENT_COMMENT_USER_TYPE: ${{ github.event.comment.user.type || '' }}
-          GATE_RESULT: ${{ needs.CLACommentGate.result || '' }}
-          GATE_ADMITTED: ${{ needs.CLACommentGate.outputs.admitted || '' }}
-          GATE_DECISION: ${{ needs.CLACommentGate.outputs.trigger_decision || 'error' }}
-          RECHECK_AUTHORIZED: ${{ needs.CLACommentGate.outputs.recheck_authorized || '' }}
-          RECHECK_DECISION: ${{ needs.CLACommentGate.outputs.recheck_decision || 'error' }}
-          SIGNER_GATE_RESULT: ${{ needs.CLASignerGate.result || '' }}
-          SIGNER_AUTHORIZED: ${{ needs.CLASignerGate.outputs.signer_authorized || '' }}
-          SIGNER_DECISION: ${{ needs.CLASignerGate.outputs.signer_decision || 'error' }}
-          SIGNER_OPENER_NOT_IN_COMMITS: ${{ needs.CLASignerGate.outputs.opener_not_in_commits || 'false' }}
-          SIGNER_HEAD_SHA: ${{ needs.CLASignerGate.outputs.head_sha || '' }}
-          SIGNER_BASE_SHA: ${{ needs.CLASignerGate.outputs.base_sha || '' }}
-          WRITER_RESULT: ${{ needs.CLAAssistant.result || '' }}
-          # `signature_recorded` means one ledger row changed. It is not the
-          # policy result: another contributor may still be unsigned. The
-          # maintained writer's `cla_passed` output is the only signal that
-          # all-signed validation and the final bot comment both succeeded.
-          WRITER_POLICY_RESULT: ${{ needs.CLAAssistant.outputs.cla_passed || 'false' }}
-          WRITER_SIGNATURE_RECORDED: ${{ needs.CLAAssistant.outputs.signature_recorded || 'false' }}
-          WRITER_HEAD_SHA: ${{ needs.CLAAssistant.outputs.validated_head_sha || '' }}
-          WRITER_RECHECK_DECISION: ${{ needs.CLAAssistant.outputs.recheck_decision || '' }}
-        run: |
-          set -euo pipefail
-          # A job failure does not change an already-green Checks API run.
-          # Once this worker has observed a candidate, fail() makes one
-          # bounded attempt to publish a failed canonical result before it
-          # exits. The guard stays disabled until the publisher is defined and
-          # all required payload fields are ready.
-          failure_fallback_ready=false
-          failure_fallback_attempted=false
-          failure_fallback_in_progress=false
-          # Once the exact-head payload exists, an admitted event is enough to
-          # justify a bounded failed-check POST when enumeration itself fails.
-          # This protects an existing green check from API outage ambiguity.
-          failure_fallback_on_unknown_candidate=false
-          candidate_check_exists=false
-          candidate_check_id=""
-          collision_scan_complete=false
-          no_refresh_requested=false
-          no_refresh_reason=""
-          # Keep every untrusted metadata response bounded before jq parses
-          # it. The Checks API has a separate raw cap below because its output
-          # fields can be much larger than PR/comment metadata.
-          max_metadata_raw_page_bytes=1048576
-          max_metadata_raw_total_bytes=10000000
-          # The counters are accessed by name in capture_bounded_response.
-          # shellcheck disable=SC2034
-          comment_raw_total_bytes=0
-          # shellcheck disable=SC2034
-          open_pr_raw_total_bytes=0
-          metadata_raw_file="$(mktemp)"
-          check_runs_file=""
-          check_raw_file=""
-          cleanup_tmp_files() {
-            local tmp_file
-            for tmp_file in "${metadata_raw_file:-}" "${check_runs_file:-}" "${check_raw_file:-}"; do
-              if [[ -n "${tmp_file}" ]]; then
-                rm -f -- "${tmp_file}" || return 1
-              fi
-            done
-            return 0
-          }
-          trap cleanup_tmp_files EXIT
-          capture_bounded_response() {
-            local output_file="${1}" page_limit="${2}" total_limit="${3}" total_name="${4}"
-            local raw_bytes pipeline_status producer_status sink_status
-            shift 4
-            : > "${output_file}"
-            set +e
-            "$@" 2>/dev/null |
-              head -c "$((page_limit + 1))" > "${output_file}"
-            pipeline_status=("${PIPESTATUS[@]}")
-            set -e
-            raw_bytes="$(LC_ALL=C wc -c < "${output_file}" | tr -d '[:space:]')"
-            [[ "${raw_bytes}" =~ ^[0-9]+$ ]] || return 1
-            (( raw_bytes <= page_limit )) || return 2
-            producer_status="${pipeline_status[0]:-1}"
-            sink_status="${pipeline_status[1]:-1}"
-            bounded_response_producer_status="${producer_status}"
-            (( sink_status == 0 )) || return 1
-            local current_total="${!total_name}"
-            [[ "${current_total}" =~ ^[0-9]+$ ]] || return 1
-            current_total=$((current_total + raw_bytes))
-            (( current_total <= total_limit )) || return 2
-            printf -v "${total_name}" '%s' "${current_total}"
-          }
-          fail() {
-            local message="${1}"
-            if [[ "${failure_fallback_ready}" == "true" &&
-                  ( "${candidate_check_exists}" == "true" ||
-                    "${failure_fallback_on_unknown_candidate}" == "true" ) &&
-                  "${failure_fallback_attempted}" == "false" &&
-                  "${failure_fallback_in_progress}" == "false" ]]; then
-              failure_fallback_attempted=true
-              failure_fallback_in_progress=true
-              if ! publish_failure_fallback; then
-                # Keep this generic. API bodies can contain untrusted text and
-                # must not be copied into a workflow error after a partial
-                # write.
-                echo "::error title=CLA check refresh::The fallback failure result could not be published for the exact head." >&2
-              fi
-              failure_fallback_in_progress=false
-            fi
-            echo "::error title=CLA check refresh preflight::${message}" >&2
-            exit 1
-          }
-          is_safe_id() {
-            local value="$1"
-            [[ "${value}" =~ ^[1-9][0-9]*$ ]] || return 1
-            (( ${#value} <= 16 )) || return 1
-            (( ${#value} != 16 || value <= 9007199254740991 ))
-          }
-          is_sha() {
-            [[ "${1}" =~ ^[0-9a-fA-F]{40}$ ]]
-          }
-          publish_no_check() {
-            # No check is correct only for an explicitly unauthorized public
-            # comment. Infrastructure, validation, and stale-head failures
-            # must fail the refresh job instead of silently preserving state.
-            if [[ "${collision_scan_complete}" != "true" ]]; then
-              no_refresh_requested=true
-              no_refresh_reason="${1:-the event did not require a CLA refresh}"
-              return 0
-            fi
-            printf 'published=false\nno_refresh=true\ndecision=no_refresh\nconclusion=neutral\nhead_sha=\n' >> "${GITHUB_OUTPUT}"
-            echo "CLA check refresh skipped: the comment was not admitted by an authenticated gate."
-            exit 0
-          }
-          mark_failure() {
-            if [[ "${policy_conclusion}" == "success" ]]; then
-              policy_conclusion=failure
-              policy_reason="${1}"
-            fi
-          }
-          require_writer_policy() {
-            local context="${1}"
-            if [[ "${WRITER_RESULT}" != "success" ]]; then
-              mark_failure "the CLA writer did not complete ${context}"
-              return 1
-            fi
-            if [[ "${WRITER_POLICY_RESULT}" != "true" ]]; then
-              # `signature_recorded=true` only says that one ledger row was
-              # persisted. It cannot authorize a green required check while
-              # another contributor remains unsigned or the final bot comment
-              # was not applied.
-              mark_failure "the CLA writer did not confirm an all-signed policy for ${context}"
-              return 1
-            fi
-            return 0
-          }
-          comment_snapshot_matches() {
-            local endpoint="$1"
-            local expected_id="$2"
-            local expected_body="$3"
-            local expected_user_id="$4"
-            local expected_issue_url="$5"
-            local raw_response response_status capture_status response_bytes http_status response_body comment_json
-            comment_snapshot_status=error
-            capture_status=0
-            capture_bounded_response "${metadata_raw_file}" 262144 2000000 comment_raw_total_bytes gh api --include \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "${endpoint}" || capture_status=$?
-            if (( capture_status == 2 )); then
-              return 1
-            fi
-            raw_response="$(<"${metadata_raw_file}")"
-            response_status="${bounded_response_producer_status:-1}"
-            response_bytes="$(LC_ALL=C printf '%s' "${raw_response}" | wc -c | tr -d '[:space:]')"
-            if ! [[ "${response_bytes}" =~ ^[0-9]+$ ]] || (( response_bytes > 262144 )); then
-              return 1
-            fi
-            http_status="$(printf '%s\n' "${raw_response}" | awk '/^HTTP\// { gsub("\r", "", $2); code=$2 } END { print code }')"
-            response_body="$(printf '%s\n' "${raw_response}" | awk 'BEGIN { body=0 } { sub(/\r$/, "") } body { print } /^$/ { body=1 }')"
-            if (( response_status != 0 )); then
-              if [[ "${http_status}" == "404" ]] &&
-                 jq -e 'type == "object" and ((.status == 404) or (.status == "404")) and (.message | type == "string" and length > 0)' <<<"${response_body}" >/dev/null 2>&1; then
-                comment_snapshot_status=missing
-              fi
-              return 1
-            fi
-            [[ "${http_status}" == "200" ]] || return 1
-            if ! comment_json="$(jq -c '
-              {
-                id: (.id // null),
-                body: (.body // ""),
-                user_id: (if .user == null then null else (.user.id // null) end),
-                user_type: (if .user == null then "" else (.user.type // "") end),
-                created_at: (.created_at // ""),
-                updated_at: (.updated_at // ""),
-                issue_url: (.issue_url // "")
-              }
-            ' <<<"${response_body}" 2>/dev/null)"; then
-              return 1
-            fi
-            if ! jq -e 'type == "object" and (.id | type == "number" and floor == . and . > 0) and (.body | type == "string") and (.user_id | type == "number" and floor == . and . > 0) and (.user_type == "User") and (.created_at | type == "string" and length > 0) and (.updated_at | type == "string") and (.issue_url | type == "string")' <<<"${comment_json}" >/dev/null 2>&1; then
-              return 1
-            fi
-            if jq -e --arg id "${expected_id}" \
-                  --arg body "${expected_body}" \
-                  --arg user_id "${expected_user_id}" \
-                  --arg issue_url "${expected_issue_url}" '
-              (.id | type == "number" and floor == . and . > 0) and
-              ((.id | tostring) == $id) and
-              (.body == $body) and
-              (.user_id | type == "number" and floor == . and . > 0) and
-              ((.user_id | tostring) == $user_id) and
-              (.user_type == "User") and
-              (.created_at | type == "string" and length > 0) and
-              (.updated_at == .created_at) and
-              (.issue_url == $issue_url)
-            ' <<<"${comment_json}" >/dev/null 2>&1; then
-              comment_snapshot_status=match
-              return 0
-            fi
-            comment_snapshot_status=changed
-            return 1
-          }
-
-          [[ "${GH_REPO}" == "manaflow-ai/subrouter" ]] || fail "The worker is not running in the canonical repository."
-          is_sha "${WORKFLOW_SHA}" || fail "The trusted CLA workflow revision is invalid."
-          is_safe_id "${REPOSITORY_ID}" || fail "The canonical repository ID is invalid."
-          is_safe_id "${PR_NUMBER}" || fail "The pull request number is invalid."
-          expected_generation='v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af'
-          [[ "${CLA_GENERATION}" == "${expected_generation}" ]] || fail "The CLA check generation does not match the reviewed v2.2 action policy."
-
-          policy_conclusion=success
-          policy_reason="all CLA admission and writer checks passed"
-          event_kind=""
-          case "${EVENT_NAME}" in
-            pull_request_target)
-              case "${EVENT_ACTION}" in
-                opened|reopened|synchronize|edited|ready_for_review) ;;
-                *) fail "The pull request event is not an accepted CLA trigger." ;;
-              esac
-              [[ "${EVENT_PR_STATE}" == "open" ]] || fail "The pull request event does not describe an open pull request."
-              [[ "${EVENT_BASE_REF}" == "main" ]] || fail "The pull request event does not target main."
-              is_sha "${EVENT_BASE_SHA}" || fail "The pull request event has an invalid base SHA."
-              [[ -n "${EVENT_BASE_REPOSITORY}" && "${EVENT_BASE_REPOSITORY,,}" == "${GH_REPO,,}" ]] || fail "The pull request event has an invalid base repository."
-              [[ "${EVENT_BASE_REPOSITORY_ID}" == "${REPOSITORY_ID}" ]] || fail "The pull request event has an invalid base repository ID."
-              [[ -n "${EVENT_HEAD_REPOSITORY}" ]] || fail "The pull request event has no head repository."
-              is_safe_id "${EVENT_HEAD_REPOSITORY_ID}" || fail "The pull request event has an invalid head repository ID."
-              is_sha "${EVENT_HEAD_SHA}" || fail "The pull request event has an invalid head SHA."
-              event_kind=lifecycle
-              ;;
-            issue_comment)
-              [[ "${EVENT_ACTION}" == "created" ]] || fail "The issue-comment event action is not supported."
-              [[ "${EVENT_ISSUE_STATE}" == "open" ]] || fail "The comment is not on an open pull request."
-              is_safe_id "${EVENT_COMMENT_ID}" || fail "The comment ID is invalid."
-              is_safe_id "${EVENT_COMMENT_USER_ID}" || fail "The commenter ID is invalid."
-              [[ "${EVENT_COMMENT_USER_TYPE}" == "User" ]] || fail "The commenter is not an authenticated human user."
-              case "${EVENT_COMMENT_BODY}" in
-                recheck) event_kind=recheck ;;
-                'I have read the CLA Document v2.2 and I hereby sign the CLA') event_kind=sign ;;
-                *) fail "The issue-comment body is not an admitted CLA command." ;;
-              esac
-              ;;
-            *)
-              fail "The worker received an unsupported event."
-              ;;
-          esac
-
-          capture_status=0
-          capture_bounded_response "${metadata_raw_file}" "${max_metadata_raw_page_bytes}" "${max_metadata_raw_total_bytes}" open_pr_raw_total_bytes gh api \
-            "repos/${GH_REPO}/pulls/${PR_NUMBER}" || capture_status=$?
-          if (( capture_status != 0 || ${bounded_response_producer_status:-1} != 0 )); then
-            fail "Could not read the live pull request before refreshing its check."
-          fi
-          if ! pr_json="$(jq -c '
-            {
-              number: (.number // null),
-              state: (.state // ""),
-              merged: (.merged_at != null),
-              base_ref: (.base.ref // ""),
-              base_sha: (.base.sha // ""),
-              base_repo: (if .base.repo == null then "" else (.base.repo.full_name // "") end),
-              base_repo_id: (if .base.repo == null then null else (.base.repo.id // null) end),
-              head_sha: (.head.sha // ""),
-              head_repo: (if .head.repo == null then "" else (.head.repo.full_name // "") end),
-              head_repo_id: (if .head.repo == null then null else (.head.repo.id // null) end)
-            }' "${metadata_raw_file}" 2>/dev/null)"; then
-            fail "Could not read the live pull request before refreshing its check."
-          fi
-          if ! jq -e --arg pr "${PR_NUMBER}" --arg repo "${GH_REPO}" '
-            def safe_id:
-              type == "number" and floor == . and . > 0 and . <= 9007199254740991;
-            def safe_sha:
-              type == "string" and test("^[0-9a-fA-F]{40}$");
-            def nonempty:
-              type == "string" and length > 0;
-            (.number | safe_id) and
-            ((.number | tostring) == $pr) and
-            (.state == "open") and
-            (.merged == false) and
-            (.base_ref == "main") and
-            (.base_repo | nonempty) and
-            ((.base_repo | ascii_downcase) == ($repo | ascii_downcase)) and
-            (.base_repo_id | safe_id) and
-            (.base_sha | safe_sha) and
-            (.head_sha | safe_sha) and
-            (.head_repo | nonempty) and
-            (.head_repo_id | safe_id)
-          ' <<<"${pr_json}" >/dev/null 2>&1; then
-            fail "The live pull request is not an open main-branch pull request with a valid head."
-          fi
-          HEAD_SHA="$(jq -er '.head_sha | strings' <<<"${pr_json}")"
-          HEAD_SHA="${HEAD_SHA,,}"
-          BASE_SHA="$(jq -er '.base_sha | strings' <<<"${pr_json}")"
-          BASE_SHA="${BASE_SHA,,}"
-          BASE_REF="$(jq -er '.base_ref | strings' <<<"${pr_json}")"
-          BASE_REPOSITORY="$(jq -er '.base_repo | strings' <<<"${pr_json}")"
-          BASE_REPOSITORY_ID="$(jq -er '.base_repo_id | numbers | tostring' <<<"${pr_json}")"
-          HEAD_REPOSITORY="$(jq -er '.head_repo | strings' <<<"${pr_json}")"
-          HEAD_REPOSITORY_ID="$(jq -er '.head_repo_id | numbers | tostring' <<<"${pr_json}")"
-          [[ "${BASE_REPOSITORY_ID}" == "${REPOSITORY_ID}" ]] || fail "The live pull request base repository ID is not canonical."
-
-          # A required check is attached to a commit SHA, not to a Pull
-          # Request number. Two open Pull Requests can therefore point at the
-          # same head commit and otherwise share one `CLA Assistant v3` result.
-          # Before any check mutation, enumerate every bounded open main-target
-          # Pull Request and require that this SHA belongs to exactly this PR.
-          # This prevents one PR's signer decision from being inherited by a
-          # different PR and prevents the refresh worker from invalidating a
-          # sibling PR's result.
-          open_pr_page_size=100
-          open_pr_page_limit=10
-          max_open_prs=1000
-          max_open_pr_page_bytes=1048576
-          max_open_pr_total_bytes=10000000
-          open_pr_count=0
-          open_pr_total_bytes=0
-          matching_open_pr_numbers=()
-          collision_detected=false
-          declare -A open_pr_seen=()
-          open_pr_list_complete=false
-          validate_open_pr_page() {
-            local page_number="${1}" page_bytes page_count
-            page_bytes="$(LC_ALL=C printf '%s' "${open_pr_page_json}" | wc -c | tr -d '[:space:]')"
-            [[ "${page_bytes}" =~ ^[0-9]+$ ]] || fail "Could not measure open Pull Request data on page ${page_number}."
-            (( page_bytes <= max_open_pr_page_bytes )) ||
-              fail "The open Pull Request page ${page_number} exceeds the bounded response limit."
-            open_pr_total_bytes=$((open_pr_total_bytes + page_bytes))
-            (( open_pr_total_bytes <= max_open_pr_total_bytes )) ||
-              fail "Open Pull Request data exceeds the bounded aggregate limit."
-            if ! jq -e --arg repo "${GH_REPO}" --argjson repo_id "${REPOSITORY_ID}" --argjson page_size "${open_pr_page_size}" '
-              def safe_id:
-                type == "number" and floor == . and . > 0 and . <= 9007199254740991;
-              def safe_sha:
-                type == "string" and test("^[0-9a-fA-F]{40}$");
-              def nonempty:
-                type == "string" and length > 0;
-              type == "array" and
-              length <= $page_size and
-              all(.[];
-                type == "object" and
-                (.number | safe_id) and
-                (.state == "open") and
-                (.base_ref == "main") and
-                (.base_repo | nonempty) and
-                ((.base_repo | ascii_downcase) == ($repo | ascii_downcase)) and
-                (.base_repo_id | safe_id and . == $repo_id) and
-                # GitHub sets head.repo and head.repo.id to null after a fork
-                # is deleted. The collision identity is the open PR number
-                # and head SHA, so source-repository metadata is deliberately
-                # optional for sibling PRs. The current PR is still required
-                # to have a complete source identity by the live PR check
-                # above.
-                (.head_sha | safe_sha)
-              )
-            ' <<<"${open_pr_page_json}" >/dev/null 2>&1; then
-              fail "GitHub returned malformed open Pull Request data on page ${page_number}."
-            fi
-            page_count="$(jq -er 'length | numbers' <<<"${open_pr_page_json}")" ||
-              fail "Could not count open Pull Requests on page ${page_number}."
-            [[ "${page_count}" =~ ^[0-9]+$ ]] ||
-              fail "GitHub returned an invalid open Pull Request count on page ${page_number}."
-            open_pr_count=$((open_pr_count + page_count))
-            (( open_pr_count <= max_open_prs )) ||
-              fail "GitHub returned more than ${max_open_prs} open Pull Requests for the bounded collision scan."
-            while IFS=$'\t' read -r open_pr_number open_pr_head; do
-              [[ -n "${open_pr_number}" && -n "${open_pr_head}" ]] ||
-                fail "GitHub returned an incomplete open Pull Request identity."
-              if [[ -n "${open_pr_seen[${open_pr_number}]+present}" ]]; then
-                fail "GitHub returned a duplicate open Pull Request while scanning for head collisions."
-              fi
-              open_pr_seen["${open_pr_number}"]=1
-              if [[ "${open_pr_head,,}" == "${HEAD_SHA}" ]]; then
-                matching_open_pr_numbers+=("${open_pr_number}")
-              fi
-            done < <(jq -r '.[] | [(.number | tostring), (.head_sha | ascii_downcase)] | @tsv' <<<"${open_pr_page_json}")
-          }
-          fetch_open_pr_page() {
-            local page_number="${1}"
-            local capture_status=0
-            capture_bounded_response "${metadata_raw_file}" "${max_metadata_raw_page_bytes}" "${max_metadata_raw_total_bytes}" open_pr_raw_total_bytes gh api --method GET \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "repos/${GH_REPO}/pulls?state=open&base=main&per_page=${open_pr_page_size}&page=${page_number}" \
-              || capture_status=$?
-            if (( capture_status == 2 )); then
-              fail "The raw open Pull Request response on page ${page_number} exceeds its bounded byte limit."
-            fi
-            if (( capture_status != 0 || ${bounded_response_producer_status:-1} != 0 )); then
-              fail "Could not inspect open Pull Requests on page ${page_number}."
-            fi
-            if ! open_pr_page_json="$(jq -c '[.[] | {
-                number: (.number // null),
-                state: (.state // ""),
-                base_ref: (.base.ref // ""),
-                base_repo: (if .base.repo == null then "" else (.base.repo.full_name // "") end),
-                base_repo_id: (if .base.repo == null then null else (.base.repo.id // null) end),
-                head_sha: (if .head == null then "" else (.head.sha // "") end),
-                head_repo: (if .head == null or .head.repo == null then null else (.head.repo.full_name // null) end),
-                head_repo_id: (if .head == null or .head.repo == null then null else (.head.repo.id // null) end)
-              }]' "${metadata_raw_file}" 2>/dev/null)"; then
-              fail "Could not inspect open Pull Requests on page ${page_number}."
-            fi
-            validate_open_pr_page "${page_number}"
-          }
-          validate_unique_open_pr_head() {
-            open_pr_count=0
-            open_pr_total_bytes=0
-            matching_open_pr_numbers=()
-            collision_detected=false
-            open_pr_seen=()
-            open_pr_list_complete=false
-            for ((open_pr_page = 1; open_pr_page <= open_pr_page_limit; open_pr_page++)); do
-              fetch_open_pr_page "${open_pr_page}"
-              open_pr_page_count="$(jq -er 'length | numbers' <<<"${open_pr_page_json}")" ||
-                fail "Could not count the open Pull Request page."
-              if (( open_pr_page_count == 0 )); then
-                open_pr_list_complete=true
-                break
-              fi
-              if (( open_pr_page == open_pr_page_limit )); then
-                fetch_open_pr_page "$((open_pr_page_limit + 1))"
-                open_pr_overflow_count="$(jq -er 'length | numbers' <<<"${open_pr_page_json}")" ||
-                  fail "Could not inspect the open Pull Request overflow page."
-                (( open_pr_overflow_count == 0 )) ||
-                  fail "The open Pull Request collision scan exceeded its bounded page limit."
-                open_pr_list_complete=true
-                break
-              fi
-            done
-            [[ "${open_pr_list_complete}" == "true" ]] ||
-              fail "The open Pull Request collision scan did not reach a validated end."
-            if (( ${#matching_open_pr_numbers[@]} != 1 )) ||
-               [[ "${matching_open_pr_numbers[0]}" != "${PR_NUMBER}" ]]; then
-              collision_detected=true
-              return 0
-            fi
-          }
-
-          if [[ "${event_kind}" == "lifecycle" ]]; then
-            if [[ "${EVENT_BASE_REF}" != "${BASE_REF}" ||
-                  "${EVENT_BASE_SHA,,}" != "${BASE_SHA}" ||
-                  "${EVENT_BASE_REPOSITORY,,}" != "${BASE_REPOSITORY,,}" ||
-                  "${EVENT_BASE_REPOSITORY_ID}" != "${BASE_REPOSITORY_ID}" ||
-                  "${EVENT_HEAD_REPOSITORY,,}" != "${HEAD_REPOSITORY,,}" ||
-                  "${EVENT_HEAD_REPOSITORY_ID}" != "${HEAD_REPOSITORY_ID}" ||
-                  "${EVENT_HEAD_SHA,,}" != "${HEAD_SHA}" ]]; then
-              # A stale lifecycle payload must never write a result for a
-              # different head. The next lifecycle event owns that head.
-              fail "The lifecycle payload does not match the live pull request identity."
-            fi
-          else
-            # An issue comment has no head SHA in its event. Re-read it and
-            # publish failure on the current live head if it was edited,
-            # deleted, or moved before this worker ran.
-            expected_issue_url="https://api.github.com/repos/${GH_REPO}/issues/${PR_NUMBER}"
-            comment_endpoint="repos/${GH_REPO}/issues/comments/${EVENT_COMMENT_ID}"
-            if ! comment_snapshot_matches "${comment_endpoint}" "${EVENT_COMMENT_ID}" \
-              "${EVENT_COMMENT_BODY}" "${EVENT_COMMENT_USER_ID}" "${expected_issue_url}"; then
-              case "${comment_snapshot_status}" in
-                missing|changed)
-                  if [[ "${WRITER_RESULT}" != "success" ]]; then
-                    # A public commenter can delete or edit its own comment
-                    # before this worker runs. No authenticated writer result
-                    # exists, so preserve any prior check and require a new
-                    # exact declaration instead of allowing comment churn to
-                    # replace a valid success with failure.
-                    publish_no_check
-                  fi
-                  echo "CLA comment changed after the authenticated writer completed; retaining the durable writer result."
-                  ;;
-                *)
-                  mark_failure "the exact declaration comment could not be read because of an API or response error"
-                  ;;
-              esac
-            fi
-          fi
-
-          # Exact issue commands are public. An unauthenticated signer or
-          # recheck requester must not be able to replace a previously valid
-          # check with failure. Only admitted commands reach the API writer.
-          if [[ "${no_refresh_requested}" != "true" ]]; then
-            case "${event_kind}" in
-              recheck)
-                if [[ "${GATE_RESULT}" != "success" || "${GATE_ADMITTED}" != "true" ]]; then
-                  if [[ "${GATE_DECISION}" == "ignored" ]]; then
-                    publish_no_check "the recheck requester was not admitted"
-                  else
-                    mark_failure "the read-only trigger gate failed while validating this recheck"
-                  fi
-                elif [[ "${RECHECK_DECISION}" == "unauthorized" &&
-                        "${RECHECK_AUTHORIZED}" == "false" ]]; then
-                  publish_no_check "the recheck requester is not an admin or maintainer"
-                elif [[ "${RECHECK_DECISION}" != "authorized" ||
-                        "${RECHECK_AUTHORIZED}" != "true" ]]; then
-                  mark_failure "the recheck authorization gate returned an invalid or failed decision"
-                fi
-                ;;
-              sign)
-                if [[ "${GATE_RESULT}" != "success" || "${GATE_ADMITTED}" != "true" ]]; then
-                  if [[ "${GATE_DECISION}" == "ignored" ]]; then
-                    publish_no_check "the declaration commenter was not admitted"
-                  else
-                    mark_failure "the read-only trigger gate failed while validating this declaration"
-                  fi
-                elif [[ "${SIGNER_GATE_RESULT}" == "success" &&
-                        "${SIGNER_DECISION}" == "unauthorized" &&
-                        "${SIGNER_AUTHORIZED}" == "false" &&
-                        "${SIGNER_OPENER_NOT_IN_COMMITS}" == "false" ]]; then
-                  publish_no_check "the declaration commenter is not tied to a current Pull Request identity"
-                elif [[ "${SIGNER_GATE_RESULT}" != "success" ||
-                        "${SIGNER_DECISION}" != "authorized" ||
-                        "${SIGNER_AUTHORIZED}" != "true" ]]; then
-                  mark_failure "the signer preflight returned an invalid or failed decision"
-                fi
-                if [[ "${no_refresh_requested}" != "true" ]]; then
-                  if ! is_sha "${SIGNER_HEAD_SHA}"; then
-                    mark_failure "the signer preflight did not return a valid head SHA"
-                  elif [[ "${SIGNER_HEAD_SHA,,}" != "${HEAD_SHA}" ]]; then
-                    fail "the signer preflight head changed before the required check refresh"
-                  fi
-                  if ! is_sha "${SIGNER_BASE_SHA}"; then
-                    mark_failure "the signer preflight did not return a valid base SHA"
-                  elif [[ "${SIGNER_BASE_SHA,,}" != "${BASE_SHA}" ]]; then
-                    fail "the signer preflight base changed before the required check refresh"
-                  fi
-                fi
-                ;;
-            esac
-          fi
-
-          if [[ "${no_refresh_requested}" != "true" ]]; then
-            case "${event_kind}" in
-              lifecycle)
-                if [[ "${GATE_RESULT}" != "success" || "${GATE_ADMITTED}" != "true" ]]; then
-                  mark_failure "the read-only trigger gate did not admit this lifecycle event"
-                fi
-                if require_writer_policy "for the pull request event" &&
-                   (! is_sha "${WRITER_HEAD_SHA}" || [[ "${WRITER_HEAD_SHA,,}" != "${HEAD_SHA}" ]]); then
-                  mark_failure "the CLA writer did not validate the current pull request head"
-                fi
-                ;;
-              recheck)
-                if [[ "${WRITER_RECHECK_DECISION}" == "unauthorized" ]]; then
-                  publish_no_check "the writer-side recheck requester is not authorized"
-                elif [[ "${WRITER_RECHECK_DECISION}" != "authorized" ]]; then
-                  mark_failure "the writer-side recheck authorization did not complete"
-                elif require_writer_policy "for the authorized recheck" &&
-                     (! is_sha "${WRITER_HEAD_SHA}" || [[ "${WRITER_HEAD_SHA,,}" != "${HEAD_SHA}" ]]); then
-                  mark_failure "the CLA writer did not validate the current pull request head"
-                fi
-                ;;
-              sign)
-                if require_writer_policy "for this declaration" &&
-                   (! is_sha "${WRITER_HEAD_SHA}" || [[ "${WRITER_HEAD_SHA,,}" != "${HEAD_SHA}" ]]); then
-                  mark_failure "the CLA writer did not validate the current pull request head"
-                fi
-                ;;
-              *)
-                fail "The worker did not normalize the event type."
-                ;;
-            esac
-          fi
-
-          if [[ "${no_refresh_requested}" != "true" &&
-                "${event_kind}" != "lifecycle" ]] &&
-             ! comment_snapshot_matches "${comment_endpoint}" "${EVENT_COMMENT_ID}" \
-               "${EVENT_COMMENT_BODY}" "${EVENT_COMMENT_USER_ID}" "${expected_issue_url}"; then
-            # The writer performs its own live validation, but the check must
-            # also describe the comment state immediately before this API
-            # write. This second snapshot closes the normal gate-to-check gap.
-            case "${comment_snapshot_status}" in
-              missing|changed)
-                if [[ "${WRITER_RESULT}" != "success" ]]; then
-                  publish_no_check
-                fi
-                echo "CLA comment changed after the authenticated writer completed; retaining the durable writer result."
-                ;;
-              *)
-                mark_failure "the exact declaration comment could not be read because of an API or response error"
-                ;;
-            esac
-          fi
-
-          if [[ "${no_refresh_requested}" != "true" ]]; then
-            if [[ -n "${SIGNER_HEAD_SHA}" ]] &&
-               (! is_sha "${SIGNER_HEAD_SHA}" || [[ "${SIGNER_HEAD_SHA,,}" != "${HEAD_SHA}" ]]); then
-              # A signer result for another head is stale. Do not write a
-              # failure against a newer head; its lifecycle event owns it.
-              fail "the signer result is bound to a different pull request head"
-            fi
-            if [[ -n "${WRITER_HEAD_SHA}" ]] &&
-               (! is_sha "${WRITER_HEAD_SHA}" || [[ "${WRITER_HEAD_SHA,,}" != "${HEAD_SHA}" ]]); then
-              if [[ "${event_kind}" == "lifecycle" ]]; then
-                fail "The lifecycle writer result is bound to a different pull request head."
-              fi
-              # A comment writer result for an older head must not overwrite
-              # the current head. Its next synchronize event owns the new
-              # check.
-              fail "the comment writer result is bound to a different pull request head"
-            fi
-          fi
-
-          # Run the collision scan after all other read-only checks and
-          # immediately before the first Checks API mutation. A second open PR
-          # can be created while earlier validation is running, so this late
-          # snapshot is the authority for whether this commit may be changed.
-          validate_unique_open_pr_head
-          collision_scan_complete=true
-          if [[ "${collision_detected}" == "true" ]]; then
-            mark_failure "the current head commit is shared by multiple open main-target Pull Requests"
-          elif [[ "${no_refresh_requested}" == "true" ]]; then
-            publish_no_check "${no_refresh_reason}"
-          fi
-
-          if [[ "${policy_conclusion}" == "success" ]]; then
-            check_title="CLA declaration validated"
-            check_summary="The maintained CLA writer validated the current pull request head and completed the authorized declaration refresh."
-          else
-            check_title="CLA declaration failed"
-            check_summary="CLA validation failed: ${policy_reason}. Correct the declaration or workflow state, then request a new check."
-          fi
-          external_id="cla-refresh:${CLA_GENERATION}:${PR_NUMBER}:${HEAD_SHA}"
-          run_url="${GITHUB_SERVER_URL}/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}"
-          payload="$(jq -n \
-            --arg name 'CLA Assistant v3' \
-            --arg head_sha "${HEAD_SHA}" \
-            --arg status 'completed' \
-            --arg conclusion "${policy_conclusion}" \
-            --arg details_url "${run_url}" \
-            --arg external_id "${external_id}" \
-            --arg title "${check_title}" \
-            --arg summary "${check_summary}" \
-            '{name:$name,head_sha:$head_sha,status:$status,conclusion:$conclusion,
-              details_url:$details_url,external_id:$external_id,
-              output:{title:$title,summary:$summary}}')"
-
-          # Enumerate the Actions app's check suites first, then enumerate all
-          # runs in each suite. The Checks API exposes at most 1,000 items
-          # through this bounded scan. Exact-boundary totals are accepted only
-          # after an explicit empty-page probe, which distinguishes exactly
-          # 1,000 items from a truncated response. A temp file avoids passing
-          # untrusted JSON in command-line arguments near Linux ARG_MAX.
-          suite_page_limit=1
-          suite_page_size=100
-          # The Checks API `check_name` query is case-sensitive, while
-          # required-check matching is case-insensitive. Enumerate every
-          # bounded Actions run in each matching suite and fold the name
-          # locally so a differently-cased producer cannot hide from the
-          # reconciliation set.
-          run_page_limit=10
-          run_page_size=100
-          max_check_suites=1000
-          max_check_runs=1000
-          # This is a raw suite scan budget, not only a matching-name budget.
-          # A commit with more than 100 Actions suites fails closed rather than
-          # silently accepting an incomplete producer set.
-          max_matching_suites=100
-          max_matching_runs=100
-          # A normal refresh fails closed above max_matching_runs. The worker
-          # continues a bounded scan after that threshold so its fallback can
-          # invalidate observed duplicates instead of leaving a green producer
-          # outside the cleanup set. The fallback has a larger, still bounded
-          # set and stops at max_fallback_runs.
-          max_fallback_runs=1000
-          max_scanned_runs=100000
-          max_check_page_bytes=262144
-          max_check_total_bytes=5000000
-          # Normal reconciliation stops at the smaller aggregate budget. A
-          # failed refresh still gets a bounded chance to invalidate the
-          # observed duplicate set before that stop is reported.
-          max_fallback_total_bytes=10000000
-          max_check_response_bytes=262144
-          # Measure raw GitHub responses before jq projects them. Check-run
-          # records can contain contributor-controlled output and annotations
-          # that are omitted by the projection below.
-          max_check_raw_page_bytes=1048576
-          max_check_raw_total_bytes=10000000
-          check_runs_file="$(mktemp)"
-          check_raw_file="$(mktemp)"
-          trap cleanup_tmp_files EXIT
-          : > "${check_runs_file}"
-          : > "${check_raw_file}"
-          all_runs='[]'
-          existing_runs='[]'
-          total_check_suites=0
-          total_check_runs=0
-          matching_check_runs=0
-          raw_check_total_bytes=0
-
-          validate_check_page_size() {
-            local label="${1}" page_bytes
-            if ! page_bytes="$(LC_ALL=C printf '%s' "${page_json}" | wc -c | tr -d '[:space:]')" ||
-               ! [[ "${page_bytes}" =~ ^[0-9]+$ ]] ||
-               (( page_bytes > max_check_page_bytes )); then
-              fail "The ${label} exceeds the ${max_check_page_bytes}-byte response limit."
-            fi
-          }
-          capture_raw_check_response() {
-            local raw_bytes pipeline_status
-            : > "${check_raw_file}"
-            set +e
-            "$@" 2>/dev/null |
-              head -c "$((max_check_raw_page_bytes + 1))" > "${check_raw_file}"
-            pipeline_status=("${PIPESTATUS[@]}")
-            set -e
-            raw_bytes="$(LC_ALL=C wc -c < "${check_raw_file}" | tr -d '[:space:]')"
-            [[ "${raw_bytes}" =~ ^[0-9]+$ ]] || return 1
-            # head intentionally reads one byte past the limit. A non-zero
-            # producer status from SIGPIPE is therefore treated as overflow,
-            # while a short response still must have a successful gh status.
-            (( raw_bytes <= max_check_raw_page_bytes )) || return 2
-            (( ${pipeline_status[0]:-1} == 0 && ${pipeline_status[1]:-1} == 0 )) || return 1
-            raw_check_total_bytes=$((raw_check_total_bytes + raw_bytes))
-            (( raw_check_total_bytes <= max_check_raw_total_bytes )) || return 2
-          }
-          validate_suite_page() {
-            local label="${1}" page_number="${2}"
-            validate_check_page_size "${label}"
-            if ! jq -e --arg expected_sha "${HEAD_SHA}" --argjson max_count "${max_check_suites}" \
-              --argjson page_number "${page_number}" --argjson page_size "${suite_page_size}" '
-              def safe_nonnegative:
-                type == "number" and floor == . and . >= 0 and . <= 9007199254740991;
-              def safe_positive:
-                type == "number" and floor == . and . > 0 and . <= 9007199254740991;
-              def safe_sha:
-                type == "string" and test("^[0-9a-fA-F]{40}$");
-              type == "object" and
-              (.total_count | safe_nonnegative) and
-              (.total_count <= $max_count) and
-              (.check_suites | type == "array" and length <= 100) and
-              (.total_count >= (.check_suites | length)) and
-              ((.check_suites | length) > 0 or .total_count <= (($page_number - 1) * $page_size)) and
-              all(.check_suites[];
-                type == "object" and
-                (.id | safe_positive) and
-                (.head_sha | safe_sha) and
-                ((.head_sha | ascii_downcase) == ($expected_sha | ascii_downcase)) and
-                (.app | type == "object") and
-                (.app.id == 15368) and
-                (.app.slug == "github-actions")
-              )
-            ' <<<"${page_json}" >/dev/null 2>&1; then
-              fail "GitHub returned invalid or unbounded check-suite data on ${label}."
-            fi
-          }
-          validate_run_page() {
-            local label="${1}" page_number="${2}"
-            validate_check_page_size "${label}"
-            if ! jq -e --arg expected_sha "${HEAD_SHA}" --argjson max_count "${max_check_runs}" \
-              --argjson page_number "${page_number}" --argjson page_size "${run_page_size}" '
-              def safe_nonnegative:
-                type == "number" and floor == . and . >= 0 and . <= 9007199254740991;
-              def safe_positive:
-                type == "number" and floor == . and . > 0 and . <= 9007199254740991;
-              def safe_sha:
-                type == "string" and test("^[0-9a-fA-F]{40}$");
-              type == "object" and
-              (.total_count | safe_nonnegative) and
-              (.total_count <= $max_count) and
-              (.check_runs | type == "array" and length <= 100) and
-              (.total_count >= (.check_runs | length)) and
-              ((.check_runs | length) > 0 or .total_count <= (($page_number - 1) * $page_size)) and
-              all(.check_runs[];
-                type == "object" and
-                (.id | safe_positive) and
-                (.name | type == "string") and
-                (.head_sha | safe_sha) and
-                ((.head_sha | ascii_downcase) == ($expected_sha | ascii_downcase)) and
-                (.app | type == "object") and
-                (.app.id == 15368) and
-                (.app.slug == "github-actions") and
-                (.external_id == null or (.external_id | type == "string")) and
-                (.status | type == "string") and
-                (.conclusion == null or (.conclusion | type == "string"))
-              )
-            ' <<<"${page_json}" >/dev/null 2>&1; then
-              fail "GitHub returned invalid or unbounded check-run data on ${label}."
-            fi
-          }
-          fetch_suite_page() {
-            local page_number="${1}"
-            local capture_status=0
-            capture_raw_check_response gh api --method GET \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "repos/${GH_REPO}/commits/${HEAD_SHA}/check-suites" \
-              -f 'app_id=15368' -f "per_page=${suite_page_size}" -f "page=${page_number}" || capture_status=$?
-            if (( capture_status != 0 )); then
-              if (( capture_status == 2 )); then
-                fail "The raw check-suite response exceeds its bounded byte limit."
-              fi
-              fail "Could not inspect check-suite page ${page_number}."
-            fi
-            if ! page_json="$(jq -c '
-                {total_count: .total_count,
-                 check_suites: [.check_suites[] | {
-                   id, head_sha,
-                   app: {id: (.app.id // null), slug: (.app.slug // null)}
-                 }]}' "${check_raw_file}" 2>/dev/null)"; then
-              fail "Could not inspect check-suite page ${page_number}."
-            fi
-            validate_suite_page "check-suite page ${page_number}" "${page_number}"
-          }
-          fetch_run_page() {
-            local suite_id="${1}" page_number="${2}"
-            local capture_status=0
-            capture_raw_check_response gh api --method GET \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "repos/${GH_REPO}/check-suites/${suite_id}/check-runs" \
-              -f 'filter=all' \
-              -f "per_page=${run_page_size}" -f "page=${page_number}" || capture_status=$?
-            if (( capture_status != 0 )); then
-              if (( capture_status == 2 )); then
-                fail "The raw check-run response exceeds its bounded byte limit."
-              fi
-              fail "Could not inspect check runs for suite ${suite_id}, page ${page_number}."
-            fi
-            if ! page_json="$(jq -c '
-                {total_count: .total_count,
-                 check_runs: [.check_runs[] | {
-                   id, name, head_sha,
-                   app: {id: (.app.id // null), slug: (.app.slug // null)},
-                   external_id, conclusion, status
-                 }]}' "${check_raw_file}" 2>/dev/null)"; then
-              fail "Could not inspect check runs for suite ${suite_id}, page ${page_number}."
-            fi
-            validate_run_page "check-suite ${suite_id}, page ${page_number}" "${page_number}"
-          }
-          validate_retained_run_bytes() {
-            local total_bytes
-            total_bytes="$(LC_ALL=C wc -c < "${check_runs_file}" | tr -d '[:space:]')"
-            [[ "${total_bytes}" =~ ^[0-9]+$ ]] || fail "Could not measure filtered check-run data."
-            if (( total_bytes > max_check_total_bytes )); then
-              if [[ "${normal_budget_exceeded}" != "true" ||
-                    "${total_bytes}" -gt "${max_fallback_total_bytes}" ]]; then
-                fail "Filtered check-run data exceeds the bounded aggregate limit."
-              fi
-            fi
-          }
-          append_target_runs() {
-            local target_runs target_count remaining
-            if ! target_runs="$(jq -c '[ .check_runs[]
-              | select((.name | type == "string") and
-                       ((.name | ascii_downcase) == "cla assistant v3") and
-                       .app.id == 15368 and .app.slug == "github-actions")
-            ]' <<<"${page_json}")"; then
-              fail "Could not filter check runs for the required CLA check."
-            fi
-            target_count="$(jq -er 'length | numbers' <<<"${target_runs}")" ||
-              fail "Could not count filtered check runs."
-            [[ "${target_count}" =~ ^[0-9]+$ ]] || fail "GitHub returned an invalid filtered check-run count."
-            remaining=$((max_fallback_runs - matching_check_runs))
-            if (( target_count > remaining )); then
-              if (( remaining > 0 )); then
-                if ! jq -c --argjson limit "${remaining}" '.[:$limit][]' <<<"${target_runs}" >> "${check_runs_file}"; then
-                  fail "Could not retain the bounded fallback check-run set."
-                fi
-              fi
-              matching_check_runs=${max_fallback_runs}
-              normal_budget_exceeded=true
-              fallback_budget_exceeded=true
-              validate_retained_run_bytes
-              return 0
-            fi
-            if ! jq -c '.[]' <<<"${target_runs}" >> "${check_runs_file}"; then
-              fail "Could not retain filtered check runs for the required CLA check."
-            fi
-            matching_check_runs=$((matching_check_runs + target_count))
-            if (( matching_check_runs > max_matching_runs )); then
-              # Continue the bounded scan so the fallback can invalidate every
-              # observed producer instead of leaving an unscanned green run.
-              normal_budget_exceeded=true
-            fi
-            validate_retained_run_bytes
-            if [[ -s "${check_runs_file}" ]]; then
-              # A filtered run is a candidate even when a later pagination or
-              # reconciliation step fails. fail() can then publish a failed
-              # current-generation result instead of leaving an old green
-              # check as the only visible state.
-              candidate_check_exists=true
-            fi
-          }
-
-          list_exact_check_runs() {
-            : > "${check_runs_file}"
-            all_runs='[]'
-            existing_runs='[]'
-            total_check_suites=0
-            total_check_runs=0
-            matching_check_runs=0
-            normal_budget_exceeded=false
-            fallback_budget_exceeded=false
-            suite_ids=()
-            declare -A suite_seen=()
-            suite_total_count=-1
-
-            for ((page_number = 1; page_number <= suite_page_limit; page_number++)); do
-              fetch_suite_page "${page_number}"
-              page_total_count="$(jq -er '.total_count | numbers' <<<"${page_json}")" ||
-                fail "GitHub returned an invalid check-suite total count."
-              if (( page_number == 1 )); then
-                suite_total_count=${page_total_count}
-              elif (( page_total_count != suite_total_count )); then
-                fail "The check-suite total changed while reading the live head."
-              fi
-              page_count="$(jq -er '.check_suites | length' <<<"${page_json}")"
-              total_check_suites=$((total_check_suites + page_count))
-              (( total_check_suites <= max_matching_suites )) ||
-                fail "GitHub returned more than ${max_matching_suites} check suites for the live head."
-              while IFS= read -r suite_id; do
-                is_safe_id "${suite_id}" || fail "GitHub returned an invalid check-suite ID."
-                if [[ -z "${suite_seen[${suite_id}]+present}" ]]; then
-                  suite_seen["${suite_id}"]=1
-                  suite_ids+=("${suite_id}")
-                fi
-              done < <(jq -r '.check_suites[].id | tostring' <<<"${page_json}")
-              if (( page_count < suite_page_size )); then
-                overflow_page=$((page_number + 1))
-                fetch_suite_page "${overflow_page}"
-                overflow_count="$(jq -er '.check_suites | length' <<<"${page_json}")"
-                overflow_total_count="$(jq -er '.total_count | numbers' <<<"${page_json}")"
-                if (( overflow_total_count != suite_total_count )) ||
-                   (( overflow_count != 0 )) ||
-                   (( suite_total_count > ((page_number - 1) * suite_page_size + page_count) )); then
-                  fail "The check-suite pagination changed while reading the live head."
-                fi
-                break
-              fi
-              if (( page_number == suite_page_limit )); then
-                overflow_page=$((suite_page_limit + 1))
-                fetch_suite_page "${overflow_page}"
-                overflow_count="$(jq -er '.check_suites | length' <<<"${page_json}")"
-                overflow_total_count="$(jq -er '.total_count | numbers' <<<"${page_json}")"
-                if (( overflow_total_count != suite_total_count )) ||
-                   (( overflow_count != 0 )) ||
-                   (( suite_total_count > page_number * suite_page_size )); then
-                  fail "GitHub returned more than ${max_check_suites} check suites for the live head."
-                fi
-              fi
-            done
-
-            for suite_id in "${suite_ids[@]}"; do
-              run_total_count=-1
-              for ((run_page_number = 1; run_page_number <= run_page_limit; run_page_number++)); do
-                fetch_run_page "${suite_id}" "${run_page_number}"
-                page_total_count="$(jq -er '.total_count | numbers' <<<"${page_json}")" ||
-                  fail "GitHub returned an invalid check-run total count."
-                if (( run_page_number == 1 )); then
-                  run_total_count=${page_total_count}
-                elif (( page_total_count != run_total_count )); then
-                  fail "The check-run total changed while reading suite ${suite_id}."
-                fi
-                page_count="$(jq -er '.check_runs | length' <<<"${page_json}")"
-                total_check_runs=$((total_check_runs + page_count))
-                (( total_check_runs <= max_scanned_runs )) ||
-                  fail "GitHub returned more than ${max_scanned_runs} bounded check runs for the live head."
-                append_target_runs
-                if [[ "${fallback_budget_exceeded}" == "true" ]]; then
-                  break
-                fi
-                if (( page_count < run_page_size )); then
-                  overflow_page=$((run_page_number + 1))
-                  fetch_run_page "${suite_id}" "${overflow_page}"
-                  overflow_count="$(jq -er '.check_runs | length' <<<"${page_json}")"
-                  overflow_total_count="$(jq -er '.total_count | numbers' <<<"${page_json}")"
-                  if (( overflow_total_count != run_total_count )) ||
-                     (( overflow_count != 0 )) ||
-                     (( run_total_count > ((run_page_number - 1) * run_page_size + page_count) )); then
-                    fail "The check-run pagination changed while reading suite ${suite_id}."
-                  fi
-                  break
-                fi
-                if (( run_page_number == run_page_limit )); then
-                  overflow_page=$((run_page_limit + 1))
-                  fetch_run_page "${suite_id}" "${overflow_page}"
-                  overflow_count="$(jq -er '.check_runs | length' <<<"${page_json}")"
-                  overflow_total_count="$(jq -er '.total_count | numbers' <<<"${page_json}")"
-                  if (( overflow_total_count != run_total_count )) ||
-                     (( overflow_count != 0 )) ||
-                     (( run_total_count > run_page_number * run_page_size )); then
-                    fail "GitHub returned more than ${max_check_runs} check runs for suite ${suite_id}."
-                  fi
-                fi
-              done
-              [[ "${fallback_budget_exceeded}" == "true" ]] && break
-            done
-            if [[ "${normal_budget_exceeded}" == "true" ]]; then
-              fail "GitHub returned more than ${max_matching_runs} CLA check runs for the live head."
-            fi
-            all_runs="$(jq -sc '.' "${check_runs_file}")"
-            existing_runs="$(jq -c --arg external_id "${external_id}" '[.[] | select(.external_id == $external_id)]' <<<"${all_runs}")"
-          }
-
-          patch_check_run() {
-            local check_id="$1"
-            local patch_payload="$2"
-            local patch_response response_bytes capture_status=0
-            is_safe_id "${check_id}" || fail "GitHub returned an invalid check-run ID."
-            capture_raw_check_response gh api --method PATCH \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "repos/${GH_REPO}/check-runs/${check_id}" --input - <<<"${patch_payload}" || capture_status=$?
-            if (( capture_status != 0 )); then
-              return 1
-            fi
-            patch_response="$(<"${check_raw_file}")"
-            response_bytes="$(LC_ALL=C printf '%s' "${patch_response}" | wc -c | tr -d '[:space:]')" || return 1
-            [[ "${response_bytes}" =~ ^[0-9]+$ ]] || return 1
-            (( response_bytes <= max_check_response_bytes )) || return 1
-            if ! jq -e --arg id "${check_id}" --arg name 'CLA Assistant v3' --arg sha "${HEAD_SHA}" \
-                      '
-              (.id | type == "number" and floor == . and . > 0 and . <= 9007199254740991) and
-              ((.id | tostring) == $id) and
-              (.name | type == "string") and
-              ((.name | ascii_downcase) == ($name | ascii_downcase)) and
-              (.head_sha | type == "string" and . == $sha) and
-              (.external_id == null or (.external_id | type == "string")) and
-              (.app.slug == "github-actions") and
-              (.app.id == 15368) and
-              (.status == "completed")
-            ' <<<"${patch_response}" >/dev/null 2>&1; then
-              return 1
-            fi
-            response="${patch_response}"
-          }
-
-          validate_failure_response() {
-            local response_json="$1"
-            local expected_id="$2"
-            local response_bytes
-            response_bytes="$(LC_ALL=C printf '%s' "${response_json}" | wc -c | tr -d '[:space:]')" || return 1
-            [[ "${response_bytes}" =~ ^[0-9]+$ ]] || return 1
-            (( response_bytes <= max_check_response_bytes )) || return 1
-            jq -e --arg expected_id "${expected_id}" \
-                    --arg name 'CLA Assistant v3' \
-                    --arg sha "${HEAD_SHA}" \
-                    --arg external_id "${external_id}" '
-              type == "object" and
-              (.id | type == "number" and floor == . and . > 0 and . <= 9007199254740991) and
-              ($expected_id == "" or ((.id | tostring) == $expected_id)) and
-              (.name | type == "string") and
-              ((.name | ascii_downcase) == ($name | ascii_downcase)) and
-              (.head_sha | type == "string") and
-              ((.head_sha | ascii_downcase) == ($sha | ascii_downcase)) and
-              (.status == "completed") and
-              (.conclusion == "failure") and
-              (.external_id == $external_id) and
-              (.app | type == "object") and
-              (.app.slug == "github-actions") and
-              (.app.id == 15368)
-            ' <<<"${response_json}" >/dev/null 2>&1
-          }
-
-          publish_failure_fallback() {
-            # This helper is deliberately bounded and side-effect limited. It
-            # fails every observed producer in one pass, then creates one
-            # current-generation failure when no current candidate exists.
-            # A job failure alone cannot invalidate a green Checks API run.
-            local observed_runs='[]'
-            local observed_bytes failure_payload update_payload
-            local fallback_response fallback_status run_id run_external_id
-            local fallback_failed=false canonical_published=false current_candidate_seen=false
-            if [[ -n "${check_runs_file:-}" && -f "${check_runs_file}" ]]; then
-              observed_bytes="$(LC_ALL=C wc -c < "${check_runs_file}" | tr -d '[:space:]')" || return 1
-              [[ "${observed_bytes}" =~ ^[0-9]+$ ]] || return 1
-              (( observed_bytes <= max_fallback_total_bytes )) || return 1
-              if ! observed_runs="$(jq -sc '.' "${check_runs_file}" 2>/dev/null)"; then
-                return 1
-              fi
-            else
-              observed_runs="${all_runs:-[]}"
-            fi
-            if ! jq -e --arg expected_sha "${HEAD_SHA}" --argjson max_runs "${max_fallback_runs}" '
-              type == "array" and length <= $max_runs and
-              all(.[];
-                type == "object" and
-                (.id | type == "number" and floor == . and . > 0 and . <= 9007199254740991) and
-                (.name | type == "string") and
-                ((.name | ascii_downcase) == "cla assistant v3") and
-                (.head_sha | type == "string") and
-                ((.head_sha | ascii_downcase) == ($expected_sha | ascii_downcase)) and
-                (.external_id == null or (.external_id | type == "string")) and
-                (.app | type == "object") and
-                (.app.id == 15368) and
-                (.app.slug == "github-actions")
-              )
-            ' <<<"${observed_runs}" >/dev/null 2>&1; then
-              return 1
-            fi
-            if ! failure_payload="$(jq --arg title 'CLA declaration refresh failed closed' \
-              --arg summary 'The CLA refresh worker encountered an unsafe validation or reconciliation state. Request a new exact-head refresh after the workflow recovers.' \
-              '.conclusion = "failure" | .output = {title: $title, summary: $summary}' <<<"${payload}")"; then
-              return 1
-            fi
-            if ! update_payload="$(jq 'del(.head_sha, .external_id)' <<<"${failure_payload}")"; then
-              return 1
-            fi
-            while IFS= read -r run_id; do
-              [[ -n "${run_id}" ]] || continue
-              run_external_id="$(jq -r --arg id "${run_id}" '.[] | select((.id | tostring) == $id) | (.external_id // "")' <<<"${observed_runs}")" || {
-                fallback_failed=true
-                continue
-              }
-              [[ "${run_external_id}" == "${external_id}" ]] && current_candidate_seen=true
-              if ! patch_check_run "${run_id}" "${update_payload}"; then
-                fallback_failed=true
-                continue
-              fi
-              fallback_response="${response:-}"
-              if ! jq -e --arg id "${run_id}" '
-                type == "object" and
-                ((.id | tostring) == $id) and
-                (.conclusion == "failure")
-              ' <<<"${fallback_response}" >/dev/null 2>&1; then
-                fallback_failed=true
-              elif [[ "${run_external_id}" == "${external_id}" ]]; then
-                canonical_published=true
-              fi
-            done < <(jq -r '.[].id | tostring' <<<"${observed_runs}" | sort -n -u)
-
-            # If a successful create/update returned an ID that was not yet
-            # visible in the bounded list, use that immutable ID once before
-            # falling back to a new POST. This avoids creating a second
-            # canonical run during normal Checks API eventual consistency.
-            if [[ "${canonical_published}" == "false" &&
-                  "${current_candidate_seen}" == "false" &&
-                  -n "${candidate_check_id}" ]]; then
-              if is_safe_id "${candidate_check_id}"; then
-                if patch_check_run "${candidate_check_id}" "${update_payload}"; then
-                  fallback_response="${response:-}"
-                  if jq -e --arg id "${candidate_check_id}" '.conclusion == "failure" and ((.id | tostring) == $id)' <<<"${fallback_response}" >/dev/null 2>&1; then
-                    current_candidate_seen=true
-                    canonical_published=true
-                  else
-                    fallback_failed=true
-                  fi
-                else
-                  fallback_failed=true
-                fi
-              else
-                fallback_failed=true
-              fi
-            fi
-            if [[ "${canonical_published}" == "false" ]]; then
-              fallback_status=0
-              capture_raw_check_response gh api --method POST \
-                --header 'Accept: application/vnd.github+json' \
-                --header 'X-GitHub-Api-Version: 2022-11-28' \
-                "repos/${GH_REPO}/check-runs" --input - <<<"${failure_payload}" || fallback_status=$?
-              if (( fallback_status == 0 )); then
-                fallback_response="$(<"${check_raw_file}")"
-              else
-                fallback_response=""
-              fi
-              if (( fallback_status != 0 )) || ! validate_failure_response "${fallback_response}" ""; then
-                fallback_failed=true
-              else
-                canonical_published=true
-              fi
-            fi
-            if [[ "${canonical_published}" != "true" ]]; then
-              return 1
-            fi
-            if [[ "${fallback_failed}" == "true" ]]; then
-              echo "::error title=CLA check refresh::A fallback failure was published, but one or more observed producers could not be invalidated." >&2
-            fi
-            return 0
-          }
-
-          exact_set_is_valid() {
-            local expected_id="$1"
-            jq -e --arg expected_id "${expected_id}" \
-                    --arg current_external_id "${external_id}" \
-                    --arg conclusion "${policy_conclusion}" '
-              type == "array" and length >= 1 and
-              ([.[] | select(.external_id == $current_external_id)] | length >= 1) and
-              ([.[] | select((.id | tostring) == $expected_id and .external_id == $current_external_id)] | length == 1) and
-              ([.[] | select((.id | tostring) == $expected_id and .external_id == $current_external_id)] | .[0].conclusion == $conclusion) and
-              (all(.[];
-                ((.id | tostring) == $expected_id and .external_id == $current_external_id and .conclusion == $conclusion) or
-                .conclusion == "failure"
-              )) and
-              (if $conclusion == "success"
-               then ([.[] | select(.conclusion == "success")] | length == 1)
-               else ([.[] | select(.conclusion == "success")] | length == 0)
-               end)
-            ' <<<"${all_runs}" >/dev/null 2>&1
-          }
-
-          repair_exact_set() {
-            local expected_id="$1"
-            local repair_failure_payload canonical_payload repair_failed=false
-            local run_id is_canonical run_conclusion
-            repair_failure_payload="$(jq --arg title 'CLA declaration duplicate producers' \
-              --arg summary 'The exact-generation CLA check set was reconciled by the sole refresh worker. Noncanonical producers were failed.' \
-              'del(.head_sha, .external_id) | .conclusion = "failure" | .output = {title: $title, summary: $summary}' <<<"${payload}")" || return 1
-            canonical_payload="$(jq 'del(.head_sha, .external_id)' <<<"${payload}")" || return 1
-            # Fail noncanonical runs first. GitHub can surface the most recent
-            # same-name result, so publishing the canonical result last keeps
-            # a valid declaration from being hidden by our own cleanup. The
-            # Checks API does not let an update change external_id, so failed
-            # duplicate generations remain visible and are checked explicitly.
-            local repair_pass
-            for repair_pass in noncanonical canonical; do
-              while IFS= read -r run_id; do
-                [[ -n "${run_id}" ]] || continue
-                is_canonical=false
-                run_conclusion=""
-                if run_conclusion="$(jq -r --arg id "${run_id}" --arg current_external_id "${external_id}" \
-                  '.[] | select((.id | tostring) == $id and .external_id == $current_external_id) | .conclusion' <<<"${all_runs}")" &&
-                   [[ -n "${run_conclusion}" ]] &&
-                   [[ "${run_id}" == "${expected_id}" ]]; then
-                  is_canonical=true
-                fi
-                if [[ "${repair_pass}" == "canonical" ]]; then
-                  [[ "${is_canonical}" == "true" ]] || continue
-                  # Publish the canonical result last, even when it already
-                  # has the desired conclusion. GitHub may surface the most
-                  # recently updated same-name run, so this prevents a
-                  # noncanonical failure from becoming the visible result.
-                  if ! patch_check_run "${run_id}" "${canonical_payload}"; then
-                    repair_failed=true
-                    echo "::error title=CLA check reconciliation::Could not restore the canonical exact-generation check run." >&2
-                  fi
-                else
-                  [[ "${is_canonical}" == "false" ]] || continue
-                  if ! patch_check_run "${run_id}" "${repair_failure_payload}"; then
-                    repair_failed=true
-                    echo "::error title=CLA check reconciliation::Could not fail a noncanonical exact-generation check run." >&2
-                  fi
-                fi
-              done < <(jq -r '.[].id | tostring' <<<"${all_runs}" | sort -n -u)
-            done
-            [[ "${repair_failed}" == "false" ]]
-          }
-
-          # The fallback is enabled only after the exact-head payload, bounded
-          # candidate file, and existing publisher are all initialized.
-          failure_fallback_ready=true
-          failure_fallback_on_unknown_candidate=true
-
-          list_exact_check_runs
-          if jq -e 'type == "array" and length > 0' <<<"${all_runs}" >/dev/null 2>&1; then
-            candidate_check_exists=true
-          fi
-          stale_runs="$(jq -c --arg current_external_id "${external_id}" '[.[] | select(.external_id != $current_external_id)]' <<<"${all_runs}")"
-          stale_count="$(jq -er 'length' <<<"${stale_runs}")"
-          if (( stale_count > 0 )); then
-            # Branch protection keys a required check by name and app, not by
-            # external_id. Fail every older generation on this exact head
-            # before accepting the current generation, so a stale success
-            # cannot satisfy the new policy after a migration.
-            stale_failure_payload="$(jq -n \
-              --arg title 'CLA declaration superseded' \
-              --arg summary 'This exact-head CLA check belongs to an older generation. It was failed before the current generation was refreshed.' \
-              '{status:"completed",conclusion:"failure",output:{title:$title,summary:$summary}}')"
-            stale_failed=false
-            while IFS= read -r stale_id; do
-              if ! patch_check_run "${stale_id}" "${stale_failure_payload}"; then
-                stale_failed=true
-                echo "::error title=CLA generation::Could not fail stale check run ${stale_id}." >&2
-              fi
-            done < <(jq -r '.[].id' <<<"${stale_runs}")
-            [[ "${stale_failed}" == "false" ]] || fail "Could not invalidate every stale-generation CLA check run."
-            list_exact_check_runs
-            if ! jq -e --arg current_external_id "${external_id}" '
-              all(.[]; .external_id == $current_external_id or .conclusion == "failure")
-            ' <<<"${all_runs}" >/dev/null 2>&1; then
-              fail "A stale-generation CLA check remained successful after invalidation."
-            fi
-          fi
-          if ! match_count="$(jq -er 'length' <<<"${existing_runs}")" ||
-             ! [[ "${match_count}" =~ ^[0-9]+$ ]]; then
-            fail "GitHub returned an invalid exact-head check-run match count."
-          fi
-          operation=created
-          existing_id=""
-          if (( match_count > 1 )); then
-            # Multiple producers can leave one successful check visible to
-            # branch protection even when another producer failed. Convert
-            # every exact-generation run to failure first, then reuse one
-            # deterministic run for this worker's result. This removes green
-            # ambiguity while preserving exactly one canonical success.
-            duplicate_failure_payload="$(jq --arg title 'CLA declaration duplicate producers' \
-              --arg summary 'Multiple exact-generation CLA producers were found. They were invalidated and reconciled by the sole refresh worker.' \
-              'del(.head_sha, .external_id) | .conclusion = "failure" | .output = {title: $title, summary: $summary}' <<<"${payload}")"
-            duplicate_failed=false
-            while IFS= read -r duplicate_id; do
-              if ! patch_check_run "${duplicate_id}" "${duplicate_failure_payload}"; then
-                duplicate_failed=true
-                echo "::error title=CLA duplicate check::Could not invalidate check run ${duplicate_id}." >&2
-              fi
-            done < <(jq -r '.[].id' <<<"${existing_runs}")
-            [[ "${duplicate_failed}" == "false" ]] || fail "Could not invalidate every duplicate exact-generation CLA check run."
-            existing_id="$(jq -er '.[0].id | tostring' <<<"${existing_runs}")"
-            candidate_check_id="${existing_id}"
-            canonical_update_payload="$(jq 'del(.head_sha, .external_id)' <<<"${payload}")"
-            if ! patch_check_run "${existing_id}" "${canonical_update_payload}"; then
-              fail "Could not publish the canonical result after invalidating duplicate CLA checks."
-            fi
-            operation=reconciled
-            list_exact_check_runs
-            if ! jq -e --arg id "${existing_id}" --arg current_external_id "${external_id}" --arg conclusion "${policy_conclusion}" '
-              length >= 1 and
-              ([.[] | select((.id | tostring) == $id and .external_id == $current_external_id)] | length == 1 and .[0].conclusion == $conclusion) and
-              (all(.[]; (.id | tostring) == $id or .conclusion == "failure")) and
-              (if $conclusion == "success"
-               then ([.[] | select(.conclusion == "success")] | length == 1)
-               else ([.[] | select(.conclusion == "success")] | length == 0)
-               end)
-            ' <<<"${all_runs}" >/dev/null 2>&1; then
-              # A concurrent producer may have created another successful
-              # run after invalidation. Keep the visible state fail-closed.
-              duplicate_failure_payload="$(jq --arg title 'CLA declaration duplicate producers' \
-                --arg summary 'The exact-generation CLA check set changed during reconciliation. All observed producers were failed; an administrator must remove the collision before retrying.' \
-                'del(.head_sha, .external_id) | .conclusion = "failure" | .output = {title: $title, summary: $summary}' <<<"${payload}")"
-              cleanup_failed=false
-              while IFS= read -r duplicate_id; do
-                if ! patch_check_run "${duplicate_id}" "${duplicate_failure_payload}"; then
-                  cleanup_failed=true
-                  echo "::error title=CLA duplicate check::Could not invalidate check run ${duplicate_id} during final cleanup." >&2
-                fi
-              done < <(jq -r '.[].id' <<<"${all_runs}")
-              [[ "${cleanup_failed}" == "false" ]] || fail "Could not invalidate every duplicate exact-generation CLA check run during final cleanup."
-              fail "The exact-generation CLA check set remained ambiguous after reconciliation."
-            fi
-          else
-            existing_id="$(jq -r '.[0].id // empty' <<<"${existing_runs}")"
-          fi
-          if [[ -n "${existing_id}" ]]; then
-            is_safe_id "${existing_id}" || fail "GitHub returned an invalid existing check-run ID."
-            candidate_check_id="${existing_id}"
-            [[ "${operation}" == "reconciled" ]] || operation=updated
-            # The Checks API accepts head_sha when creating a run, but PATCH
-            # identifies the existing run by ID and does not accept that
-            # create-only field. Keep the immutable head assertion in the
-            # lookup and response validation, while omitting it from PATCH.
-            update_payload="$(jq 'del(.head_sha, .external_id)' <<<"${payload}")"
-            if [[ "${operation}" == "reconciled" ]]; then
-              : # patch_check_run already returned and validated the response.
-            elif ! patch_check_run "${existing_id}" "${update_payload}"; then
-              fail "Could not update the exact-head CLA check run."
-            fi
-            candidate_check_exists=true
-          else
-            operation=created
-            capture_status=0
-            capture_raw_check_response gh api --method POST \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "repos/${GH_REPO}/check-runs" --input - <<<"${payload}" || capture_status=$?
-            if (( capture_status != 0 )); then
-              fail "Could not create the exact-head CLA check run."
-            fi
-            response="$(<"${check_raw_file}")"
-            candidate_check_exists=true
-          fi
-          if ! jq -e --arg name 'CLA Assistant v3' --arg sha "${HEAD_SHA}" \
-                    --arg conclusion "${policy_conclusion}" --arg external_id "${external_id}" '
-            (.id | type == "number" and floor == . and . > 0 and . <= 9007199254740991) and
-            (.name | type == "string") and
-            ((.name | ascii_downcase) == ($name | ascii_downcase)) and
-            (.head_sha | type == "string" and . == $sha) and
-            (.status == "completed") and
-            (.conclusion == $conclusion) and
-            (.external_id == $external_id) and
-            (.app.slug == "github-actions") and
-            (.app.id == 15368)
-          ' <<<"${response}" >/dev/null 2>&1; then
-            fail "GitHub did not confirm the expected exact-head CLA check run."
-          fi
-          response_bytes="$(LC_ALL=C printf '%s' "${response}" | wc -c | tr -d '[:space:]')"
-          [[ "${response_bytes}" =~ ^[0-9]+$ ]] || fail "GitHub returned an invalid exact-head CLA check response size."
-          (( response_bytes <= max_check_response_bytes )) ||
-            fail "The exact-head CLA check response exceeds the ${max_check_response_bytes}-byte limit."
-          if ! candidate_check_id="$(jq -er 'if (.id | type == "number" and floor == . and . > 0 and . <= 9007199254740991) then (.id | tostring) else error("invalid id") end' <<<"${response}")"; then
-            fail "GitHub did not return a safe exact-head CLA check ID."
-          fi
-          candidate_check_exists=true
-
-          # Re-read after every create or update. This closes the final race
-          # where another producer publishes a same-name check after the
-          # initial scan. Every noncanonical run is failed, and the canonical
-          # run is restored to the policy conclusion before this job can claim
-          # success. The bounded scan permits at most 100 matching runs.
-          list_exact_check_runs
-          if ! exact_set_is_valid "${candidate_check_id}"; then
-            if ! repair_exact_set "${candidate_check_id}"; then
-              fail "Could not reconcile every exact-generation CLA check run."
-            fi
-            list_exact_check_runs
-            exact_set_is_valid "${candidate_check_id}" ||
-              fail "The exact-generation CLA check set remained ambiguous after final reconciliation."
-          fi
-          if [[ "${policy_conclusion}" == "success" ]]; then
-            # A sibling can open after the first collision snapshot and before
-            # this worker publishes its final success. Re-scan immediately
-            # before claiming success. On a collision, fail() uses the bounded
-            # observed run set to invalidate the inherited green producer.
-            validate_unique_open_pr_head
-            if [[ "${collision_detected}" == "true" ]]; then
-              fail "The current head became shared by multiple open main-target Pull Requests during final reconciliation."
-            fi
-          fi
-          printf 'published=true\nno_refresh=false\ndecision=published\nconclusion=%s\nhead_sha=%s\n' \
-            "${policy_conclusion}" "${HEAD_SHA}" >> "${GITHUB_OUTPUT}"
-          echo "CLA check ${operation} on ${HEAD_SHA} with conclusion ${policy_conclusion}."
-
-      - name: "Confirm exact-head refresh"
-        id: refresh-check
-        if: success()
-        env:
-          PUBLISHED: ${{ steps.validate-refresh.outputs.published || 'false' }}
-          NO_REFRESH: ${{ steps.validate-refresh.outputs.no_refresh || 'false' }}
-          REFRESH_DECISION: ${{ steps.validate-refresh.outputs.decision || 'error' }}
-          REFRESH_CONCLUSION: ${{ steps.validate-refresh.outputs.conclusion || 'failure' }}
-          REFRESH_HEAD_SHA: ${{ steps.validate-refresh.outputs.head_sha || '' }}
-        run: |
-          set -euo pipefail
-          if [[ "${PUBLISHED}" != "true" ]]; then
-            if [[ "${NO_REFRESH}" == "true" && "${REFRESH_DECISION}" == "no_refresh" ]]; then
-              printf 'refreshed=false\ndecision=no_refresh\nconclusion=neutral\nhead_sha=\n' >> "${GITHUB_OUTPUT}"
-              echo "CLA check refresh skipped because this public event did not require a refresh."
-              exit 0
-            fi
-            echo "::error title=CLA check refresh::No exact-head CLA check was published; the workflow result is invalid." >&2
-            exit 1
-          fi
-          [[ "${REFRESH_HEAD_SHA}" =~ ^[0-9a-fA-F]{40}$ ]] || {
-            echo "::error title=CLA check refresh::The worker did not return a valid exact head SHA." >&2
-            exit 1
-          }
-          case "${REFRESH_CONCLUSION}" in
-            success) ;;
-            failure)
-              echo "::error title=CLA check refresh::The exact-head CLA check was published with failure." >&2
-              exit 1
-              ;;
-            *)
-              echo "::error title=CLA check refresh::The worker returned an invalid conclusion." >&2
-              exit 1
-              ;;
-          esac
-          printf 'refreshed=true\ndecision=published\nconclusion=%s\nhead_sha=%s\n' \
-            "${REFRESH_CONCLUSION}" "${REFRESH_HEAD_SHA}" >> "${GITHUB_OUTPUT}"
+          ISSUE_NUMBER: ${{ github.event.issue.number || '' }}
+          PR_NUMBER: ${{ github.event.issue.number || '' }}
+          COMMENT_ID: ${{ github.event.comment.id || '' }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at || '' }}
+          COMMENT_AUTHOR_ID: ${{ github.event.comment.user.id || '' }}
+          COMMENT_AUTHOR_LOGIN: ${{ github.event.comment.user.login || '' }}
+          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type || '' }}
+          COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association || '' }}
+          WORKFLOW_PATH: ".github/workflows/cla.yml"
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          CLA_GENERATION: ${{ env.CLA_GENERATION }}
+          TARGET_EVENT: "pull_request_target"
+          TARGET_BASE_REF: "main"
+          SIGNATURE_RECORDED: ${{ needs.CLALedgerWriter.outputs.signature_recorded || '' }}
+          WRITER_POLICY_RESULT: ${{ needs.CLALedgerWriter.outputs.cla_passed || '' }}
+          WRITER_RESULT: ${{ needs.CLALedgerWriter.result || '' }}
+        run: bash .github/scripts/rerun-failed-cla.sh
 
   LockMergedPullRequest:
     name: "Lock merged pull request"
@@ -3116,11 +1747,14 @@ jobs:
       pull-requests: write # The lock endpoint also requires Pull requests write access.
     steps:
       - name: "Require GitHub-hosted runner"
-        if: runner.environment != 'github-hosted'
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
           set -euo pipefail
-          echo "::error title=CLA runner policy::CLA policy requires a GitHub-hosted runner."
-          exit 1
+          if [[ "${RUNNER_ENVIRONMENT}" != "github-hosted" ]]; then
+            echo "::error title=CLA runner policy::CLA policy requires a GitHub-hosted runner."
+            exit 1
+          fi
       - name: "Lock merged pull request"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1460,6 +1460,7 @@ jobs:
     if: >-
       always() &&
       github.repository == 'manaflow-ai/subrouter' &&
+      github.run_attempt == 1 &&
       needs.CLACommentGate.result == 'success' &&
       needs.CLACommentGate.outputs.admitted == 'true' &&
       github.event_name == 'issue_comment' &&
@@ -1527,6 +1528,7 @@ jobs:
           COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association || '' }}
           WORKFLOW_PATH: ".github/workflows/cla.yml"
           WORKFLOW_SHA: ${{ github.workflow_sha }}
+          RUN_ATTEMPT: ${{ github.run_attempt || '' }}
           CLA_GENERATION: ${{ env.CLA_GENERATION }}
           TARGET_EVENT: "pull_request_target"
           TARGET_BASE_REF: "main"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,4 @@
-name: "CLA policy workflow"
+name: "CLA Assistant v3 policy"
 on:
   issue_comment:
     types: [created]
@@ -68,13 +68,14 @@ jobs:
     permissions:
       # The gate authenticates recheck requesters through the live Pull
       # Request API. It never writes repository, issue, or check state.
+      contents: read # Read only the trusted helper at github.workflow_sha.
       issues: read # Read the live issue comment and Pull Request for recheck authorization.
       pull-requests: read # Read the live Pull Request identity before any writer runs.
     outputs:
       admitted: ${{ steps.validate-trigger.outputs.admitted }}
       trigger_decision: ${{ steps.validate-trigger.outputs.decision || 'error' }}
-      recheck_authorized: ${{ steps.classify-recheck.outputs.authorized || 'false' }}
-      recheck_decision: ${{ steps.classify-recheck.outputs.decision || 'error' }}
+      recheck_authorized: ${{ steps.classify_recheck.outputs.authorized || 'false' }}
+      recheck_decision: ${{ steps.classify_recheck.outputs.decision || 'error' }}
     steps:
       - name: "Require GitHub-hosted runner"
         env:
@@ -152,15 +153,31 @@ jobs:
           fi
           echo "CLA event admitted"
 
-      - name: "Authorize recheck requester"
-        id: authorize-recheck
-        # Convert API failures into an explicit tri-state output below. The
-        # worker then publishes a failed required check for errors, while an
-        # ordinary unauthorized requester remains a no-op.
-        continue-on-error: true
+      # This helper is checked out from the trusted workflow revision, never
+      # from a Pull Request head. It owns the bounded API reads and the
+      # authorized/unauthorized/retry/error contract for external forks.
+      - name: "Checkout trusted recheck authorizer"
+        id: checkout_recheck_helper
         if: >-
           success() &&
-          github.event_name == 'issue_comment'
+          github.event_name == 'issue_comment' &&
+          github.event.comment.body == 'recheck'
+        continue-on-error: true
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2, immutable
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/cla-recheck-auth.sh
+          sparse-checkout-cone-mode: false
+
+      - name: "Authorize recheck requester"
+        id: authorize_recheck
+        if: >-
+          always() &&
+          github.event_name == 'issue_comment' &&
+          github.event.comment.body == 'recheck'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -169,259 +186,62 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body || '' }}
           COMMENT_USER_ID: ${{ github.event.comment.user.id || '' }}
           COMMENT_USER_LOGIN: ${{ github.event.comment.user.login || '' }}
+          COMMENT_USER_TYPE: ${{ github.event.comment.user.type || '' }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at || '' }}
         run: |
           set -euo pipefail
-          max_gate_raw_page_bytes=1048576
-          max_gate_raw_total_bytes=5000000
-          gate_raw_total_bytes=0
-          gate_raw_file="$(mktemp)"
-          trap 'rm -f -- "${gate_raw_file}"' EXIT
-          capture_bounded_gate_response() {
-            local raw_bytes pipeline_status producer_status sink_status
-            : > "${gate_raw_file}"
-            set +e
-            "$@" 2>/dev/null |
-              head -c "$((max_gate_raw_page_bytes + 1))" > "${gate_raw_file}"
-            pipeline_status=("${PIPESTATUS[@]}")
-            set -e
-            raw_bytes="$(LC_ALL=C wc -c < "${gate_raw_file}" | tr -d '[:space:]')"
-            [[ "${raw_bytes}" =~ ^[0-9]+$ ]] || return 1
-            (( raw_bytes <= max_gate_raw_page_bytes )) || return 2
-            producer_status="${pipeline_status[0]:-1}"
-            sink_status="${pipeline_status[1]:-1}"
-            gate_response_status="${producer_status}"
-            (( sink_status == 0 )) || return 1
-            gate_raw_total_bytes=$((gate_raw_total_bytes + raw_bytes))
-            (( gate_raw_total_bytes <= max_gate_raw_total_bytes )) || return 2
-          }
-          printf 'authorized=false\ndecision=unauthorized\n' >> "${GITHUB_OUTPUT}"
-          fail() {
-            printf 'decision=error\n' >> "${GITHUB_OUTPUT}"
-            echo "::error title=CLA recheck policy::${1}" >&2
+          [[ -x .github/scripts/cla-recheck-auth.sh ]] || {
+            echo "::error title=CLA recheck policy::The trusted authorizer checkout did not provide the helper." >&2
             exit 1
           }
-          # Actions expression equality is case-insensitive. Keep this step
-          # broad and enforce the command byte-for-byte in the shell, so a
-          # comment such as RECHECK is ignored instead of becoming a failed
-          # maintainer authorization attempt.
-          if [[ "${COMMENT_BODY}" != "recheck" ]]; then
-            exit 0
-          fi
-          [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]] || fail "The recheck event has an invalid pull request number."
-          [[ "${COMMENT_ID}" =~ ^[1-9][0-9]*$ ]] || fail "The recheck comment has an invalid ID."
-          if (( ${#PR_NUMBER} > 16 )) ||
-             (( ${#PR_NUMBER} == 16 && PR_NUMBER > 9007199254740991 )); then
-            fail "The recheck event has an unsafe pull request number."
-          fi
-          if (( ${#COMMENT_ID} > 16 )) ||
-             (( ${#COMMENT_ID} == 16 && COMMENT_ID > 9007199254740991 )); then
-            fail "The recheck comment has an unsafe ID."
-          fi
-          [[ "${COMMENT_USER_ID}" =~ ^[1-9][0-9]*$ ]] || fail "The recheck commenter has an invalid identity."
-          if (( ${#COMMENT_USER_ID} > 16 )) ||
-             (( ${#COMMENT_USER_ID} == 16 && COMMENT_USER_ID > 9007199254740991 )); then
-            fail "The recheck commenter has an unsafe identity."
-          fi
-          [[ "${COMMENT_USER_LOGIN}" =~ ^[A-Za-z0-9][A-Za-z0-9-]*$ ]] || fail "The recheck commenter has an invalid login."
-          (( ${#COMMENT_USER_LOGIN} <= 39 )) || fail "The recheck commenter login is too long."
-
-          capture_status=0
-          capture_bounded_gate_response gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" || capture_status=$?
-          if (( capture_status == 2 || ${gate_response_status:-1} != 0 )); then
-            fail "Could not read the live pull request before authorizing recheck."
-          fi
-          if ! pr_json="$(jq -c '
-            {
-              number: (.number | tostring),
-              state: (.state // ""),
-              merged: (.merged_at != null),
-              base_ref: (.base.ref // ""),
-              base_repo: (if .base.repo == null then "" else (.base.repo.full_name // "") end),
-              base_repo_id: (if .base.repo == null then null else (.base.repo.id // null) end),
-              opener_id: (if .user == null then null else (.user.id // null) end)
-            }
-          }' "${gate_raw_file}" 2>/dev/null)"; then
-            fail "Could not read the live pull request before authorizing recheck."
-          fi
-          if ! jq -e --arg repo "${GH_REPO}" --arg pr "${PR_NUMBER}" '
-            def safe_id:
-              type == "number" and floor == . and . > 0 and . <= 9007199254740991;
-            (.number == $pr) and
-            (.state == "open") and
-            (.merged == false) and
-            (.base_ref == "main") and
-            (.base_repo | type == "string" and length > 0) and
-            ((.base_repo | ascii_downcase) == ($repo | ascii_downcase)) and
-            (.base_repo_id | safe_id) and
-            (.opener_id | safe_id)
-          ' <<<"${pr_json}" >/dev/null 2>&1; then
-            fail "The live pull request is not an open main-branch pull request in this repository."
-          fi
-          capture_status=0
-          capture_bounded_gate_response gh api "repos/${GH_REPO}/issues/comments/${COMMENT_ID}" || capture_status=$?
-          if (( capture_status == 2 || ${gate_response_status:-1} != 0 )); then
-            fail "Could not read the live recheck comment before authorizing it."
-          fi
-          if ! comment_json="$(jq -c '
-            {
-              id: (.id // 0),
-              body: (.body // ""),
-              user_id: (if .user == null then null else (.user.id // null) end),
-              user_login: (if .user == null then "" else (.user.login // "") end),
-              user_type: (if .user == null then "" else (.user.type // "") end),
-              issue_url: (.issue_url // ""),
-              created_at: (.created_at // ""),
-              updated_at: (.updated_at // "")
-            }
-          }' "${gate_raw_file}" 2>/dev/null)"; then
-            fail "Could not read the live recheck comment before authorizing it."
-          fi
-          expected_issue_url="https://api.github.com/repos/${GH_REPO}/issues/${PR_NUMBER}"
-          if ! jq -e --arg id "${COMMENT_ID}" \
-                    --arg body "${COMMENT_BODY}" \
-                    --arg user_id "${COMMENT_USER_ID}" \
-                    --arg user_login "${COMMENT_USER_LOGIN}" \
-                    --arg issue_url "${expected_issue_url}" '
-            (.id | type == "number" and floor == . and . > 0) and
-            ((.id | tostring) == $id) and
-            (.body == $body) and
-            (.user_id | type == "number" and floor == . and . > 0) and
-            ((.user_id | tostring) == $user_id) and
-            (.user_login | type == "string" and test("^[A-Za-z0-9][A-Za-z0-9-]{0,38}$")) and
-            ((.user_login | ascii_downcase) == ($user_login | ascii_downcase)) and
-            (.user_type == "User") and
-            (.issue_url == $issue_url) and
-            (.created_at | type == "string" and length > 0) and
-            (.updated_at == .created_at)
-          ' <<<"${comment_json}" >/dev/null 2>&1; then
-            fail "The live recheck comment no longer matches the authenticated event."
-          fi
-          live_comment_user_id="$(jq -er '.user_id | numbers | tostring' <<<"${comment_json}")"
-          live_comment_login="$(jq -er '.user_login | strings' <<<"${comment_json}")"
-          if [[ "${COMMENT_USER_ID}" != "${live_comment_user_id}" ]]; then
-            fail "The recheck commenter identity changed before authorization."
-          fi
-          # The opener identity is validated above for the live PR, but it is
-          # not an authorization bypass. A write-level opener can sign through
-          # signer-preflight, yet only a live admin or maintain role may use
-          # the privileged recheck path.
-          permission_response=""
-          capture_status=0
-          capture_bounded_gate_response gh api --include \
-            --header 'Accept: application/vnd.github+json' \
-            --header 'X-GitHub-Api-Version: 2022-11-28' \
-            "repos/${GH_REPO}/collaborators/${live_comment_login}/permission" || capture_status=$?
-          if (( capture_status == 2 )); then
-            fail "Could not verify the recheck requester's live repository permission."
-          fi
-          permission_response="$(<"${gate_raw_file}")"
-          permission_status="${gate_response_status:-1}"
-          permission_http_status="$(printf '%s\n' "${permission_response}" | awk '/^HTTP\// { gsub("\r", "", $2); code=$2 } END { print code }')"
-          permission_response_body="$(printf '%s\n' "${permission_response}" | awk 'BEGIN { body=0 } { sub(/\r$/, "") } body { print } /^$/ { body=1 }')"
-          if (( permission_status != 0 )); then
-            if [[ "${permission_http_status}" == "404" ]] &&
-               jq -e 'type == "object" and ((.status == 404) or (.status == "404")) and (.message | type == "string" and length > 0)' \
-                 <<<"${permission_response_body}" >/dev/null 2>&1; then
-              # GitHub returns a validated 404 for a non-collaborator. It is
-              # ordinary unauthorized public input, not an infrastructure
-              # failure. Other status or malformed responses fail closed.
-              echo "CLA recheck ignored: requester is not a repository collaborator"
-              exit 0
-            fi
-            fail "Could not verify the recheck requester's live repository permission."
-          fi
-          [[ "${permission_http_status}" == "200" ]] ||
-            fail "GitHub returned an unexpected HTTP status while verifying repository permission."
-          if ! jq -e --arg expected_id "${COMMENT_USER_ID}" '
-            type == "object" and
-            (.user | type == "object") and
-            (.user.id | type == "number" and floor == . and . > 0 and . <= 9007199254740991) and
-            ((.user.id | tostring) == $expected_id)
-          ' <<<"${permission_response_body}" >/dev/null 2>&1; then
-            fail "GitHub returned permission data for a different collaborator identity."
-          fi
-          if ! permission="$(jq -er '.permission | strings' <<<"${permission_response_body}" 2>/dev/null)"; then
-            fail "GitHub returned an invalid repository permission response."
-          fi
-          role_name=""
-          if ! role_name="$(jq -er '.role_name | strings' <<<"${permission_response_body}" 2>/dev/null)"; then
-            role_name=""
-          fi
-          case "${role_name}" in
-            admin|maintain)
-              printf 'authorized=true\ndecision=authorized\n' >> "${GITHUB_OUTPUT}"
-              echo "CLA recheck requester has live repository maintainer permission."
-              exit 0
-              ;;
-            push|write|none|read|pull|triage)
-              # A valid non-maintainer is ordinary public input, not a
-              # workflow error. Keep the gate green with an explicit false
-              # admission so broad workflow-required policies cannot be used
-              # as a denial-of-service primitive.
-              echo "CLA recheck ignored: requester has no repository maintainer permission"
-              exit 0
-              ;;
-            '')
-              # Older GitHub responses may omit role_name. Accept only the
-              # documented admin or maintain permission, never generic write.
-              if [[ "${permission}" == "admin" || "${permission}" == "maintain" ]]; then
-                printf 'authorized=true\ndecision=authorized\n' >> "${GITHUB_OUTPUT}"
-                echo "CLA recheck requester has live repository admin permission."
-                exit 0
-              fi
-              case "${permission}" in
-                push|write|none|read|pull|maintain|triage)
-                  echo "CLA recheck ignored: requester has no repository maintainer permission"
-                  exit 0
-                  ;;
-                *)
-                  fail "GitHub returned an unknown repository permission while authorizing recheck."
-                  ;;
-              esac
-              ;;
-            *)
-              fail "GitHub returned an unknown repository role while authorizing recheck."
-              ;;
-          esac
+          bash .github/scripts/cla-recheck-auth.sh
 
       - name: "Classify recheck authorization"
-        id: classify-recheck
+        id: classify_recheck
         if: always()
         env:
-          ACTION_OUTCOME: ${{ steps.authorize-recheck.outcome || 'unknown' }}
-          ACTION_AUTHORIZED: ${{ steps.authorize-recheck.outputs.authorized || 'false' }}
-          ACTION_DECISION: ${{ steps.authorize-recheck.outputs.decision || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_BODY: ${{ github.event.comment.body || '' }}
+          CHECKOUT_OUTCOME: ${{ steps.checkout_recheck_helper.outcome || 'skipped' }}
+          ACTION_OUTCOME: ${{ steps.authorize_recheck.outcome || 'unknown' }}
+          ACTION_AUTHORIZED: ${{ steps.authorize_recheck.outputs.authorized || 'false' }}
+          ACTION_DECISION: ${{ steps.authorize_recheck.outputs.decision || '' }}
         run: |
           set -euo pipefail
-          case "${ACTION_OUTCOME}" in
-            success)
-              case "${ACTION_DECISION}" in
-                authorized)
-                  if [[ "${ACTION_AUTHORIZED}" != "true" ]]; then
-                    printf 'authorized=false\ndecision=error\n' >> "${GITHUB_OUTPUT}"
-                    echo "::error title=CLA recheck policy::The authorization step returned an inconsistent admission." >&2
-                    exit 0
-                  fi
-                  printf 'authorized=true\ndecision=authorized\n' >> "${GITHUB_OUTPUT}"
-                  ;;
-                unauthorized)
-                  if [[ "${ACTION_AUTHORIZED}" != "false" ]]; then
-                    printf 'authorized=false\ndecision=error\n' >> "${GITHUB_OUTPUT}"
-                    echo "::error title=CLA recheck policy::The authorization step returned an inconsistent denial." >&2
-                    exit 0
-                  fi
-                  printf 'authorized=false\ndecision=unauthorized\n' >> "${GITHUB_OUTPUT}"
-                  ;;
-                *)
-                  printf 'authorized=false\ndecision=error\n' >> "${GITHUB_OUTPUT}"
-                  echo "::error title=CLA recheck policy::The authorization step returned an unknown decision." >&2
-                  exit 1
-                  ;;
-              esac
+          if [[ "${EVENT_NAME}" != "issue_comment" || "${EVENT_BODY}" != "recheck" ]]; then
+            printf 'authorized=false\ndecision=ignored\n' >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if [[ "${CHECKOUT_OUTCOME}" != "success" ]]; then
+            printf 'authorized=false\ndecision=error\n' >> "${GITHUB_OUTPUT}"
+            echo "::error title=CLA recheck policy::The trusted authorizer checkout did not complete." >&2
+            exit 1
+          fi
+          case "${ACTION_DECISION}" in
+            authorized)
+              if [[ "${ACTION_OUTCOME}" != "success" || "${ACTION_AUTHORIZED}" != "true" ]]; then
+                printf 'authorized=false\ndecision=error\n' >> "${GITHUB_OUTPUT}"
+                echo "::error title=CLA recheck policy::The authorizer returned an inconsistent authorization." >&2
+                exit 1
+              fi
+              printf 'authorized=true\ndecision=authorized\n' >> "${GITHUB_OUTPUT}"
               ;;
-            failure|cancelled|skipped|*)
+            unauthorized)
+              if [[ "${ACTION_OUTCOME}" != "success" || "${ACTION_AUTHORIZED}" != "false" ]]; then
+                printf 'authorized=false\ndecision=error\n' >> "${GITHUB_OUTPUT}"
+                echo "::error title=CLA recheck policy::The authorizer returned an inconsistent denial." >&2
+                exit 1
+              fi
+              printf 'authorized=false\ndecision=unauthorized\n' >> "${GITHUB_OUTPUT}"
+              ;;
+            retry)
+              printf 'authorized=false\ndecision=retry\n' >> "${GITHUB_OUTPUT}"
+              echo "::error title=CLA recheck policy::GitHub API access was unavailable after bounded retries." >&2
+              exit 1
+              ;;
+            *)
               printf 'authorized=false\ndecision=error\n' >> "${GITHUB_OUTPUT}"
-              echo "::error title=CLA recheck policy::The authorization step did not complete." >&2
+              echo "::error title=CLA recheck policy::The authorizer returned an invalid decision." >&2
               exit 1
               ;;
           esac
@@ -1650,18 +1470,14 @@ jobs:
       (
         (
           github.event.comment.body == 'recheck' &&
-          needs.CLACommentGate.outputs.recheck_authorized == 'true' &&
-          needs.CLALedgerWriter.result == 'success'
+          needs.CLACommentGate.outputs.recheck_decision == 'authorized'
         ) ||
         (
           github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
           needs.CLASignerGate.result == 'success' &&
           needs.CLASignerGate.outputs.signer_authorized == 'true' &&
           needs.CLALedgerWriter.result == 'success' &&
-          (
-            needs.CLALedgerWriter.outputs.cla_passed == 'true' ||
-            needs.CLALedgerWriter.outputs.signature_recorded == 'true'
-          )
+          needs.CLALedgerWriter.outputs.cla_passed == 'true'
         )
       )
     runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
@@ -1717,6 +1533,7 @@ jobs:
           SIGNATURE_RECORDED: ${{ needs.CLALedgerWriter.outputs.signature_recorded || '' }}
           WRITER_POLICY_RESULT: ${{ needs.CLALedgerWriter.outputs.cla_passed || '' }}
           WRITER_RESULT: ${{ needs.CLALedgerWriter.result || '' }}
+          RECHECK_DECISION: ${{ needs.CLACommentGate.outputs.recheck_decision || '' }}
         run: bash .github/scripts/rerun-failed-cla.sh
 
   LockMergedPullRequest:
@@ -1728,23 +1545,14 @@ jobs:
       github.event.pull_request.merged == true
     runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
     timeout-minutes: 10
-    # Locking a merged PR does not need signature or repository-write access.
-    # Keep a distinct repository-and-PR group. A later edited event must not
-    # replace a pending merge-lock run in the signer queue.
-    # The lock preflight keeps base and opener identity immutable while it
-    # permits a merged source head to advance or disappear.
-    # The lock endpoint accepts either Issues or Pull requests write access.
-    # Declare both scopes explicitly because GitHub Actions can otherwise issue
-    # a token that passes the issue preflight but cannot lock a Pull Request.
-    # Dependabot-created pull_request_target runs can still receive a read-only
-    # token; a trusted post-merge worker or dedicated Dependabot secret may be
-    # needed to lock those merged conversations.
     concurrency:
-      group: "cla-lock-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}"
+      group: "cla-lock-${{ github.repository }}-${{ github.event.pull_request.number }}"
       cancel-in-progress: false
     permissions:
-      issues: write # Lock the conversation after a verified merged Pull Request.
-      pull-requests: write # The lock endpoint also requires Pull requests write access.
+      # Both scopes are required by GitHub's lock endpoint. No contents or
+      # Actions write capability is granted to this mutation job.
+      issues: write
+      pull-requests: write
     steps:
       - name: "Require GitHub-hosted runner"
         env:
@@ -1755,12 +1563,20 @@ jobs:
             echo "::error title=CLA runner policy::CLA policy requires a GitHub-hosted runner."
             exit 1
           fi
-      - name: "Lock merged pull request"
+      - name: "Checkout trusted lock helper"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2, immutable
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/lock-merged-pr.sh
+          sparse-checkout-cone-mode: false
+      - name: "Lock verified merged pull request"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
           CANONICAL_REPOSITORY_ID: ${{ github.repository_id || '' }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action || '' }}
           EVENT_REPOSITORY: ${{ github.event.repository.full_name || '' }}
@@ -1775,324 +1591,8 @@ jobs:
           EVENT_OPENER_ID: ${{ github.event.pull_request.user.id || '' }}
         run: |
           set -euo pipefail
-
-          # Bound every live lock-preflight response before jq parses it. The
-          # Pull Request and issue endpoints are GitHub-controlled metadata;
-          # a bounded raw stream keeps an unexpectedly large response from
-          # reaching the parser or accumulating across repeated identity
-          # checks.
-          max_lock_raw_page_bytes=1048576
-          max_lock_raw_total_bytes=5000000
-          lock_raw_total_bytes=0
-          lock_raw_file="$(mktemp)"
-          lock_write_raw_file="$(mktemp)"
-          trap 'rm -f -- "${lock_raw_file}" "${lock_write_raw_file}"' EXIT
-          capture_lock_response() {
-            local raw_bytes pipeline_status
-            : > "${lock_raw_file}"
-            set +e
-            "$@" 2>/dev/null |
-              head -c "$((max_lock_raw_page_bytes + 1))" > "${lock_raw_file}"
-            pipeline_status=("${PIPESTATUS[@]}")
-            set -e
-            raw_bytes="$(LC_ALL=C wc -c < "${lock_raw_file}" | tr -d '[:space:]')"
-            [[ "${raw_bytes}" =~ ^[0-9]+$ ]] || return 1
-            (( raw_bytes <= max_lock_raw_page_bytes )) || return 2
-            (( ${pipeline_status[0]:-1} == 0 && ${pipeline_status[1]:-1} == 0 )) || return 1
-            lock_raw_total_bytes=$((lock_raw_total_bytes + raw_bytes))
-            (( lock_raw_total_bytes <= max_lock_raw_total_bytes )) || return 2
-          }
-          lock_api() {
-            local capture_status=0
-            capture_lock_response "$@" || capture_status=$?
-            (( capture_status == 0 )) || return 1
-            cat "${lock_raw_file}"
-          }
-
-          # Keep the lock mutation response bounded before inspecting it. The
-          # body is intentionally suppressed; only a validated numeric HTTP
-          # status is emitted for diagnosis, so GitHub error text and headers
-          # cannot disclose response data in the Actions log.
-          lock_write_http_status=""
-          lock_write_exit_status=1
-          capture_lock_write_response() {
-            local raw_bytes pipeline_status
-            : > "${lock_write_raw_file}"
-            set +e
-            gh api --method PUT \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              --include \
-              --silent \
-              "${lock_endpoint}" \
-              --field lock_reason=resolved 2>/dev/null |
-              head -c "$((max_lock_raw_page_bytes + 1))" > "${lock_write_raw_file}"
-            pipeline_status=("${PIPESTATUS[@]}")
-            set -e
-            raw_bytes="$(LC_ALL=C wc -c < "${lock_write_raw_file}" | tr -d '[:space:]')"
-            [[ "${raw_bytes}" =~ ^[0-9]+$ ]] || return 1
-            (( raw_bytes <= max_lock_raw_page_bytes )) || return 2
-            lock_raw_total_bytes=$((lock_raw_total_bytes + raw_bytes))
-            (( lock_raw_total_bytes <= max_lock_raw_total_bytes )) || return 2
-            lock_write_exit_status="${pipeline_status[0]:-1}"
-            [[ "${lock_write_exit_status}" =~ ^[0-9]+$ ]] || return 1
-            lock_write_http_status="$(LC_ALL=C sed -nE \
-              's#^HTTP/[0-9.]+[[:space:]]([0-9]{3})([[:space:]].*)?$#\1#p' \
-              "${lock_write_raw_file}" | tail -n 1)"
-          }
-
-          report_lock_write_failure() {
-            if [[ "${lock_write_http_status}" =~ ^[0-9]{3}$ ]]; then
-              echo "::error title=CLA lock failed::GitHub returned HTTP ${lock_write_http_status} while locking pull request ${PR_NUMBER}." >&2
-            else
-              echo "::error title=CLA lock failed::The lock request failed before a valid HTTP status was received for pull request ${PR_NUMBER}." >&2
-            fi
+          [[ -x .github/scripts/lock-merged-pr.sh ]] || {
+            echo "::error title=CLA lock policy::The trusted lock helper was not checked out." >&2
             exit 1
           }
-
-          # The event is untrusted. Validate the immutable event identity and
-          # the live merged Pull Request before writing the lock. The live
-          # source head is intentionally not compared with the event head:
-          # GitHub can advance or delete that source after a merge.
-          is_safe_positive_integer() {
-            local value="$1"
-            [[ "${value}" =~ ^[1-9][0-9]*$ ]] || return 1
-            if (( ${#value} > 16 )); then
-              return 1
-            fi
-            if (( ${#value} == 16 )) && (( value > 9007199254740991 )); then
-              return 1
-            fi
-          }
-
-          fail_lock_preflight() {
-            echo "::error title=CLA lock preflight failed::The closed pull_request_target identity did not pass live validation." >&2
-            exit 1
-          }
-
-          [[ "${GH_REPO}" == "manaflow-ai/subrouter" ]] || fail_lock_preflight
-          is_safe_positive_integer "${PR_NUMBER}" || fail_lock_preflight
-          is_safe_positive_integer "${CANONICAL_REPOSITORY_ID}" || fail_lock_preflight
-          if [[ "${EVENT_NAME}" != "pull_request_target" ||
-                "${EVENT_ACTION}" != "closed" ||
-                "${EVENT_PR_STATE}" != "closed" ||
-                "${EVENT_PR_MERGED}" != "true" ||
-                "${EVENT_PR_NUMBER}" != "${PR_NUMBER}" ||
-                -z "${EVENT_REPOSITORY}" ||
-                "${EVENT_REPOSITORY,,}" != "${GH_REPO,,}" ||
-                "${EVENT_BASE_REF}" != "main" ||
-                -z "${EVENT_BASE_REPOSITORY}" ||
-                -z "${EVENT_BASE_REPOSITORY_ID}" ||
-                -z "${EVENT_OPENER_LOGIN}" ||
-                -z "${EVENT_OPENER_ID}" ]]; then
-            fail_lock_preflight
-          fi
-          is_safe_positive_integer "${EVENT_REPOSITORY_ID}" || fail_lock_preflight
-          is_safe_positive_integer "${EVENT_BASE_REPOSITORY_ID}" || fail_lock_preflight
-          is_safe_positive_integer "${EVENT_OPENER_ID}" || fail_lock_preflight
-          if [[ "${EVENT_REPOSITORY_ID}" != "${CANONICAL_REPOSITORY_ID}" ||
-                "${EVENT_BASE_REPOSITORY_ID}" != "${CANONICAL_REPOSITORY_ID}" ]]; then
-            fail_lock_preflight
-          fi
-
-          pr_endpoint="repos/${GH_REPO}/pulls/${PR_NUMBER}"
-          if ! live_pr_raw="$(lock_api gh api "${pr_endpoint}")" ||
-             ! live_pr_json="$(jq -c '
-            {
-              number: .number,
-              state: (.state // ""),
-              merged: (.merged_at != null),
-              base_ref: (.base.ref // ""),
-              base_repo: (if .base.repo == null then null else (.base.repo.full_name // "") end),
-              base_repo_id: (if .base.repo == null then null else (.base.repo.id // null) end),
-              head_sha: (.head.sha // ""),
-              head_ref: (.head.ref // ""),
-              head_repo: (if .head.repo == null then null else (.head.repo.full_name // "") end),
-              head_repo_id: (if .head.repo == null then null else (.head.repo.id // null) end),
-              opener_login: (if .user == null then "" else (.user.login // "") end),
-              opener_id: (if .user == null then null else (.user.id // null) end)
-            }
-          ' <<<"${live_pr_raw}" 2>/dev/null)"; then
-            fail_lock_preflight
-          fi
-
-          if ! jq -e --arg pr "${PR_NUMBER}" --arg repo "${GH_REPO}" '
-            def safe_id:
-              type == "number" and floor == . and . > 0 and . <= 9007199254740991;
-            def nonempty_string:
-              type == "string" and (gsub("^\\s+|\\s+$"; "") | length > 0);
-            (.number | type == "number") and
-            ((.number | tostring) == $pr) and
-            (.state == "closed") and
-            (.merged == true) and
-            (.base_ref == "main") and
-            (.base_repo | nonempty_string) and
-            ((.base_repo | ascii_downcase) == ($repo | ascii_downcase)) and
-            (.base_repo_id | safe_id) and
-            (.head_sha | nonempty_string) and
-            (.head_ref | nonempty_string) and
-            (if .head_repo == null then .head_repo_id == null else
-              (.head_repo | nonempty_string) and
-              (.head_repo_id | safe_id)
-            end) and
-            (.opener_login | nonempty_string) and
-            (.opener_id | safe_id)
-          ' <<<"${live_pr_json}" >/dev/null 2>&1; then
-            fail_lock_preflight
-          fi
-
-          if ! live_base_ref="$(jq -er '.base_ref | strings' <<<"${live_pr_json}" 2>/dev/null)" ||
-             ! live_base_repo="$(jq -er '.base_repo | strings' <<<"${live_pr_json}" 2>/dev/null)" ||
-             ! live_base_repo_id="$(jq -er '.base_repo_id | numbers | tostring' <<<"${live_pr_json}" 2>/dev/null)" ||
-             ! live_opener_login="$(jq -er '.opener_login | strings' <<<"${live_pr_json}" 2>/dev/null)" ||
-             ! live_opener_id="$(jq -er '.opener_id | numbers | tostring' <<<"${live_pr_json}" 2>/dev/null)"; then
-            fail_lock_preflight
-          fi
-          is_safe_positive_integer "${live_base_repo_id}" || fail_lock_preflight
-          is_safe_positive_integer "${live_opener_id}" || fail_lock_preflight
-          if [[ "${EVENT_BASE_REF}" != "${live_base_ref}" ||
-                "${EVENT_BASE_REPOSITORY,,}" != "${live_base_repo,,}" ||
-                "${EVENT_BASE_REPOSITORY_ID}" != "${live_base_repo_id}" ||
-                "${EVENT_REPOSITORY_ID}" != "${live_base_repo_id}" ||
-                "${EVENT_OPENER_ID}" != "${live_opener_id}" ||
-                "${EVENT_OPENER_LOGIN,,}" != "${live_opener_login,,}" ]]; then
-            fail_lock_preflight
-          fi
-
-          issue_endpoint="repos/${GH_REPO}/issues/${PR_NUMBER}"
-          lock_endpoint="${issue_endpoint}/lock"
-          lock_identity_changed() {
-            # GitHub has no conditional lock endpoint or lock owner token. Do
-            # not issue an unconditional DELETE here, because another trusted
-            # actor could have acquired the lock after this worker's PUT. Keep
-            # the lock and require an administrator to inspect the mismatch.
-            echo "::error title=CLA lock failed::The pull request identity changed after locking; the lock remains for administrator review." >&2
-            exit 1
-          }
-          if ! lock_state_raw="$(lock_api gh api "${issue_endpoint}")" ||
-             ! locked="$(jq -er 'if (.locked | type) == "boolean" then (.locked | tostring) else error("invalid lock state") end' <<<"${lock_state_raw}" 2>/dev/null)"; then
-            echo "::error title=CLA lock failed::Could not read lock state for pull request ${PR_NUMBER}." >&2
-            exit 1
-          fi
-          case "${locked}" in
-            true)
-            if ! already_locked_pr_raw="$(lock_api gh api "${pr_endpoint}")" ||
-               ! already_locked_pr="$(jq -c '{
-              number: .number,
-              state: (.state // ""),
-              merged: (.merged_at != null),
-              base_ref: (.base.ref // ""),
-              base_repo: (.base.repo.full_name // ""),
-              base_repo_id: (.base.repo.id // 0),
-              opener_login: (.user.login // ""),
-              opener_id: (.user.id // 0)
-            }' <<<"${already_locked_pr_raw}" 2>/dev/null)"; then
-              fail_lock_preflight
-            fi
-            if ! jq -e --arg pr "${PR_NUMBER}" --arg repo "${GH_REPO}" \
-              --arg event_base_ref "${EVENT_BASE_REF}" \
-              --arg event_base_repo "${EVENT_BASE_REPOSITORY}" \
-              --arg event_base_repo_id "${EVENT_BASE_REPOSITORY_ID}" \
-              --arg event_opener_id "${EVENT_OPENER_ID}" \
-              --arg event_opener_login "${EVENT_OPENER_LOGIN}" '
-              def safe_id:
-                type == "number" and floor == . and . > 0 and . <= 9007199254740991;
-              (.number | type == "number") and
-              ((.number | tostring) == $pr) and
-              (.state == "closed") and (.merged == true) and
-              (.base_ref == $event_base_ref) and
-              ((.base_repo | ascii_downcase) == ($event_base_repo | ascii_downcase)) and
-              ((.base_repo | type == "string") and (.base_repo_id | safe_id) and
-               ((.base_repo_id | tostring) == $event_base_repo_id)) and
-              ((.opener_id | safe_id) and ((.opener_id | tostring) == $event_opener_id)) and
-              ((.opener_login | ascii_downcase) == ($event_opener_login | ascii_downcase)) and
-              ((.base_repo | ascii_downcase) == ($repo | ascii_downcase))
-            ' <<<"${already_locked_pr}" >/dev/null 2>&1; then
-              lock_identity_changed
-            fi
-            if ! lock_state_raw="$(lock_api gh api "${issue_endpoint}")" ||
-               ! still_locked="$(jq -er 'if (.locked | type) == "boolean" then (.locked | tostring) else error("invalid lock state") end' <<<"${lock_state_raw}" 2>/dev/null)"; then
-              echo "::error title=CLA lock failed::Could not verify the lock state after the merged pull request identity check." >&2
-              exit 1
-            fi
-            if [[ "${still_locked}" != "true" ]]; then
-              echo "::error title=CLA lock failed::The merged pull request was unlocked during identity validation." >&2
-              exit 1
-            fi
-            echo "Pull request ${PR_NUMBER} is already locked"
-            exit 0
-            ;;
-            false)
-            ;;
-            *)
-            echo "::error title=CLA lock failed::GitHub returned an invalid lock state for this pull request." >&2
-            exit 1
-            ;;
-          esac
-          capture_lock_write_response || report_lock_write_failure
-          if [[ "${lock_write_exit_status}" != "0" ||
-                "${lock_write_http_status}" != "204" ]]; then
-            report_lock_write_failure
-          fi
-          if ! lock_state_raw="$(lock_api gh api "${issue_endpoint}")" ||
-             ! locked_after="$(jq -er 'if (.locked | type) == "boolean" then (.locked | tostring) else error("invalid lock state") end' <<<"${lock_state_raw}" 2>/dev/null)"; then
-            echo "::error title=CLA lock failed::Could not verify lock state for pull request ${PR_NUMBER}." >&2
-            exit 1
-          fi
-          if [[ "${locked_after}" != "true" ]]; then
-            echo "::error title=CLA lock failed::GitHub did not report pull request ${PR_NUMBER} as locked after the lock request." >&2
-            exit 1
-          fi
-          if ! final_live_pr_raw="$(lock_api gh api "${pr_endpoint}")" ||
-             ! final_live_pr_json="$(jq -c '.' <<<"${final_live_pr_raw}" 2>/dev/null)"; then
-            lock_identity_changed
-          fi
-          if ! jq -e --arg pr "${PR_NUMBER}" --arg repo "${GH_REPO}" '
-            def safe_id:
-              type == "number" and floor == . and . > 0 and . <= 9007199254740991;
-            def nonempty_string:
-              type == "string" and (gsub("^\\s+|\\s+$"; "") | length > 0);
-            (.number | type == "number") and
-            ((.number | tostring) == $pr) and
-            (.state == "closed") and
-            (.merged_at != null) and
-            (.base.ref == "main") and
-            (.base.repo.full_name | nonempty_string) and
-            ((.base.repo.full_name | ascii_downcase) == ($repo | ascii_downcase)) and
-            (.base.repo.id | safe_id) and
-            (.head.sha | nonempty_string) and
-            (.head.ref | nonempty_string) and
-            (if .head.repo == null then .head.repo.id == null else
-              (.head.repo.full_name | nonempty_string) and
-              (.head.repo.id | safe_id)
-            end) and
-            (.user.login | nonempty_string) and
-            (.user.id | safe_id)
-          ' <<<"${final_live_pr_json}" >/dev/null 2>&1; then
-            lock_identity_changed
-          fi
-          final_base_ref="$(jq -er '.base.ref | strings' <<<"${final_live_pr_json}")"
-          final_base_repo="$(jq -er '.base.repo.full_name | strings' <<<"${final_live_pr_json}")"
-          final_base_repo_id="$(jq -er '.base.repo.id | numbers | tostring' <<<"${final_live_pr_json}")"
-          final_opener_id="$(jq -er '.user.id | numbers | tostring' <<<"${final_live_pr_json}")"
-          final_opener_login="$(jq -er '.user.login | strings' <<<"${final_live_pr_json}")"
-          if [[ "${final_base_ref}" != "${EVENT_BASE_REF}" ||
-                "${final_base_repo,,}" != "${EVENT_BASE_REPOSITORY,,}" ||
-                "${final_base_repo_id}" != "${EVENT_BASE_REPOSITORY_ID}" ||
-                "${final_opener_id}" != "${EVENT_OPENER_ID}" ||
-                "${final_opener_login,,}" != "${EVENT_OPENER_LOGIN,,}" ]]; then
-            lock_identity_changed
-          fi
-          # Re-read the issue lock after the final identity check. A trusted
-          # actor can unlock a conversation between the first verification and
-          # the PR GET; reporting success without this second read would claim
-          # a lock that no longer exists.
-          if ! lock_state_raw="$(lock_api gh api "${issue_endpoint}")" ||
-             ! final_locked="$(jq -er 'if (.locked | type) == "boolean" then (.locked | tostring) else error("invalid lock state") end' <<<"${lock_state_raw}" 2>/dev/null)"; then
-            echo "::error title=CLA lock failed::Could not verify the final lock state for pull request ${PR_NUMBER}." >&2
-            exit 1
-          fi
-          if [[ "${final_locked}" != "true" ]]; then
-            echo "::error title=CLA lock failed::The pull request was unlocked after identity validation." >&2
-            exit 1
-          fi
+          bash .github/scripts/lock-merged-pr.sh

--- a/tests/test_cla_lock_workflow.sh
+++ b/tests/test_cla_lock_workflow.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Behavior tests for the trusted merged-Pull-Request lock helper.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT_DIR/.github/scripts/lock-merged-pr.sh"
+test -x "$SCRIPT"
+command -v jq >/dev/null
+
+work="$(mktemp -d)"
+trap 'rm -rf -- "$work"' EXIT
+printf 'false\n' >"$work/locked"
+cat >"$work/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+endpoint=''
+method=GET
+for arg in "$@"; do
+  [[ "$arg" == repos/* ]] && endpoint="$arg"
+  [[ "$arg" == PUT ]] && method=PUT
+done
+case "$method:$endpoint" in
+  GET:repos/manaflow-ai/subrouter/pulls/294)
+    printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+    printf '%s\n' '{"number":294,"state":"closed","merged_at":"2026-09-02T00:00:00Z","base":{"ref":"main","repo":{"full_name":"manaflow-ai/subrouter","id":100}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":null},"user":{"login":"contributor","id":300}}'
+    ;;
+  GET:repos/manaflow-ai/subrouter/issues/294)
+    printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n{"locked":%s}\n' "$(<"$FAKE_LOCK_STATE")"
+    ;;
+  PUT:repos/manaflow-ai/subrouter/issues/294/lock)
+    printf 'true\n' >"$FAKE_LOCK_STATE"
+    printf 'HTTP/2 204\r\n\r\n'
+    ;;
+  *)
+    echo "unexpected API endpoint: $method:$endpoint" >&2
+    exit 1
+    ;;
+esac
+GH
+chmod +x "$work/gh"
+
+export PATH="$work:$PATH"
+export GH_TOKEN=test-token GH_REPO=manaflow-ai/subrouter PR_NUMBER=294
+export CANONICAL_REPOSITORY_ID=100 EVENT_NAME=pull_request_target EVENT_ACTION=closed
+export EVENT_REPOSITORY=manaflow-ai/subrouter EVENT_REPOSITORY_ID=100 EVENT_PR_NUMBER=294
+export EVENT_PR_STATE=closed EVENT_PR_MERGED=true EVENT_BASE_REF=main
+export EVENT_BASE_REPOSITORY=manaflow-ai/subrouter EVENT_BASE_REPOSITORY_ID=100
+export EVENT_OPENER_LOGIN=contributor EVENT_OPENER_ID=300
+export FAKE_LOCK_STATE="$work/locked"
+
+output="$work/output"
+bash "$SCRIPT" >"$output"
+grep -Fq 'Locked merged Pull Request 294.' "$output"
+
+# A second delivery is idempotent and still revalidates the live identity.
+bash "$SCRIPT" >"$output"
+grep -Fq 'Pull Request 294 is already locked.' "$output"
+
+# A close event targeting another branch must fail before any API call.
+export EVENT_BASE_REF=release
+if bash "$SCRIPT" >"$output" 2>&1; then
+  echo 'unexpected success for a non-main close event' >&2
+  exit 1
+fi
+grep -Fq 'event base is not canonical main' "$output"
+
+echo 'CLA lock behavior tests passed'

--- a/tests/test_cla_recheck_auth.sh
+++ b/tests/test_cla_recheck_auth.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Behavior tests for the read-only recheck authorizer.
+# The fixtures model an external-fork Pull Request and an already-green CLA
+# check. They exercise API responses through a fake `gh` command, not workflow
+# source text.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT_DIR/.github/scripts/cla-recheck-auth.sh"
+readonly PR_NUMBER=301
+readonly COMMENT_ID=900
+readonly COMMENT_AUTHOR_ID=25807
+readonly COMMENT_AUTHOR_LOGIN=danielraffel
+readonly COMMENT_BODY=recheck
+readonly COMMENT_CREATED_AT=2026-09-02T03:42:16Z
+
+command -v jq >/dev/null
+test -x "$SCRIPT"
+
+api_calls=()
+pull_attempts=0
+
+fake_gh() {
+  local endpoint="${!#}"
+  local method=GET
+  local arg
+  for arg in "$@"; do
+    [[ "$arg" == POST ]] && method=POST
+  done
+  [[ "$method" == GET ]] || {
+    echo "unexpected write method: $method" >&2
+    return 97
+  }
+  api_calls+=("$endpoint")
+
+  case "$FAKE_MODE:$endpoint" in
+    external-fork:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    external-fork:repos/manaflow-ai/subrouter/pulls/301)
+      pull_attempts=$((pull_attempts + 1))
+      if (( pull_attempts < 3 )); then
+        printf 'HTTP/2 503\r\ncontent-type: application/json\r\n\r\n{"message":"temporary upstream failure"}\n'
+        return 1
+      fi
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",merged_at:null,user:{id:25807,login:"danielraffel"},base:{ref:"main",repo:{id:1228491972,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"danielraffel/subrouter"}}}'
+      ;;
+    external-fork:repos/manaflow-ai/subrouter/issues/comments/900)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc --arg created "$COMMENT_CREATED_AT" '{id:900,body:"recheck",user:{id:25807,login:"danielraffel",type:"User"},issue_url:"https://api.github.com/repos/manaflow-ai/subrouter/issues/301",created_at:$created,updated_at:$created}'
+      ;;
+    external-fork:repos/manaflow-ai/subrouter/collaborators/danielraffel/permission)
+      printf 'HTTP/2 404\r\ncontent-type: application/json\r\n\r\n{"message":"Not Found","status":404}\n'
+      return 1
+      ;;
+    transport-error:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    transport-error:repos/manaflow-ai/subrouter/pulls/301)
+      printf 'HTTP/2 503\r\ncontent-type: application/json\r\n\r\n{"message":"service unavailable"}\n'
+      return 1
+      ;;
+    authorized:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    authorized:repos/manaflow-ai/subrouter/pulls/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",merged_at:null,user:{id:25807,login:"danielraffel"},base:{ref:"main",repo:{id:1228491972,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"danielraffel/subrouter"}}}'
+      ;;
+    authorized:repos/manaflow-ai/subrouter/issues/comments/900)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc --arg created "$COMMENT_CREATED_AT" '{id:900,body:"recheck",user:{id:25807,login:"danielraffel",type:"User"},issue_url:"https://api.github.com/repos/manaflow-ai/subrouter/issues/301",created_at:$created,updated_at:$created}'
+      ;;
+    authorized:repos/manaflow-ai/subrouter/collaborators/danielraffel/permission)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{user:{id:25807,login:"danielraffel"},permission:"maintain",role_name:"maintain"}'
+      ;;
+    malformed:*)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n{"unexpected":true}\n'
+      ;;
+    *)
+      echo "fixture endpoint missing for $FAKE_MODE:$endpoint" >&2
+      return 98
+      ;;
+  esac
+}
+
+gh() { fake_gh "$@"; }
+export -f fake_gh gh
+
+run_case() {
+  local mode="$1" expected_status="$2" expected_decision="$3" expected_action="$4"
+  local work status
+  work="$(mktemp -d)"
+  export FAKE_MODE="$mode" pull_attempts=0
+  export GH_REPO=manaflow-ai/subrouter PR_NUMBER COMMENT_ID COMMENT_BODY
+  export COMMENT_USER_ID="$COMMENT_AUTHOR_ID" COMMENT_USER_LOGIN="$COMMENT_AUTHOR_LOGIN"
+  export GITHUB_OUTPUT="$work/output.env"
+  export CLA_RECHECK_RETRY_DELAY_SECONDS=0
+  : >"$GITHUB_OUTPUT"
+  set +e
+  (cd "$ROOT_DIR" && bash "$SCRIPT") >"$work/log" 2>&1
+  status="$?"
+  set -e
+  [[ "$status" == "$expected_status" ]] || { cat "$work/log" >&2; echo "case $mode status $status" >&2; return 1; }
+  grep -Fxq "authorized=false" "$GITHUB_OUTPUT" || grep -Fxq "authorized=true" "$GITHUB_OUTPUT"
+  grep -Fxq "decision=$expected_decision" "$GITHUB_OUTPUT" || { cat "$work/output.env" >&2; return 1; }
+  grep -Fxq "check_action=$expected_action" "$GITHUB_OUTPUT" || { cat "$work/output.env" >&2; return 1; }
+  if [[ "$mode" == external-fork ]]; then
+    [[ "$pull_attempts" == 3 ]] || { echo "external-fork did not retry pull API" >&2; return 1; }
+  fi
+  rm -rf "$work"
+}
+
+# Daniel's external-fork PR already has a durable CLA signature and a green
+# required check. A temporary Pulls API failure must be retried, then a valid
+# non-collaborator response is an unauthorized no-op that preserves green.
+run_case external-fork 0 unauthorized preserve
+
+# Persistent API failure is a retry state, not an unauthorized denial and not a
+# new failure check. The caller can retry after GitHub recovers.
+run_case transport-error 1 retry preserve
+
+# A valid maintainer response admits the refresh path.
+run_case authorized 0 authorized refresh
+
+# Malformed API data is an explicit error and must never be treated as a
+# successful or unauthorized authorization.
+run_case malformed 1 error fail
+
+echo "CLA recheck authorization behavior tests passed"

--- a/tests/test_cla_recheck_auth.sh
+++ b/tests/test_cla_recheck_auth.sh
@@ -75,6 +75,18 @@ fake_gh() {
       printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
       jq -nc '{number:301,state:"open",merged_at:null,user:{id:25807,login:"danielraffel"},base:{ref:"main",repo:{id:1228491972,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:null}}'
       ;;
+    missing-state:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    missing-merged:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    missing-merged:repos/manaflow-ai/subrouter/pulls/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",user:{id:25807,login:"danielraffel"},base:{ref:"main",repo:{id:1228491972,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"danielraffel/subrouter"}}}'
+      ;;
     transport-error:repos/manaflow-ai/subrouter/issues/301)
       printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
       jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
@@ -154,6 +166,12 @@ run_case closed-404 0 unauthorized preserve
 # A current PR with a missing head repository is malformed identity data. It
 # must fail closed instead of being mistaken for an unrelated deleted fork.
 run_case current-null 1 error fail
+
+# Missing state is malformed, not a closed Pull Request denial.
+run_case missing-state 1 error fail
+
+# Missing merged_at must not be interpreted as an explicit unmerged state.
+run_case missing-merged 1 error fail
 
 # A valid maintainer response admits the refresh path.
 run_case authorized 0 authorized refresh

--- a/tests/test_cla_recheck_auth.sh
+++ b/tests/test_cla_recheck_auth.sh
@@ -39,8 +39,12 @@ fake_gh() {
       jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
       ;;
     external-fork:repos/manaflow-ai/subrouter/pulls/301)
-      pull_attempts=$((pull_attempts + 1))
-      if (( pull_attempts < 3 )); then
+      local attempt
+      attempt="$(<"${PULL_ATTEMPTS_FILE}")"
+      attempt=$((attempt + 1))
+      printf '%s\n' "$attempt" >"${PULL_ATTEMPTS_FILE}"
+      pull_attempts="$attempt"
+      if (( attempt < 3 )); then
         printf 'HTTP/2 503\r\ncontent-type: application/json\r\n\r\n{"message":"temporary upstream failure"}\n'
         return 1
       fi
@@ -54,6 +58,22 @@ fake_gh() {
     external-fork:repos/manaflow-ai/subrouter/collaborators/danielraffel/permission)
       printf 'HTTP/2 404\r\ncontent-type: application/json\r\n\r\n{"message":"Not Found","status":404}\n'
       return 1
+      ;;
+    closed-404:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    closed-404:repos/manaflow-ai/subrouter/pulls/301)
+      printf 'HTTP/2 404\r\ncontent-type: application/json\r\n\r\n{"message":"Not Found","status":404}\n'
+      return 1
+      ;;
+    current-null:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    current-null:repos/manaflow-ai/subrouter/pulls/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",merged_at:null,user:{id:25807,login:"danielraffel"},base:{ref:"main",repo:{id:1228491972,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:null}}'
       ;;
     transport-error:repos/manaflow-ai/subrouter/issues/301)
       printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
@@ -96,9 +116,11 @@ run_case() {
   local mode="$1" expected_status="$2" expected_decision="$3" expected_action="$4"
   local work status
   work="$(mktemp -d)"
-  export FAKE_MODE="$mode" pull_attempts=0
+  export FAKE_MODE="$mode" pull_attempts=0 PULL_ATTEMPTS_FILE="$work/pull-attempts"
+  printf '0\n' >"$PULL_ATTEMPTS_FILE"
   export GH_REPO=manaflow-ai/subrouter PR_NUMBER COMMENT_ID COMMENT_BODY
-  export COMMENT_USER_ID="$COMMENT_AUTHOR_ID" COMMENT_USER_LOGIN="$COMMENT_AUTHOR_LOGIN"
+  export COMMENT_USER_ID="$COMMENT_AUTHOR_ID" COMMENT_USER_LOGIN="$COMMENT_AUTHOR_LOGIN" \
+    COMMENT_USER_TYPE=User COMMENT_CREATED_AT
   export GITHUB_OUTPUT="$work/output.env"
   export CLA_RECHECK_RETRY_DELAY_SECONDS=0
   : >"$GITHUB_OUTPUT"
@@ -111,7 +133,7 @@ run_case() {
   grep -Fxq "decision=$expected_decision" "$GITHUB_OUTPUT" || { cat "$work/output.env" >&2; return 1; }
   grep -Fxq "check_action=$expected_action" "$GITHUB_OUTPUT" || { cat "$work/output.env" >&2; return 1; }
   if [[ "$mode" == external-fork ]]; then
-    [[ "$pull_attempts" == 3 ]] || { echo "external-fork did not retry pull API" >&2; return 1; }
+    [[ "$(<"$PULL_ATTEMPTS_FILE")" == 3 ]] || { echo "external-fork did not retry pull API" >&2; return 1; }
   fi
   rm -rf "$work"
 }
@@ -124,6 +146,14 @@ run_case external-fork 0 unauthorized preserve
 # Persistent API failure is a retry state, not an unauthorized denial and not a
 # new failure check. The caller can retry after GitHub recovers.
 run_case transport-error 1 retry preserve
+
+# A validated Pulls 404 means the PR disappeared between the issue and Pulls
+# reads. Preserve the existing check as an ordinary no-op.
+run_case closed-404 0 unauthorized preserve
+
+# A current PR with a missing head repository is malformed identity data. It
+# must fail closed instead of being mistaken for an unrelated deleted fork.
+run_case current-null 1 error fail
 
 # A valid maintainer response admits the refresh path.
 run_case authorized 0 authorized refresh

--- a/tests/test_cla_recheck_auth.sh
+++ b/tests/test_cla_recheck_auth.sh
@@ -79,6 +79,26 @@ fake_gh() {
       printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
       jq -nc '{number:301,pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
       ;;
+    unsupported-issue-state:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"pending",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    unsupported-pull-state:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    unsupported-pull-state:repos/manaflow-ai/subrouter/pulls/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"pending",merged_at:null,user:{id:25807,login:"danielraffel"},base:{ref:"main",repo:{id:1228491972,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"danielraffel/subrouter"}}}'
+      ;;
+    nonstring-state:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:42,pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    closed-state:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"closed",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
     missing-merged:repos/manaflow-ai/subrouter/issues/301)
       printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
       jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
@@ -169,6 +189,13 @@ run_case current-null 1 error fail
 
 # Missing state is malformed, not a closed Pull Request denial.
 run_case missing-state 1 error fail
+
+# Unsupported issue and Pulls state values are malformed, not closed Pull
+# Request denials. They must fail before any authorization decision.
+run_case unsupported-issue-state 1 error fail
+run_case unsupported-pull-state 1 error fail
+run_case nonstring-state 1 error fail
+run_case closed-state 0 unauthorized preserve
 
 # Missing merged_at must not be interpreted as an explicit unmerged state.
 run_case missing-merged 1 error fail

--- a/tests/test_cla_recheck_auth.sh
+++ b/tests/test_cla_recheck_auth.sh
@@ -67,6 +67,16 @@ fake_gh() {
       printf 'HTTP/2 404\r\ncontent-type: application/json\r\n\r\n{"message":"Not Found","status":404}\n'
       return 1
       ;;
+    closed-404-no-status:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    closed-404-no-status:repos/manaflow-ai/subrouter/pulls/301)
+      # GitHub error bodies normally omit the HTTP status. The status line is
+      # the authoritative 404 signal.
+      printf 'HTTP/2 404\r\ncontent-type: application/json\r\n\r\n{"message":"Not Found","documentation_url":"https://docs.github.com/rest"}\n'
+      return 1
+      ;;
     current-null:repos/manaflow-ai/subrouter/issues/301)
       printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
       jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
@@ -177,7 +187,11 @@ run_case() {
   status="$?"
   set -e
   [[ "$status" == "$expected_status" ]] || { cat "$work/log" >&2; echo "case $mode status $status" >&2; return 1; }
-  grep -Fxq "authorized=false" "$GITHUB_OUTPUT" || grep -Fxq "authorized=true" "$GITHUB_OUTPUT"
+  if [[ "$mode" == authorized ]]; then
+    grep -Fxq "authorized=true" "$GITHUB_OUTPUT" || { cat "$work/output.env" >&2; return 1; }
+  else
+    grep -Fxq "authorized=false" "$GITHUB_OUTPUT" || { cat "$work/output.env" >&2; return 1; }
+  fi
   grep -Fxq "decision=$expected_decision" "$GITHUB_OUTPUT" || { cat "$work/output.env" >&2; return 1; }
   grep -Fxq "check_action=$expected_action" "$GITHUB_OUTPUT" || { cat "$work/output.env" >&2; return 1; }
   if [[ "$mode" == external-fork ]]; then
@@ -198,6 +212,7 @@ run_case transport-error 1 retry preserve
 # A validated Pulls 404 means the PR disappeared between the issue and Pulls
 # reads. Preserve the existing check as an ordinary no-op.
 run_case closed-404 0 unauthorized preserve
+run_case closed-404-no-status 0 unauthorized preserve
 
 # A current PR with a missing head repository is malformed identity data. It
 # must fail closed instead of being mistaken for an unrelated deleted fork.

--- a/tests/test_cla_recheck_auth.sh
+++ b/tests/test_cla_recheck_auth.sh
@@ -131,6 +131,22 @@ fake_gh() {
       printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
       jq -nc '{user:{id:25807,login:"danielraffel"},permission:"maintain",role_name:"maintain"}'
       ;;
+    open-merged:repos/manaflow-ai/subrouter/issues/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/301"}}'
+      ;;
+    open-merged:repos/manaflow-ai/subrouter/pulls/301)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{number:301,state:"open",merged_at:"2026-09-02T03:42:16Z",user:{id:25807,login:"danielraffel"},base:{ref:"main",repo:{id:1228491972,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"danielraffel/subrouter"}}}'
+      ;;
+    open-merged:repos/manaflow-ai/subrouter/issues/comments/900)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc --arg created "$COMMENT_CREATED_AT" '{id:900,body:"recheck",user:{id:25807,login:"danielraffel",type:"User"},issue_url:"https://api.github.com/repos/manaflow-ai/subrouter/issues/301",created_at:$created,updated_at:$created}'
+      ;;
+    open-merged:repos/manaflow-ai/subrouter/collaborators/danielraffel/permission)
+      printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n'
+      jq -nc '{user:{id:25807,login:"danielraffel"},permission:"maintain",role_name:"maintain"}'
+      ;;
     malformed:*)
       printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n{"unexpected":true}\n'
       ;;
@@ -202,6 +218,10 @@ run_case missing-merged 1 error fail
 
 # A valid maintainer response admits the refresh path.
 run_case authorized 0 authorized refresh
+
+# An open Pull Request with a non-null merged_at value is inconsistent and
+# must fail closed instead of authorizing a refresh.
+run_case open-merged 1 error fail
 
 # Malformed API data is an explicit error and must never be treated as a
 # successful or unauthorized authorization.

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -167,6 +167,8 @@ fake_gh() {
     repos/manaflow-ai/subrouter/commits/*/check-runs\?*)
       if [[ "$FAKE_MODE" == duplicate-success ]]; then
         jq -nc --arg sha "$SHA" '{check_runs:[{id:7001,name:"CLA Assistant v3",head_sha:$sha,status:"completed",conclusion:"failure",app:{id:15368,slug:"github-actions"},details_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001/job/9001"},{id:7002,name:"CLA Assistant v3",head_sha:$sha,status:"completed",conclusion:"success",app:{id:15368,slug:"github-actions"},details_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001/job/9011"}]}'
+      elif [[ "$FAKE_MODE" == duplicate-check ]]; then
+        jq -nc --arg sha "$SHA" '{check_runs:[{id:7001,name:"CLA Assistant v3",head_sha:$sha,status:"completed",conclusion:"failure",app:{id:15368,slug:"github-actions"},details_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001/job/9001"},{id:7002,name:"CLA Assistant v3",head_sha:$sha,status:"completed",conclusion:"failure",app:{id:15368,slug:"github-actions"},details_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001/job/9011"}]}'
       else
         jq -nc --arg sha "$SHA" --argjson count "$check_count" '
           {check_runs: [range(0;$count) | {id:(7001 + .),name:"CLA Assistant v3",head_sha:$sha,status:"completed",conclusion:"failure",app:{id:15368,slug:"github-actions"},details_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001/job/9001"}]}
@@ -203,6 +205,7 @@ run_case() {
   export COMMENT_AUTHOR_ASSOCIATION=NONE WORKFLOW_PATH=.github/workflows/cla.yml WORKFLOW_SHA
   export CLA_GENERATION="$GENERATION" TARGET_EVENT=pull_request_target TARGET_BASE_REF=main
   export SIGNATURE_RECORDED=false
+  export RUN_ATTEMPT=1
   export WRITER_POLICY_RESULT=true
   export WRITER_RESULT=success
   export RECHECK_DECISION=authorized
@@ -216,6 +219,9 @@ run_case() {
   fi
   if [[ "$mode" == deleted-comment-unsigned ]]; then
     export WRITER_POLICY_RESULT=false
+  fi
+  if [[ "$mode" == rerun-attempt ]]; then
+    export RUN_ATTEMPT=2
   fi
   set +e
   (cd "$ROOT_DIR" && bash "$SCRIPT") >"$work/output" 2>&1
@@ -236,6 +242,7 @@ run_case() {
 }
 
 run_case valid pass
+run_case rerun-attempt fail
 run_case null-head fail
 run_case null-unrelated pass
 run_case no-run pass
@@ -249,7 +256,10 @@ run_case partial-sign fail
 run_case active-run pass
 run_case many-runs fail
 run_case collision fail
-run_case duplicate-check fail
+# Repeated lifecycle events can leave more than one failed native check for the
+# same source head. The helper must select the exact failed job and tolerate
+# those non-green historical duplicates.
+run_case duplicate-check pass
 run_case duplicate-success fail
 run_case duplicate-job fail
 run_case stale-marker fail

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -205,6 +205,7 @@ run_case() {
   export SIGNATURE_RECORDED=false
   export WRITER_POLICY_RESULT=true
   export WRITER_RESULT=success
+  export RECHECK_DECISION=authorized
   if [[ "$mode" == partial-sign ]]; then
     export COMMENT_BODY='I have read the CLA Document v2.2 and I hereby sign the CLA'
     export SIGNATURE_RECORDED=true
@@ -242,7 +243,9 @@ run_case no-run-unsigned fail
 run_case deleted-comment pass
 run_case deleted-comment-empty pass
 run_case deleted-comment-unsigned pass
-run_case partial-sign pass
+# A recorded signature is only a ledger-write signal. It must not promote a
+# required check while another contributor remains unsigned.
+run_case partial-sign fail
 run_case active-run pass
 run_case many-runs fail
 run_case collision fail

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -258,7 +258,7 @@ run_case many-runs fail
 run_case collision fail
 # Repeated lifecycle events can leave more than one failed native check for the
 # same source head. The helper must select the exact failed job and tolerate
-# those non-green historical duplicates.
+# those non-green historical duplicates, while rejecting any green duplicate.
 run_case duplicate-check pass
 run_case duplicate-success fail
 run_case duplicate-job fail

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Behavior tests for the trusted CLA rerun helper.
+# These tests execute the helper with a mock GitHub API. They do not inspect
+# workflow source text, and the mock never receives a write token.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT_DIR/.github/scripts/rerun-failed-cla.sh"
+command -v jq >/dev/null
+test -f "$SCRIPT"
+
+readonly SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+WORKFLOW_SHA="$(git -C "$ROOT_DIR" rev-parse HEAD)"
+readonly WORKFLOW_SHA
+readonly GENERATION=v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af
+export SHA WORKFLOW_SHA GENERATION
+
+fake_gh() {
+  local endpoint=""
+  local arg
+  local method=GET
+  for arg in "$@"; do
+    [[ "$arg" == repos/* ]] && endpoint="$arg"
+    [[ "$arg" == POST ]] && method=POST
+  done
+  [[ -n "$endpoint" ]] || { echo "mock endpoint missing" >&2; return 1; }
+  if [[ "$method" == POST ]]; then
+    printf '%s\n' "$endpoint" >>"$FAKE_POST_FILE"
+    printf '{}\n'
+    return 0
+  fi
+
+  local head_repo='contributor/subrouter'
+  local head_repo_id=200
+  local marker="CLA generation $GENERATION"
+  local check_count=1
+  local run_count=1
+  case "$FAKE_MODE" in
+    null-head) head_repo=''; head_repo_id='' ;;
+    null-unrelated) ;;
+    collision) ;;
+    duplicate-check) check_count=2 ;;
+    duplicate-success) ;;
+    duplicate-job) ;;
+    stale-marker) marker='CLA generation v2.2-action-0000000000000000000000000000000000000000' ;;
+    no-run|no-run-unsigned) run_count=0 ;;
+    deleted-comment|deleted-comment-empty)
+      run_count=0
+      if [[ "$endpoint" == repos/manaflow-ai/subrouter/issues/comments/900 ]]; then
+        printf 'HTTP/2 404\r\ncontent-type: application/json\r\n\r\n{"message":"Not Found","status":404}\n'
+        return 1
+      fi
+      ;;
+    deleted-comment-unsigned)
+      if [[ "$endpoint" == repos/manaflow-ai/subrouter/issues/comments/900 ]]; then
+        printf 'HTTP/2 404\r\ncontent-type: application/json\r\n\r\n'
+        return 1
+      fi
+      ;;
+    link-truncated)
+      if [[ "$endpoint" == repos/manaflow-ai/subrouter/pulls\?* ]]; then
+        printf 'HTTP/2 200\r\nLink: <https://api.github.com/repos/manaflow-ai/subrouter/pulls?page=next>; rel="next"\r\n\r\n'
+        jq -nc --arg sha "$SHA" '[{number:294,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:$sha,repo:null}}]'
+        return 0
+      fi
+      ;;
+    oversized)
+      if [[ "$endpoint" == repos/manaflow-ai/subrouter/issues/294 ]]; then
+        printf '{"number":294,"state":"open","pull_request":{"url":"https://api.github.com/repos/manaflow-ai/subrouter/pulls/294"},"padding":"'
+        printf '%*s' 1100000 '' | tr ' ' A
+        printf '"}\n'
+        return 0
+      fi
+      ;;
+    active-run)
+      if [[ "$endpoint" == repos/manaflow-ai/subrouter/actions/workflows/6002/runs\?* ]]; then
+        jq -nc --arg sha "$SHA" '{workflow_runs:[{id:7999,workflow_id:6002,path:".github/workflows/cla.yml",event:"pull_request_target",status:"in_progress",conclusion:null,head_sha:$sha,head_branch:"feature",created_at:"2026-08-31T07:30:00Z",html_url:"https://github.com/manaflow-ai/subrouter/actions/runs/7999",pull_requests:[{number:294,base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:$sha}}]},{id:8001,workflow_id:6002,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$sha,head_branch:"feature",created_at:"2026-08-31T07:00:00Z",html_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001",pull_requests:[{number:294,base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:$sha}}]}]}'
+        return 0
+      fi
+      ;;
+    many-runs)
+      if [[ "$endpoint" == repos/manaflow-ai/subrouter/actions/workflows/6002/runs\?* ]]; then
+        page="${endpoint##*page=}"
+        page="${page%%[^0-9]*}"
+        [[ "$page" =~ ^[1-9][0-9]*$ ]] || return 1
+        offset=$(( (page - 1) * 100 ))
+        if (( page <= 10 )); then
+          if (( page < 10 )); then
+            printf 'HTTP/2 200\r\nLink: <https://api.github.com/repos/manaflow-ai/subrouter/actions/workflows/6002/runs?page=%d>; rel="next"\r\n\r\n' "$((page + 1))"
+          else
+            printf 'HTTP/2 200\r\n\r\n'
+          fi
+          jq -nc --arg sha "$SHA" --argjson offset "$offset" '{workflow_runs:[range(0;100) as $n | {id:(8001 + $offset + $n),workflow_id:6002,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$sha,head_branch:"feature",created_at:"2026-08-31T07:00:00Z",html_url:("https://github.com/manaflow-ai/subrouter/actions/runs/" + ((8001 + $offset + $n)|tostring)),pull_requests:[{number:294,base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:$sha}}]}]}'
+          return 0
+        fi
+      fi
+      ;;
+  esac
+
+  case "$endpoint" in
+    repos/manaflow-ai/subrouter/issues/294)
+      jq -nc '{number:294,state:"open",pull_request:{url:"https://api.github.com/repos/manaflow-ai/subrouter/pulls/294"}}'
+      ;;
+    repos/manaflow-ai/subrouter/issues/comments/900)
+      jq -nc --arg body "$COMMENT_BODY" --arg created "$COMMENT_CREATED_AT" --arg login "$COMMENT_AUTHOR_LOGIN" --argjson id "$COMMENT_AUTHOR_ID" \
+        '{id:900,issue_url:"https://api.github.com/repos/manaflow-ai/subrouter/issues/294",body:$body,user:{id:$id,login:$login,type:"User"},created_at:$created,updated_at:$created}'
+      ;;
+    repos/manaflow-ai/subrouter/pulls/294)
+      if [[ "$FAKE_MODE" == null-head ]]; then
+        jq -nc --arg sha "$SHA" '{number:294,state:"open",merged_at:null,user:{id:300,login:"contributor"},base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:$sha,repo:null}}'
+      else
+        jq -nc --arg sha "$SHA" --arg repo "$head_repo" --argjson repo_id "$head_repo_id" \
+          '{number:294,state:"open",merged_at:null,user:{id:300,login:"contributor"},base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:$sha,repo:{id:$repo_id,full_name:$repo}}}'
+      fi
+      ;;
+    repos/manaflow-ai/subrouter/pulls\?state=open*)
+      if [[ "$FAKE_MODE" == collision ]]; then
+        jq -nc --arg sha "$SHA" '[{number:294,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:$sha,repo:null}},{number:295,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/subrouter"}},head:{ref:"other",sha:$sha,repo:null}}]'
+      elif [[ "$FAKE_MODE" == null-unrelated ]]; then
+        jq -nc --arg sha "$SHA" '[{number:294,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:$sha,repo:{id:200,full_name:"contributor/subrouter"}}},{number:295,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/subrouter"}},head:{ref:"deleted",sha:"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",repo:null}}]'
+      else
+        jq -nc --arg sha "$SHA" '[{number:294,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:$sha,repo:null}}]'
+      fi
+      ;;
+    repos/manaflow-ai/subrouter/actions/workflows\?*)
+      jq -nc '[{id:6001,path:".github/workflows/other.yml",state:"active"},{id:6002,path:".github/workflows/cla.yml",state:"active"}]' | jq '{workflows:.}'
+      ;;
+    repos/manaflow-ai/subrouter/actions/workflows/6002/runs\?*)
+      if [[ "$run_count" == 0 ]]; then
+        jq -nc '{workflow_runs:[]}'
+      else
+        jq -nc --arg sha "$SHA" --arg marker "$marker" \
+          '{workflow_runs:[{id:8001,workflow_id:6002,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$sha,head_branch:"feature",created_at:"2026-08-31T07:00:00Z",html_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001",pull_requests:[{number:294,base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:$sha}}]}]}'
+      fi
+      ;;
+    repos/manaflow-ai/subrouter/actions/runs/8001)
+      jq -nc --arg sha "$SHA" '{id:8001,workflow_id:6002,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$sha,head_branch:"feature",created_at:"2026-08-31T07:00:00Z",html_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001",pull_requests:[{number:294,base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/subrouter"}},head:{ref:"feature",sha:$sha}}]}'
+      ;;
+    repos/manaflow-ai/subrouter/actions/runs/8001/jobs\?*)
+      if [[ "$FAKE_MODE" == duplicate-job ]]; then
+        jq -nc --arg sha "$SHA" --arg marker "$marker" \
+          '{jobs:[{id:9001,run_id:8001,name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$sha,html_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001/job/9001",steps:[{name:$marker,status:"completed",conclusion:"success"}]},{id:9011,run_id:8001,name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$sha,html_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001/job/9011",steps:[{name:$marker,status:"completed",conclusion:"success"}]},{id:9002,run_id:8001,name:"CLA ledger writer",status:"completed",conclusion:"success",head_sha:$sha,steps:[]},{id:9003,run_id:8001,name:"Validate CLA trigger",status:"completed",conclusion:"success",head_sha:$sha,steps:[]}]}'
+      else
+        jq -nc --arg sha "$SHA" --arg marker "$marker" \
+          '{jobs:[{id:9001,run_id:8001,name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$sha,html_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001/job/9001",steps:[{name:$marker,status:"completed",conclusion:"success"}]},{id:9002,run_id:8001,name:"CLA ledger writer",status:"completed",conclusion:"success",head_sha:$sha,steps:[]},{id:9003,run_id:8001,name:"Validate CLA trigger",status:"completed",conclusion:"success",head_sha:$sha,steps:[]}]}'
+      fi
+      ;;
+    repos/manaflow-ai/subrouter/contents/signatures/version2/cla.json\?ref=cla-signatures)
+      if [[ "$FAKE_MODE" == partial-sign ]]; then
+        ledger_content="$(jq -nc --arg created "$COMMENT_CREATED_AT" '{signedContributors:[{name:"contributor",id:300,comment_id:900,created_at:$created,repoId:100,pullRequestNo:294}]}' | base64 | tr -d '\n')"
+        jq -nc --arg content "$ledger_content" '{type:"file",encoding:"base64",content:$content}'
+      else
+        echo "mock has no fixture for $endpoint" >&2
+        return 1
+      fi
+      ;;
+    repos/manaflow-ai/subrouter/actions/jobs/9001)
+      jq -nc --arg sha "$SHA" --arg marker "$marker" \
+        '{id:9001,run_id:8001,name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$sha,html_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001/job/9001",steps:[{name:$marker,status:"completed",conclusion:"success"}]}'
+      ;;
+    repos/manaflow-ai/subrouter/commits/*/check-runs\?*)
+      if [[ "$FAKE_MODE" == duplicate-success ]]; then
+        jq -nc --arg sha "$SHA" '{check_runs:[{id:7001,name:"CLA Assistant v3",head_sha:$sha,status:"completed",conclusion:"failure",app:{id:15368,slug:"github-actions"},details_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001/job/9001"},{id:7002,name:"CLA Assistant v3",head_sha:$sha,status:"completed",conclusion:"success",app:{id:15368,slug:"github-actions"},details_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001/job/9011"}]}'
+      else
+        jq -nc --arg sha "$SHA" --argjson count "$check_count" '
+          {check_runs: [range(0;$count) | {id:(7001 + .),name:"CLA Assistant v3",head_sha:$sha,status:"completed",conclusion:"failure",app:{id:15368,slug:"github-actions"},details_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001/job/9001"}]}
+        '
+      fi
+      ;;
+    repos/manaflow-ai/subrouter/check-runs/7001)
+      jq -nc --arg sha "$SHA" '{id:7001,name:"CLA Assistant v3",head_sha:$sha,status:"completed",conclusion:"failure",app:{id:15368,slug:"github-actions"},details_url:"https://github.com/manaflow-ai/subrouter/actions/runs/8001/job/9001"}'
+      ;;
+    *)
+      echo "mock has no fixture for $endpoint" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Export one stable command shim. The helper invokes `gh` from a bounded child
+# shell, so exporting the shim and its fixture function keeps every API call
+# on the same deterministic mock path.
+gh() { fake_gh "$@"; }
+export -f fake_gh gh
+
+run_case() {
+  local mode="$1"
+  local expected="$2"
+  local work status
+  work="$(mktemp -d)"
+  export FAKE_MODE="$mode"
+  export FAKE_POST_FILE="$work/posts"
+  : >"$FAKE_POST_FILE"
+  export GH_REPO=manaflow-ai/subrouter EVENT_NAME=issue_comment ISSUE_NUMBER=294 PR_NUMBER=294
+  export COMMENT_ID=900 COMMENT_BODY=recheck COMMENT_CREATED_AT=2026-08-31T08:00:00Z
+  export COMMENT_AUTHOR_ID=300 COMMENT_AUTHOR_LOGIN=contributor COMMENT_AUTHOR_TYPE=User
+  export COMMENT_AUTHOR_ASSOCIATION=NONE WORKFLOW_PATH=.github/workflows/cla.yml WORKFLOW_SHA
+  export CLA_GENERATION="$GENERATION" TARGET_EVENT=pull_request_target TARGET_BASE_REF=main
+  export SIGNATURE_RECORDED=false
+  export WRITER_POLICY_RESULT=true
+  export WRITER_RESULT=success
+  if [[ "$mode" == partial-sign ]]; then
+    export COMMENT_BODY='I have read the CLA Document v2.2 and I hereby sign the CLA'
+    export SIGNATURE_RECORDED=true
+    export WRITER_POLICY_RESULT=false
+  fi
+  if [[ "$mode" == no-run-unsigned ]]; then
+    export WRITER_POLICY_RESULT=false
+  fi
+  if [[ "$mode" == deleted-comment-unsigned ]]; then
+    export WRITER_POLICY_RESULT=false
+  fi
+  set +e
+  (cd "$ROOT_DIR" && bash "$SCRIPT") >"$work/output" 2>&1
+  status="$?"
+  set -e
+  if [[ "$expected" == pass ]]; then
+    [[ "$status" == 0 ]] || { cat "$work/output" >&2; echo "case $mode failed" >&2; return 1; }
+    if [[ "$mode" == no-run || "$mode" == no-run-unsigned || "$mode" == deleted-comment || "$mode" == deleted-comment-empty ]]; then
+      [[ ! -s "$FAKE_POST_FILE" ]] || { echo "case $mode unexpectedly posted" >&2; return 1; }
+    else
+      grep -Fq '/actions/runs/8001/rerun' "$FAKE_POST_FILE" || { cat "$work/output" >&2; echo "case $mode did not post full rerun" >&2; return 1; }
+    fi
+  else
+    [[ "$status" != 0 ]] || { cat "$work/output" >&2; echo "case $mode unexpectedly passed" >&2; return 1; }
+    [[ ! -s "$FAKE_POST_FILE" ]] || { cat "$work/output" >&2; echo "case $mode posted after rejection" >&2; return 1; }
+  fi
+  rm -rf "$work"
+}
+
+run_case valid pass
+run_case null-head fail
+run_case null-unrelated pass
+run_case no-run pass
+run_case no-run-unsigned fail
+run_case deleted-comment pass
+run_case deleted-comment-empty pass
+run_case deleted-comment-unsigned pass
+run_case partial-sign pass
+run_case active-run pass
+run_case many-runs fail
+run_case collision fail
+run_case duplicate-check fail
+run_case duplicate-success fail
+run_case duplicate-job fail
+run_case stale-marker fail
+run_case link-truncated fail
+run_case oversized fail
+echo "CLA rerun behavior tests passed"

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -22,6 +22,12 @@ fake_gh() {
   for arg in "$@"; do
     [[ "$arg" == repos/* ]] && endpoint="$arg"
     [[ "$arg" == POST ]] && method=POST
+    # The production helper must retain API response bodies for its bounded
+    # parser. Fail the mock if a caller suppresses the body with --silent.
+    if [[ "$arg" == --silent ]]; then
+      echo "mock rejected --silent: response bodies are required" >&2
+      return 97
+    fi
   done
   [[ -n "$endpoint" ]] || { echo "mock endpoint missing" >&2; return 1; }
   if [[ "$method" == POST ]]; then


### PR DESCRIPTION
## Summary

- Make the native `CLA Assistant v3` lifecycle job the only required-check producer.
- Replace duplicated recheck authorization with the trusted, bounded external-fork helper at workflow SHA.
- Pin `manaflow-ai/cla-github-action` to `212a0f2dd659b24b48a30ba35966e06dc41736af` and require explicit `cla_passed=true` before a signing rerun can be considered green.
- Keep ledger writes on protected `cla-signatures:signatures/version2/cla.json` with the Austin (`38676809`) and Aziz (`67667005`) opener-only allowlist.
- Split merged-PR locking into a fixed-hosted, bounded helper with `issues:write` and `pull-requests:write` only.

## Required-check and ledger activation plan

The branch already contains the empty `signatures/version2/cla.json` bootstrap and the protected `cla-signatures` branch. After this workflow is merged, verify one successful native `CLA Assistant v3` check on a real lifecycle event, then require that exact context from GitHub Actions app 15368 on `main`. Do not activate the `main` ruleset before that verification. Do not mutate ledger contents in this PR.

## Verification

- `bash tests/test_cla_recheck_auth.sh`
- `bash tests/test_cla_rerun_workflow.sh`
- `bash tests/test_cla_lock_workflow.sh`
- `actionlint .github/workflows/cla.yml`
- `shellcheck .github/scripts/*.sh tests/test_cla*.sh`
- `git diff --check`

The workflow runs trusted helpers from `${{ github.workflow_sha }}` and never checks out a pull request head. The exact-head review is intentionally pending the cmux guard incident hold.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790931411&installation_model_id=21920&pr_number=303&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F303&signature=57e06c1f487b8f0b47829d7e2af4eabf8ccf61262e126211b54e38aae8b242e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the duplicated CLA recheck and rerun paths with read-only, bounded helpers and binds the required check to the native `CLA Assistant v3` workflow. Rechecks now distinguish authorized, retryable, and invalid requests; validated GitHub 404s preserve the existing check, while malformed responses fail closed.

- Reruns require a live open PR, unchanged `recheck` comment, current `admin`/`maintain` role, and no writer token in the authorizer; external-fork PRs are handled with bounded API retries.
- The rerun helper pins `manaflow-ai/cla-github-action` to `212a0f2dd659b24b48a30ba35966e06dc41736af`, preserves API response bodies for parsing, verifies the exact failed native job and generation marker, and reruns the full workflow.
- Duplicate failed lifecycle checks are tolerated only when every same-name check on the head is a completed failure; success or in-progress duplicates fail closed.
- Merged-PR locking uses a separate helper with only `issues:write` and `pull-requests:write`, revalidating the live PR before and after locking.
- Ledger writes remain protected at `cla-signatures:signatures/version2/cla.json`, with the Austin (`38676809`) and Aziz (`67667005`) opener-only allowlist.

**Rollout**

The empty `signatures/version2/cla.json` bootstrap and protected `cla-signatures` branch are already in place. After merging, verify one real native `CLA Assistant v3` check, then require that exact context from GitHub Actions app 15368 on `main`; do not activate the `main` ruleset before verification.

<sup>Written for commit 09ef9d036f91d41675016d3bfa3609c335af23bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure handling for authorized CLA recheck requests.
  * Added automatic reruns of failed CLA validation workflows after approved recheck requests.
  * Added post-merge pull request locking with identity and lock-state verification.

* **Bug Fixes**
  * Improved handling of missing pull requests and related API responses during CLA checks.

* **Documentation**
  * Documented CLA recheck authorization and post-merge lock workflows, including permissions, validation, retries, and protections.

* **Tests**
  * Added coverage for authorization, retries, invalid requests, workflow reruns, pull request locking, and idempotent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->