### PR TITLE
fix: stop treating a skipped recheck authorization as a CLA failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,16 @@ jobs:
       - name: Test
         run: CGO_ENABLED=0 go test ./...
 
+      - name: Test CLA workflow policy
+        # tests/ had no CI wiring, so a change that made the CLA required check
+        # fail on every ordinary pull request reached main unnoticed.
+        run: |
+          shopt -s nullglob
+          for suite in tests/*.sh; do
+            echo "== ${suite}"
+            bash "${suite}"
+          done
+
       - name: Test optional shadow rehearsal
         # The full shadow suite runs in this required Linux job. The hosted
         # macOS image does not permit loopback listeners from child fixtures.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -419,7 +419,16 @@ jobs:
                   ;;
               esac
               ;;
-            failure|cancelled|skipped|*)
+            skipped)
+              # Lifecycle events carry no recheck command, so the authorization
+              # step never runs. Absence of a recheck request is not a failure:
+              # classifying it as one made every ordinary pull_request_target
+              # event fail this job, which failed the required check for every
+              # pull request. It stays fail-closed because no authorization is
+              # granted here.
+              printf 'authorized=false\ndecision=not_applicable\n' >> "${GITHUB_OUTPUT}"
+              ;;
+            failure|cancelled|*)
               printf 'authorized=false\ndecision=error\n' >> "${GITHUB_OUTPUT}"
               echo "::error title=CLA recheck policy::The authorization step did not complete." >&2
               exit 1

--- a/tests/test_cla_recheck_classifier.sh
+++ b/tests/test_cla_recheck_classifier.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Runs the "Classify recheck authorization" step body straight out of
+# cla.yml against the outcomes GitHub can hand it.
+#
+# The classifier treated a skipped authorization step as a failure. On a
+# pull_request_target event there is no recheck command, so that step is always
+# skipped, and every ordinary pull request failed the trigger job and therefore
+# the required CLA check. The step is fail-closed by never granting
+# authorization, which is a separate property from failing the job.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW="$HERE/../.github/workflows/cla.yml"
+failures=0
+
+check() {
+  if [ "$2" -eq 0 ]; then printf 'ok   %s\n' "$1"
+  else printf 'FAIL %s\n' "$1"; failures=$((failures + 1)); fi
+}
+
+# Extract the classifier body: the `run: |` block of the step whose id is
+# classify-recheck, dedented to a runnable script.
+extract_classifier() {
+  # Deliberately no PyYAML: this test must run on any runner that has a stock
+  # python3. The block is found by its step id and taken by indentation.
+  python3 - "$WORKFLOW" <<'PY'
+import sys
+
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+start = None
+for index, line in enumerate(lines):
+    if line.strip() == "id: classify-recheck":
+        for cursor in range(index, len(lines)):
+            if lines[cursor].strip() in ("run: |", "run: |-"):
+                start = cursor + 1
+                break
+        break
+if start is None:
+    raise SystemExit("classify-recheck run block not found")
+
+indent = len(lines[start]) - len(lines[start].lstrip())
+body = []
+for line in lines[start:]:
+    if line.strip() and (len(line) - len(line.lstrip())) < indent:
+        break
+    body.append(line[indent:] if len(line) >= indent else line)
+sys.stdout.write("\n".join(body).rstrip() + "\n")
+PY
+}
+
+run_classifier() { # run_classifier <outcome> <authorized> <decision>
+  local script output_file
+  script="$(mktemp)"; output_file="$(mktemp)"
+  extract_classifier >"$script" || return 99
+  ACTION_OUTCOME="$1" ACTION_AUTHORIZED="$2" ACTION_DECISION="$3" \
+    GITHUB_OUTPUT="$output_file" bash "$script" >/dev/null 2>&1
+  local status=$?
+  CLASSIFIER_OUTPUT="$(cat "$output_file")"
+  rm -f "$script" "$output_file"
+  return $status
+}
+
+run_classifier skipped false ""
+status=$?
+[ "$status" -eq 0 ]
+check "a skipped authorization step does not fail the job" $?
+grep -q "authorized=false" <<<"$CLASSIFIER_OUTPUT"
+check "a skipped authorization step grants nothing" $?
+
+run_classifier success true authorized
+status=$?
+[ "$status" -eq 0 ] && grep -q "authorized=true" <<<"$CLASSIFIER_OUTPUT"
+check "an authorized recheck is admitted" $?
+
+run_classifier success false unauthorized
+status=$?
+[ "$status" -eq 0 ] && grep -q "authorized=false" <<<"$CLASSIFIER_OUTPUT"
+check "an unauthorized recheck is denied without failing" $?
+
+run_classifier success true unauthorized
+[ $? -eq 0 ] && grep -q "decision=error" <<<"$CLASSIFIER_OUTPUT"
+check "an inconsistent denial is reported as an error" $?
+
+run_classifier failure false ""
+[ $? -ne 0 ]
+check "a failed authorization step still fails the job" $?
+
+run_classifier cancelled false ""
+[ $? -ne 0 ]
+check "a cancelled authorization step still fails the job" $?
+
+if [ "$failures" -ne 0 ]; then printf '%d check(s) failed\n' "$failures"; exit 1; fi
+printf 'CLA recheck classifier tests passed\n'


### PR DESCRIPTION
main is unmergeable right now. #297 correctly made the native job the required-check producer (the ruleset never accepted the Checks API check run, which is why every merge was refused with `Required status check "CLA Assistant v3" is expected`), but it also classifies a **skipped** authorization step as an error. A `pull_request_target` event carries no recheck command, so `authorize-recheck` is always skipped, so `Validate CLA trigger` fails, so the required check fails on every ordinary pull request.

A skipped step now classifies as `authorized=false, decision=not_applicable`. The fail-closed property is that no authorization is granted; failing the job is a separate thing and was not intended for lifecycle events. `failure` and `cancelled` still fail.

`tests/` had no CI wiring, which is how this reached main. The Linux job now runs every suite in `tests/`. The new `tests/test_cla_recheck_classifier.sh` extracts the classifier body straight out of `cla.yml` and drives it with each outcome GitHub can produce, including the skipped case; it fails without this change. It parses the block by indentation rather than PyYAML so it runs on a stock runner.

https://claude.ai/code/session_01KhBTe7aDNkqgQLH14687j9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791113432&installation_model_id=21920&pr_number=310&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F310&signature=540f92ecc93d7a48c568f3f98b40a791aa5d368042d9feb212a065fd7fc688f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLA recheck classifier so a skipped authorization step no longer fails the required check. `pull_request_target` events carry no recheck command, so every ordinary pull request was failing "Validate CLA trigger"; a skipped step now records `authorized=false, decision=not_applicable` instead of an error. The job still fails on `failure` and `cancelled`, and no authorization is granted, so fail-closed behavior is unchanged.

**Tests**
- Wires `tests/` into the Linux CI job, which previously had no coverage.
- Adds a classifier test that runs the step body from `cla.yml` against each outcome GitHub can produce, including the skipped case; it fails without this fix.

<sup>Written for commit 8c123cfb99d49707c89c8efa5a7bce51c7680caf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

