### PR TITLE
Guard the supervised worker deploy path with automatic rollback

### DIFF
--- a/deploy/macos/DEPLOY.md
+++ b/deploy/macos/DEPLOY.md
@@ -57,6 +57,12 @@ human clears `/Library/LaunchDaemons/<label>.plist.supervisor-transaction/upgrad
 `subrouter-verify.sh` (every 5 minutes) keeps the contract checks and defers
 recovery whenever the guard heartbeat is fresh.
 
+The guard stands down entirely while `subrouter-deploy.sh` holds its lock, for
+up to five minutes: the deploy owns the outcome and reverts on its own, and a
+guard tick inside that window would record the untested candidate as last-good.
+For the same reason the deploy keeps its own private copy of the outgoing
+binary and rolls back to that, never to the shared last-good file.
+
 Both honor a `maintenance` sentinel younger than 90 minutes.
 
 ```bash

--- a/deploy/macos/DEPLOY.md
+++ b/deploy/macos/DEPLOY.md
@@ -1,0 +1,77 @@
+# Deploying a worker to a supervised macOS host
+
+The supervisor binds the public port only after the first worker answers
+`/_subrouter/ready` inside `--ready-timeout` (30s by default). A restart
+therefore turns a slow or broken worker into a total outage: `supervise` exits
+before it binds, launchd restarts it every 30 seconds, and clients get
+connection refused until someone puts the old binary back. That happened twice
+on cmux-lawrence on 2026-09-04 and blocked every agent on the tailnet.
+
+Replacing the binary and asking the supervisor to upgrade has no such failure
+mode. The listener stays bound, the new generation starts behind it, and the
+old generation keeps serving if the new one never becomes ready.
+
+## Install a binary
+
+```bash
+sudo subrouter-deploy.sh install /path/to/candidate --label v0.1.130
+sudo subrouter-deploy.sh status
+```
+
+`install` refuses a candidate that does not answer `--help`, refuses to start
+while health is already down, saves the serving binary as last-good, hot-swaps
+through the control socket, and restores the previous binary by itself if the
+candidate never becomes ready or public health drops.
+
+Without `--label`, `/etc/subrouter-version` records `local:<sha>`, so
+`subrouter-autoupdate.sh` replaces the build with the next release. Pass the
+label of the release you are impersonating to keep a local build in place.
+
+## Never do this
+
+```bash
+sudo cp candidate /usr/local/bin/subrouter          # no rollback, no staging
+sudo launchctl bootout system/ai.manaflow.subrouter-team   # closes the port
+sudo launchctl bootstrap system /Library/LaunchDaemons/ai.manaflow.subrouter-team.plist
+```
+
+A `bootout` is only correct when the plist itself changed, because `kickstart
+-k` reuses the cached environment. In that case set the maintenance sentinel
+first so the watchdogs do not fight the restart, and clear it after:
+
+```bash
+sudo touch /var/lib/subrouter-verify/maintenance
+# bootout, confirm the supervisor and worker pids are gone, bootstrap
+sudo rm /var/lib/subrouter-verify/maintenance
+```
+
+## Watchdogs
+
+`subrouter-guard.sh` (`ai.manaflow.subrouter-guard`, every 60s) records the
+binary that is serving traffic as last-good, and on two consecutive failed
+health probes restores it and restarts the service. That bounds a bad-worker
+outage at about two minutes. A rollback also writes the autoupdate inhibit
+sentinel, so a bad release cannot flap: worker updates stay paused until a
+human clears `/Library/LaunchDaemons/<label>.plist.supervisor-transaction/upgrade-inhibited`.
+
+`subrouter-verify.sh` (every 5 minutes) keeps the contract checks and defers
+recovery whenever the guard heartbeat is fresh.
+
+Both honor a `maintenance` sentinel younger than 90 minutes.
+
+```bash
+sudo tail -f /var/log/subrouter-guard.log
+sudo tail -f /var/log/subrouter-verify.log
+```
+
+## Recovering a host that is already down
+
+```bash
+sudo subrouter-deploy.sh rollback     # control-socket swap, listener stays up
+```
+
+If the service is restart-looping, the control socket is gone. Wait one minute
+for the guard, or do it by hand: restore
+`/var/lib/subrouter-verify/subrouter.last-good` over the binary, `bootout`,
+confirm both pids are gone (`bootstrap` fails with `Input/output error` while
+the old job drains under its 600s `ExitTimeOut`), then `bootstrap`.

--- a/deploy/macos/ai.manaflow.subrouter-guard.plist
+++ b/deploy/macos/ai.manaflow.subrouter-guard.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>ai.manaflow.subrouter-guard</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/bin/subrouter-guard.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StartInterval</key>
+	<integer>60</integer>
+	<key>Nice</key>
+	<integer>5</integer>
+	<key>StandardOutPath</key>
+	<string>/var/log/subrouter-guard.log</string>
+	<key>StandardErrorPath</key>
+	<string>/var/log/subrouter-guard.log</string>
+</dict>
+</plist>

--- a/deploy/macos/subrouter-autoupdate.sh
+++ b/deploy/macos/subrouter-autoupdate.sh
@@ -28,7 +28,9 @@ fi
 trap release_subrouter_mutation_lease EXIT
 
 if [ -e "$UPGRADE_INHIBIT_FILE" ]; then
-  log "deployment transaction is active; worker update deferred"
+  # The sentinel is also how an operator or subrouter-guard.sh pins the worker
+  # after a rollback, so print why rather than assuming a live transaction.
+  log "worker update deferred: $(sed -n '1p' "$UPGRADE_INHIBIT_FILE" 2>/dev/null || echo "$UPGRADE_INHIBIT_FILE exists")"
   exit 0
 fi
 

--- a/deploy/macos/subrouter-deploy.sh
+++ b/deploy/macos/subrouter-deploy.sh
@@ -106,11 +106,33 @@ take_lock() {
     rmdir "$LOCK_DIR" 2>/dev/null || true
     mkdir "$LOCK_DIR" 2>/dev/null || die "cannot take $LOCK_DIR"
   fi
-  trap 'rmdir "$LOCK_DIR" 2>/dev/null || true; rm -f "$UPGRADE_INHIBIT_FILE" 2>/dev/null || true' EXIT
+  trap release_lock EXIT
+}
+
+# An operator or subrouter-guard.sh can pin worker autoupdate by writing the
+# inhibit sentinel. A deploy must borrow that file, not consume it: clearing
+# someone else's pin on exit would let the updater reinstall the release the
+# pin exists to keep out.
+HAD_INHIBIT=0
+PREEXISTING_INHIBIT=""
+
+release_lock() {
+  if [ "$HAD_INHIBIT" -eq 1 ]; then
+    printf '%s\n' "$PREEXISTING_INHIBIT" >"$UPGRADE_INHIBIT_FILE" 2>/dev/null || true
+    chmod 0600 "$UPGRADE_INHIBIT_FILE" 2>/dev/null || true
+  else
+    rm -f "$UPGRADE_INHIBIT_FILE" 2>/dev/null || true
+  fi
+  rmdir "$LOCK_DIR" 2>/dev/null || true
 }
 
 inhibit_autoupdate() {
   mkdir -p "$(dirname "$UPGRADE_INHIBIT_FILE")"
+  if [ -e "$UPGRADE_INHIBIT_FILE" ]; then
+    HAD_INHIBIT=1
+    PREEXISTING_INHIBIT="$(cat "$UPGRADE_INHIBIT_FILE" 2>/dev/null || true)"
+    log "an autoupdate pin is in place; it will be restored when this deploy finishes"
+  fi
   printf 'subrouter-deploy.sh running (pid %s)\n' "$$" >"$UPGRADE_INHIBIT_FILE"
   chmod 0600 "$UPGRADE_INHIBIT_FILE"
 }

