### PR TITLE
Fix Claude profile removal when the legacy instance root is a symlink

### DIFF
--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -742,6 +742,18 @@ func normalizedProfileRemovalPath(path string) (string, error) {
 	return filepath.Abs(filepath.Clean(path))
 }
 
+// sameProfileRemovalPath reports whether a path recorded in a removal manifest
+// or marker names the directory the caller is walking. A stage written before
+// aliased roots collapsed carries the legacy spelling, so string equality alone
+// would leave that stage unowned and its credential stranded. Physical identity
+// is the property these records exist to prove.
+func sameProfileRemovalPath(recorded, expected string) (bool, error) {
+	if recorded == expected {
+		return true, nil
+	}
+	return profileInstancePathsAliasForOS(runtime.GOOS, recorded, expected)
+}
+
 func newProfileRemovalOperationID() (string, error) {
 	var value [16]byte
 	if _, err := rand.Read(value[:]); err != nil {
@@ -873,8 +885,12 @@ func readProfileRemovalOperationMarkerIdentity(directory, expectedOriginalPath s
 	if err != nil {
 		return entry, false, err
 	}
+	sameOriginal, err := sameProfileRemovalPath(marker.OriginalPath, originalPath)
+	if err != nil {
+		return entry, false, err
+	}
 	if marker.Version != profileRemovalOperationMarkerVersion ||
-		marker.OriginalPath != originalPath ||
+		!sameOriginal ||
 		!validProfileRemovalOperationID(marker.OperationID) ||
 		!validProfileCredentialSetVersion(marker.CredentialSetVersion) {
 		return entry, false, fmt.Errorf("Claude profile removal operation marker %q does not match its exact identity", markerPath)
@@ -944,9 +960,17 @@ func readOwnedProfileRemovalStage(stagingRoot, expectedOriginalPath string) (sta
 	if err != nil {
 		return entry, err
 	}
+	sameOriginal, err := sameProfileRemovalPath(manifest.OriginalPath, expectedOriginal)
+	if err != nil {
+		return entry, err
+	}
+	sameRoot, err := sameProfileRemovalPath(manifest.StagingRoot, expectedRoot)
+	if err != nil {
+		return entry, err
+	}
 	if manifest.Version != profileRemovalStageManifestVersion ||
-		manifest.OriginalPath != expectedOriginal ||
-		manifest.StagingRoot != expectedRoot ||
+		!sameOriginal ||
+		!sameRoot ||
 		manifest.EntryName != profileRemovalStageEntryName ||
 		!validProfileRemovalOperationID(manifest.OperationID) ||
 		!validProfileCredentialSetVersion(manifest.CredentialSetVersion) {
@@ -2327,14 +2351,17 @@ func profileCredentialEntriesVersion(entries []profileCredentialVersionEntry) (s
 		ordered[index].originalPath = normalizedPath
 	}
 	sort.Slice(ordered, func(left, right int) bool { return ordered[left].originalPath < ordered[right].originalPath })
+	// A credential-set version identifies the credential, not the words used to
+	// reach it. Framing the physical directory keeps one version across a path
+	// set that names a directory once and a path set that names it twice, which
+	// is what a stage written before aliased roots collapsed relies on.
+	framed, err := profileCredentialVersionFrames(ordered)
+	if err != nil {
+		return "", err
+	}
 	hash := sha256.New()
 	_, _ = hash.Write([]byte("subrouter-claude-profile-credential-v2\x00"))
-	var priorPath string
-	for index, entry := range ordered {
-		if index != 0 && entry.originalPath == priorPath {
-			return "", fmt.Errorf("duplicate Claude profile credential path %q", entry.originalPath)
-		}
-		priorPath = entry.originalPath
+	for _, entry := range framed {
 		writeCredentialVersionFrame(hash, []byte(entry.originalPath))
 		flags := byte(0)
 		if entry.instancePresent {
@@ -2351,6 +2378,41 @@ func profileCredentialEntriesVersion(entries []profileCredentialVersionEntry) (s
 		writeCredentialVersionFrame(hash, payload)
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// profileCredentialVersionFrames reduces path-sorted entries to one frame per
+// physical directory, keyed by that directory. Two spellings of one directory
+// carry the same credential, so they contribute one frame; a genuine repeat of
+// one spelling stays an error, and two spellings that disagree about what they
+// hold mean the traversal raced a writer.
+func profileCredentialVersionFrames(ordered []profileCredentialVersionEntry) ([]profileCredentialVersionEntry, error) {
+	framed := make([]profileCredentialVersionEntry, 0, len(ordered))
+	byIdentity := make(map[string]int, len(ordered))
+	var priorPath string
+	for index, entry := range ordered {
+		if index != 0 && entry.originalPath == priorPath {
+			return nil, fmt.Errorf("duplicate Claude profile credential path %q", entry.originalPath)
+		}
+		priorPath = entry.originalPath
+		identity, err := profileInstancePhysicalIdentity(entry.originalPath)
+		if err != nil {
+			return nil, err
+		}
+		if position, seen := byIdentity[identity]; seen {
+			kept := framed[position]
+			if kept.instancePresent != entry.instancePresent ||
+				kept.payloadPresent != entry.payloadPresent ||
+				!bytes.Equal(bytes.TrimSpace(kept.payload), bytes.TrimSpace(entry.payload)) {
+				return nil, fmt.Errorf("Claude profile credential path %q changed while it was read through another name", identity)
+			}
+			continue
+		}
+		entry.originalPath = identity
+		byIdentity[identity] = len(framed)
+		framed = append(framed, entry)
+	}
+	sort.Slice(framed, func(left, right int) bool { return framed[left].originalPath < framed[right].originalPath })
+	return framed, nil
 }
 
 func writeCredentialVersionFrame(writer io.Writer, value []byte) {

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -315,6 +315,34 @@ func (s Store) profileInstanceRoots() ([]string, error) {
 	return append(roots, legacyRoot), nil
 }
 
+// preCollapseCredentialVersionPaths returns the path set a build that predates
+// the root collapse would have hashed: every spelling of every instance path.
+// It returns nil when no path has a second spelling, so callers can tell that
+// there is no older version to be compatible with.
+func (s Store) preCollapseCredentialVersionPaths(instancePaths []string) []string {
+	seen := make(map[string]struct{}, 2*len(instancePaths))
+	expanded := make([]string, 0, 2*len(instancePaths))
+	aliased := false
+	for _, instancePath := range instancePaths {
+		spellings := s.instancePathSpellings(instancePath)
+		if len(spellings) > 1 {
+			aliased = true
+		}
+		for _, spelling := range spellings {
+			if _, duplicate := seen[spelling]; duplicate {
+				continue
+			}
+			seen[spelling] = struct{}{}
+			expanded = append(expanded, spelling)
+		}
+	}
+	if !aliased {
+		return nil
+	}
+	sort.Strings(expanded)
+	return expanded
+}
+
 func (s Store) profileInstancePaths(dir string) ([]string, error) {
 	if !safeProfileDir(dir) {
 		return nil, errors.New("Claude profile directory is invalid")
@@ -1250,7 +1278,21 @@ func (s Store) ReconcileProfileInstanceStagesContext(ctx context.Context) (err e
 			return err
 		}
 		if currentCredentialSetVersion != credentialSetVersion {
-			return fmt.Errorf("Claude profile %q credential changed during interrupted removal recovery", profileName)
+			// A stage written before aliased roots collapsed recorded a version
+			// that framed each spelling of the directory separately. Recovering
+			// that stage is the point of adopting it, so compare against the
+			// version that build would have computed before refusing.
+			matched := false
+			if compatPaths := s.preCollapseCredentialVersionPaths(paths); compatPaths != nil {
+				compatVersion, compatErr := s.profileCredentialVersionLocked(ctx, compatPaths, true)
+				if compatErr != nil {
+					return compatErr
+				}
+				matched = compatVersion == credentialSetVersion
+			}
+			if !matched {
+				return fmt.Errorf("Claude profile %q credential changed during interrupted removal recovery", profileName)
+			}
 		}
 		liveByPath := make(map[string]bool)
 		anyLive := false
@@ -2351,17 +2393,14 @@ func profileCredentialEntriesVersion(entries []profileCredentialVersionEntry) (s
 		ordered[index].originalPath = normalizedPath
 	}
 	sort.Slice(ordered, func(left, right int) bool { return ordered[left].originalPath < ordered[right].originalPath })
-	// A credential-set version identifies the credential, not the words used to
-	// reach it. Framing the physical directory keeps one version across a path
-	// set that names a directory once and a path set that names it twice, which
-	// is what a stage written before aliased roots collapsed relies on.
-	framed, err := profileCredentialVersionFrames(ordered)
-	if err != nil {
-		return "", err
-	}
 	hash := sha256.New()
 	_, _ = hash.Write([]byte("subrouter-claude-profile-credential-v2\x00"))
-	for _, entry := range framed {
+	var priorPath string
+	for index, entry := range ordered {
+		if index != 0 && entry.originalPath == priorPath {
+			return "", fmt.Errorf("duplicate Claude profile credential path %q", entry.originalPath)
+		}
+		priorPath = entry.originalPath
 		writeCredentialVersionFrame(hash, []byte(entry.originalPath))
 		flags := byte(0)
 		if entry.instancePresent {
@@ -2378,41 +2417,6 @@ func profileCredentialEntriesVersion(entries []profileCredentialVersionEntry) (s
 		writeCredentialVersionFrame(hash, payload)
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
-}
-
-// profileCredentialVersionFrames reduces path-sorted entries to one frame per
-// physical directory, keyed by that directory. Two spellings of one directory
-// carry the same credential, so they contribute one frame; a genuine repeat of
-// one spelling stays an error, and two spellings that disagree about what they
-// hold mean the traversal raced a writer.
-func profileCredentialVersionFrames(ordered []profileCredentialVersionEntry) ([]profileCredentialVersionEntry, error) {
-	framed := make([]profileCredentialVersionEntry, 0, len(ordered))
-	byIdentity := make(map[string]int, len(ordered))
-	var priorPath string
-	for index, entry := range ordered {
-		if index != 0 && entry.originalPath == priorPath {
-			return nil, fmt.Errorf("duplicate Claude profile credential path %q", entry.originalPath)
-		}
-		priorPath = entry.originalPath
-		identity, err := profileInstancePhysicalIdentity(entry.originalPath)
-		if err != nil {
-			return nil, err
-		}
-		if position, seen := byIdentity[identity]; seen {
-			kept := framed[position]
-			if kept.instancePresent != entry.instancePresent ||
-				kept.payloadPresent != entry.payloadPresent ||
-				!bytes.Equal(bytes.TrimSpace(kept.payload), bytes.TrimSpace(entry.payload)) {
-				return nil, fmt.Errorf("Claude profile credential path %q changed while it was read through another name", identity)
-			}
-			continue
-		}
-		entry.originalPath = identity
-		byIdentity[identity] = len(framed)
-		framed = append(framed, entry)
-	}
-	sort.Slice(framed, func(left, right int) bool { return framed[left].originalPath < framed[right].originalPath })
-	return framed, nil
 }
 
 func writeCredentialVersionFrame(writer io.Writer, value []byte) {

--- a/internal/agents/claude/store.go
+++ b/internal/agents/claude/store.go
@@ -290,14 +290,38 @@ func (s Store) legacyInstancePath(instancePath string) (string, bool) {
 	return filepath.Join(home, ".codex-accounts", rel), true
 }
 
+// profileInstanceRoots lists the physically distinct directories that hold
+// profile instances, canonical root first. The legacy root is dropped when it
+// only spells the canonical root differently, which is what a
+// ~/.codex-accounts symlink does. Removal stages a credential under one
+// spelling and records that spelling in the stage ownership manifest, so a
+// second spelling of the same directory would rediscover the stage under a
+// name the manifest never claimed and reject its own work.
+func (s Store) profileInstanceRoots() ([]string, error) {
+	canonicalRoot := filepath.Clean(s.InstancesDir())
+	roots := []string{canonicalRoot}
+	legacyRoot, ok := s.legacyInstancePath(canonicalRoot)
+	if !ok {
+		return roots, nil
+	}
+	legacyRoot = filepath.Clean(legacyRoot)
+	alias, err := profileInstancePathsAliasForOS(runtime.GOOS, canonicalRoot, legacyRoot)
+	if err != nil {
+		return nil, err
+	}
+	if alias {
+		return roots, nil
+	}
+	return append(roots, legacyRoot), nil
+}
+
 func (s Store) profileInstancePaths(dir string) ([]string, error) {
 	if !safeProfileDir(dir) {
 		return nil, errors.New("Claude profile directory is invalid")
 	}
-	canonicalRoot := filepath.Clean(s.InstancesDir())
-	roots := []string{canonicalRoot}
-	if legacyRoot, ok := s.legacyInstancePath(canonicalRoot); ok {
-		roots = append(roots, legacyRoot)
+	roots, err := s.profileInstanceRoots()
+	if err != nil {
+		return nil, err
 	}
 	unique := make(map[string]string, len(roots))
 	for _, root := range roots {
@@ -306,9 +330,8 @@ func (s Store) profileInstancePaths(dir string) ([]string, error) {
 			return nil, errors.New("Claude profile directory escapes its instance root")
 		}
 		candidate = filepath.Clean(candidate)
-		key := candidate
-		if _, exists := unique[key]; !exists {
-			unique[key] = candidate
+		if _, exists := unique[candidate]; !exists {
+			unique[candidate] = candidate
 		}
 	}
 	paths := make([]string, 0, len(unique))
@@ -1024,9 +1047,9 @@ func (s Store) ReconcileProfileInstanceStagesContext(ctx context.Context) (err e
 
 	registeredByPath := make(map[string]string)
 	pathsByProfile := make(map[string][]string)
-	instanceRoots := []string{filepath.Clean(s.InstancesDir())}
-	if legacyRoot, ok := s.legacyInstancePath(s.InstancesDir()); ok {
-		instanceRoots = append(instanceRoots, filepath.Clean(legacyRoot))
+	instanceRoots, err := s.profileInstanceRoots()
+	if err != nil {
+		return err
 	}
 	for name, profile := range data.Profiles {
 		if profile.Name != name {
@@ -1354,13 +1377,37 @@ func (s Store) profileCredentialBackups(
 	return backups, nil
 }
 
-func deleteProfileKeychainCredentialsContext(ctx context.Context, instancePaths []string) error {
+// deleteProfileKeychainCredentialsContext clears the Keychain item for every
+// spelling of each instance path. A Keychain service is derived from the exact
+// directory string Claude Code ran with, so an aliased legacy spelling keeps
+// its own item even though the filesystem paths collapse to one directory.
+func (s Store) deleteProfileKeychainCredentialsContext(ctx context.Context, instancePaths []string) error {
+	visited := make(map[string]struct{}, 2*len(instancePaths))
 	for _, instancePath := range instancePaths {
-		if err := deleteKeychainCredentialContext(ctx, instancePath); err != nil {
-			return err
+		for _, spelling := range s.instancePathSpellings(instancePath) {
+			if _, seen := visited[spelling]; seen {
+				continue
+			}
+			visited[spelling] = struct{}{}
+			if err := deleteKeychainCredentialContext(ctx, spelling); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
+}
+
+// instancePathSpellings returns the given instance path plus its legacy alias,
+// if the store exposes one.
+func (s Store) instancePathSpellings(instancePath string) []string {
+	cleaned := filepath.Clean(instancePath)
+	spellings := []string{cleaned}
+	if legacy, ok := s.legacyInstancePath(cleaned); ok {
+		if legacy = filepath.Clean(legacy); legacy != cleaned {
+			spellings = append(spellings, legacy)
+		}
+	}
+	return spellings
 }
 
 func cloneProfilesFile(data profilesFile) profilesFile {
@@ -1718,7 +1765,7 @@ func (s Store) RemoveProfileContext(ctx context.Context, name string) (removed b
 			// The registry deletion is already visible. Roll forward so a
 			// returned removed=true never leaves an invisible staged secret.
 			cleanupErr := errors.Join(
-				deleteProfileKeychainCredentialsContext(ctx, instancePaths),
+				s.deleteProfileKeychainCredentialsContext(ctx, instancePaths),
 				deleteStagedProfileInstancesWithSync(staged, s.syncProfileRemovalParents),
 			)
 			if cleanupErr != nil {
@@ -1729,7 +1776,7 @@ func (s Store) RemoveProfileContext(ctx context.Context, name string) (removed b
 		}
 		return false, errors.Join(writeErr, rollbackStagedProfileInstancesWithSync(staged, s.syncProfileRemovalParents))
 	}
-	if err := deleteProfileKeychainCredentialsContext(ctx, instancePaths); err != nil {
+	if err := s.deleteProfileKeychainCredentialsContext(ctx, instancePaths); err != nil {
 		// The caller's deadline may be the reason cleanup failed. Rollback must
 		// have its own bounded lifetime so it can restore the credential and
 		// registry atomically instead of reusing an already-canceled context.
@@ -1821,7 +1868,7 @@ func (s Store) RemoveUnpublishedProfileContext(ctx context.Context, name string)
 	if writeErr := s.writeProfiles(data); writeErr != nil {
 		if profileRegistryWriteCommitted(writeErr) {
 			cleanupErr := errors.Join(
-				deleteProfileKeychainCredentialsContext(ctx, instancePaths),
+				s.deleteProfileKeychainCredentialsContext(ctx, instancePaths),
 				deleteStagedProfileInstancesWithSync(staged, s.syncProfileRemovalParents),
 			)
 			return true, errors.Join(writeErr, cleanupErr)
@@ -1832,7 +1879,7 @@ func (s Store) RemoveUnpublishedProfileContext(ctx context.Context, name string)
 	// The removal is committed at this point. In particular, do not restore the
 	// registry or staged credential when Keychain cleanup fails.
 	cleanupErr := errors.Join(
-		deleteProfileKeychainCredentialsContext(ctx, instancePaths),
+		s.deleteProfileKeychainCredentialsContext(ctx, instancePaths),
 		deleteStagedProfileInstancesWithSync(staged, s.syncProfileRemovalParents),
 	)
 	if cleanupErr != nil {
@@ -2123,7 +2170,7 @@ func (s Store) CompleteExactProfileRemovalContext(
 		return false, err
 	}
 	cleanupErr := errors.Join(
-		deleteProfileKeychainCredentialsContext(ctx, instancePaths),
+		s.deleteProfileKeychainCredentialsContext(ctx, instancePaths),
 		deleteStagedProfileInstancesWithSync(staged, s.syncProfileRemovalParents),
 		deleteOrphanedStagedProfileInstancesWithSync(instancePaths, s.syncProfileRemovalParents),
 	)
@@ -2486,22 +2533,28 @@ func (s Store) readCredentialPayloadLocked(ctx context.Context, instancePath str
 	if err != nil {
 		return nil, false, fmt.Errorf("resolve current user for Claude Keychain lookup: %w", err)
 	}
-	service := "Claude Code-credentials-" + keychainHash(instancePath)
-	keychainCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(keychainCtx, "security", "find-generic-password", "-s", service, "-a", u.Username, "-w")
-	body, err = cmd.Output()
-	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() == 44 {
-			return nil, false, nil
+	// Claude Code keys its Keychain service by the exact directory string it
+	// ran with, so a credential written under an aliased legacy spelling is
+	// invisible to the canonical spelling alone.
+	for _, spelling := range s.instancePathSpellings(instancePath) {
+		service := "Claude Code-credentials-" + keychainHash(spelling)
+		keychainCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		cmd := exec.CommandContext(keychainCtx, "security", "find-generic-password", "-s", service, "-a", u.Username, "-w")
+		body, err = cmd.Output()
+		cancel()
+		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && exitErr.ExitCode() == 44 {
+				continue
+			}
+			return nil, false, fmt.Errorf("read Claude credential from keychain: %w", err)
 		}
-		return nil, false, fmt.Errorf("read Claude credential from keychain: %w", err)
+		if len(bytes.TrimSpace(body)) == 0 {
+			continue
+		}
+		return body, true, nil
 	}
-	if len(bytes.TrimSpace(body)) == 0 {
-		return nil, false, nil
-	}
-	return body, true, nil
+	return nil, false, nil
 }
 
 func (s Store) CleanupInstance(dir string) error {
@@ -2521,10 +2574,10 @@ func (s Store) CleanupInstanceContext(ctx context.Context, dir string) error {
 		return err
 	}
 	defer closeProfileCredentialLocks(credentialLocks)
+	if err := s.deleteProfileKeychainCredentialsContext(ctx, instancePaths); err != nil {
+		return err
+	}
 	for _, instancePath := range instancePaths {
-		if err := deleteKeychainCredentialContext(ctx, instancePath); err != nil {
-			return err
-		}
 		if err := os.RemoveAll(instancePath); err != nil {
 			return err
 		}

--- a/internal/agents/claude/store_test.go
+++ b/internal/agents/claude/store_test.go
@@ -3702,13 +3702,28 @@ func TestReconcileAdoptsStageRecordedUnderAnAliasedLegacySpelling(t *testing.T) 
 		t.Fatal("profile missing before staging")
 	}
 	// A build that predates the root collapse staged the removal under the
-	// legacy spelling and stopped before it committed, so the stage ownership
-	// manifest names a directory the canonical walk no longer visits.
-	staged, err := stageProfileInstancePaths([]string{filepath.Join(legacyRoot, profile.Dir)})
+	// legacy spelling and stopped before it committed. Its stage names a
+	// directory the canonical walk no longer visits, and its credential-set
+	// version framed both spellings of that one directory.
+	canonicalPath := filepath.Join(store.InstancesDir(), profile.Dir)
+	legacyPath := filepath.Join(legacyRoot, profile.Dir)
+	preCollapseVersion, err := filesystemProfileCredentialVersion([]string{canonicalPath, legacyPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	staged, err := stageProfileInstancePathsWithVersion(
+		[]string{legacyPath},
+		preCollapseVersion,
+		syncProfileRemovalParents,
+	)
 	if err != nil || len(staged) != 1 {
 		t.Fatalf("stage under the legacy spelling = %v, err %v", staged, err)
 	}
-	canonicalPath := filepath.Join(store.InstancesDir(), profile.Dir)
+	if current, versionErr := filesystemProfileCredentialVersion([]string{canonicalPath}); versionErr != nil {
+		t.Fatal(versionErr)
+	} else if current == preCollapseVersion {
+		t.Fatal("pre-collapse credential version is indistinguishable from the collapsed one")
+	}
 	if _, err := os.Lstat(canonicalPath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("staging left the live instance directory in place: %v", err)
 	}

--- a/internal/agents/claude/store_test.go
+++ b/internal/agents/claude/store_test.go
@@ -3638,9 +3638,7 @@ func TestRemoveProfileWhenLegacyInstanceRootAliasesCanonicalRoot(t *testing.T) {
 	// ~/.codex-accounts is a symlink to ~/.subrouter/codex on installs that
 	// predate the rename, so the legacy root is a second spelling of the one
 	// canonical instances directory rather than a separate location.
-	if err := os.Symlink(store.Dir, filepath.Dir(legacyRoot)); err != nil {
-		t.Fatal(err)
-	}
+	linkAliasedLegacyInstanceRoot(t, store, legacyRoot)
 	if err := store.ImportProfileCredential("work", CredentialInfo{AccessToken: "access", RefreshToken: "refresh"}); err != nil {
 		t.Fatal(err)
 	}
@@ -3668,5 +3666,60 @@ func TestRemoveProfileWhenLegacyInstanceRootAliasesCanonicalRoot(t *testing.T) {
 	}
 	if roots, listErr := stagedProfileInstanceRoots(instancePath); listErr != nil || len(roots) != 0 {
 		t.Fatalf("removal left stage roots %v, err %v", roots, listErr)
+	}
+}
+
+// linkAliasedLegacyInstanceRoot makes the legacy instance root a symlink to the
+// canonical store directory. Windows grants symlink creation only with
+// Developer Mode or SeCreateSymbolicLinkPrivilege, so an unprivileged run there
+// skips instead of failing.
+func linkAliasedLegacyInstanceRoot(t *testing.T, store Store, legacyRoot string) {
+	t.Helper()
+	if err := os.Symlink(store.Dir, filepath.Dir(legacyRoot)); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("symlinked legacy instance root is unavailable: %v", err)
+		}
+		t.Fatal(err)
+	}
+}
+
+func TestReconcileAdoptsStageRecordedUnderAnAliasedLegacySpelling(t *testing.T) {
+	home := t.TempDir()
+	store := Store{Dir: filepath.Join(home, ".subrouter", "codex")}
+	if err := os.MkdirAll(store.InstancesDir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	legacyRoot, ok := store.legacyInstancePath(store.InstancesDir())
+	if !ok {
+		t.Fatal("test store did not expose legacy instance root")
+	}
+	linkAliasedLegacyInstanceRoot(t, store, legacyRoot)
+	if err := store.ImportProfileCredential("work", CredentialInfo{AccessToken: "access", RefreshToken: "refresh"}); err != nil {
+		t.Fatal(err)
+	}
+	profile, found := store.FindProfile("work")
+	if !found {
+		t.Fatal("profile missing before staging")
+	}
+	// A build that predates the root collapse staged the removal under the
+	// legacy spelling and stopped before it committed, so the stage ownership
+	// manifest names a directory the canonical walk no longer visits.
+	staged, err := stageProfileInstancePaths([]string{filepath.Join(legacyRoot, profile.Dir)})
+	if err != nil || len(staged) != 1 {
+		t.Fatalf("stage under the legacy spelling = %v, err %v", staged, err)
+	}
+	canonicalPath := filepath.Join(store.InstancesDir(), profile.Dir)
+	if _, err := os.Lstat(canonicalPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("staging left the live instance directory in place: %v", err)
+	}
+	if err := store.ReconcileProfileInstanceStagesContext(t.Context()); err != nil {
+		t.Fatalf("reconcile a legacy-spelled stage: %v", err)
+	}
+	credential, readErr := os.ReadFile(filepath.Join(canonicalPath, ".credentials.json"))
+	if readErr != nil || !strings.Contains(string(credential), "access") {
+		t.Fatalf("reconcile did not restore the staged credential: %q, err %v", credential, readErr)
+	}
+	if roots, listErr := stagedProfileInstanceRoots(canonicalPath); listErr != nil || len(roots) != 0 {
+		t.Fatalf("reconcile left stage roots %v, err %v", roots, listErr)
 	}
 }

--- a/internal/agents/claude/store_test.go
+++ b/internal/agents/claude/store_test.go
@@ -3624,3 +3624,49 @@ func TestFetchFableUsageWindowsHeaderless429ReturnsNoWindows(t *testing.T) {
 		t.Fatalf("windows = %+v, want none for a headerless 429", windows)
 	}
 }
+
+func TestRemoveProfileWhenLegacyInstanceRootAliasesCanonicalRoot(t *testing.T) {
+	home := t.TempDir()
+	store := Store{Dir: filepath.Join(home, ".subrouter", "codex")}
+	if err := os.MkdirAll(store.InstancesDir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	legacyRoot, ok := store.legacyInstancePath(store.InstancesDir())
+	if !ok {
+		t.Fatal("test store did not expose legacy instance root")
+	}
+	// ~/.codex-accounts is a symlink to ~/.subrouter/codex on installs that
+	// predate the rename, so the legacy root is a second spelling of the one
+	// canonical instances directory rather than a separate location.
+	if err := os.Symlink(store.Dir, filepath.Dir(legacyRoot)); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ImportProfileCredential("work", CredentialInfo{AccessToken: "access", RefreshToken: "refresh"}); err != nil {
+		t.Fatal(err)
+	}
+	profile, found := store.FindProfile("work")
+	if !found {
+		t.Fatal("profile missing before removal")
+	}
+	instancePath := filepath.Join(store.InstancesDir(), profile.Dir)
+	removed, err := store.RemoveProfileContext(t.Context(), "work")
+	if !removed || err != nil {
+		t.Fatalf("removal across an aliased legacy root = removed %v, err %v", removed, err)
+	}
+	paths, err := store.profileInstancePaths(profile.Dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) != 1 || paths[0] != filepath.Clean(instancePath) {
+		t.Fatalf("aliased instance paths = %v, want only %q", paths, instancePath)
+	}
+	if _, found := store.FindProfile("work"); found {
+		t.Fatal("removed profile is still registered")
+	}
+	if _, err := os.Lstat(instancePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("instance directory survived removal: %v", err)
+	}
+	if roots, listErr := stagedProfileInstanceRoots(instancePath); listErr != nil || len(roots) != 0 {
+		t.Fatalf("removal left stage roots %v, err %v", roots, listErr)
+	}
+}


### PR DESCRIPTION
`sr claude remove <name>` failed on installs that predate the `~/.subrouter` rename:

```
subrouter: validate staged Claude profile credential identity: Claude profile removal stage
".../.claude-<dir>.remove-<n>" ownership manifest does not match its exact identity
```

`~/.codex-accounts` is a symlink to `~/.subrouter/codex`, so `profileInstancePaths` returned two spellings of one directory. Staging moved the credential under the legacy spelling and wrote that spelling into the stage ownership manifest; post-stage validation walked the canonical spelling, found the same physical stage, and rejected it because the manifest claimed the other name. Every removal rolled back.

`profileInstanceRoots` now drops the legacy root when `profileInstancePathsAliasForOS` says it aliases the canonical root, and both `profileInstancePaths` and `ReconcileProfileInstanceStagesContext` take their roots from it. One physical directory gets one path, so the manifest records the spelling validation reads back.

Keychain services are keyed by the exact directory string Claude Code ran with, so collapsing the paths would strand an item written under the legacy spelling. Credential reads and deletes now visit every spelling of an instance path.

First commit adds the failing test, second adds the fix. `go test ./internal/agents/claude/` passes; the `cmd/subrouter` package is flaky on this Mac with a different test failing per run on `main` as well.

https://claude.ai/code/session_01WrnNG3U5oGktrjT9yeSh4M

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791112679&installation_model_id=21920&pr_number=309&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F309&signature=8d1e5f8c084d888b5f7ecb5aa686a31f739ae139e8ac49cebfce4dc69b0b9d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `sr claude remove <name>` failing on installs where `~/.codex-accounts` is a symlink to `~/.subrouter/codex`. The legacy root was treated as a separate instance root, so removal staged the credential under one spelling of the directory and validation read the stage under the other, rejected the ownership manifest, and rolled back. Instance roots are now collapsed when the legacy path aliases the canonical one, and Keychain credential reads and deletes still visit every spelling so credentials stored under the legacy path are not stranded.

**Additional fixes**
- Removal-stage manifest and marker checks now compare the physical directory, so a stage written before the root collapse under the legacy spelling stays owned and its credential is restored.
- Credential-set versions are keyed by physical directory, so a directory named twice and named once produce the same version.
- Reconciliation now adopts a stage written before the roots collapsed by recomputing the credential-set version over the pre-collapse spelling set instead of refusing it.

<sup>Written for commit 98d2b023b169c397abd39bcd5bd73e4b84bec45a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude profile handling when legacy and canonical storage paths refer to the same physical location.
  * Prevented duplicate processing of aliased profile directories during cleanup, recovery, and removal.
  * Improved credential consistency checks and Keychain cleanup across equivalent path spellings.
  * Restored credentials correctly when recovery data references a legacy path.
  * Improved profile deletion and recovery reliability when storage paths use aliases or symlinks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->