### PR TITLE
Bind the public listener even when the first worker is not ready

### DIFF
--- a/cmd/subrouter/supervisor.go
+++ b/cmd/subrouter/supervisor.go
@@ -273,12 +273,17 @@ func startWorkerGeneration(config supervisorConfig, role generationRole) (*worke
 		done:      make(chan struct{}),
 	}
 	go func() { generation.setWaitError(command.Wait()) }()
-	if err := waitForWorkerReady(generation, config.ReadyTimeout); err != nil {
-		if role == generationReplacement || workerAlreadyExited(generation) {
+	answered, err := waitForWorkerReady(generation, config.ReadyTimeout)
+	if err != nil {
+		// A worker that never answered is not serving anything, so binding in
+		// front of it would only turn connection refused into 502s while
+		// hiding a hard failure. Only an unready-but-answering worker is worth
+		// serving with.
+		if role == generationReplacement || workerAlreadyExited(generation) || !answered {
 			terminateWorker(generation, time.Second)
 			return nil, err
 		}
-		slog.Error("initial worker did not report ready; serving with it anyway rather than leaving the public port closed",
+		slog.Error("initial worker answers on its socket but does not report ready; serving with it rather than leaving the public port closed",
 			"generation", generation.id, "pid", command.Process.Pid, "timeout", config.ReadyTimeout, "error", err)
 		go reportDelayedWorkerReadiness(generation, config.ReadyTimeout)
 		return generation, nil
@@ -307,7 +312,7 @@ func reportDelayedWorkerReadiness(generation *workerGeneration, timeout time.Dur
 	if deadline < time.Minute {
 		deadline = time.Minute
 	}
-	if err := waitForWorkerReady(generation, deadline); err != nil {
+	if _, err := waitForWorkerReady(generation, deadline); err != nil {
 		if !workerAlreadyExited(generation) {
 			slog.Error("worker is serving but still not ready", "generation", generation.id, "waited", deadline, "error", err)
 		}
@@ -329,7 +334,11 @@ func terminateWorker(worker *workerGeneration, gracePeriod time.Duration) {
 	<-worker.done
 }
 
-func waitForWorkerReady(generation *workerGeneration, timeout time.Duration) error {
+// waitForWorkerReady reports whether the worker ever answered the readiness
+// endpoint at all, separately from whether it reported ready. A worker that
+// answers 503 is listening and can serve proxy traffic; one that never answers
+// is not serving anything, and the two deserve different decisions.
+func waitForWorkerReady(generation *workerGeneration, timeout time.Duration) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	transport := &http.Transport{
@@ -351,13 +360,15 @@ func waitForWorkerReady(generation *workerGeneration, timeout time.Duration) err
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	var lastErr error
+	answered := false
 	for {
 		request, _ := http.NewRequestWithContext(ctx, http.MethodGet, readyURL, nil)
 		response, err := client.Do(request)
 		if err == nil {
+			answered = true
 			_ = response.Body.Close()
 			if response.StatusCode == http.StatusOK {
-				return nil
+				return true, nil
 			}
 			lastErr = fmt.Errorf("ready check returned status %d", response.StatusCode)
 		} else {
@@ -365,12 +376,12 @@ func waitForWorkerReady(generation *workerGeneration, timeout time.Duration) err
 		}
 		select {
 		case <-generation.done:
-			return fmt.Errorf("worker exited before readiness: %w", generation.waitError())
+			return answered, fmt.Errorf("worker exited before readiness: %w", generation.waitError())
 		case <-ctx.Done():
 			if lastErr != nil {
-				return fmt.Errorf("worker readiness timed out after %s: last error: %w", timeout, lastErr)
+				return answered, fmt.Errorf("worker readiness timed out after %s: last error: %w", timeout, lastErr)
 			}
-			return fmt.Errorf("worker readiness timed out after %s", timeout)
+			return answered, fmt.Errorf("worker readiness timed out after %s", timeout)
 		case <-ticker.C:
 		}
 	}

--- a/cmd/subrouter/supervisor.go
+++ b/cmd/subrouter/supervisor.go
@@ -91,7 +91,7 @@ func supervise(args []string) error {
 	if err := validateSupervisorConfig(config); err != nil {
 		return err
 	}
-	initial, err := startWorkerGeneration(config)
+	initial, err := startWorkerGeneration(config, generationInitial)
 	if err != nil {
 		return err
 	}
@@ -178,7 +178,28 @@ func validateSupervisorConfig(config supervisorConfig) error {
 	return nil
 }
 
-func startWorkerGeneration(config supervisorConfig) (*workerGeneration, error) {
+// generationRole says what is lost when a new worker never reports ready.
+//
+// A replacement generation costs nothing to refuse: the current worker keeps
+// serving behind the bound listener, so a candidate that cannot become ready
+// is simply discarded. The initial generation is the opposite. Refusing it
+// means `supervise` returns before it binds the public port, launchd restarts
+// the job, and clients get connection refused for as long as the worker stays
+// unready. On 2026-09-04 that turned one provider's unusable credentials into
+// a total outage of a proxy whose other providers were fine, twice.
+//
+// Readiness is a routing preference, not a serving capability: the worker's
+// mux answers proxy traffic as soon as it listens, and the scheduler already
+// falls back to stale scores with per-request 401/429 failover. So at cold
+// start the supervisor serves with an unready worker and says so, loudly.
+type generationRole uint8
+
+const (
+	generationInitial generationRole = iota
+	generationReplacement
+)
+
+func startWorkerGeneration(config supervisorConfig, role generationRole) (*workerGeneration, error) {
 	socketDir, err := os.MkdirTemp("", "subrouter-worker-")
 	if err != nil {
 		return nil, err
@@ -253,11 +274,46 @@ func startWorkerGeneration(config supervisorConfig) (*workerGeneration, error) {
 	}
 	go func() { generation.setWaitError(command.Wait()) }()
 	if err := waitForWorkerReady(generation, config.ReadyTimeout); err != nil {
-		terminateWorker(generation, time.Second)
-		return nil, err
+		if role == generationReplacement || workerAlreadyExited(generation) {
+			terminateWorker(generation, time.Second)
+			return nil, err
+		}
+		slog.Error("initial worker did not report ready; serving with it anyway rather than leaving the public port closed",
+			"generation", generation.id, "pid", command.Process.Pid, "timeout", config.ReadyTimeout, "error", err)
+		go reportDelayedWorkerReadiness(generation, config.ReadyTimeout)
+		return generation, nil
 	}
 	slog.Info("subrouter worker ready", "generation", generation.id, "pid", command.Process.Pid, "addr", address)
 	return generation, nil
+}
+
+// workerAlreadyExited reports whether the worker process is gone. A worker
+// that died has nothing to serve, so an unready-but-serving generation is not
+// an option and the error stays fatal.
+func workerAlreadyExited(generation *workerGeneration) bool {
+	select {
+	case <-generation.done:
+		return true
+	default:
+		return false
+	}
+}
+
+// reportDelayedWorkerReadiness records when a worker that missed its readiness
+// deadline catches up, so an operator reading the log can tell a slow start
+// from a permanently unready one.
+func reportDelayedWorkerReadiness(generation *workerGeneration, timeout time.Duration) {
+	deadline := 10 * timeout
+	if deadline < time.Minute {
+		deadline = time.Minute
+	}
+	if err := waitForWorkerReady(generation, deadline); err != nil {
+		if !workerAlreadyExited(generation) {
+			slog.Error("worker is serving but still not ready", "generation", generation.id, "waited", deadline, "error", err)
+		}
+		return
+	}
+	slog.Info("worker reported ready after serving unready", "generation", generation.id)
 }
 
 func terminateWorker(worker *workerGeneration, gracePeriod time.Duration) {
@@ -526,7 +582,7 @@ func (s *supervisor) upgradeLocked() error {
 			return fmt.Errorf("inspect upgrade inhibit marker: %w", err)
 		}
 	}
-	next, err := startWorkerGeneration(s.config)
+	next, err := startWorkerGeneration(s.config, generationReplacement)
 	if err != nil {
 		return err
 	}

--- a/cmd/subrouter/supervisor_test.go
+++ b/cmd/subrouter/supervisor_test.go
@@ -52,6 +52,10 @@ func runFakeWorker() {
 	retired := make(chan struct{})
 	var retiredOnce sync.Once
 	mux.HandleFunc("/_subrouter/ready", func(w http.ResponseWriter, _ *http.Request) {
+		if os.Getenv("SUBROUTER_TEST_FAKE_WORKER_NEVER_READY") == "1" {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 	})
 	mux.HandleFunc("/_subrouter/test-private-data-router", func(w http.ResponseWriter, _ *http.Request) {
@@ -669,7 +673,7 @@ func TestSlotRetirementDrainsPinnedStreamBeforeSupervisorExit(t *testing.T) {
 		WorkerStopGrace:     time.Second,
 		ExpectProxyProtocol: true,
 	}
-	initial, err := startWorkerGeneration(config)
+	initial, err := startWorkerGeneration(config, generationInitial)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -946,7 +950,7 @@ func TestStartWorkerGenerationKeepsSocketPathDialable(t *testing.T) {
 		WorkerBin:    os.Args[0],
 		ReadyTimeout: 10 * time.Second,
 	}
-	generation, err := startWorkerGeneration(config)
+	generation, err := startWorkerGeneration(config, generationInitial)
 	if err != nil {
 		t.Fatalf("startWorkerGeneration: %v", err)
 	}
@@ -988,7 +992,7 @@ func TestStartWorkerGenerationScopesPrivateRouterEnvToConfiguredSocket(t *testin
 		generation, err := startWorkerGeneration(supervisorConfig{
 			WorkerBin: os.Args[0], ReadyTimeout: 10 * time.Second,
 			LocalDataSocket: localDataSocket,
-		})
+		}, generationInitial)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1124,4 +1128,70 @@ func supervisorBackendPresent(statuses []front.BackendStatus, id string) bool {
 		}
 	}
 	return false
+}
+
+// A worker that serves traffic but never reports ready must not keep the
+// public listener closed. Refusing the initial generation is what turned one
+// provider's unusable credentials into a total outage on 2026-09-04: the
+// supervisor exited before binding and launchd restart-looped it.
+func TestInitialWorkerGenerationServesWhenReadinessNeverArrives(t *testing.T) {
+	t.Setenv("SUBROUTER_TEST_FAKE_WORKER", "1")
+	t.Setenv("SUBROUTER_TEST_FAKE_WORKER_NEVER_READY", "1")
+	config := supervisorConfig{WorkerBin: os.Args[0], ReadyTimeout: 300 * time.Millisecond}
+
+	generation, err := startWorkerGeneration(config, generationInitial)
+	if err != nil {
+		t.Fatalf("initial generation must start without readiness: %v", err)
+	}
+	t.Cleanup(func() { terminateWorker(generation, time.Second) })
+
+	connection, err := net.DialTimeout(generation.network, generation.address, time.Second)
+	if err != nil {
+		t.Fatalf("dial unready worker: %v", err)
+	}
+	defer connection.Close()
+	if err := front.WriteProxyProtocolHeader(connection, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprint(connection, "GET / HTTP/1.0\r\nHost: worker\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	_ = connection.SetReadDeadline(time.Now().Add(2 * time.Second))
+	body, err := io.ReadAll(connection)
+	if err != nil {
+		t.Fatalf("read from unready worker: %v", err)
+	}
+	if !strings.Contains(string(body), "fake-worker") {
+		t.Fatalf("unready worker did not serve proxy traffic: %q", body)
+	}
+}
+
+// A replacement generation is free to refuse: the current worker keeps serving.
+func TestReplacementWorkerGenerationStillRequiresReadiness(t *testing.T) {
+	t.Setenv("SUBROUTER_TEST_FAKE_WORKER", "1")
+	t.Setenv("SUBROUTER_TEST_FAKE_WORKER_NEVER_READY", "1")
+	config := supervisorConfig{WorkerBin: os.Args[0], ReadyTimeout: 300 * time.Millisecond}
+
+	generation, err := startWorkerGeneration(config, generationReplacement)
+	if err == nil {
+		terminateWorker(generation, time.Second)
+		t.Fatal("a replacement worker that never becomes ready must be rejected")
+	}
+}
+
+// An initial worker that exits has nothing to serve, so the error stays fatal
+// instead of leaving the supervisor routing to a dead socket.
+func TestInitialWorkerGenerationStillFailsWhenWorkerExits(t *testing.T) {
+	t.Setenv("SUBROUTER_TEST_FAKE_WORKER", "1")
+	binary := filepath.Join(t.TempDir(), "exiting-worker")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	config := supervisorConfig{WorkerBin: binary, ReadyTimeout: 300 * time.Millisecond}
+
+	generation, err := startWorkerGeneration(config, generationInitial)
+	if err == nil {
+		terminateWorker(generation, time.Second)
+		t.Fatal("a worker that exited must not be treated as serving")
+	}
 }

--- a/cmd/subrouter/supervisor_test.go
+++ b/cmd/subrouter/supervisor_test.go
@@ -48,6 +48,13 @@ func runFakeWorker() {
 		fmt.Fprintln(os.Stderr, "fake worker: no inherited listener:", err)
 		os.Exit(1)
 	}
+	if os.Getenv("SUBROUTER_TEST_FAKE_WORKER_HANG") == "1" {
+		// Alive, holding the inherited listener, never serving. A bare
+		// select{} would panic on deadlock and exit, which is a different
+		// failure than the one under test.
+		time.Sleep(time.Hour)
+		return
+	}
 	mux := http.NewServeMux()
 	retired := make(chan struct{})
 	var retiredOnce sync.Once
@@ -1193,5 +1200,25 @@ func TestInitialWorkerGenerationStillFailsWhenWorkerExits(t *testing.T) {
 	if err == nil {
 		terminateWorker(generation, time.Second)
 		t.Fatal("a worker that exited must not be treated as serving")
+	}
+}
+
+// A worker that never answers on its socket is not serving anything, so the
+// initial generation must stay fatal: binding in front of it would turn
+// connection refused into 502s and hide a hard failure.
+func TestInitialWorkerGenerationStillFailsWhenWorkerNeverAnswers(t *testing.T) {
+	t.Setenv("SUBROUTER_TEST_FAKE_WORKER", "1")
+	t.Setenv("SUBROUTER_TEST_FAKE_WORKER_HANG", "1")
+	config := supervisorConfig{WorkerBin: os.Args[0], ReadyTimeout: 300 * time.Millisecond}
+
+	generation, err := startWorkerGeneration(config, generationInitial)
+	if err == nil {
+		terminateWorker(generation, time.Second)
+		t.Fatal("a worker that never answers must not be served in front of")
+	}
+	// The worker must still have been alive: this has to be the never-answered
+	// decision, not the already-exited one.
+	if strings.Contains(err.Error(), "worker exited before readiness") {
+		t.Fatalf("worker died instead of hanging, so the test proved nothing: %v", err)
 	}
 }


### PR DESCRIPTION
The supervisor waits for `/_subrouter/ready` before it binds `--addr`. For a replacement generation that costs nothing: the current worker keeps serving, so a candidate that never becomes ready is discarded and the listener never moves. For the first generation it is the opposite. `supervise` returns before binding, launchd restarts the job, and every client gets connection refused for as long as the worker stays unready.

That took the team proxy on cmux-lawrence down twice on 2026-09-04. The worker was healthy and answering on its own socket; only readiness was false. Readiness waits for the startup Codex usage-score sweep (`requiresStartupScoreReadiness` + `ensureStartupScores`, with `RetryFailedSweep: true`), and every stored Codex credential on that host fails the isolation check, so the sweep can never publish. Claude, Bedrock and Kimi routing needed none of it and none of it was reachable. Measured against an isolated copy of that host's state: v0.1.125 is ready in 1s, a main-based build answers 503 for ever while health answers 200 the whole time.

Readiness there is a routing preference, not a serving capability. The worker's mux answers proxy traffic as soon as it listens, and the scheduler already starts on fallback scores with per-request 401/429 failover, which is what the standalone startup fetch explicitly relies on ("the real scores are fetched in the background and swapped in once ready").

So `startWorkerGeneration` now takes a `generationRole`. The initial generation serves with an unready worker and logs an error saying exactly that, then logs again if the worker catches up. A replacement generation keeps the strict gate. A worker that has already exited stays fatal in both cases, because a dead worker has nothing to serve.

Trade-off worth naming in review: at cold start the router can pick accounts from fallback scores for a short window, so the first requests may land on a saturated account and take a 429 retry. That is strictly better than serving nothing, and it is the same window the standalone fetch already accepts.

Tests: three new cases in `supervisor_test.go` (initial serves unready, replacement still refuses, exited worker still fatal), driven by a `SUBROUTER_TEST_FAKE_WORKER_NEVER_READY` mode on the existing fake worker. Full `./cmd/subrouter` package passes (130s).

https://claude.ai/code/session_01KhBTe7aDNkqgQLH14687j9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791110921&installation_model_id=21920&pr_number=308&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F308&signature=f25f9e0b2e8d486c0f22bc901808e484867034a3337adb0f6127896ec589c130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds the public listener even when the first worker answers on its socket but never reports ready, so cold-start outages like the one on 2026-09-04 no longer leave clients with connection refused.

Previously the supervisor waited for `/_subrouter/ready` before binding; an initial worker that never became ready caused `supervise` to return, launchd restarted the job, and every client got connection refused. The worker's mux serves proxy traffic as soon as it listens, so readiness is only a routing preference, not a serving capability. Now the initial generation serves with a worker that is listening but unready, logging an error and continuing to watch for up to 10x the ready timeout for it to catch up. Replacement generations keep the strict gate. A worker that never answered or already exited stays fatal, since serving in front of it would only turn connection refused into 502s.

- The first requests at cold start can land on fallback scores and take a 429 retry, the same window the standalone startup fetch already accepts.
- Four new tests cover initial serves unready, replacement still refuses, exited worker stays fatal, and never-answering worker stays fatal.

<sup>Written for commit 40d454c75a15fc0487090183da2589fb99deedab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Initial worker generations can continue serving traffic when readiness reporting is delayed or unavailable, provided the worker remains active.
  * Replacement worker generations that fail readiness are now terminated to prevent incomplete upgrades.
  * Initial workers that exit unexpectedly during startup remain treated as failures.
  * Delayed readiness is monitored for longer and recorded for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->