--- a/deploy/macos/subrouter-deploy.sh
+++ b/deploy/macos/subrouter-deploy.sh
@@ -193,11 +193,16 @@ cmd_install() {
   # The binary that is serving traffic right now is by definition good.
   mkdir -p "$(dirname "$LAST_GOOD")"
   cp -p "$BIN" "$LAST_GOOD"
+  # The rollback source is this private copy, never $LAST_GOOD. That file is
+  # shared with subrouter-guard.sh, which promotes whatever binary is answering
+  # health; between the swap below and the generation switch the old worker is
+  # still serving, so a guard tick there would record the untested candidate as
+  # last-good and this rollback would "restore" the candidate over itself.
   local backup="${BIN}.backup-$(date +%Y%m%d-%H%M%S)"
   cp -p "$BIN" "$backup"
   log "current worker ${current_sha:0:12} saved to $LAST_GOOD and $backup"
 
-  if ! swap_and_verify "$candidate" "$LAST_GOOD" "candidate ${candidate_sha:0:12}"; then
+  if ! swap_and_verify "$candidate" "$backup" "candidate ${candidate_sha:0:12}"; then
     die "install failed and the previous worker was restored; the listener never dropped"
   fi
 
@@ -217,7 +222,9 @@ cmd_rollback() {
   [ "$good_sha" != "$current_sha" ] || { log "last-good is already installed ($good_sha)"; exit 0; }
   take_lock
   inhibit_autoupdate
-  if ! swap_and_verify "$LAST_GOOD" "$BIN" "last-good ${good_sha:0:12}"; then
+  local rollback_from="${BIN}.rejected-$(date +%Y%m%d-%H%M%S)"
+  cp -p "$BIN" "$rollback_from"
+  if ! swap_and_verify "$LAST_GOOD" "$rollback_from" "last-good ${good_sha:0:12}"; then
     die "rollback could not take effect through the control socket; the service may be restart-looping, see subrouter-guard.sh"
   fi
   printf '%s\n' "rollback:${good_sha:0:12}" >"${VERSION_FILE}.new"

--- a/deploy/macos/subrouter-deploy.sh
+++ b/deploy/macos/subrouter-deploy.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# subrouter-deploy.sh installs a worker binary onto a supervised host without
+# ever closing the public listener.
+#
+# Why this exists: on 2026-09-04 a hand-built worker was copied over
+# /usr/local/bin/subrouter and the LaunchDaemon was booted out and bootstrapped
+# to pick it up. That binary needed longer than the supervisor's 30s
+# --ready-timeout to answer /_subrouter/ready, so `supervise` aborted before it
+# bound 0.0.0.0:31415, launchd restarted it, and the whole team lost the proxy
+# for seven minutes. A supervisor restart makes worker readiness fatal.
+#
+# The supervisor already has a failure-atomic upgrade path: replace the worker
+# binary, then POST /_subrouter/upgrade on the control socket. The supervisor
+# starts the new generation behind the still-bound listener, waits for its
+# readiness, and keeps serving from the old generation if the new one never
+# becomes ready. subrouter-autoupdate.sh has always used it. This script gives
+# operators and agents the same path for a binary that did not come from a
+# release, so the only way to lose the listener is to bypass this script.
+set -euo pipefail
+
+BIN="${SUBROUTER_BIN:-/usr/local/bin/subrouter}"
+LABEL="${SUBROUTER_LABEL:-ai.manaflow.subrouter-team}"
+PLIST="${SUBROUTER_PLIST:-/Library/LaunchDaemons/${LABEL}.plist}"
+STATE="${SUBROUTER_DEPLOY_STATE:-/var/lib/subrouter-verify}"
+LAST_GOOD="${SUBROUTER_LAST_GOOD:-${STATE}/subrouter.last-good}"
+VERSION_FILE="${SUBROUTER_VERSION_FILE:-/etc/subrouter-version}"
+HEALTH_URL="${SUBROUTER_HEALTH_URL:-http://127.0.0.1:31415/_subrouter/health}"
+UPGRADE_INHIBIT_FILE="${SUBROUTER_UPGRADE_INHIBIT_FILE:-${PLIST}.supervisor-transaction/upgrade-inhibited}"
+HEALTH_TIMEOUT_SECS="${SUBROUTER_DEPLOY_HEALTH_TIMEOUT_SECS:-45}"
+LOCK_DIR="${SUBROUTER_DEPLOY_LOCK_DIR:-${STATE}/deploy.lock}"
+
+log() { printf 'subrouter-deploy: %s\n' "$*" >&2; }
+die() { log "$*"; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage:
+  subrouter-deploy.sh install <candidate-binary> [--label <version-text>]
+  subrouter-deploy.sh rollback
+  subrouter-deploy.sh status
+
+install   Hot-swap the worker behind the live listener and roll back by itself
+          if the candidate never becomes ready or public health drops.
+rollback  Put the recorded last-good worker back the same way.
+status    Print the live binary, the recorded last-good, and health.
+
+Never run `launchctl bootout` on the subrouter LaunchDaemon to pick up a new
+worker. A restart turns a slow or broken worker into a total outage, because
+the supervisor binds the public port only after the first worker is ready.
+EOF
+}
+
+control_socket() {
+  if [ -n "${SUBROUTER_CONTROL_SOCKET:-}" ]; then
+    printf '%s\n' "$SUBROUTER_CONTROL_SOCKET"
+    return
+  fi
+  [ -f "$PLIST" ] || die "cannot find $PLIST; set SUBROUTER_CONTROL_SOCKET"
+  PLIST="$PLIST" python3 - <<'PY'
+import os, plistlib
+with open(os.environ["PLIST"], "rb") as stream:
+    arguments = plistlib.load(stream).get("ProgramArguments") or []
+for index, argument in enumerate(arguments):
+    if argument == "--control-socket" and index + 1 < len(arguments):
+        print(arguments[index + 1])
+        break
+    if argument.startswith("--control-socket="):
+        print(argument.split("=", 1)[1])
+        break
+PY
+}
+
+sha_of() { [ -f "$1" ] && shasum -a 256 "$1" | awk '{print $1}' || echo "missing"; }
+
+health_ok() { curl -fsS --max-time 5 "$HEALTH_URL" >/dev/null 2>&1; }
+
+wait_health() {
+  local deadline=$((SECONDS + HEALTH_TIMEOUT_SECS))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    health_ok && return 0
+    sleep 1
+  done
+  return 1
+}
+
+request_upgrade() {
+  local socket="$1"
+  curl -fsS --max-time 120 --unix-socket "$socket" -X POST "http://localhost/_subrouter/upgrade"
+}
+
+restore_binary() {
+  local source="$1"
+  install -m 0755 "$source" "${BIN}.rollback"
+  mv -f "${BIN}.rollback" "$BIN"
+}
+
+take_lock() {
+  mkdir -p "$STATE"
+  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    # A crashed deploy must not block the next one forever, but a live deploy
+    # must not be joined by a second writer either.
+    if [ -n "$(find "$LOCK_DIR" -maxdepth 0 -mmin -30 2>/dev/null)" ]; then
+      die "another deploy holds $LOCK_DIR (started less than 30 minutes ago)"
+    fi
+    log "clearing stale lock $LOCK_DIR"
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+    mkdir "$LOCK_DIR" 2>/dev/null || die "cannot take $LOCK_DIR"
+  fi
+  trap 'rmdir "$LOCK_DIR" 2>/dev/null || true; rm -f "$UPGRADE_INHIBIT_FILE" 2>/dev/null || true' EXIT
+}
+
+inhibit_autoupdate() {
+  mkdir -p "$(dirname "$UPGRADE_INHIBIT_FILE")"
+  printf 'subrouter-deploy.sh running (pid %s)\n' "$$" >"$UPGRADE_INHIBIT_FILE"
+  chmod 0600 "$UPGRADE_INHIBIT_FILE"
+}
+
+swap_and_verify() {
+  # swap_and_verify <new-binary> <fallback-binary> <description>
+  local candidate="$1" fallback="$2" description="$3"
+  local socket
+  socket="$(control_socket)"
+  [ -S "$socket" ] || die "control socket $socket is not a socket; is ${LABEL} running?"
+
+  install -m 0755 "$candidate" "${BIN}.new"
+  mv -f "${BIN}.new" "$BIN"
+
+  if ! request_upgrade "$socket" >/dev/null; then
+    log "${description} never became ready; the old generation is still serving"
+    restore_binary "$fallback"
+    request_upgrade "$socket" >/dev/null 2>&1 || true
+    return 1
+  fi
+
+  if ! wait_health; then
+    log "${description} took the new generation but public health failed; restoring"
+    restore_binary "$fallback"
+    request_upgrade "$socket" >/dev/null 2>&1 || true
+    wait_health || log "health is still down after restoring; check subrouter-guard.log"
+    return 1
+  fi
+  return 0
+}
+
+cmd_install() {
+  local candidate="${1:-}"
+  shift || true
+  local version_label=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --label) version_label="${2:-}"; shift 2 ;;
+      *) die "unknown option $1" ;;
+    esac
+  done
+
+  [ -n "$candidate" ] || { usage; exit 2; }
+  [ -f "$candidate" ] || die "$candidate does not exist"
+  [ -x "$candidate" ] || die "$candidate is not executable"
+  "$candidate" --help >/dev/null 2>&1 || die "$candidate does not answer --help; wrong arch or a corrupt download"
+
+  local candidate_sha current_sha
+  candidate_sha="$(sha_of "$candidate")"
+  current_sha="$(sha_of "$BIN")"
+  [ "$candidate_sha" != "$current_sha" ] || { log "candidate is already installed ($candidate_sha)"; exit 0; }
+
+  health_ok || die "public health is down right now; fix the outage before installing (subrouter-deploy.sh rollback, or check /var/log/subrouter-guard.log)"
+
+  take_lock
+  inhibit_autoupdate
+
+  # The binary that is serving traffic right now is by definition good.
+  mkdir -p "$(dirname "$LAST_GOOD")"
+  cp -p "$BIN" "$LAST_GOOD"
+  local backup="${BIN}.backup-$(date +%Y%m%d-%H%M%S)"
+  cp -p "$BIN" "$backup"
+  log "current worker ${current_sha:0:12} saved to $LAST_GOOD and $backup"
+
+  if ! swap_and_verify "$candidate" "$LAST_GOOD" "candidate ${candidate_sha:0:12}"; then
+    die "install failed and the previous worker was restored; the listener never dropped"
+  fi
+
+  printf '%s\n' "${version_label:-local:${candidate_sha:0:12}}" >"${VERSION_FILE}.new"
+  mv -f "${VERSION_FILE}.new" "$VERSION_FILE"
+  log "installed ${candidate_sha:0:12}; old connections are draining"
+  if [ -z "$version_label" ]; then
+    log "note: /etc/subrouter-version now reads local:${candidate_sha:0:12}, so subrouter-autoupdate.sh will replace this build with the next release"
+  fi
+}
+
+cmd_rollback() {
+  [ -f "$LAST_GOOD" ] || die "no recorded last-good worker at $LAST_GOOD"
+  local good_sha current_sha
+  good_sha="$(sha_of "$LAST_GOOD")"
+  current_sha="$(sha_of "$BIN")"
+  [ "$good_sha" != "$current_sha" ] || { log "last-good is already installed ($good_sha)"; exit 0; }
+  take_lock
+  inhibit_autoupdate
+  if ! swap_and_verify "$LAST_GOOD" "$BIN" "last-good ${good_sha:0:12}"; then
+    die "rollback could not take effect through the control socket; the service may be restart-looping, see subrouter-guard.sh"
+  fi
+  printf '%s\n' "rollback:${good_sha:0:12}" >"${VERSION_FILE}.new"
+  mv -f "${VERSION_FILE}.new" "$VERSION_FILE"
+  log "rolled back to ${good_sha:0:12}"
+}
+
+cmd_status() {
+  printf 'live      %s %s\n' "$BIN" "$(sha_of "$BIN")"
+  printf 'last-good %s %s\n' "$LAST_GOOD" "$(sha_of "$LAST_GOOD")"
+  printf 'version   %s\n' "$(cat "$VERSION_FILE" 2>/dev/null || echo unknown)"
+  if health_ok; then printf 'health    ok\n'; else printf 'health    DOWN\n'; fi
+}
+
+case "${1:-}" in
+  install) shift; cmd_install "$@" ;;
+  rollback) shift; cmd_rollback "$@" ;;
+  status) shift; cmd_status "$@" ;;
+  -h|--help|help|"") usage ;;
+  *) usage; exit 2 ;;
+esac

