### PR TITLE
deploy: carry legacy EnvironmentFile drop-ins into slot units

### DIFF
--- a/cmd/subrouter/deploy_scripts_test.go
+++ b/cmd/subrouter/deploy_scripts_test.go
@@ -4021,3 +4021,148 @@ func requireChecksumTool(t *testing.T) {
 	}
 	t.Skip("sha256sum or shasum is required for this installer test")
 }
+
+func TestFrontSlotInstallerCarriesLegacyEnvironmentFilesIntoSlotUnit(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("the installer's atomic symlink replacement uses GNU mv -T")
+	}
+	requireDeployScriptTools(t, "bash", "curl", "jq", "python3", "sha256sum")
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	for _, tc := range []struct {
+		name            string
+		legacyFiles     string
+		wantDirectives  []string
+		wantAbsentPaths []string
+	}{
+		{
+			name: "operator drop-ins follow the legacy unit into the slot template",
+			legacyFiles: "/etc/default/subrouter (ignore_errors=yes)\n" +
+				"/etc/subrouter-fable.env (ignore_errors=yes)\n" +
+				"/etc/subrouter-stack.env (ignore_errors=no)\n",
+			wantDirectives: []string{
+				"EnvironmentFile=-/etc/subrouter-fable.env\n",
+				"EnvironmentFile=/etc/subrouter-stack.env\n",
+			},
+		},
+		{
+			name:            "a legacy unit with only the defaults file adds nothing",
+			legacyFiles:     "/etc/default/subrouter (ignore_errors=yes)\n",
+			wantAbsentPaths: []string{"/etc/subrouter-fable.env", "/etc/subrouter-stack.env"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stateDir := t.TempDir()
+			fakeBin := filepath.Join(stateDir, "bin")
+			releaseRoot := filepath.Join(stateDir, "releases")
+			slotRoot := filepath.Join(stateDir, "slots")
+			frontRoot := filepath.Join(stateDir, "front")
+			controlRoot := filepath.Join(stateDir, "control")
+			unitRoot := filepath.Join(stateDir, "units")
+			logDir := filepath.Join(stateDir, "log")
+			slotEnvDir := filepath.Join(stateDir, "slot-env")
+			serviceHome := filepath.Join(stateDir, "home")
+			for _, directory := range []string{fakeBin, releaseRoot, slotRoot, frontRoot, controlRoot, unitRoot, logDir, serviceHome} {
+				if err := os.MkdirAll(directory, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			serviceUser := os.Getenv("USER")
+			if serviceUser == "" {
+				serviceUser = "nobody"
+			}
+			serviceGroupOutput, err := exec.Command("id", "-gn").Output()
+			if err != nil {
+				t.Fatal(err)
+			}
+			serviceGroup := strings.TrimSpace(string(serviceGroupOutput))
+
+			writeExecutableTestFile(t, filepath.Join(fakeBin, "id"), "#!/bin/sh\nprintf '0\\n'\n")
+			writeExecutableTestFile(t, filepath.Join(fakeBin, "curl"), "#!/bin/sh\nexit 0\n")
+			writeExecutableTestFile(t, filepath.Join(fakeBin, "python3"), "#!/bin/sh\nexit 0\n")
+			writeExecutableTestFile(t, filepath.Join(fakeBin, "systemctl"), `#!/bin/sh
+case "$1" in
+  show)
+    case "$*" in
+      *"-p User --value") printf '%s\n' "$SERVICE_USER" ;;
+      *"-p Group --value") printf '%s\n' "$SERVICE_GROUP" ;;
+      *"-p Environment --value") printf 'HOME=%s\n' "$SERVICE_HOME" ;;
+      *"-p EnvironmentFiles --value") printf '%s' "$LEGACY_ENVIRONMENT_FILES" ;;
+    esac
+    ;;
+  is-active) exit 1 ;;
+esac
+exit 0
+`)
+			releaseDir := filepath.Join(releaseRoot, "v9.9.9")
+			if err := os.MkdirAll(releaseDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeExecutableTestFile(t, filepath.Join(releaseDir, "subrouter"), "#!/bin/sh\nprintf 'commands: serve front supervise\\n'\n")
+
+			command := exec.Command(mustLookPath(t, "bash"),
+				filepath.Join(repoRoot, "deploy", "gcp", "install-front-slots.sh"),
+				"prepare-fresh-topology", "v9.9.9", "slot-a")
+			command.Env = append(os.Environ(),
+				"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+				"SERVICE_USER="+serviceUser,
+				"SERVICE_GROUP="+serviceGroup,
+				"SERVICE_HOME="+serviceHome,
+				"LEGACY_ENVIRONMENT_FILES="+tc.legacyFiles,
+				"SUBROUTER_RELEASE_ROOT="+releaseRoot,
+				"SUBROUTER_SLOT_ROOT="+slotRoot,
+				"SUBROUTER_FRONT_ROOT="+frontRoot,
+				"SUBROUTER_CONTROL_ROOT="+controlRoot,
+				"SUBROUTER_STATE_DIR="+stateDir,
+				"SUBROUTER_FRONT_CONTROL_SOCKET="+filepath.Join(stateDir, "front.sock"),
+				"SUBROUTER_FRONT_ENV="+filepath.Join(stateDir, "subrouter-front"),
+				"SUBROUTER_DEFAULTS_FILE=/etc/default/subrouter",
+				"SUBROUTER_SLOT_ENV_DIR="+slotEnvDir,
+				"SUBROUTER_LOG_DIR="+logDir,
+				"SUBROUTER_LEGACY_SERVICE=subrouter.service",
+				"SUBROUTER_SLOT_UNIT="+filepath.Join(unitRoot, "subrouter-slot@.service"),
+				"SUBROUTER_FRONT_UNIT="+filepath.Join(unitRoot, "subrouter-front.service"),
+				"SUBROUTER_VERIFY_UNIT="+filepath.Join(unitRoot, "subrouter-verify.service"),
+				"SUBROUTER_VERIFY_DROPIN_DIR="+filepath.Join(unitRoot, "subrouter-verify.service.d"),
+				"SUBROUTER_DEPLOYMENT_CONTRACT="+filepath.Join(repoRoot, "deploy", "gcp", "deployment-contract.py"),
+			)
+			if output, err := command.CombinedOutput(); err != nil {
+				t.Fatalf("prepare fresh topology: %v\n%s", err, output)
+			}
+
+			slotUnit, err := os.ReadFile(filepath.Join(unitRoot, "subrouter-slot@.service"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			frontUnit, err := os.ReadFile(filepath.Join(unitRoot, "subrouter-front.service"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			slotText := string(slotUnit)
+			if got := strings.Count(slotText, "EnvironmentFile=-/etc/default/subrouter\n"); got != 1 {
+				t.Fatalf("defaults file loaded %d times, want once:\n%s", got, slotText)
+			}
+			slotEnvLine := "EnvironmentFile=" + slotEnvDir + "/%i\n"
+			execStart := strings.Index(slotText, "ExecStart=")
+			for _, directive := range tc.wantDirectives {
+				at := strings.Index(slotText, directive)
+				if at < 0 {
+					t.Fatalf("slot unit is missing %q:\n%s", directive, slotText)
+				}
+				if at < strings.Index(slotText, slotEnvLine) || at > execStart {
+					t.Fatalf("%q must sit between the slot env file and ExecStart:\n%s", directive, slotText)
+				}
+				if strings.Contains(string(frontUnit), directive) {
+					t.Fatalf("front unit must not load worker credentials:\n%s", frontUnit)
+				}
+			}
+			for _, path := range tc.wantAbsentPaths {
+				if strings.Contains(slotText, path) {
+					t.Fatalf("slot unit unexpectedly references %s:\n%s", path, slotText)
+				}
+			}
+			if len(tc.wantDirectives) == 0 && strings.Count(slotText, "EnvironmentFile=") != 2 {
+				t.Fatalf("slot unit should load exactly the defaults and slot env files:\n%s", slotText)
+			}
+		})
+	}
+}

--- a/deploy/gcp/install-front-slots.sh
+++ b/deploy/gcp/install-front-slots.sh
@@ -195,6 +195,38 @@ install_release() {
   log "retained release ${tag} (${expected})"
 }
 
+# legacy_environment_files prints every EnvironmentFile the legacy service
+# loads, one "<path>\t<ignore_errors>" pair per line, except the shared
+# defaults file the slot template already loads. Operator drop-ins such as the
+# Bedrock and Stack credential files exist only as legacy unit drop-ins, so a
+# slot template that ignores them starts workers without those credentials.
+legacy_environment_files() {
+  local entry path ignore
+  while IFS= read -r entry; do
+    entry="${entry#EnvironmentFiles=}"
+    path="${entry%% *}"
+    [[ "${path}" == /* ]] || continue
+    [[ "${path}" != "${DEFAULTS_FILE}" ]] || continue
+    ignore=no
+    [[ "${entry}" != *"(ignore_errors=yes)"* ]] || ignore=yes
+    printf '%s\t%s\n' "${path}" "${ignore}"
+  done < <(systemctl show "${LEGACY_SERVICE}" -p EnvironmentFiles --value 2>/dev/null || true)
+}
+
+# slot_environment_file_lines renders the legacy EnvironmentFile entries as
+# slot unit directives, preserving each entry's ignore-missing flag.
+slot_environment_file_lines() {
+  local path ignore
+  while IFS=$'\t' read -r path ignore; do
+    [[ -n "${path}" ]] || continue
+    if [[ "${ignore}" == yes ]]; then
+      printf 'EnvironmentFile=-%s\n' "${path}"
+    else
+      printf 'EnvironmentFile=%s\n' "${path}"
+    fi
+  done < <(legacy_environment_files)
+}
+
 write_units() {
   local service_user service_group service_home
   service_user="$(systemctl show "${LEGACY_SERVICE}" -p User --value)"
@@ -227,7 +259,8 @@ write_units() {
   chmod 0644 "${SLOT_ENV_DIR}/slot-a" "${SLOT_ENV_DIR}/slot-b"
   write_verify_front_address "127.0.0.1:31416"
 
-  local slot_tmp front_tmp
+  local slot_tmp front_tmp legacy_environment
+  legacy_environment="$(slot_environment_file_lines)"
   slot_tmp="$(mktemp "${SLOT_UNIT}.tmp.XXXXXX")"
   front_tmp="$(mktemp "${FRONT_UNIT}.tmp.XXXXXX")"
   cat >"${slot_tmp}" <<UNIT
@@ -244,7 +277,8 @@ Environment=HOME=${service_home}
 Environment=GOMEMLIMIT=160MiB
 EnvironmentFile=-${DEFAULTS_FILE}
 EnvironmentFile=${SLOT_ENV_DIR}/%i
-ExecStart=${CONTROL_ROOT}/subrouter supervise \\
+${legacy_environment:+${legacy_environment}
+}ExecStart=${CONTROL_ROOT}/subrouter supervise \\
   --expect-proxy-protocol \\
   --addr \${SUBROUTER_SLOT_ADDR} \\
   --control-socket \${SUBROUTER_SLOT_CONTROL_SOCKET} \\


### PR DESCRIPTION
The slot unit template written by `deploy/gcp/install-front-slots.sh` loaded only `/etc/default/subrouter` and `/etc/subrouter/slots/%i`. The legacy `subrouter.service` drop-ins `/etc/subrouter-fable.env` (SUBROUTER_CLAUDE_FABLE_API_KEY) and `/etc/subrouter-stack.env` (SUBROUTER_STACK_*, SUBROUTER_PUBLIC_URL) never followed the workers, so the 2026-08-31 production `migrate-front` started slot-a without Stack tenant control. `POST /_subrouter/auth/stack` on https://sr.cmux.com returned 404 (the handler's not-configured branch) and https://cmux.com/dashboard/coderouter showed "Accounts could not load" for two days.

Production was repaired by hand on 2026-09-02: a `10-legacy-env.conf` drop-in for `subrouter-slot@.service`, then slot-b prepared on the same v0.1.63 worker, front switched, slot-a retired and disabled. This PR makes the installer do that itself.

`write_units` now reads the legacy unit's `EnvironmentFiles`, skips the defaults file it already loads, and emits one `EnvironmentFile` directive per remaining entry between the slot env file and `ExecStart`, preserving each entry's ignore-missing flag. The front unit is unchanged.

Commit 1 adds the Linux-only test (the installer uses GNU `mv -T`) and fails on `main`; commit 2 adds the fix. Verified in a `golang:1.26` container: `TestFrontSlotInstallerCarriesLegacyEnvironmentFilesIntoSlotUnit`, `TestFrontSlotInstallerSafelyBeginsDormantStaleMigrationReconciliation`, `TestFrontSlotInstallerPersistsRebootAndRollbackTargets` pass.

Follow-ups not in this PR: production's worker stays pinned to v0.1.63 because v0.1.126+ never passes `/_subrouter/ready` there (RequireIsolatedOAuth plus 17 dead Codex accounts, zero fresh usage scores); `subrouter-verify.timer` still alerts on the retired legacy unit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`deploy/gcp/install-front-slots.sh` now copies the legacy `subrouter.service` `EnvironmentFiles` into each generated `subrouter-slot@.service` unit, so operator credential drop-ins like `/etc/subrouter-fable.env` and `/etc/subrouter-stack.env` follow workers into the front topology. Previously the slot template ignored them, which caused the 2026-08-31 production migration to start slot-a without Stack tenant control (`/_subrouter/auth/stack` returned 404 and the dashboard showed "Accounts could not load" until a manual drop-in was added on 2026-09-02).

- `write_units` reads the legacy unit's `EnvironmentFiles`, skips the defaults file it already loads, and emits one `EnvironmentFile` directive per remaining entry, preserving each entry's ignore-missing flag.
- The front unit is unchanged; only the slot template carries the legacy credentials.
- Adds a Linux-only regression test that fails on `main` and passes with the fix.

<sup>Written for commit 5ffabd47b6c8f00995e6c64a64b9662775e3d859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Slot-based services now carry forward applicable environment files from the legacy service configuration.
  - Optional environment files preserve their existing behavior when files are absent.
  - Shared defaults continue to load once, while worker-specific credentials remain excluded from front units.

- **Tests**
  - Added coverage confirming environment file propagation, default-loading behavior, credential separation, and handling of missing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->