### PR TITLE
Harden security-sensitive state migration and Go toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Test optional shadow rehearsal
-        run: python3.12 deploy/tests/run-shadow-rehearsal-test.py
-
       - name: Test functional canary runner and helper
         run: |
           python3 deploy/macos/tests/run-functional-canary-test.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Test optional shadow rehearsal
-        run: python3 deploy/tests/run-shadow-rehearsal-test.py
+        run: python3.12 deploy/tests/run-shadow-rehearsal-test.py
 
       - name: Test functional canary runner and helper
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
         run: CGO_ENABLED=0 go test ./...
 
       - name: Test optional shadow rehearsal
+        # The full shadow suite runs in this required Linux job. The hosted
+        # macOS image does not permit loopback listeners from child fixtures.
         run: python3 deploy/tests/run-shadow-rehearsal-test.py
 
       # CI only builds for linux/amd64, but releases cross-compile for every

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM golang:1.24-bookworm AS build
+FROM golang:1.26-bookworm AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/deploy/run-shadow-rehearsal.py
+++ b/deploy/run-shadow-rehearsal.py
@@ -536,10 +536,7 @@ def _load_serve_args(raw_path: str | None) -> list[str]:
 
 
 def _probe(base_url: str, path: str) -> bool:
-    try:
-        if not ipaddress.ip_address(urllib.parse.urlsplit(base_url).hostname or "").is_loopback:
-            return False
-    except ValueError:
+    if not _is_loopback_base_url(base_url):
         return False
     try:
         with DIRECT_LOOPBACK_OPENER.open(base_url + path, timeout=0.5) as response:
@@ -555,10 +552,7 @@ def _probe(base_url: str, path: str) -> bool:
 
 
 def _owned_health(base_url: str, key: bytes) -> bool:
-    try:
-        if not ipaddress.ip_address(urllib.parse.urlsplit(base_url).hostname or "").is_loopback:
-            return False
-    except ValueError:
+    if not _is_loopback_base_url(base_url):
         return False
     challenge = secrets.token_bytes(32)
     request = urllib.request.Request(
@@ -575,6 +569,14 @@ def _owned_health(base_url: str, key: bytes) -> bool:
         expected = hmac.new(key, SHADOW_HEALTH_DOMAIN + challenge, hashlib.sha256).hexdigest()
         return parsed.get("ok") is True and isinstance(proof, str) and hmac.compare_digest(proof, expected)
     except (OSError, urllib.error.URLError, json.JSONDecodeError, AttributeError):
+        return False
+
+
+def _is_loopback_base_url(base_url: str) -> bool:
+    try:
+        host = urllib.parse.urlsplit(base_url).hostname or ""
+        return host.lower() == "localhost" or ipaddress.ip_address(host).is_loopback
+    except ValueError:
         return False
 
 

--- a/deploy/run-shadow-rehearsal.py
+++ b/deploy/run-shadow-rehearsal.py
@@ -412,6 +412,8 @@ def _run_callback(
 
 
 def _add_loopback_no_proxy(environment: dict[str, str]) -> None:
+    if not _is_loopback_base_url(environment.get("SUBROUTER_SHADOW_BASE_URL", "")):
+        return
     hosts = {"127.0.0.1", "localhost"}
     base_url = environment.get("SUBROUTER_SHADOW_BASE_URL", "")
     try:

--- a/deploy/run-shadow-rehearsal.py
+++ b/deploy/run-shadow-rehearsal.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import hmac
+import ipaddress
 import json
 import os
 import secrets
@@ -536,6 +537,11 @@ def _load_serve_args(raw_path: str | None) -> list[str]:
 
 def _probe(base_url: str, path: str) -> bool:
     try:
+        if not ipaddress.ip_address(urllib.parse.urlsplit(base_url).hostname or "").is_loopback:
+            return False
+    except ValueError:
+        return False
+    try:
         with DIRECT_LOOPBACK_OPENER.open(base_url + path, timeout=0.5) as response:
             if response.status != 200:
                 return False
@@ -549,6 +555,11 @@ def _probe(base_url: str, path: str) -> bool:
 
 
 def _owned_health(base_url: str, key: bytes) -> bool:
+    try:
+        if not ipaddress.ip_address(urllib.parse.urlsplit(base_url).hostname or "").is_loopback:
+            return False
+    except ValueError:
+        return False
     challenge = secrets.token_bytes(32)
     request = urllib.request.Request(
         base_url + "/_subrouter/health",

--- a/deploy/run-shadow-rehearsal.py
+++ b/deploy/run-shadow-rehearsal.py
@@ -30,6 +30,7 @@ SHADOW_HEALTH_DOMAIN = b"subrouter-shadow-health-v1\x00"
 CALLBACK_RUN_ENV = "SUBROUTER_SHADOW_CALLBACK_RUN_ID"
 CANDIDATE_RUN_ENV = "SUBROUTER_SHADOW_CANDIDATE_RUN_ID"
 PROBE_RESPONSE_MAX_BYTES = 4096
+DIRECT_LOOPBACK_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 
 CREDENTIAL_SERVE_OPTIONS = {
     "admin-token": "SUBROUTER_ADMIN_TOKEN_FILE",
@@ -516,7 +517,7 @@ def _load_serve_args(raw_path: str | None) -> list[str]:
 
 def _probe(base_url: str, path: str) -> bool:
     try:
-        with urllib.request.urlopen(base_url + path, timeout=0.5) as response:
+        with DIRECT_LOOPBACK_OPENER.open(base_url + path, timeout=0.5) as response:
             if response.status != 200:
                 return False
             body = response.read(PROBE_RESPONSE_MAX_BYTES + 1)
@@ -535,7 +536,7 @@ def _owned_health(base_url: str, key: bytes) -> bool:
         headers={SHADOW_CHALLENGE_HEADER: challenge.hex()},
     )
     try:
-        with urllib.request.urlopen(request, timeout=0.5) as response:
+        with DIRECT_LOOPBACK_OPENER.open(request, timeout=0.5) as response:
             if response.status != 200:
                 return False
             body = response.read(4096)

--- a/deploy/run-shadow-rehearsal.py
+++ b/deploy/run-shadow-rehearsal.py
@@ -358,6 +358,7 @@ def _run_callback(
     # closes accidental daemonization and ordinary setsid escapes; code that
     # deliberately clears it already has the callback's authorized privileges.
     callback_environment = dict(environment)
+    _add_loopback_no_proxy(callback_environment)
     callback_run_id = secrets.token_hex(32)
     callback_environment[CALLBACK_RUN_ENV] = callback_run_id
     with log_path.open("wb") as output:
@@ -398,6 +399,24 @@ def _run_callback(
             )
         if group_remained or detached:
             _fail("shadow callback left descendant processes")
+
+
+def _add_loopback_no_proxy(environment: dict[str, str]) -> None:
+    hosts = {"127.0.0.1", "localhost"}
+    base_url = environment.get("SUBROUTER_SHADOW_BASE_URL", "")
+    try:
+        host = urllib.parse.urlsplit(base_url).hostname
+    except ValueError:
+        host = None
+    if host:
+        hosts.add(host)
+    for variable in ("NO_PROXY", "no_proxy"):
+        existing = {
+            item.strip()
+            for item in environment.get(variable, "").split(",")
+            if item.strip()
+        }
+        environment[variable] = ",".join(sorted(existing | hosts))
 
 
 def _marked_process_ids(marker_name: str, run_id: str) -> set[int]:

--- a/deploy/run-shadow-rehearsal.py
+++ b/deploy/run-shadow-rehearsal.py
@@ -31,7 +31,16 @@ SHADOW_HEALTH_DOMAIN = b"subrouter-shadow-health-v1\x00"
 CALLBACK_RUN_ENV = "SUBROUTER_SHADOW_CALLBACK_RUN_ID"
 CANDIDATE_RUN_ENV = "SUBROUTER_SHADOW_CANDIDATE_RUN_ID"
 PROBE_RESPONSE_MAX_BYTES = 4096
-DIRECT_LOOPBACK_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, file, code, msg, headers, new_url):
+        return None
+
+
+DIRECT_LOOPBACK_OPENER = urllib.request.build_opener(
+    urllib.request.ProxyHandler({}), _NoRedirectHandler()
+)
 
 CREDENTIAL_SERVE_OPTIONS = {
     "admin-token": "SUBROUTER_ADMIN_TOKEN_FILE",

--- a/deploy/tests/run-shadow-rehearsal-test.py
+++ b/deploy/tests/run-shadow-rehearsal-test.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 RUNNER = ROOT / "deploy" / "run-shadow-rehearsal.py"
+HOSTED_STARTUP_TIMEOUT_SECONDS = 30
 
 
 def _free_port() -> int:
@@ -193,7 +194,7 @@ Path(os.environ["TEST_CALLBACK_ADDR_WITNESS"]).write_text(os.environ["SUBROUTER_
         # Hosted macOS runners can take several seconds to start a fresh
         # interpreter while the runner is under load. Keep the readiness
         # assertion strict, but do not turn scheduler delay into a false fail.
-        startup_timeout_seconds: int = 15,
+        startup_timeout_seconds: int = HOSTED_STARTUP_TIMEOUT_SECONDS,
         callback_timeout_seconds: int = 5,
     ) -> subprocess.CompletedProcess[str]:
         environment = dict(os.environ)
@@ -708,7 +709,7 @@ server.server_close()
             env=environment,
         )
         try:
-            deadline = time.monotonic() + 5
+            deadline = time.monotonic() + HOSTED_STARTUP_TIMEOUT_SECONDS
             while not _listening(port) and time.monotonic() < deadline:
                 time.sleep(0.01)
             self.assertTrue(_listening(port), "spoof listener did not start")
@@ -791,7 +792,7 @@ time.sleep(60)
         # Process startup can be delayed by concurrent cross-build and race
         # jobs on shared CI hosts; the production callback still has its own
         # explicit timeout. Wait long enough to observe that it actually began.
-        deadline = time.monotonic() + 30
+        deadline = time.monotonic() + HOSTED_STARTUP_TIMEOUT_SECONDS
         while not self.canary_witness.exists() and time.monotonic() < deadline:
             time.sleep(0.05)
         self.assertTrue(self.canary_witness.exists())
@@ -857,7 +858,7 @@ time.sleep(60)
                 "--canary-callback",
                 str(resistant),
                 "--startup-timeout-seconds",
-                "5",
+                str(HOSTED_STARTUP_TIMEOUT_SECONDS),
                 "--callback-timeout-seconds",
                 "120",
             ],
@@ -866,7 +867,7 @@ time.sleep(60)
             stderr=subprocess.PIPE,
             env=environment,
         )
-        deadline = time.monotonic() + 30
+        deadline = time.monotonic() + HOSTED_STARTUP_TIMEOUT_SECONDS
         while not self.canary_witness.exists() and time.monotonic() < deadline:
             time.sleep(0.05)
         self.assertTrue(self.canary_witness.exists(), "runner never entered resistant callback")

--- a/deploy/tests/run-shadow-rehearsal-test.py
+++ b/deploy/tests/run-shadow-rehearsal-test.py
@@ -190,7 +190,10 @@ Path(os.environ["TEST_CALLBACK_ADDR_WITNESS"]).write_text(os.environ["SUBROUTER_
         serve_args: Path | None = None,
         addr_host: str = "127.0.0.1",
         environment_overrides: dict[str, str] | None = None,
-        startup_timeout_seconds: int = 5,
+        # Hosted macOS runners can take several seconds to start a fresh
+        # interpreter while the runner is under load. Keep the readiness
+        # assertion strict, but do not turn scheduler delay into a false fail.
+        startup_timeout_seconds: int = 15,
         callback_timeout_seconds: int = 5,
     ) -> subprocess.CompletedProcess[str]:
         environment = dict(os.environ)
@@ -237,7 +240,7 @@ Path(os.environ["TEST_CALLBACK_ADDR_WITNESS"]).write_text(os.environ["SUBROUTER_
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=environment,
-            timeout=15,
+            timeout=max(30, startup_timeout_seconds + callback_timeout_seconds + 20),
         )
 
     def test_success_proves_process_listener_and_workspace_absence(self) -> None:

--- a/deploy/tests/run-shadow-rehearsal-test.py
+++ b/deploy/tests/run-shadow-rehearsal-test.py
@@ -65,7 +65,7 @@ import signal
 import subprocess
 import sys
 import time
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 parser = argparse.ArgumentParser()
@@ -129,7 +129,7 @@ class Handler(BaseHTTPRequestHandler):
     def log_message(self, *_args):
         pass
 
-server = ThreadingHTTPServer((host, int(port)), Handler)
+server = HTTPServer((host, int(port)), Handler)
 signal.signal(signal.SIGTERM, lambda *_args: (_ for _ in ()).throw(SystemExit(0)))
 server.serve_forever()
 """,
@@ -634,7 +634,7 @@ import json
 import os
 import sys
 import threading
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 class Handler(BaseHTTPRequestHandler):
@@ -656,7 +656,7 @@ class Handler(BaseHTTPRequestHandler):
     def log_message(self, *_args):
         pass
 
-server = ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler)
+server = HTTPServer(("127.0.0.1", int(sys.argv[1])), Handler)
 server.serve_forever()
 server.server_close()
 """,

--- a/deploy/tests/run-shadow-rehearsal-test.py
+++ b/deploy/tests/run-shadow-rehearsal-test.py
@@ -17,6 +17,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 RUNNER = ROOT / "deploy" / "run-shadow-rehearsal.py"
 HOSTED_STARTUP_TIMEOUT_SECONDS = 30
+HOSTED_STARTUP_OBSERVATION_MARGIN_SECONDS = 15
 
 
 def _free_port() -> int:
@@ -792,7 +793,7 @@ time.sleep(60)
         # Process startup can be delayed by concurrent cross-build and race
         # jobs on shared CI hosts; the production callback still has its own
         # explicit timeout. Wait long enough to observe that it actually began.
-        deadline = time.monotonic() + HOSTED_STARTUP_TIMEOUT_SECONDS
+        deadline = time.monotonic() + HOSTED_STARTUP_TIMEOUT_SECONDS + HOSTED_STARTUP_OBSERVATION_MARGIN_SECONDS
         while not self.canary_witness.exists() and time.monotonic() < deadline:
             time.sleep(0.05)
         self.assertTrue(self.canary_witness.exists())
@@ -867,7 +868,7 @@ time.sleep(60)
             stderr=subprocess.PIPE,
             env=environment,
         )
-        deadline = time.monotonic() + HOSTED_STARTUP_TIMEOUT_SECONDS
+        deadline = time.monotonic() + HOSTED_STARTUP_TIMEOUT_SECONDS + HOSTED_STARTUP_OBSERVATION_MARGIN_SECONDS
         while not self.canary_witness.exists() and time.monotonic() < deadline:
             time.sleep(0.05)
         self.assertTrue(self.canary_witness.exists(), "runner never entered resistant callback")

--- a/deploy/tests/run-shadow-rehearsal-test.py
+++ b/deploy/tests/run-shadow-rehearsal-test.py
@@ -781,7 +781,7 @@ time.sleep(60)
                 "--canary-callback",
                 str(sleeping),
                 "--startup-timeout-seconds",
-                "5",
+                str(HOSTED_STARTUP_TIMEOUT_SECONDS),
                 "--callback-timeout-seconds",
                 "120",
             ],

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/manaflow-ai/subrouter
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1
@@ -9,7 +9,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/klauspost/compress v1.19.0
 	github.com/mattn/go-runewidth v0.0.19
-	golang.org/x/sys v0.40.0
+	golang.org/x/sys v0.44.0
 	golang.org/x/term v0.39.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -36,7 +36,7 @@ github.com/klauspost/compress v1.19.0 h1:sXLILfc9jV2QYWkzFOPWStmcUVH2RHEB1JCdY2o
 github.com/klauspost/compress v1.19.0/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
-golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
-golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.39.0 h1:RclSuaJf32jOqZz74CkPA9qFuVTX7vhLlpfj/IGWlqY=
 golang.org/x/term v0.39.0/go.mod h1:yxzUCTP/U+FzoxfdKmLaA0RV1WgE0VY7hXBwKtY/4ww=

--- a/internal/agents/claude/migrate_test.go
+++ b/internal/agents/claude/migrate_test.go
@@ -190,7 +190,14 @@ func TestMigrateSharedStatePreservesOpenFileWritesWhenDeduplicating(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
+	if string(body) != "before\n" {
+		t.Fatalf("shared file = %q, want existing target writer preserved", body)
+	}
+	body, err = os.ReadFile(targetPath + ".subrouter-legacy-1")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if string(body) != "before\nafter\n" {
-		t.Fatalf("deduplicated file = %q, want open-file writes preserved", body)
+		t.Fatalf("retained source file = %q, want open-file writes preserved", body)
 	}
 }

--- a/internal/agents/claude/migrate_test.go
+++ b/internal/agents/claude/migrate_test.go
@@ -107,3 +107,41 @@ func TestMigrateSessionMissingEverywhere(t *testing.T) {
 		t.Fatalf("from = %q, want empty when no profile has the session", from)
 	}
 }
+
+func TestMigrateSharedStatePreservesOpenFileWrites(t *testing.T) {
+	_, sourceDir, targetDir := migrateTestStore(t)
+	sourcePath := filepath.Join(sourceDir, "projects", "history.jsonl")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(sourcePath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString("before\n"); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := migrateDirectoryToShared(filepath.Join(sourceDir, "projects"), filepath.Join(targetDir, "projects")); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString("after\n"); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(targetDir, "projects", "history.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "before\nafter\n" {
+		t.Fatalf("migrated file = %q, want open-file writes preserved", body)
+	}
+}

--- a/internal/agents/claude/migrate_test.go
+++ b/internal/agents/claude/migrate_test.go
@@ -145,3 +145,52 @@ func TestMigrateSharedStatePreservesOpenFileWrites(t *testing.T) {
 		t.Fatalf("migrated file = %q, want open-file writes preserved", body)
 	}
 }
+
+func TestMigrateSharedStatePreservesOpenFileWritesWhenDeduplicating(t *testing.T) {
+	_, sourceDir, targetDir := migrateTestStore(t)
+	sourcePath := filepath.Join(sourceDir, "projects", "history.jsonl")
+	targetPath := filepath.Join(targetDir, "projects", "history.jsonl")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(targetPath, []byte("before\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(sourcePath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if _, err := file.WriteString("before\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(targetPath, info.ModTime(), info.ModTime()); err != nil {
+		t.Fatal(err)
+	}
+	if err := migrateDirectoryToShared(filepath.Join(sourceDir, "projects"), filepath.Join(targetDir, "projects")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString("after\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "before\nafter\n" {
+		t.Fatalf("deduplicated file = %q, want open-file writes preserved", body)
+	}
+}

--- a/internal/agents/claude/shared_state_test.go
+++ b/internal/agents/claude/shared_state_test.go
@@ -91,6 +91,10 @@ func TestExistingProfileHistoryMigratesDirectoryConflicts(t *testing.T) {
 	if err := store.prepareSharedState(instance); err != nil {
 		t.Fatal(err)
 	}
+	sharedBody, err := os.ReadFile(filepath.Join(shared, "projects", "conflict"))
+	if err != nil || string(sharedBody) != "shared" {
+		t.Fatalf("shared conflict was changed: %q, %v", sharedBody, err)
+	}
 	body, err := os.ReadFile(filepath.Join(shared, "projects", "conflict.subrouter-legacy-1", "session.jsonl"))
 	if err != nil || string(body) != "profile" {
 		t.Fatalf("directory conflict was not preserved: %q, %v", body, err)

--- a/internal/agents/claude/shared_state_test.go
+++ b/internal/agents/claude/shared_state_test.go
@@ -70,6 +70,33 @@ func TestExistingProfileHistoryMigratesAndPreservesConflicts(t *testing.T) {
 	}
 }
 
+func TestExistingProfileHistoryMigratesDirectoryConflicts(t *testing.T) {
+	root := t.TempDir()
+	instance := filepath.Join(root, "profile")
+	shared := filepath.Join(root, ".claude")
+	if err := os.MkdirAll(filepath.Join(instance, "projects", "conflict"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(shared, "projects"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(instance, "projects", "conflict", "session.jsonl"), []byte("profile"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(shared, "projects", "conflict"), []byte("shared"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	store := Store{Dir: root, SharedStateDir: shared}
+	if err := store.prepareSharedState(instance); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(shared, "projects", "conflict.subrouter-legacy-1", "session.jsonl"))
+	if err != nil || string(body) != "profile" {
+		t.Fatalf("directory conflict was not preserved: %q, %v", body, err)
+	}
+}
+
 func TestConcurrentSharedStatePreparationIsIdempotent(t *testing.T) {
 	root := t.TempDir()
 	instance := filepath.Join(root, "profile")

--- a/internal/agents/claude/shared_state_windows_test.go
+++ b/internal/agents/claude/shared_state_windows_test.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+package claude
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSharedStateMigrationRejectsJunctionOutsideSourceRoot(t *testing.T) {
+	root := t.TempDir()
+	instance := filepath.Join(root, "profile")
+	shared := filepath.Join(root, "shared")
+	external := filepath.Join(root, "external")
+	if err := os.MkdirAll(filepath.Join(instance, "projects"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(shared, "projects"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(external, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(external, "secret.jsonl")
+	if err := os.WriteFile(secret, []byte("must stay outside migration root"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	junction := filepath.Join(instance, "projects", "outside")
+	output, err := exec.Command("cmd.exe", "/d", "/c", "mklink", "/J", junction, external).CombinedOutput()
+	if err != nil {
+		t.Fatalf("create test junction: %v: %s", err, output)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(junction) })
+
+	store := Store{Dir: root, SharedStateDir: shared}
+	err = store.prepareSharedState(instance)
+	if err == nil {
+		t.Fatal("migration accepted a junction that leaves the source root")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "outside") &&
+		!strings.Contains(strings.ToLower(err.Error()), "root") {
+		t.Fatalf("migration failed for an unrelated reason: %v", err)
+	}
+	if body, readErr := os.ReadFile(secret); readErr != nil || string(body) != "must stay outside migration root" {
+		t.Fatalf("external file changed after rejected migration: %q, %v", body, readErr)
+	}
+	if _, statErr := os.Lstat(filepath.Join(instance, "projects")); statErr != nil {
+		t.Fatalf("source state was removed after rejected migration: %v", statErr)
+	}
+}

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -3171,7 +3171,10 @@ func linkRootFile(source, target *os.Root, sourcePath, targetPath, sourceAbsolut
 		temporaryRelative = fmt.Sprintf("%s-%d", targetRelative+".subrouter-migrating", index)
 	}
 	if err := volumeRoot.Link(sourceRelative, temporaryRelative); err != nil {
-		return err
+		if renameErr := volumeRoot.Rename(sourceRelative, targetRelative); renameErr != nil {
+			return fmt.Errorf("link migrated file: %w (rename fallback: %v)", err, renameErr)
+		}
+		return nil
 	}
 	removeTemporary := true
 	defer func() {
@@ -3182,7 +3185,6 @@ func linkRootFile(source, target *os.Root, sourcePath, targetPath, sourceAbsolut
 	if err := volumeRoot.Link(temporaryRelative, targetRelative); err != nil {
 		return err
 	}
-	removeTemporary = false
 	info, err := volumeRoot.Lstat(sourceRelative)
 	if err != nil {
 		return err
@@ -3194,6 +3196,10 @@ func linkRootFile(source, target *os.Root, sourcePath, targetPath, sourceAbsolut
 	if !os.SameFile(info, targetInfo) {
 		return errors.New("source and target files differ after linking")
 	}
+	if err := volumeRoot.Remove(temporaryRelative); err != nil {
+		return fmt.Errorf("remove temporary migration link: %w", err)
+	}
+	removeTemporary = false
 	if err := source.Remove(sourcePath); err != nil {
 		return fmt.Errorf("remove migrated file %q: %w", sourcePath, err)
 	}

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -2790,15 +2790,12 @@ func (s Store) prepareSharedState(instancePath string) (err error) {
 func migrateDirectoryToShared(source, target string) error {
 	// The shared-state root is created by prepareSharedState, but keep this
 	// helper safe for direct callers and first-run migrations as well.
-	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
-		return fmt.Errorf("create shared parent directory: %w", err)
-	}
-	sourceParent, err := os.OpenRoot(filepath.Dir(source))
+	sourceParent, err := openMigrationDirectoryRoot(filepath.Dir(source), false)
 	if err != nil {
 		return fmt.Errorf("open profile parent root: %w", err)
 	}
 	defer sourceParent.Close()
-	targetParent, err := os.OpenRoot(filepath.Dir(target))
+	targetParent, err := openMigrationDirectoryRoot(filepath.Dir(target), true)
 	if err != nil {
 		return fmt.Errorf("open shared parent root: %w", err)
 	}
@@ -2880,6 +2877,56 @@ func migrateDirectoryToShared(source, target string) error {
 		return err
 	}
 	return nil
+}
+
+func openMigrationDirectoryRoot(path string, create bool) (*os.Root, error) {
+	path = filepath.Clean(path)
+	if resolved, resolveErr := filepath.EvalSymlinks(path); resolveErr == nil {
+		// Resolve pre-existing platform links, such as macOS /var, before the
+		// rooted walk. The root then pins the resolved directory and is not
+		// affected if the original path is replaced during migration.
+		path = resolved
+	}
+	volume := filepath.VolumeName(path)
+	rootPath := volume + string(filepath.Separator)
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		return nil, err
+	}
+	relative, err := filepath.Rel(rootPath, path)
+	if err != nil {
+		root.Close()
+		return nil, err
+	}
+	if relative == "." {
+		return root, nil
+	}
+	for _, part := range strings.Split(relative, string(filepath.Separator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		info, statErr := root.Lstat(part)
+		if errors.Is(statErr, os.ErrNotExist) && create {
+			if statErr = root.Mkdir(part, 0o700); statErr == nil {
+				info, statErr = root.Lstat(part)
+			}
+		}
+		if statErr != nil {
+			root.Close()
+			return nil, statErr
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			root.Close()
+			return nil, fmt.Errorf("migration parent component %q is not a directory", part)
+		}
+		next, openErr := root.OpenRoot(part)
+		root.Close()
+		if openErr != nil {
+			return nil, openErr
+		}
+		root = next
+	}
+	return root, nil
 }
 
 func mergeDirectoryPreservingConflicts(source, target *os.Root) error {
@@ -3059,7 +3106,12 @@ func copyRootFile(source, target *os.Root, sourcePath, targetPath string, mode o
 		_ = target.Remove(targetPath)
 		return err
 	}
-	if before.Size() != after.Size() || !before.ModTime().Equal(after.ModTime()) || !os.SameFile(before, after) {
+	named, err := source.Lstat(sourcePath)
+	if err != nil {
+		_ = target.Remove(targetPath)
+		return err
+	}
+	if before.Size() != after.Size() || !before.ModTime().Equal(after.ModTime()) || !os.SameFile(before, after) || !os.SameFile(before, named) {
 		_ = target.Remove(targetPath)
 		return fmt.Errorf("source file %q changed during migration", sourcePath)
 	}

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -2843,7 +2843,7 @@ func migrateDirectoryToShared(source, target string) error {
 			return fmt.Errorf("open shared state root: %w", err)
 		}
 		defer targetRoot.Close()
-		if err := mergeDirectoryPreservingConflicts(sourceRoot, targetRoot, target); err != nil {
+		if err := mergeDirectoryPreservingConflicts(sourceRoot, targetRoot, source, target); err != nil {
 			return err
 		}
 		if err := removeRootContents(sourceRoot); err != nil {
@@ -2983,11 +2983,11 @@ func openMigrationDirectoryRoot(path string, create bool) (*os.Root, error) {
 	return root, nil
 }
 
-func mergeDirectoryPreservingConflicts(source, target *os.Root, targetAbsolute string) error {
-	return mergeRootDirectory(source, target, ".", ".", targetAbsolute)
+func mergeDirectoryPreservingConflicts(source, target *os.Root, sourceAbsolute, targetAbsolute string) error {
+	return mergeRootDirectory(source, target, ".", ".", sourceAbsolute, targetAbsolute)
 }
 
-func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative, targetAbsolute string) error {
+func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative, sourceAbsolute, targetAbsolute string) error {
 	entries, err := readRootDirectory(source, sourceRelative)
 	if err != nil {
 		return err
@@ -3040,7 +3040,7 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative,
 			if err := target.MkdirAll(destination, 0o700); err != nil {
 				return err
 			}
-			if err := mergeRootDirectory(source, target, sourcePath, destination, targetAbsolute); err != nil {
+			if err := mergeRootDirectory(source, target, sourcePath, destination, sourceAbsolute, targetAbsolute); err != nil {
 				return err
 			}
 			if err := source.Remove(sourcePath); err != nil {
@@ -3067,7 +3067,7 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative,
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("unsupported profile state entry %q", sourcePath)
 		}
-		if err := copyRootFile(source, target, sourcePath, destination, info.Mode().Perm()); err != nil {
+		if err := linkRootFile(source, target, sourcePath, destination, sourceAbsolute, targetAbsolute); err != nil {
 			return err
 		}
 	}
@@ -3132,86 +3132,52 @@ func availableRootPath(root *os.Root, path string) (string, error) {
 	}
 }
 
-func copyRootFile(source, target *os.Root, sourcePath, targetPath string, mode os.FileMode) error {
+func linkRootFile(source, target *os.Root, sourcePath, targetPath, sourceAbsolute, targetAbsolute string) error {
 	if err := target.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
 		return err
 	}
-	input, err := source.Open(sourcePath)
+	volume := filepath.VolumeName(sourceAbsolute)
+	if volume != filepath.VolumeName(targetAbsolute) {
+		return fmt.Errorf("cannot migrate file %q across filesystem volumes", sourcePath)
+	}
+	rootPath := volume + string(filepath.Separator)
+	volumeRoot, err := os.OpenRoot(rootPath)
 	if err != nil {
 		return err
 	}
-	defer input.Close()
-	before, err := input.Stat()
+	defer volumeRoot.Close()
+	sourcePathAbsolute := filepath.Join(sourceAbsolute, sourcePath)
+	targetPathAbsolute := filepath.Join(targetAbsolute, targetPath)
+	sourceRelative, err := filepath.Rel(rootPath, sourcePathAbsolute)
 	if err != nil {
 		return err
 	}
-	temporaryPath := targetPath + ".subrouter-migrating"
-	for index := 1; ; index++ {
-		if _, statErr := target.Lstat(temporaryPath); errors.Is(statErr, os.ErrNotExist) {
-			break
-		} else if statErr != nil {
-			return statErr
-		}
-		temporaryPath = fmt.Sprintf("%s-%d", targetPath+".subrouter-migrating", index)
-	}
-	output, err := target.OpenFile(temporaryPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	targetRelative, err := filepath.Rel(rootPath, targetPathAbsolute)
 	if err != nil {
 		return err
 	}
-	removeTemporary := true
-	defer func() {
-		if removeTemporary {
-			_ = target.Remove(temporaryPath)
-		}
-	}()
-	if err := output.Chmod(mode.Perm()); err != nil {
-		_ = output.Close()
-		return err
-	}
-	if _, err := io.Copy(output, input); err != nil {
-		_ = output.Close()
-		return err
-	}
-	if err := output.Sync(); err != nil {
-		_ = output.Close()
-		return err
-	}
-	if err := setRootFileModTime(output, before.ModTime()); err != nil {
-		_ = output.Close()
-		return err
-	}
-	if err := output.Close(); err != nil {
-		return err
-	}
-	if _, err := target.Lstat(targetPath); !errors.Is(err, os.ErrNotExist) {
+	if _, err := volumeRoot.Lstat(targetRelative); !errors.Is(err, os.ErrNotExist) {
 		if err == nil {
 			return errors.New("target file appeared during migration")
 		}
 		return err
 	}
-	if err := target.Link(temporaryPath, targetPath); err != nil {
+	if err := volumeRoot.Link(sourceRelative, targetRelative); err != nil {
 		return err
 	}
-	if err := target.Remove(temporaryPath); err != nil {
-		return err
-	}
-	removeTemporary = false
-	after, err := input.Stat()
+	info, err := volumeRoot.Lstat(sourceRelative)
 	if err != nil {
 		return err
 	}
-	named, err := source.Lstat(sourcePath)
+	targetInfo, err := volumeRoot.Lstat(targetRelative)
 	if err != nil {
 		return err
 	}
-	if before.Size() != after.Size() || !before.ModTime().Equal(after.ModTime()) || !os.SameFile(before, after) || !os.SameFile(before, named) {
-		return fmt.Errorf("source file %q changed during migration", sourcePath)
-	}
-	if err := input.Close(); err != nil {
-		return err
+	if !os.SameFile(info, targetInfo) {
+		return errors.New("source and target files differ after linking")
 	}
 	if err := source.Remove(sourcePath); err != nil {
-		_ = target.Remove(targetPath)
+		_ = volumeRoot.Remove(targetRelative)
 		return fmt.Errorf("remove migrated file %q: %w", sourcePath, err)
 	}
 	return nil

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -2788,6 +2788,11 @@ func (s Store) prepareSharedState(instancePath string) (err error) {
 }
 
 func migrateDirectoryToShared(source, target string) error {
+	// The shared-state root is created by prepareSharedState, but keep this
+	// helper safe for direct callers and first-run migrations as well.
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		return fmt.Errorf("create shared parent directory: %w", err)
+	}
 	sourceParent, err := os.OpenRoot(filepath.Dir(source))
 	if err != nil {
 		return fmt.Errorf("open profile parent root: %w", err)

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -2788,8 +2788,21 @@ func (s Store) prepareSharedState(instancePath string) (err error) {
 }
 
 func migrateDirectoryToShared(source, target string) error {
-	if info, err := os.Lstat(source); err == nil && info.Mode()&os.ModeSymlink != 0 {
-		current, readErr := os.Readlink(source)
+	sourceParent, err := os.OpenRoot(filepath.Dir(source))
+	if err != nil {
+		return fmt.Errorf("open profile parent root: %w", err)
+	}
+	defer sourceParent.Close()
+	targetParent, err := os.OpenRoot(filepath.Dir(target))
+	if err != nil {
+		return fmt.Errorf("open shared parent root: %w", err)
+	}
+	defer targetParent.Close()
+	sourceName := filepath.Base(source)
+	targetName := filepath.Base(target)
+
+	if info, err := sourceParent.Lstat(sourceName); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		current, readErr := sourceParent.Readlink(sourceName)
 		if readErr != nil {
 			return readErr
 		}
@@ -2800,25 +2813,25 @@ func migrateDirectoryToShared(source, target string) error {
 		currentAbs, _ := filepath.Abs(currentPath)
 		targetAbs, _ := filepath.Abs(target)
 		if currentAbs == targetAbs {
-			return os.MkdirAll(target, 0o700)
+			return targetParent.MkdirAll(targetName, 0o700)
 		}
 		return fmt.Errorf("existing symlink points to %s", current)
 	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	if err := os.MkdirAll(target, 0o700); err != nil {
+	if err := targetParent.MkdirAll(targetName, 0o700); err != nil {
 		return err
 	}
-	if info, err := os.Lstat(source); err == nil {
+	if info, err := sourceParent.Lstat(sourceName); err == nil {
 		if !info.IsDir() {
 			return errors.New("existing profile state is not a directory")
 		}
-		sourceRoot, err := os.OpenRoot(source)
+		sourceRoot, err := sourceParent.OpenRoot(sourceName)
 		if err != nil {
 			return fmt.Errorf("open profile state root: %w", err)
 		}
 		defer sourceRoot.Close()
-		targetRoot, err := os.OpenRoot(target)
+		targetRoot, err := targetParent.OpenRoot(targetName)
 		if err != nil {
 			return fmt.Errorf("open shared state root: %w", err)
 		}
@@ -2829,29 +2842,24 @@ func migrateDirectoryToShared(source, target string) error {
 		if err := removeRootContents(sourceRoot); err != nil {
 			return err
 		}
-		parentRoot, err := os.OpenRoot(filepath.Dir(source))
-		if err != nil {
-			return fmt.Errorf("open profile parent root: %w", err)
-		}
-		defer parentRoot.Close()
-		if err := parentRoot.Remove(filepath.Base(source)); err != nil {
+		if err := sourceParent.Remove(sourceName); err != nil {
 			return fmt.Errorf("remove migrated profile state: %w", err)
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	if err := os.Symlink(target, source); err != nil {
+	if err := sourceParent.Symlink(target, sourceName); err != nil {
 		if !errors.Is(err, os.ErrExist) {
 			return err
 		}
 		// A launcher outside this process may have published the same link
 		// without using Subrouter's lock. Treat only the exact intended link as
 		// an idempotent success; every other replacement remains fail-closed.
-		info, statErr := os.Lstat(source)
+		info, statErr := sourceParent.Lstat(sourceName)
 		if statErr != nil || info.Mode()&os.ModeSymlink == 0 {
 			return err
 		}
-		current, readErr := os.Readlink(source)
+		current, readErr := sourceParent.Readlink(sourceName)
 		if readErr != nil {
 			return readErr
 		}

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -2820,6 +2820,8 @@ func migrateDirectoryToShared(source, target string) error {
 		return fmt.Errorf("existing symlink points to %s", current)
 	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
+	} else if err == nil && info.Mode()&os.ModeIrregular != 0 {
+		return errors.New("existing profile state is an unsupported reparse point")
 	}
 	if err := targetParent.MkdirAll(targetName, 0o700); err != nil {
 		return err
@@ -2974,7 +2976,7 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative,
 		if err != nil {
 			return err
 		}
-		isLink := info.Mode()&os.ModeSymlink != 0
+		isLink := info.Mode()&(os.ModeSymlink|os.ModeIrregular) != 0
 		isDirectory := !isLink && info.IsDir()
 		if targetInfo, err := target.Lstat(destination); err == nil {
 			if !isDirectory || !targetInfo.IsDir() {
@@ -2988,7 +2990,7 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative,
 						if statErr != nil {
 							return statErr
 						}
-						if !os.SameFile(info, current) || info.Size() != current.Size() || !info.ModTime().Equal(current.ModTime()) || info.Mode().Perm() != targetInfo.Mode().Perm() {
+						if !os.SameFile(info, current) || info.Size() != current.Size() || !info.ModTime().Equal(current.ModTime()) || info.Mode().Perm() != targetInfo.Mode().Perm() || !info.ModTime().Equal(targetInfo.ModTime()) {
 						} else {
 							if removeErr := source.Remove(sourcePath); removeErr != nil {
 								return fmt.Errorf("remove already migrated file %q: %w", sourcePath, removeErr)

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -2922,6 +2922,9 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative 
 			if err := mergeRootDirectory(source, target, sourcePath, destination); err != nil {
 				return err
 			}
+			if err := source.Remove(sourcePath); err != nil {
+				return fmt.Errorf("remove migrated directory %q: %w", sourcePath, err)
+			}
 			continue
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
@@ -2934,6 +2937,9 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative 
 			}
 			if err := target.Symlink(link, destination); err != nil {
 				return err
+			}
+			if err := source.Remove(sourcePath); err != nil {
+				return fmt.Errorf("remove migrated symlink %q: %w", sourcePath, err)
 			}
 			continue
 		}
@@ -2976,6 +2982,10 @@ func copyRootFile(source, target *os.Root, sourcePath, targetPath string, mode o
 		return err
 	}
 	defer input.Close()
+	before, err := input.Stat()
+	if err != nil {
+		return err
+	}
 	output, err := target.OpenFile(targetPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
 	if err != nil {
 		return err
@@ -2990,7 +3000,28 @@ func copyRootFile(source, target *os.Root, sourcePath, targetPath string, mode o
 		_ = target.Remove(targetPath)
 		return err
 	}
-	return output.Close()
+	if err := output.Close(); err != nil {
+		_ = target.Remove(targetPath)
+		return err
+	}
+	after, err := input.Stat()
+	if err != nil {
+		_ = target.Remove(targetPath)
+		return err
+	}
+	if before.Size() != after.Size() || !before.ModTime().Equal(after.ModTime()) || !os.SameFile(before, after) {
+		_ = target.Remove(targetPath)
+		return fmt.Errorf("source file %q changed during migration", sourcePath)
+	}
+	if err := input.Close(); err != nil {
+		_ = target.Remove(targetPath)
+		return err
+	}
+	if err := source.Remove(sourcePath); err != nil {
+		_ = target.Remove(targetPath)
+		return fmt.Errorf("remove migrated file %q: %w", sourcePath, err)
+	}
+	return nil
 }
 
 func removeRootContents(root *os.Root) error {

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -2838,7 +2838,7 @@ func migrateDirectoryToShared(source, target string) error {
 			return fmt.Errorf("open shared state root: %w", err)
 		}
 		defer targetRoot.Close()
-		if err := mergeDirectoryPreservingConflicts(sourceRoot, targetRoot); err != nil {
+		if err := mergeDirectoryPreservingConflicts(sourceRoot, targetRoot, target); err != nil {
 			return err
 		}
 		if err := removeRootContents(sourceRoot); err != nil {
@@ -2929,11 +2929,11 @@ func openMigrationDirectoryRoot(path string, create bool) (*os.Root, error) {
 	return root, nil
 }
 
-func mergeDirectoryPreservingConflicts(source, target *os.Root) error {
-	return mergeRootDirectory(source, target, ".", ".")
+func mergeDirectoryPreservingConflicts(source, target *os.Root, targetAbsolute string) error {
+	return mergeRootDirectory(source, target, ".", ".", targetAbsolute)
 }
 
-func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative string) error {
+func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative, targetAbsolute string) error {
 	entries, err := readRootDirectory(source, sourceRelative)
 	if err != nil {
 		return err
@@ -2960,10 +2960,17 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative 
 						return compareErr
 					}
 					if equal {
-						if removeErr := source.Remove(sourcePath); removeErr != nil {
-							return fmt.Errorf("remove already migrated file %q: %w", sourcePath, removeErr)
+						current, statErr := source.Lstat(sourcePath)
+						if statErr != nil {
+							return statErr
 						}
-						continue
+						if !os.SameFile(info, current) || info.Size() != current.Size() || !info.ModTime().Equal(current.ModTime()) {
+						} else {
+							if removeErr := source.Remove(sourcePath); removeErr != nil {
+								return fmt.Errorf("remove already migrated file %q: %w", sourcePath, removeErr)
+							}
+							continue
+						}
 					}
 				}
 				destination, err = availableRootPath(target, destination)
@@ -2978,7 +2985,7 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative 
 			if err := target.MkdirAll(destination, 0o700); err != nil {
 				return err
 			}
-			if err := mergeRootDirectory(source, target, sourcePath, destination); err != nil {
+			if err := mergeRootDirectory(source, target, sourcePath, destination, targetAbsolute); err != nil {
 				return err
 			}
 			if err := source.Remove(sourcePath); err != nil {
@@ -3005,7 +3012,7 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative 
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("unsupported profile state entry %q", sourcePath)
 		}
-		if err := copyRootFile(source, target, sourcePath, destination, info.Mode().Perm()); err != nil {
+		if err := copyRootFile(source, target, sourcePath, destination, info.Mode().Perm(), targetAbsolute); err != nil {
 			return err
 		}
 	}
@@ -3070,7 +3077,7 @@ func availableRootPath(root *os.Root, path string) (string, error) {
 	}
 }
 
-func copyRootFile(source, target *os.Root, sourcePath, targetPath string, mode os.FileMode) error {
+func copyRootFile(source, target *os.Root, sourcePath, targetPath string, mode os.FileMode, targetAbsolute string) error {
 	if err := target.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
 		return err
 	}
@@ -3100,6 +3107,23 @@ func copyRootFile(source, target *os.Root, sourcePath, targetPath string, mode o
 	if err := output.Close(); err != nil {
 		_ = target.Remove(targetPath)
 		return err
+	}
+	targetNamed, err := target.Lstat(targetPath)
+	if err != nil {
+		_ = target.Remove(targetPath)
+		return err
+	}
+	if err := os.Chtimes(filepath.Join(targetAbsolute, targetPath), before.ModTime(), before.ModTime()); err != nil {
+		_ = target.Remove(targetPath)
+		return err
+	}
+	targetAfter, err := target.Lstat(targetPath)
+	if err != nil || !os.SameFile(targetNamed, targetAfter) {
+		_ = target.Remove(targetPath)
+		if err != nil {
+			return err
+		}
+		return errors.New("target file changed while restoring modification time")
 	}
 	after, err := input.Stat()
 	if err != nil {

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -3021,8 +3021,8 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative,
 						}
 						if !os.SameFile(info, current) || info.Size() != current.Size() || !info.ModTime().Equal(current.ModTime()) || info.Mode().Perm() != targetInfo.Mode().Perm() || !info.ModTime().Equal(targetInfo.ModTime()) {
 						} else {
-							if removeErr := source.Remove(sourcePath); removeErr != nil {
-								return fmt.Errorf("remove already migrated file %q: %w", sourcePath, removeErr)
+							if err := linkRootFile(source, target, sourcePath, destination, sourceAbsolute, targetAbsolute, true); err != nil {
+								return err
 							}
 							continue
 						}
@@ -3067,7 +3067,7 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative,
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("unsupported profile state entry %q", sourcePath)
 		}
-		if err := linkRootFile(source, target, sourcePath, destination, sourceAbsolute, targetAbsolute); err != nil {
+		if err := linkRootFile(source, target, sourcePath, destination, sourceAbsolute, targetAbsolute, false); err != nil {
 			return err
 		}
 	}
@@ -3132,7 +3132,7 @@ func availableRootPath(root *os.Root, path string) (string, error) {
 	}
 }
 
-func linkRootFile(source, target *os.Root, sourcePath, targetPath, sourceAbsolute, targetAbsolute string) error {
+func linkRootFile(source, target *os.Root, sourcePath, targetPath, sourceAbsolute, targetAbsolute string, replaceExisting bool) error {
 	if err := target.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
 		return err
 	}
@@ -3156,15 +3156,40 @@ func linkRootFile(source, target *os.Root, sourcePath, targetPath, sourceAbsolut
 	if err != nil {
 		return err
 	}
-	if _, err := volumeRoot.Lstat(targetRelative); !errors.Is(err, os.ErrNotExist) {
-		if err == nil {
-			return errors.New("target file appeared during migration")
+	if !replaceExisting {
+		if _, err := volumeRoot.Lstat(targetRelative); !errors.Is(err, os.ErrNotExist) {
+			if err == nil {
+				return errors.New("target file appeared during migration")
+			}
+			return err
 		}
+	}
+	temporaryRelative := targetRelative + ".subrouter-migrating"
+	for index := 1; ; index++ {
+		if _, statErr := volumeRoot.Lstat(temporaryRelative); errors.Is(statErr, os.ErrNotExist) {
+			break
+		} else if statErr != nil {
+			return statErr
+		}
+		temporaryRelative = fmt.Sprintf("%s-%d", targetRelative+".subrouter-migrating", index)
+	}
+	if err := volumeRoot.Link(sourceRelative, temporaryRelative); err != nil {
 		return err
 	}
-	if err := volumeRoot.Link(sourceRelative, targetRelative); err != nil {
+	removeTemporary := true
+	defer func() {
+		if removeTemporary {
+			_ = volumeRoot.Remove(temporaryRelative)
+		}
+	}()
+	if replaceExisting {
+		if err := volumeRoot.Rename(temporaryRelative, targetRelative); err != nil {
+			return err
+		}
+	} else if err := volumeRoot.Link(temporaryRelative, targetRelative); err != nil {
 		return err
 	}
+	removeTemporary = false
 	info, err := volumeRoot.Lstat(sourceRelative)
 	if err != nil {
 		return err
@@ -3177,7 +3202,6 @@ func linkRootFile(source, target *os.Root, sourcePath, targetPath, sourceAbsolut
 		return errors.New("source and target files differ after linking")
 	}
 	if err := source.Remove(sourcePath); err != nil {
-		_ = volumeRoot.Remove(targetRelative)
 		return fmt.Errorf("remove migrated file %q: %w", sourcePath, err)
 	}
 	return nil

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -2880,7 +2880,11 @@ func migrateDirectoryToShared(source, target string) error {
 }
 
 func openMigrationDirectoryRoot(path string, create bool) (*os.Root, error) {
-	path = filepath.Clean(path)
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	path = filepath.Clean(absolute)
 	var suffix []string
 	for {
 		if _, statErr := os.Lstat(path); statErr == nil {

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -3145,45 +3145,66 @@ func copyRootFile(source, target *os.Root, sourcePath, targetPath string, mode o
 	if err != nil {
 		return err
 	}
-	output, err := target.OpenFile(targetPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	temporaryPath := targetPath + ".subrouter-migrating"
+	for index := 1; ; index++ {
+		if _, statErr := target.Lstat(temporaryPath); errors.Is(statErr, os.ErrNotExist) {
+			break
+		} else if statErr != nil {
+			return statErr
+		}
+		temporaryPath = fmt.Sprintf("%s-%d", targetPath+".subrouter-migrating", index)
+	}
+	output, err := target.OpenFile(temporaryPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
+		return err
+	}
+	removeTemporary := true
+	defer func() {
+		if removeTemporary {
+			_ = target.Remove(temporaryPath)
+		}
+	}()
+	if err := output.Chmod(mode.Perm()); err != nil {
+		_ = output.Close()
 		return err
 	}
 	if _, err := io.Copy(output, input); err != nil {
 		_ = output.Close()
-		_ = target.Remove(targetPath)
 		return err
 	}
 	if err := output.Sync(); err != nil {
 		_ = output.Close()
-		_ = target.Remove(targetPath)
 		return err
 	}
 	if err := setRootFileModTime(output, before.ModTime()); err != nil {
 		_ = output.Close()
-		_ = target.Remove(targetPath)
 		return err
 	}
 	if err := output.Close(); err != nil {
-		_ = target.Remove(targetPath)
 		return err
 	}
+	if _, err := target.Lstat(targetPath); !errors.Is(err, os.ErrNotExist) {
+		if err == nil {
+			return errors.New("target file appeared during migration")
+		}
+		return err
+	}
+	if err := target.Rename(temporaryPath, targetPath); err != nil {
+		return err
+	}
+	removeTemporary = false
 	after, err := input.Stat()
 	if err != nil {
-		_ = target.Remove(targetPath)
 		return err
 	}
 	named, err := source.Lstat(sourcePath)
 	if err != nil {
-		_ = target.Remove(targetPath)
 		return err
 	}
 	if before.Size() != after.Size() || !before.ModTime().Equal(after.ModTime()) || !os.SameFile(before, after) || !os.SameFile(before, named) {
-		_ = target.Remove(targetPath)
 		return fmt.Errorf("source file %q changed during migration", sourcePath)
 	}
 	if err := input.Close(); err != nil {
-		_ = target.Remove(targetPath)
 		return err
 	}
 	if err := source.Remove(sourcePath); err != nil {

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -3012,7 +3012,7 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative,
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("unsupported profile state entry %q", sourcePath)
 		}
-		if err := copyRootFile(source, target, sourcePath, destination, info.Mode().Perm(), targetAbsolute); err != nil {
+		if err := copyRootFile(source, target, sourcePath, destination, info.Mode().Perm()); err != nil {
 			return err
 		}
 	}
@@ -3077,7 +3077,7 @@ func availableRootPath(root *os.Root, path string) (string, error) {
 	}
 }
 
-func copyRootFile(source, target *os.Root, sourcePath, targetPath string, mode os.FileMode, targetAbsolute string) error {
+func copyRootFile(source, target *os.Root, sourcePath, targetPath string, mode os.FileMode) error {
 	if err := target.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
 		return err
 	}
@@ -3104,26 +3104,14 @@ func copyRootFile(source, target *os.Root, sourcePath, targetPath string, mode o
 		_ = target.Remove(targetPath)
 		return err
 	}
+	if err := setRootFileModTime(output, before.ModTime()); err != nil {
+		_ = output.Close()
+		_ = target.Remove(targetPath)
+		return err
+	}
 	if err := output.Close(); err != nil {
 		_ = target.Remove(targetPath)
 		return err
-	}
-	targetNamed, err := target.Lstat(targetPath)
-	if err != nil {
-		_ = target.Remove(targetPath)
-		return err
-	}
-	if err := os.Chtimes(filepath.Join(targetAbsolute, targetPath), before.ModTime(), before.ModTime()); err != nil {
-		_ = target.Remove(targetPath)
-		return err
-	}
-	targetAfter, err := target.Lstat(targetPath)
-	if err != nil || !os.SameFile(targetNamed, targetAfter) {
-		_ = target.Remove(targetPath)
-		if err != nil {
-			return err
-		}
-		return errors.New("target file changed while restoring modification time")
 	}
 	after, err := input.Stat()
 	if err != nil {

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -2907,6 +2907,18 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative 
 		isDirectory := info.IsDir()
 		if targetInfo, err := target.Lstat(destination); err == nil {
 			if !isDirectory || !targetInfo.IsDir() {
+				if !isDirectory && info.Mode().IsRegular() && targetInfo.Mode().IsRegular() {
+					equal, compareErr := rootFilesEqual(source, target, sourcePath, destination, info)
+					if compareErr != nil {
+						return compareErr
+					}
+					if equal {
+						if removeErr := source.Remove(sourcePath); removeErr != nil {
+							return fmt.Errorf("remove already migrated file %q: %w", sourcePath, removeErr)
+						}
+						continue
+					}
+				}
 				destination, err = availableRootPath(target, destination)
 				if err != nil {
 					return err
@@ -2951,6 +2963,44 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative 
 		}
 	}
 	return nil
+}
+
+func rootFilesEqual(source, target *os.Root, sourcePath, targetPath string, sourceInfo os.FileInfo) (bool, error) {
+	targetInfo, err := target.Stat(targetPath)
+	if err != nil {
+		return false, err
+	}
+	if sourceInfo.Size() != targetInfo.Size() {
+		return false, nil
+	}
+	input, err := source.Open(sourcePath)
+	if err != nil {
+		return false, err
+	}
+	defer input.Close()
+	output, err := target.Open(targetPath)
+	if err != nil {
+		return false, err
+	}
+	defer output.Close()
+	left := make([]byte, 32*1024)
+	right := make([]byte, len(left))
+	for {
+		leftN, leftErr := input.Read(left)
+		rightN, rightErr := output.Read(right)
+		if leftN != rightN || !bytes.Equal(left[:leftN], right[:rightN]) {
+			return false, nil
+		}
+		if leftErr == io.EOF || rightErr == io.EOF {
+			return leftErr == io.EOF && rightErr == io.EOF, nil
+		}
+		if leftErr != nil {
+			return false, leftErr
+		}
+		if rightErr != nil {
+			return false, rightErr
+		}
+	}
 }
 
 func readRootDirectory(root *os.Root, relative string) ([]os.DirEntry, error) {

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -3019,10 +3019,9 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative,
 						if statErr != nil {
 							return statErr
 						}
-						if !os.SameFile(info, current) || info.Size() != current.Size() || !info.ModTime().Equal(current.ModTime()) || info.Mode().Perm() != targetInfo.Mode().Perm() || !info.ModTime().Equal(targetInfo.ModTime()) {
-						} else {
-							if err := linkRootFile(source, target, sourcePath, destination, sourceAbsolute, targetAbsolute, true); err != nil {
-								return err
+						if os.SameFile(info, current) && info.Size() == current.Size() && info.ModTime().Equal(current.ModTime()) && info.Mode().Perm() == targetInfo.Mode().Perm() && info.ModTime().Equal(targetInfo.ModTime()) && os.SameFile(info, targetInfo) {
+							if removeErr := source.Remove(sourcePath); removeErr != nil {
+								return fmt.Errorf("remove already migrated file %q: %w", sourcePath, removeErr)
 							}
 							continue
 						}
@@ -3067,7 +3066,7 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative,
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("unsupported profile state entry %q", sourcePath)
 		}
-		if err := linkRootFile(source, target, sourcePath, destination, sourceAbsolute, targetAbsolute, false); err != nil {
+		if err := linkRootFile(source, target, sourcePath, destination, sourceAbsolute, targetAbsolute); err != nil {
 			return err
 		}
 	}
@@ -3132,7 +3131,7 @@ func availableRootPath(root *os.Root, path string) (string, error) {
 	}
 }
 
-func linkRootFile(source, target *os.Root, sourcePath, targetPath, sourceAbsolute, targetAbsolute string, replaceExisting bool) error {
+func linkRootFile(source, target *os.Root, sourcePath, targetPath, sourceAbsolute, targetAbsolute string) error {
 	if err := target.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
 		return err
 	}
@@ -3156,13 +3155,11 @@ func linkRootFile(source, target *os.Root, sourcePath, targetPath, sourceAbsolut
 	if err != nil {
 		return err
 	}
-	if !replaceExisting {
-		if _, err := volumeRoot.Lstat(targetRelative); !errors.Is(err, os.ErrNotExist) {
-			if err == nil {
-				return errors.New("target file appeared during migration")
-			}
-			return err
+	if _, err := volumeRoot.Lstat(targetRelative); !errors.Is(err, os.ErrNotExist) {
+		if err == nil {
+			return errors.New("target file appeared during migration")
 		}
+		return err
 	}
 	temporaryRelative := targetRelative + ".subrouter-migrating"
 	for index := 1; ; index++ {
@@ -3182,11 +3179,7 @@ func linkRootFile(source, target *os.Root, sourcePath, targetPath, sourceAbsolut
 			_ = volumeRoot.Remove(temporaryRelative)
 		}
 	}()
-	if replaceExisting {
-		if err := volumeRoot.Rename(temporaryRelative, targetRelative); err != nil {
-			return err
-		}
-	} else if err := volumeRoot.Link(temporaryRelative, targetRelative); err != nil {
+	if err := volumeRoot.Link(temporaryRelative, targetRelative); err != nil {
 		return err
 	}
 	removeTemporary = false

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -2881,11 +2881,30 @@ func migrateDirectoryToShared(source, target string) error {
 
 func openMigrationDirectoryRoot(path string, create bool) (*os.Root, error) {
 	path = filepath.Clean(path)
-	if resolved, resolveErr := filepath.EvalSymlinks(path); resolveErr == nil {
-		// Resolve pre-existing platform links, such as macOS /var, before the
-		// rooted walk. The root then pins the resolved directory and is not
-		// affected if the original path is replaced during migration.
-		path = resolved
+	var suffix []string
+	for {
+		if _, statErr := os.Lstat(path); statErr == nil {
+			resolved, resolveErr := filepath.EvalSymlinks(path)
+			if resolveErr != nil {
+				return nil, resolveErr
+			}
+			for index := len(suffix) - 1; index >= 0; index-- {
+				resolved = filepath.Join(resolved, suffix[index])
+			}
+			path = resolved
+			break
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return nil, statErr
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			if !create {
+				return nil, os.ErrNotExist
+			}
+			break
+		}
+		suffix = append(suffix, filepath.Base(path))
+		path = parent
 	}
 	volume := filepath.VolumeName(path)
 	rootPath := volume + string(filepath.Separator)
@@ -2964,7 +2983,7 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative,
 						if statErr != nil {
 							return statErr
 						}
-						if !os.SameFile(info, current) || info.Size() != current.Size() || !info.ModTime().Equal(current.ModTime()) {
+						if !os.SameFile(info, current) || info.Size() != current.Size() || !info.ModTime().Equal(current.ModTime()) || info.Mode().Perm() != targetInfo.Mode().Perm() {
 						} else {
 							if removeErr := source.Remove(sourcePath); removeErr != nil {
 								return fmt.Errorf("remove already migrated file %q: %w", sourcePath, removeErr)

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -2790,6 +2790,9 @@ func (s Store) prepareSharedState(instancePath string) (err error) {
 func migrateDirectoryToShared(source, target string) error {
 	// The shared-state root is created by prepareSharedState, but keep this
 	// helper safe for direct callers and first-run migrations as well.
+	if err := validateMigrationSourceParents(filepath.Dir(source)); err != nil {
+		return fmt.Errorf("validate profile parent path: %w", err)
+	}
 	sourceParent, err := openMigrationDirectoryRoot(filepath.Dir(source), false)
 	if err != nil {
 		return fmt.Errorf("open profile parent root: %w", err)
@@ -2879,6 +2882,32 @@ func migrateDirectoryToShared(source, target string) error {
 		return err
 	}
 	return nil
+}
+
+func validateMigrationSourceParents(path string) error {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	current := filepath.Clean(abs)
+	for {
+		info, statErr := os.Lstat(current)
+		if statErr == nil {
+			if info.Mode()&os.ModeIrregular != 0 {
+				return fmt.Errorf("profile parent %q is a reparse point", current)
+			}
+			if info.Mode()&os.ModeSymlink != 0 && filepath.Clean(current) != string(filepath.Separator)+"var" {
+				return fmt.Errorf("profile parent %q is a symbolic link", current)
+			}
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return statErr
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+		current = parent
+	}
 }
 
 func openMigrationDirectoryRoot(path string, create bool) (*os.Root, error) {

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -2870,20 +2870,23 @@ func migrateDirectoryToShared(source, target string) error {
 }
 
 func mergeDirectoryPreservingConflicts(source, target *os.Root) error {
-	return mergeRootDirectory(source, target, ".")
+	return mergeRootDirectory(source, target, ".", ".")
 }
 
-func mergeRootDirectory(source, target *os.Root, relative string) error {
-	entries, err := readRootDirectory(source, relative)
+func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative string) error {
+	entries, err := readRootDirectory(source, sourceRelative)
 	if err != nil {
 		return err
 	}
 	for _, entry := range entries {
-		rel := entry.Name()
-		if relative != "." {
-			rel = filepath.Join(relative, rel)
+		sourcePath := entry.Name()
+		if sourceRelative != "." {
+			sourcePath = filepath.Join(sourceRelative, sourcePath)
 		}
-		destination := rel
+		destination := entry.Name()
+		if targetRelative != "." {
+			destination = filepath.Join(targetRelative, destination)
+		}
 		if info, err := target.Lstat(destination); err == nil {
 			if !entry.IsDir() || !info.IsDir() {
 				destination, err = availableRootPath(target, destination)
@@ -2898,17 +2901,17 @@ func mergeRootDirectory(source, target *os.Root, relative string) error {
 			if err := target.MkdirAll(destination, 0o700); err != nil {
 				return err
 			}
-			if err := mergeRootDirectory(source, target, rel); err != nil {
+			if err := mergeRootDirectory(source, target, sourcePath, destination); err != nil {
 				return err
 			}
 			continue
 		}
-		info, err := source.Lstat(rel)
+		info, err := source.Lstat(sourcePath)
 		if err != nil {
 			return err
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
-			link, err := source.Readlink(rel)
+			link, err := source.Readlink(sourcePath)
 			if err != nil {
 				return err
 			}
@@ -2921,9 +2924,9 @@ func mergeRootDirectory(source, target *os.Root, relative string) error {
 			continue
 		}
 		if !info.Mode().IsRegular() {
-			return fmt.Errorf("unsupported profile state entry %q", rel)
+			return fmt.Errorf("unsupported profile state entry %q", sourcePath)
 		}
-		if err := copyRootFile(source, target, rel, destination, info.Mode().Perm()); err != nil {
+		if err := copyRootFile(source, target, sourcePath, destination, info.Mode().Perm()); err != nil {
 			return err
 		}
 	}

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -3189,7 +3189,10 @@ func copyRootFile(source, target *os.Root, sourcePath, targetPath string, mode o
 		}
 		return err
 	}
-	if err := target.Rename(temporaryPath, targetPath); err != nil {
+	if err := target.Link(temporaryPath, targetPath); err != nil {
+		return err
+	}
+	if err := target.Remove(temporaryPath); err != nil {
 		return err
 	}
 	removeTemporary = false

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -2900,8 +2900,13 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative 
 		if targetRelative != "." {
 			destination = filepath.Join(targetRelative, destination)
 		}
-		if info, err := target.Lstat(destination); err == nil {
-			if !entry.IsDir() || !info.IsDir() {
+		info, err := source.Lstat(sourcePath)
+		if err != nil {
+			return err
+		}
+		isDirectory := info.IsDir()
+		if targetInfo, err := target.Lstat(destination); err == nil {
+			if !isDirectory || !targetInfo.IsDir() {
 				destination, err = availableRootPath(target, destination)
 				if err != nil {
 					return err
@@ -2910,7 +2915,7 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative 
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
-		if entry.IsDir() {
+		if isDirectory {
 			if err := target.MkdirAll(destination, 0o700); err != nil {
 				return err
 			}
@@ -2918,10 +2923,6 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative 
 				return err
 			}
 			continue
-		}
-		info, err := source.Lstat(sourcePath)
-		if err != nil {
-			return err
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
 			link, err := source.Readlink(sourcePath)

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -2970,7 +2970,8 @@ func mergeRootDirectory(source, target *os.Root, sourceRelative, targetRelative,
 		if err != nil {
 			return err
 		}
-		isDirectory := info.IsDir()
+		isLink := info.Mode()&os.ModeSymlink != 0
+		isDirectory := !isLink && info.IsDir()
 		if targetInfo, err := target.Lstat(destination); err == nil {
 			if !isDirectory || !targetInfo.IsDir() {
 				if !isDirectory && info.Mode().IsRegular() && targetInfo.Mode().IsRegular() {

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -2809,15 +2809,33 @@ func migrateDirectoryToShared(source, target string) error {
 	if err := os.MkdirAll(target, 0o700); err != nil {
 		return err
 	}
-	if info, err := os.Stat(source); err == nil {
+	if info, err := os.Lstat(source); err == nil {
 		if !info.IsDir() {
 			return errors.New("existing profile state is not a directory")
 		}
-		if err := mergeDirectoryPreservingConflicts(source, target); err != nil {
+		sourceRoot, err := os.OpenRoot(source)
+		if err != nil {
+			return fmt.Errorf("open profile state root: %w", err)
+		}
+		defer sourceRoot.Close()
+		targetRoot, err := os.OpenRoot(target)
+		if err != nil {
+			return fmt.Errorf("open shared state root: %w", err)
+		}
+		defer targetRoot.Close()
+		if err := mergeDirectoryPreservingConflicts(sourceRoot, targetRoot); err != nil {
 			return err
 		}
-		if err := os.RemoveAll(source); err != nil {
+		if err := removeRootContents(sourceRoot); err != nil {
 			return err
+		}
+		parentRoot, err := os.OpenRoot(filepath.Dir(source))
+		if err != nil {
+			return fmt.Errorf("open profile parent root: %w", err)
+		}
+		defer parentRoot.Close()
+		if err := parentRoot.Remove(filepath.Base(source)); err != nil {
+			return fmt.Errorf("remove migrated profile state: %w", err)
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return err
@@ -2851,45 +2869,124 @@ func migrateDirectoryToShared(source, target string) error {
 	return nil
 }
 
-func mergeDirectoryPreservingConflicts(source, target string) error {
-	return filepath.WalkDir(source, func(path string, entry os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
+func mergeDirectoryPreservingConflicts(source, target *os.Root) error {
+	return mergeRootDirectory(source, target, ".")
+}
+
+func mergeRootDirectory(source, target *os.Root, relative string) error {
+	entries, err := readRootDirectory(source, relative)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		rel := entry.Name()
+		if relative != "." {
+			rel = filepath.Join(relative, rel)
 		}
-		if path == source {
-			return nil
+		destination := rel
+		if info, err := target.Lstat(destination); err == nil {
+			if !entry.IsDir() || !info.IsDir() {
+				destination, err = availableRootPath(target, destination)
+				if err != nil {
+					return err
+				}
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
 		}
-		rel, err := filepath.Rel(source, path)
+		if entry.IsDir() {
+			if err := target.MkdirAll(destination, 0o700); err != nil {
+				return err
+			}
+			if err := mergeRootDirectory(source, target, rel); err != nil {
+				return err
+			}
+			continue
+		}
+		info, err := source.Lstat(rel)
 		if err != nil {
 			return err
 		}
-		destination := filepath.Join(target, rel)
-		if entry.IsDir() {
-			return os.MkdirAll(destination, 0o700)
-		}
-		if _, err := os.Lstat(destination); errors.Is(err, os.ErrNotExist) {
-			if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			link, err := source.Readlink(rel)
+			if err != nil {
 				return err
 			}
-			return os.Rename(path, destination)
-		} else if err != nil {
-			return err
+			if err := target.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+				return err
+			}
+			if err := target.Symlink(link, destination); err != nil {
+				return err
+			}
+			continue
 		}
-		destination = availableLegacyPath(destination)
-		if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
-			return err
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("unsupported profile state entry %q", rel)
 		}
-		return os.Rename(path, destination)
-	})
-}
-
-func availableLegacyPath(path string) string {
-	for index := 1; ; index++ {
-		candidate := fmt.Sprintf("%s.subrouter-legacy-%d", path, index)
-		if _, err := os.Lstat(candidate); errors.Is(err, os.ErrNotExist) {
-			return candidate
+		if err := copyRootFile(source, target, rel, destination, info.Mode().Perm()); err != nil {
+			return err
 		}
 	}
+	return nil
+}
+
+func readRootDirectory(root *os.Root, relative string) ([]os.DirEntry, error) {
+	directory, err := root.Open(relative)
+	if err != nil {
+		return nil, err
+	}
+	defer directory.Close()
+	return directory.ReadDir(-1)
+}
+
+func availableRootPath(root *os.Root, path string) (string, error) {
+	for index := 1; ; index++ {
+		candidate := fmt.Sprintf("%s.subrouter-legacy-%d", path, index)
+		if _, err := root.Lstat(candidate); errors.Is(err, os.ErrNotExist) {
+			return candidate, nil
+		} else if err != nil {
+			return "", err
+		}
+	}
+}
+
+func copyRootFile(source, target *os.Root, sourcePath, targetPath string, mode os.FileMode) error {
+	if err := target.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
+		return err
+	}
+	input, err := source.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+	output, err := target.OpenFile(targetPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(output, input); err != nil {
+		_ = output.Close()
+		_ = target.Remove(targetPath)
+		return err
+	}
+	if err := output.Sync(); err != nil {
+		_ = output.Close()
+		_ = target.Remove(targetPath)
+		return err
+	}
+	return output.Close()
+}
+
+func removeRootContents(root *os.Root) error {
+	entries, err := readRootDirectory(root, ".")
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if err := root.RemoveAll(entry.Name()); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s Store) syncMCPServers(instancePath string) error {

--- a/internal/agents/claude/store_mtime_unix.go
+++ b/internal/agents/claude/store_mtime_unix.go
@@ -1,0 +1,15 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package claude
+
+import (
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func setRootFileModTime(file *os.File, modTime time.Time) error {
+	value := unix.NsecToTimeval(modTime.UnixNano())
+	return unix.Futimes(int(file.Fd()), []unix.Timeval{value, value})
+}

--- a/internal/agents/claude/store_mtime_windows.go
+++ b/internal/agents/claude/store_mtime_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package claude
+
+import (
+	"os"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func setRootFileModTime(file *os.File, modTime time.Time) error {
+	value := uint64(modTime.UnixNano()/100) + 116444736000000000
+	fileTime := windows.Filetime{LowDateTime: uint32(value), HighDateTime: uint32(value >> 32)}
+	return windows.SetFileTime(windows.Handle(file.Fd()), nil, &fileTime, &fileTime)
+}


### PR DESCRIPTION
## Summary
- update the Go baseline from 1.24 to 1.26 and update `golang.org/x/sys` to v0.44.0
- replace path-based Claude shared-state migration with pinned `os.Root` traversal and copy/remove operations
- add a Windows junction escape regression test

## Security rationale
The old migration used `filepath.WalkDir` and path-based `os.Rename`, which allowed a same-user process to race path checks. The new implementation confines reads, writes, and removals to pinned roots. The Windows test verifies that a junction cannot escape the source root.

## Verification
- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./cmd/subrouter ./internal/accounts ./internal/proxy`
- `go vet ./...`
- `GOTOOLCHAIN=go1.26.8+auto govulncheck ./...`
- all release target cross-builds
- Windows test package compile
- shadow rehearsal and launch-agent transaction tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791092835&installation_model_id=21920&pr_number=306&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F306&signature=858adfdc99608ae30ffb9eb8294ecc35641bbbd5626e93a434a644feccf4baf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Claude shared-state migration against path-based race conditions, makes it resumable after interruption, preserves file timestamps, and bumps the Go toolchain to 1.26 with `golang.org/x/sys` v0.44.0.

- Replaces path-based `filepath.WalkDir` and `os.Rename` with pinned `os.Root` handles, resolving and normalizing parent paths first, so a same-user process can no longer swap a parent directory mid-migration.
- Publishes each file as a hard link sharing the source inode and rejects a source that changed during copying, with a rename fallback if linking fails and cleanup of temporary migration links. A retry deduplicates an already-copied file only when source and target still share that inode with unchanged metadata; otherwise the source is retained under a legacy name. Either way, a process holding the source open keeps writing to the same inode, so interrupted migrations resume cleanly and migrated files keep their original modification times.
- Conflicts, including directory-vs-file collisions, are preserved under `.subrouter-legacy-N` names; file symlinks are recreated from their target string, and directory links such as Windows junctions and other reparse points are rejected.
- Adds regression tests proving a junction cannot escape the source root and that writes via a handle open during migration land in the migrated or retained file.
- Routes shadow health probes through a direct loopback opener that never follows redirects, accepts `localhost` and loopback addresses as valid base URLs, rejects everything else, and adds loopback hosts to `NO_PROXY` so ambient proxies can't break rehearsal.
- Raises rehearsal startup and test timeouts, uses deterministic single-threaded `HTTPServer` fixtures, pins the test runner to `python3.12`, and drops the duplicate rehearsal step from `ci.yml` so busy hosted macOS runners don't fail readiness assertions.

<sup>Written for commit 5da922b637d6d68a383adabe29aca56cf43854e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile-state migration safety by preventing access outside the intended source location.
  * Preserved source data when migration validation fails or files change during migration.
  * Retained conflicting files under legacy names instead of overwriting them.
  * Improved handling of symlinks, supported files, and file timestamps across platforms.
  * Improved shadow deployment health checks when HTTP proxy settings are present.

* **Chores**
  * Updated the application’s Go runtime and module requirements.
  * Increased shadow rehearsal startup and execution time allowances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->