--- a/deploy/macos/subrouter-guard.sh
+++ b/deploy/macos/subrouter-guard.sh
@@ -37,6 +37,10 @@ HEALTH_WAIT_SECS="${SUBROUTER_GUARD_HEALTH_WAIT_SECS:-45}"
 # Injectable so the test can assert on launchd calls without touching launchd.
 LAUNCHCTL="${SUBROUTER_LAUNCHCTL:-launchctl}"
 UPGRADE_INHIBIT_FILE="${SUBROUTER_UPGRADE_INHIBIT_FILE:-${PLIST}.supervisor-transaction/upgrade-inhibited}"
+DEPLOY_LOCK_DIR="${SUBROUTER_DEPLOY_LOCK_DIR:-${STATE}/deploy.lock}"
+DEPLOY_LOCK_GRACE_MINS="${SUBROUTER_GUARD_DEPLOY_LOCK_GRACE_MINS:-5}"
+GUARD_LOCK_DIR="${SUBROUTER_GUARD_LOCK_DIR:-${STATE}/guard.lock}"
+GUARD_LOCK_STALE_MINS="${SUBROUTER_GUARD_LOCK_STALE_MINS:-10}"
 
 mkdir -p "$STATE"
 now_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -95,6 +99,29 @@ restart_service() {
 }
 
 : >"$HEARTBEAT"
+
+# One actor at a time. launchd will not overlap this job with itself, but an
+# operator running it by hand during a scheduled run would double-restart the
+# service, and this job kills processes.
+if ! mkdir "$GUARD_LOCK_DIR" 2>/dev/null; then
+  if [ -n "$(find "$GUARD_LOCK_DIR" -maxdepth 0 -mmin "-${GUARD_LOCK_STALE_MINS}" 2>/dev/null)" ]; then
+    emit INFO "another subrouter-guard run holds $GUARD_LOCK_DIR"
+    exit 0
+  fi
+  emit ALERT "clearing stale guard lock $GUARD_LOCK_DIR"
+  rmdir "$GUARD_LOCK_DIR" 2>/dev/null || true
+  mkdir "$GUARD_LOCK_DIR" 2>/dev/null || { emit ALERT "cannot take $GUARD_LOCK_DIR"; exit 0; }
+fi
+trap 'rmdir "$GUARD_LOCK_DIR" 2>/dev/null || true' EXIT
+
+# subrouter-deploy.sh owns the outcome while it runs: it swaps the binary,
+# waits for the new generation, and reverts on its own. A guard tick inside
+# that window would either record the untested candidate as last-good or
+# restart the service under the deploy, so stand down and say so.
+if [ -d "$DEPLOY_LOCK_DIR" ] && [ -n "$(find "$DEPLOY_LOCK_DIR" -maxdepth 0 -mmin "-${DEPLOY_LOCK_GRACE_MINS}" 2>/dev/null)" ]; then
+  emit INFO "subrouter-deploy.sh holds $DEPLOY_LOCK_DIR; standing down this cycle"
+  exit 0
+fi
 
 if probe_health; then
   rm -f "$STRIKES_FILE"

--- a/deploy/macos/subrouter-guard.sh
+++ b/deploy/macos/subrouter-guard.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# subrouter-guard.sh is the fast outage watchdog for the supervised proxy.
+#
+# subrouter-verify.sh already self-heals a service that was booted out or
+# wedged, but it runs every five minutes and its recovery is a kickstart. A
+# kickstart cannot fix the failure that actually took the fleet down on
+# 2026-09-04: a worker binary that never answers /_subrouter/ready inside the
+# supervisor's --ready-timeout makes `supervise` exit before it binds the
+# public port, so launchd restarts it every 30 seconds and the port stays
+# closed no matter how often it is kicked. The only recovery is to put the
+# previous worker binary back.
+#
+# So this job does two things a health check alone cannot:
+#   - while health is good, it records the serving binary as last-good
+#   - while health is down, it restores that binary and restarts the service
+#
+# It runs every 60 seconds and acts on the second consecutive failure, which
+# bounds a bad-worker outage at about two minutes without reacting to a single
+# transient probe failure.
+set -uo pipefail
+
+LABEL="${SUBROUTER_LABEL:-ai.manaflow.subrouter-team}"
+PLIST="${SUBROUTER_PLIST:-/Library/LaunchDaemons/${LABEL}.plist}"
+BIN="${SUBROUTER_BIN:-/usr/local/bin/subrouter}"
+SUPERVISOR_BIN="${SUBROUTER_SUPERVISOR_BIN:-/usr/local/libexec/subrouter-supervisor}"
+STATE="${SUBROUTER_VERIFY_STATE:-/var/lib/subrouter-verify}"
+LAST_GOOD="${SUBROUTER_LAST_GOOD:-${STATE}/subrouter.last-good}"
+HEALTH="${SUBROUTER_HEALTH_URL:-http://127.0.0.1:31415/_subrouter/health}"
+ALERTS="${SUBROUTER_ALERTS_FILE:-${STATE}/alerts.log}"
+HEARTBEAT="${SUBROUTER_GUARD_HEARTBEAT:-${STATE}/guard.heartbeat}"
+STRIKES_FILE="${STATE}/guard.strikes"
+MAINTENANCE="${STATE}/maintenance"
+STRIKE_THRESHOLD="${SUBROUTER_GUARD_STRIKE_THRESHOLD:-2}"
+PROBE_TIMEOUT_SECS="${SUBROUTER_GUARD_PROBE_TIMEOUT_SECS:-4}"
+RESTART_WAIT_SECS="${SUBROUTER_GUARD_RESTART_WAIT_SECS:-10}"
+HEALTH_WAIT_SECS="${SUBROUTER_GUARD_HEALTH_WAIT_SECS:-45}"
+# Injectable so the test can assert on launchd calls without touching launchd.
+LAUNCHCTL="${SUBROUTER_LAUNCHCTL:-launchctl}"
+UPGRADE_INHIBIT_FILE="${SUBROUTER_UPGRADE_INHIBIT_FILE:-${PLIST}.supervisor-transaction/upgrade-inhibited}"
+
+mkdir -p "$STATE"
+now_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+emit() { # level msg...
+  local level="$1"; shift
+  local line="$now_iso [$level] $*"
+  echo "SUBROUTER-GUARD $line"
+  echo "guard $line" >>"$ALERTS" 2>/dev/null || true
+}
+
+probe_health() { curl -fsS --max-time "$PROBE_TIMEOUT_SECS" "$HEALTH" >/dev/null 2>&1; }
+
+wait_health() {
+  local deadline=$((SECONDS + HEALTH_WAIT_SECS))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    probe_health && return 0
+    sleep 2
+  done
+  return 1
+}
+
+sha_of() { [ -f "$1" ] && shasum -a 256 "$1" | awk '{print $1}' || echo "missing"; }
+
+read_strikes() {
+  local value
+  value="$(cat "$STRIKES_FILE" 2>/dev/null || echo 0)"
+  case "$value" in ''|*[!0-9]*) value=0 ;; esac
+  printf '%s' "$value"
+}
+
+# Exact-path pids only. A pattern like `pkill -f subrouter` on a shared box
+# kills unrelated sessions, and this job runs as root.
+supervisor_pids() { pgrep -f "^${SUPERVISOR_BIN} supervise" 2>/dev/null | tr '\n' ' '; }
+worker_pids() { pgrep -f "^${BIN} serve " 2>/dev/null | tr '\n' ' '; }
+
+restart_service() {
+  # A restart-looping supervisor has to be removed from the launchd domain and
+  # confirmed dead before bootstrap, or bootstrap fails with
+  # "Input/output error" while the old job drains under its ExitTimeOut.
+  "$LAUNCHCTL" bootout "system/${LABEL}" >/dev/null 2>&1 || true
+  local deadline=$((SECONDS + RESTART_WAIT_SECS))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    [ -z "$(supervisor_pids)$(worker_pids)" ] && break
+    sleep 1
+  done
+  local leftover
+  leftover="$(supervisor_pids)$(worker_pids)"
+  if [ -n "${leftover// /}" ]; then
+    emit ALERT "force killing draining pids: ${leftover}"
+    # shellcheck disable=SC2086
+    kill -KILL ${leftover} 2>/dev/null || true
+    sleep 2
+  fi
+  "$LAUNCHCTL" bootstrap system "$PLIST" >/dev/null 2>&1 || true
+}
+
+: >"$HEARTBEAT"
+
+if probe_health; then
+  rm -f "$STRIKES_FILE"
+  live_sha="$(sha_of "$BIN")"
+  good_sha="$(sha_of "$LAST_GOOD")"
+  if [ "$live_sha" != "missing" ] && [ "$live_sha" != "$good_sha" ]; then
+    # The binary answering health right now is the one worth keeping.
+    mkdir -p "$(dirname "$LAST_GOOD")"
+    if cp -p "$BIN" "${LAST_GOOD}.new" && mv -f "${LAST_GOOD}.new" "$LAST_GOOD"; then
+      emit INFO "recorded last-good worker ${live_sha:0:12}"
+    else
+      rm -f "${LAST_GOOD}.new"
+      emit ALERT "could not record last-good worker ${live_sha:0:12}"
+    fi
+  fi
+  exit 0
+fi
+
+strikes=$(( $(read_strikes) + 1 ))
+printf '%s\n' "$strikes" >"$STRIKES_FILE"
+
+if [ -e "$MAINTENANCE" ] && [ -n "$(find "$MAINTENANCE" -mmin -90 2>/dev/null)" ]; then
+  emit INFO "health down (strike ${strikes}); fresh maintenance sentinel, no recovery"
+  exit 0
+fi
+
+if [ "$strikes" -lt "$STRIKE_THRESHOLD" ]; then
+  emit ALERT "health down (strike ${strikes}/${STRIKE_THRESHOLD}); acting next cycle if it persists"
+  exit 0
+fi
+
+live_sha="$(sha_of "$BIN")"
+good_sha="$(sha_of "$LAST_GOOD")"
+
+if [ "$good_sha" != "missing" ] && [ "$live_sha" != "$good_sha" ]; then
+  emit ALERT "health down ${strikes} cycles with worker ${live_sha:0:12}; rolling back to last-good ${good_sha:0:12}"
+  cp -p "$BIN" "${BIN}.rejected-$(date +%Y%m%d-%H%M%S)" 2>/dev/null || true
+  # Stop subrouter-autoupdate.sh before it reinstalls the binary we are about
+  # to remove. Without this, a bad release flaps: updater installs it, guard
+  # rolls it back, updater installs it again two minutes later. Worker updates
+  # stay paused until a human clears the sentinel, which is the safe direction
+  # after an automatic rollback.
+  mkdir -p "$(dirname "$UPGRADE_INHIBIT_FILE")" 2>/dev/null || true
+  printf 'subrouter-guard.sh rolled back worker %s at %s; clear this file after review\n' \
+    "${live_sha:0:12}" "$now_iso" >"$UPGRADE_INHIBIT_FILE" 2>/dev/null || true
+  chmod 0600 "$UPGRADE_INHIBIT_FILE" 2>/dev/null || true
+  emit ALERT "worker autoupdate paused by $UPGRADE_INHIBIT_FILE until a human clears it"
+  if install -m 0755 "$LAST_GOOD" "${BIN}.rollback" && mv -f "${BIN}.rollback" "$BIN"; then
+    restart_service
+  else
+    rm -f "${BIN}.rollback"
+    emit ALERT "could not write ${BIN}; rollback failed"
+  fi
+elif ! "$LAUNCHCTL" print "system/${LABEL}" >/dev/null 2>&1; then
+  emit ALERT "health down ${strikes} cycles and ${LABEL} is not in the launchd domain; bootstrapping"
+  [ -f "$PLIST" ] && "$LAUNCHCTL" bootstrap system "$PLIST" >/dev/null 2>&1
+else
+  emit ALERT "health down ${strikes} cycles on the last-good worker; restarting ${LABEL}"
+  restart_service
+fi
+
+if wait_health; then
+  emit INFO "recovery succeeded: health answering again"
+  rm -f "$STRIKES_FILE"
+else
+  emit ALERT "recovery did not restore health; this needs a human"
+fi

--- a/deploy/macos/subrouter-verify.sh
+++ b/deploy/macos/subrouter-verify.sh
@@ -103,8 +103,19 @@ ver=$(cat /etc/subrouter-version 2>/dev/null || echo unknown)
 PLIST="${SUBROUTER_PLIST:-/Library/LaunchDaemons/${LABEL}.plist}"
 MAINTENANCE="$STATE/maintenance"
 DOWN_MARKER="$STATE/health.down"
+GUARD_HEARTBEAT="${SUBROUTER_GUARD_HEARTBEAT:-$STATE/guard.heartbeat}"
+# subrouter-guard.sh probes every 60s and can also roll a bad worker binary
+# back, which this five-minute pass cannot. When it is alive, it owns recovery:
+# two jobs kickstarting the same service in the same window race each other and
+# make the logs unreadable. Alerts below stay unconditional either way.
+guard_alive=0
+if [ -e "$GUARD_HEARTBEAT" ] && [ -n "$(find "$GUARD_HEARTBEAT" -mmin -3 2>/dev/null)" ]; then
+  guard_alive=1
+fi
 if [ "$health_ok" -eq 0 ]; then
-  if [ -e "$MAINTENANCE" ] && [ -n "$(find "$MAINTENANCE" -mmin -90 2>/dev/null)" ]; then
+  if [ "$guard_alive" -eq 1 ]; then
+    emit INFO "service down; subrouter-guard.sh is live and owns recovery"
+  elif [ -e "$MAINTENANCE" ] && [ -n "$(find "$MAINTENANCE" -mmin -90 2>/dev/null)" ]; then
     emit INFO "service down; maintenance sentinel is fresh, skipping recovery ($MAINTENANCE)"
   else
     if [ -e "$MAINTENANCE" ]; then

--- a/deploy/macos/tests/deploy-install-test.sh
+++ b/deploy/macos/tests/deploy-install-test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Exercises subrouter-deploy.sh against a fake supervisor control socket and a
+# file-backed health probe. Nothing here touches a real service.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY="$HERE/../subrouter-deploy.sh"
+failures=0
+
+check() {
+  if [ "$2" -eq 0 ]; then printf 'ok   %s\n' "$1"
+  else printf 'FAIL %s\n' "$1"; failures=$((failures + 1)); fi
+}
+
+start_fake_supervisor() { # start_fake_supervisor <upgrade-exit-code>
+  UPGRADE_MODE="$1"
+  python3 - "$ROOT/control.sock" "$UPGRADE_MODE" "$ROOT/health" "$ROOT/upgrade.calls" <<'PY' &
+import http.server, json, os, socket, socketserver, sys, threading
+
+path, mode, health, calls = sys.argv[1:5]
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        with open(calls, "a") as stream:
+            stream.write(self.path + "\n")
+        if mode == "fail":
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(b"not ready")
+            return
+        if mode == "unhealthy":
+            # The generation switches, but the public port stops answering.
+            try:
+                os.remove(health)
+            except FileNotFoundError:
+                pass
+        body = json.dumps({"active": {"id": "gen-2"}}).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+class Server(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    address_family = socket.AF_UNIX
+    def server_bind(self):
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        socketserver.TCPServer.server_bind(self)
+
+Server(path, Handler).serve_forever()
+PY
+  FAKE_PID=$!
+  for _ in $(seq 1 50); do [ -S "$ROOT/control.sock" ] && break; sleep 0.1; done
+}
+
+setup() { # setup <upgrade-mode>
+  ROOT="$(mktemp -d)"
+  mkdir -p "$ROOT/bin" "$ROOT/state" "$ROOT/etc"
+  printf '#!/bin/sh\nexit 0\n' >"$ROOT/bin/subrouter"; chmod 0755 "$ROOT/bin/subrouter"
+  printf '#!/bin/sh\n# candidate\nexit 0\n' >"$ROOT/candidate"; chmod 0755 "$ROOT/candidate"
+  printf 'ok\n' >"$ROOT/health"
+  : >"$ROOT/upgrade.calls"
+  export SUBROUTER_BIN="$ROOT/bin/subrouter"
+  export SUBROUTER_DEPLOY_STATE="$ROOT/state"
+  export SUBROUTER_LAST_GOOD="$ROOT/state/subrouter.last-good"
+  export SUBROUTER_VERSION_FILE="$ROOT/etc/subrouter-version"
+  export SUBROUTER_HEALTH_URL="file://$ROOT/health"
+  export SUBROUTER_CONTROL_SOCKET="$ROOT/control.sock"
+  export SUBROUTER_UPGRADE_INHIBIT_FILE="$ROOT/transaction/upgrade-inhibited"
+  export SUBROUTER_DEPLOY_LOCK_DIR="$ROOT/state/deploy.lock"
+  export SUBROUTER_DEPLOY_HEALTH_TIMEOUT_SECS=3
+  start_fake_supervisor "$1"
+}
+
+teardown() { kill "$FAKE_PID" 2>/dev/null; wait "$FAKE_PID" 2>/dev/null; rm -rf "$ROOT"; }
+
+# 1. A candidate that becomes ready is installed and recorded.
+setup ok
+bash "$DEPLOY" install "$ROOT/candidate" --label v9.9.9 >/dev/null 2>&1
+rc=$?
+[ "$rc" -eq 0 ] && cmp -s "$ROOT/bin/subrouter" "$ROOT/candidate"
+check "a ready candidate is installed" $?
+[ "$(cat "$SUBROUTER_VERSION_FILE")" = "v9.9.9" ]
+check "the version label is recorded" $?
+[ -f "$SUBROUTER_LAST_GOOD" ]
+check "the previous worker is saved as last-good" $?
+[ ! -e "$SUBROUTER_UPGRADE_INHIBIT_FILE" ]
+check "a clean deploy leaves no autoupdate pin behind" $?
+teardown
+
+# 2. A candidate that never becomes ready is rolled back inside the script.
+setup fail
+before="$(shasum -a 256 "$ROOT/bin/subrouter" | awk '{print $1}')"
+bash "$DEPLOY" install "$ROOT/candidate" >/dev/null 2>&1
+rc=$?
+after="$(shasum -a 256 "$ROOT/bin/subrouter" | awk '{print $1}')"
+[ "$rc" -ne 0 ] && [ "$before" = "$after" ]
+check "a candidate that fails readiness is reverted and reported" $?
+[ ! -s "$SUBROUTER_VERSION_FILE" ] 2>/dev/null || [ ! -f "$SUBROUTER_VERSION_FILE" ]
+check "a failed install does not record a version" $?
+teardown
+
+# 3. A candidate that switches but kills public health is rolled back too.
+setup unhealthy
+before="$(shasum -a 256 "$ROOT/bin/subrouter" | awk '{print $1}')"
+bash "$DEPLOY" install "$ROOT/candidate" >/dev/null 2>&1
+rc=$?
+after="$(shasum -a 256 "$ROOT/bin/subrouter" | awk '{print $1}')"
+[ "$rc" -ne 0 ] && [ "$before" = "$after" ]
+check "a candidate that breaks public health is reverted" $?
+[ "$(wc -l <"$ROOT/upgrade.calls")" -ge 2 ]
+check "the restored binary is switched back in through the control socket" $?
+teardown
+
+# 4. An operator pin survives a deploy.
+setup ok
+mkdir -p "$(dirname "$SUBROUTER_UPGRADE_INHIBIT_FILE")"
+printf 'pinned by hand\n' >"$SUBROUTER_UPGRADE_INHIBIT_FILE"
+bash "$DEPLOY" install "$ROOT/candidate" >/dev/null 2>&1
+grep -q "pinned by hand" "$SUBROUTER_UPGRADE_INHIBIT_FILE" 2>/dev/null
+check "an existing autoupdate pin is restored after a deploy" $?
+teardown
+
+# 5. An install is refused while public health is already down.
+setup ok
+rm -f "$ROOT/health"
+before="$(shasum -a 256 "$ROOT/bin/subrouter" | awk '{print $1}')"
+bash "$DEPLOY" install "$ROOT/candidate" >/dev/null 2>&1
+rc=$?
+after="$(shasum -a 256 "$ROOT/bin/subrouter" | awk '{print $1}')"
+[ "$rc" -ne 0 ] && [ "$before" = "$after" ]
+check "install is refused during an outage" $?
+teardown
+
+# 6. rollback puts the recorded last-good binary back.
+setup ok
+mkdir -p "$ROOT/state"
+printf '#!/bin/sh\nexit 0\n# good\n' >"$SUBROUTER_LAST_GOOD"; chmod 0755 "$SUBROUTER_LAST_GOOD"
+bash "$DEPLOY" rollback >/dev/null 2>&1
+rc=$?
+[ "$rc" -eq 0 ] && cmp -s "$ROOT/bin/subrouter" "$SUBROUTER_LAST_GOOD"
+check "rollback installs the recorded last-good worker" $?
+teardown
+
+if [ "$failures" -ne 0 ]; then printf '%d check(s) failed\n' "$failures"; exit 1; fi
+printf 'all checks passed\n'

--- a/deploy/macos/tests/deploy-install-test.sh
+++ b/deploy/macos/tests/deploy-install-test.sh
@@ -14,16 +14,22 @@ check() {
 
 start_fake_supervisor() { # start_fake_supervisor <upgrade-exit-code>
   UPGRADE_MODE="$1"
-  python3 - "$ROOT/control.sock" "$UPGRADE_MODE" "$ROOT/health" "$ROOT/upgrade.calls" <<'PY' &
+  python3 - "$ROOT/control.sock" "$UPGRADE_MODE" "$ROOT/health" "$ROOT/upgrade.calls" "$SUBROUTER_LAST_GOOD" "$ROOT/bin/subrouter" <<'PY' &
 import http.server, json, os, socket, socketserver, sys, threading
 
-path, mode, health, calls = sys.argv[1:5]
+path, mode, health, calls, last_good, live = sys.argv[1:7]
 
 class Handler(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
         with open(calls, "a") as stream:
             stream.write(self.path + "\n")
-        if mode == "fail":
+        if mode == "clobber_fail":
+            # Stand in for a subrouter-guard tick that promotes whatever binary
+            # is on disk while the old generation still answers health.
+            os.makedirs(os.path.dirname(last_good), exist_ok=True)
+            with open(live, "rb") as source, open(last_good, "wb") as target:
+                target.write(source.read())
+        if mode in ("fail", "clobber_fail"):
             self.send_response(500)
             self.end_headers()
             self.wfile.write(b"not ready")
@@ -146,6 +152,17 @@ bash "$DEPLOY" rollback >/dev/null 2>&1
 rc=$?
 [ "$rc" -eq 0 ] && cmp -s "$ROOT/bin/subrouter" "$SUBROUTER_LAST_GOOD"
 check "rollback installs the recorded last-good worker" $?
+teardown
+
+# 7. Regression: the rollback source must be private to this deploy. Sharing
+# $LAST_GOOD with subrouter-guard.sh let a guard tick record the untested
+# candidate mid-install, so the "rollback" restored the candidate over itself.
+setup clobber_fail
+before="$(shasum -a 256 "$ROOT/bin/subrouter" | awk '{print $1}')"
+bash "$DEPLOY" install "$ROOT/candidate" >/dev/null 2>&1
+after="$(shasum -a 256 "$ROOT/bin/subrouter" | awk '{print $1}')"
+[ "$before" = "$after" ]
+check "rollback survives last-good being overwritten mid-install" $?
 teardown
 
 if [ "$failures" -ne 0 ]; then printf '%d check(s) failed\n' "$failures"; exit 1; fi

--- a/deploy/macos/tests/guard-rollback-test.sh
+++ b/deploy/macos/tests/guard-rollback-test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Exercises subrouter-guard.sh decision paths against a fake launchd and a
+# file-backed health probe. Nothing here touches the real service.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$HERE/../subrouter-guard.sh"
+failures=0
+
+check() { # check <description> <condition-result>
+  if [ "$2" -eq 0 ]; then
+    printf 'ok   %s\n' "$1"
+  else
+    printf 'FAIL %s\n' "$1"
+    failures=$((failures + 1))
+  fi
+}
+
+setup() {
+  ROOT="$(mktemp -d)"
+  mkdir -p "$ROOT/state" "$ROOT/bin"
+  printf 'live\n' >"$ROOT/bin/subrouter"
+  chmod 0755 "$ROOT/bin/subrouter"
+  cat >"$ROOT/bin/launchctl" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$LAUNCHCTL_CALLS"
+[ "${1:-}" = "print" ] && exit "${LAUNCHCTL_PRINT_EXIT:-0}"
+exit 0
+FAKE
+  chmod 0755 "$ROOT/bin/launchctl"
+  : >"$ROOT/calls"
+  export LAUNCHCTL_CALLS="$ROOT/calls"
+  export SUBROUTER_VERIFY_STATE="$ROOT/state"
+  export SUBROUTER_BIN="$ROOT/bin/subrouter"
+  export SUBROUTER_SUPERVISOR_BIN="$ROOT/bin/subrouter-supervisor"
+  export SUBROUTER_LAST_GOOD="$ROOT/state/subrouter.last-good"
+  export SUBROUTER_HEALTH_URL="file://$ROOT/health"
+  export SUBROUTER_PLIST="$ROOT/service.plist"
+  export SUBROUTER_LAUNCHCTL="$ROOT/bin/launchctl"
+  export SUBROUTER_UPGRADE_INHIBIT_FILE="$ROOT/transaction/upgrade-inhibited"
+  export SUBROUTER_GUARD_HEALTH_WAIT_SECS=1
+  export SUBROUTER_GUARD_RESTART_WAIT_SECS=1
+  export SUBROUTER_GUARD_PROBE_TIMEOUT_SECS=2
+  : >"$ROOT/service.plist"
+}
+
+teardown() { rm -rf "$ROOT"; }
+
+healthy() { printf 'ok\n' >"$ROOT/health"; }
+unhealthy() { rm -f "$ROOT/health"; }
+
+# 1. A healthy pass records the serving binary as last-good.
+setup
+healthy
+bash "$GUARD" >/dev/null 2>&1
+[ -f "$SUBROUTER_LAST_GOOD" ] && [ "$(cat "$SUBROUTER_LAST_GOOD")" = "live" ]
+check "healthy pass records last-good" $?
+
+# 2. A single failed probe only counts a strike.
+unhealthy
+bash "$GUARD" >/dev/null 2>&1
+[ "$(cat "$ROOT/state/guard.strikes")" = "1" ] && [ ! -s "$LAUNCHCTL_CALLS" ]
+check "first failure takes no action" $?
+teardown
+
+# 3. Two failures on a binary that differs from last-good roll it back.
+setup
+healthy
+bash "$GUARD" >/dev/null 2>&1          # records last-good = "live"
+printf 'broken\n' >"$ROOT/bin/subrouter"
+unhealthy
+bash "$GUARD" >/dev/null 2>&1
+bash "$GUARD" >/dev/null 2>&1
+[ "$(cat "$ROOT/bin/subrouter")" = "live" ]
+check "second failure restores the last-good worker" $?
+grep -q "^bootout system/" "$LAUNCHCTL_CALLS" && grep -q "^bootstrap system " "$LAUNCHCTL_CALLS"
+check "rollback restarts the service with bootout then bootstrap" $?
+ls "$ROOT"/bin/subrouter.rejected-* >/dev/null 2>&1
+check "rollback keeps the rejected binary for inspection" $?
+[ -f "$SUBROUTER_UPGRADE_INHIBIT_FILE" ]
+check "rollback pauses worker autoupdate so a bad release cannot flap" $?
+teardown
+
+# 4. Two failures on the last-good binary restart without touching the binary.
+setup
+healthy
+bash "$GUARD" >/dev/null 2>&1
+unhealthy
+bash "$GUARD" >/dev/null 2>&1
+bash "$GUARD" >/dev/null 2>&1
+[ "$(cat "$ROOT/bin/subrouter")" = "live" ] && ! ls "$ROOT"/bin/subrouter.rejected-* >/dev/null 2>&1
+check "no rollback when the live worker is already last-good" $?
+grep -q "^bootout system/" "$LAUNCHCTL_CALLS"
+check "unhealthy last-good worker still gets a restart" $?
+[ ! -f "$SUBROUTER_UPGRADE_INHIBIT_FILE" ]
+check "a plain restart leaves worker autoupdate enabled" $?
+teardown
+
+# 5. A fresh maintenance sentinel suppresses recovery entirely.
+setup
+healthy
+bash "$GUARD" >/dev/null 2>&1
+printf 'broken\n' >"$ROOT/bin/subrouter"
+unhealthy
+: >"$ROOT/state/maintenance"
+bash "$GUARD" >/dev/null 2>&1
+bash "$GUARD" >/dev/null 2>&1
+[ "$(cat "$ROOT/bin/subrouter")" = "broken" ] && [ ! -s "$LAUNCHCTL_CALLS" ]
+check "fresh maintenance sentinel blocks rollback and restart" $?
+teardown
+
+# 6. Recovery that restores health clears the strike counter.
+setup
+healthy
+bash "$GUARD" >/dev/null 2>&1
+printf 'broken\n' >"$ROOT/bin/subrouter"
+unhealthy
+bash "$GUARD" >/dev/null 2>&1
+export SUBROUTER_GUARD_HEALTH_WAIT_SECS=10
+( sleep 1; healthy ) &
+bash "$GUARD" >/dev/null 2>&1
+wait
+[ ! -f "$ROOT/state/guard.strikes" ]
+check "successful recovery clears the strike counter" $?
+teardown
+
+if [ "$failures" -ne 0 ]; then
+  printf '%d check(s) failed\n' "$failures"
+  exit 1
+fi
+printf 'all checks passed\n'

--- a/deploy/macos/tests/guard-rollback-test.sh
+++ b/deploy/macos/tests/guard-rollback-test.sh
@@ -38,6 +38,8 @@ FAKE
   export SUBROUTER_PLIST="$ROOT/service.plist"
   export SUBROUTER_LAUNCHCTL="$ROOT/bin/launchctl"
   export SUBROUTER_UPGRADE_INHIBIT_FILE="$ROOT/transaction/upgrade-inhibited"
+  export SUBROUTER_DEPLOY_LOCK_DIR="$ROOT/state/deploy.lock"
+  export SUBROUTER_GUARD_LOCK_DIR="$ROOT/state/guard.lock"
   export SUBROUTER_GUARD_HEALTH_WAIT_SECS=1
   export SUBROUTER_GUARD_RESTART_WAIT_SECS=1
   export SUBROUTER_GUARD_PROBE_TIMEOUT_SECS=2
@@ -122,6 +124,45 @@ bash "$GUARD" >/dev/null 2>&1
 wait
 [ ! -f "$ROOT/state/guard.strikes" ]
 check "successful recovery clears the strike counter" $?
+teardown
+
+# 7. A running deploy owns the outcome: no promotion, no restart, no rollback.
+setup
+healthy
+mkdir -p "$SUBROUTER_DEPLOY_LOCK_DIR"
+printf 'candidate\n' >"$ROOT/bin/subrouter"
+bash "$GUARD" >/dev/null 2>&1
+[ ! -f "$SUBROUTER_LAST_GOOD" ]
+check "no last-good promotion while a deploy holds the lock" $?
+unhealthy
+bash "$GUARD" >/dev/null 2>&1
+bash "$GUARD" >/dev/null 2>&1
+[ "$(cat "$ROOT/bin/subrouter")" = "candidate" ] && [ ! -s "$LAUNCHCTL_CALLS" ]
+check "no rollback or restart while a deploy holds the lock" $?
+teardown
+
+# 8. A stale deploy lock must not disable the guard for ever.
+setup
+healthy
+bash "$GUARD" >/dev/null 2>&1
+mkdir -p "$SUBROUTER_DEPLOY_LOCK_DIR"
+# Backdate the lock past the grace window.
+touch -t "$(date -v-30M +%Y%m%d%H%M 2>/dev/null || date -d '30 minutes ago' +%Y%m%d%H%M)" "$SUBROUTER_DEPLOY_LOCK_DIR"
+printf 'broken\n' >"$ROOT/bin/subrouter"
+unhealthy
+bash "$GUARD" >/dev/null 2>&1
+bash "$GUARD" >/dev/null 2>&1
+[ "$(cat "$ROOT/bin/subrouter")" = "live" ]
+check "a stale deploy lock does not block recovery" $?
+teardown
+
+# 9. A second concurrent guard run does nothing.
+setup
+healthy
+mkdir -p "$SUBROUTER_GUARD_LOCK_DIR"
+bash "$GUARD" >/dev/null 2>&1
+[ ! -f "$SUBROUTER_LAST_GOOD" ]
+check "a concurrent guard run stands down" $?
 teardown
 
 if [ "$failures" -ne 0 ]; then


### PR DESCRIPTION
Twice on 2026-09-04 a hand-installed worker binary took the team proxy on cmux-lawrence completely down. The supervisor binds the public port only after the first worker answers `/_subrouter/ready` inside `--ready-timeout`, so a worker that starts too slowly makes `supervise` exit before it binds; launchd then restart-loops it and clients get connection refused. Recovery both times was restoring the previous binary by hand.

`subrouter-verify.sh` detected it but its recovery is a kickstart, which cannot fix a binary that will never become ready, and it only runs every five minutes.

This adds two things.

`subrouter-deploy.sh` gives operators the failure-atomic path `subrouter-autoupdate.sh` already uses for releases: swap the binary, POST `/_subrouter/upgrade` on the control socket, restore the previous binary if the candidate never becomes ready or public health drops. The listener never closes.

`subrouter-guard.sh` (new 60s LaunchDaemon) covers a bypass of that path. While health is good it records the serving binary as last-good; after two consecutive failed probes it restores last-good and restarts the service, bounding the outage at about two minutes. A rollback sets the autoupdate inhibit sentinel so a bad release cannot be reinstalled every two minutes, and `subrouter-verify.sh` now defers recovery while the guard heartbeat is fresh so the two jobs cannot race.

`deploy/macos/DEPLOY.md` documents the path and the one case where `bootout` is still correct (a plist change), with the maintenance sentinel.

Tests: `deploy/macos/tests/guard-rollback-test.sh` drives the guard against a fake launchd and a file-backed health probe, covering last-good promotion, the strike threshold, rollback vs plain restart, the autoupdate pause, the maintenance sentinel, and strike clearing. All pass.

Both scripts and the guard job are installed and live on cmux-lawrence.

https://claude.ai/code/session_01KhBTe7aDNkqgQLH14687j9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791106619&installation_model_id=21920&pr_number=307&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F307&signature=517f4114caa84d5d12d6ee67b81cd5f82f8aea0e120d001448b6ce3584d107f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a slow or broken worker binary from taking the supervised macOS proxy down, as happened twice on cmux-lawrence on 2026-09-04. Adds a failure-atomic deploy script and a 60s watchdog that restores the last-good binary automatically, bounding outages at about two minutes.

**New Features**
- `subrouter-deploy.sh` hot-swaps workers through the control socket and rolls back to its own private copy of the previous binary if the candidate never becomes ready or public health drops; the listener never closes.
- `subrouter-guard.sh` runs as the `ai.manaflow.subrouter-guard` LaunchDaemon every 60s, records the serving binary as last-good, and rolls back on the second consecutive failed probe; it stands down while a deploy holds its lock.
- A guard rollback writes the autoupdate inhibit sentinel so a bad release cannot flap; worker updates stay paused until a human clears it.
- `subrouter-deploy.sh` preserves an existing autoupdate pin instead of deleting it, and `subrouter-autoupdate.sh` reports the pin's reason instead of assuming a live transaction.
- `subrouter-verify.sh` defers recovery while the guard heartbeat is fresh so the two jobs do not race.
- `deploy/macos/DEPLOY.md` documents the install path and when a `bootout` is still correct; tests cover the deploy and guard decision paths against a fake supervisor and launchd.

Both scripts and the guard job are installed and live on cmux-lawrence.

<sup>Written for commit 517da09587ef878ea1d7ae7c732e6b0314076e13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safer macOS worker updates with live listener continuity, health checks, rollback, and deployment status options.
  * Added automatic monitoring that restores the last known-good worker after repeated health failures.
  * Added safeguards to prevent conflicting automatic updates during deployments and recovery.

* **Bug Fixes**
  * Improved verification and recovery behavior by coordinating with the monitoring process, avoiding duplicate recovery actions.

* **Documentation**
  * Added macOS deployment and recovery guidance, including update procedures, watchdog behavior, and manual recovery steps.

* **Tests**
  * Added coverage for health checks, rollback scenarios, maintenance mode, and recovery outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->