### PR TITLE
fix: a restart must survive losing the shell that started it

### DIFF
--- a/deploy/macos/DEPLOY.md
+++ b/deploy/macos/DEPLOY.md
@@ -35,15 +35,24 @@ sudo launchctl bootout system/ai.manaflow.subrouter-team   # closes the port
 sudo launchctl bootstrap system /Library/LaunchDaemons/ai.manaflow.subrouter-team.plist
 ```
 
-A `bootout` is only correct when the plist itself changed, because `kickstart
--k` reuses the cached environment. In that case set the maintenance sentinel
-first so the watchdogs do not fight the restart, and clear it after:
+Typing that sequence by hand is how the router was left down on 2026-09-04: the
+ssh session running it was interrupted between the bootout and the bootstrap,
+so the service stayed out of the launchd domain with the port closed, and the
+maintenance sentinel the operator had set kept the watchdog from healing it.
+
+Anything that needs a real restart, including a plist change (`kickstart -k`
+reuses the cached environment) or a new supervisor, goes through these instead.
+Both hold the maintenance sentinel only for the operation, clear it on every
+exit path including an interrupt, and run the stop/start as one detached
+sequence that finishes even if the caller dies:
 
 ```bash
-sudo touch /var/lib/subrouter-verify/maintenance
-# bootout, confirm the supervisor and worker pids are gone, bootstrap
-sudo rm /var/lib/subrouter-verify/maintenance
+sudo subrouter-deploy.sh restart-daemon
+sudo subrouter-deploy.sh install-supervisor /path/to/subrouter-supervisor
 ```
+
+`install-supervisor` keeps the outgoing binary and puts it back if health does
+not return.
 
 ## Watchdogs
 
@@ -63,7 +72,11 @@ guard tick inside that window would record the untested candidate as last-good.
 For the same reason the deploy keeps its own private copy of the outgoing
 binary and rolls back to that, never to the shared last-good file.
 
-Both honor a `maintenance` sentinel younger than 90 minutes.
+Both honor a `maintenance` sentinel younger than 90 minutes, with one
+exception: if the service is not in the launchd domain at all, the guard
+bootstraps it anyway once the sentinel is older than three minutes. A hand
+restart passes through that state for seconds; an interrupted one leaves the
+service there for good, and the sentinel must not make that permanent.
 
 ```bash
 sudo tail -f /var/log/subrouter-guard.log

--- a/deploy/macos/subrouter-deploy.sh
+++ b/deploy/macos/subrouter-deploy.sh
@@ -28,6 +28,10 @@ HEALTH_URL="${SUBROUTER_HEALTH_URL:-http://127.0.0.1:31415/_subrouter/health}"
 UPGRADE_INHIBIT_FILE="${SUBROUTER_UPGRADE_INHIBIT_FILE:-${PLIST}.supervisor-transaction/upgrade-inhibited}"
 HEALTH_TIMEOUT_SECS="${SUBROUTER_DEPLOY_HEALTH_TIMEOUT_SECS:-45}"
 LOCK_DIR="${SUBROUTER_DEPLOY_LOCK_DIR:-${STATE}/deploy.lock}"
+SUPERVISOR_BIN="${SUBROUTER_SUPERVISOR_BIN:-/usr/local/libexec/subrouter-supervisor}"
+MAINTENANCE="${SUBROUTER_MAINTENANCE_FILE:-${STATE}/maintenance}"
+LAUNCHCTL="${SUBROUTER_LAUNCHCTL:-launchctl}"
+RESTART_WAIT_SECS="${SUBROUTER_DEPLOY_RESTART_WAIT_SECS:-12}"
 
 log() { printf 'subrouter-deploy: %s\n' "$*" >&2; }
 die() { log "$*"; exit 1; }
@@ -36,17 +40,28 @@ usage() {
   cat <<'EOF'
 Usage:
   subrouter-deploy.sh install <candidate-binary> [--label <version-text>]
+  subrouter-deploy.sh install-supervisor <candidate-binary>
+  subrouter-deploy.sh restart-daemon
   subrouter-deploy.sh rollback
   subrouter-deploy.sh status
 
 install   Hot-swap the worker behind the live listener and roll back by itself
           if the candidate never becomes ready or public health drops.
+install-supervisor
+          Replace the supervisor, which owns the listener and therefore needs a
+          restart, then verify health and put the old binary back if it does
+          not return.
+restart-daemon
+          Stop and start the LaunchDaemon as one detached operation that
+          finishes even if the shell or ssh session that started it dies.
 rollback  Put the recorded last-good worker back the same way.
 status    Print the live binary, the recorded last-good, and health.
 
-Never run `launchctl bootout` on the subrouter LaunchDaemon to pick up a new
-worker. A restart turns a slow or broken worker into a total outage, because
-the supervisor binds the public port only after the first worker is ready.
+Never run `launchctl bootout` on the subrouter LaunchDaemon by hand. A restart
+turns a slow or broken worker into a total outage, because the supervisor binds
+the public port only after the first worker is ready, and a bootout whose shell
+dies before the bootstrap leaves the service out of the launchd domain with the
+port closed. `restart-daemon` exists so that sequence cannot be interrupted.
 EOF
 }
 
@@ -239,8 +254,110 @@ cmd_status() {
   if health_ok; then printf 'health    ok\n'; else printf 'health    DOWN\n'; fi
 }
 
+# restart_daemon_body performs the whole stop/start sequence. It is written to
+# a script and run detached, so an interrupted caller cannot leave the service
+# booted out with the port closed: the sequence keeps running to the bootstrap.
+restart_daemon_body() {
+  cat <<'BODY'
+set -u
+LABEL="__LABEL__"
+PLIST="__PLIST__"
+SUPERVISOR_BIN="__SUPERVISOR_BIN__"
+BIN="__BIN__"
+LAUNCHCTL="__LAUNCHCTL__"
+RESTART_WAIT_SECS="__RESTART_WAIT_SECS__"
+"$LAUNCHCTL" bootout "system/${LABEL}" >/dev/null 2>&1 || true
+deadline=$((SECONDS + RESTART_WAIT_SECS))
+while [ "$SECONDS" -lt "$deadline" ]; do
+  pids="$(pgrep -f "^${SUPERVISOR_BIN} supervise" 2>/dev/null; pgrep -f "^${BIN} serve " 2>/dev/null)"
+  [ -z "$pids" ] && break
+  sleep 1
+done
+pids="$(pgrep -f "^${SUPERVISOR_BIN} supervise" 2>/dev/null; pgrep -f "^${BIN} serve " 2>/dev/null)"
+[ -n "$pids" ] && kill -KILL $pids 2>/dev/null
+sleep 1
+"$LAUNCHCTL" bootstrap system "$PLIST" >/dev/null 2>&1 || true
+BODY
+}
+
+restart_daemon() {
+  local script
+  script="$(mktemp)"
+  restart_daemon_body \
+    | sed -e "s#__LABEL__#${LABEL}#" -e "s#__PLIST__#${PLIST}#" \
+          -e "s#__SUPERVISOR_BIN__#${SUPERVISOR_BIN}#" -e "s#__BIN__#${BIN}#" \
+          -e "s#__LAUNCHCTL__#${LAUNCHCTL}#" -e "s#__RESTART_WAIT_SECS__#${RESTART_WAIT_SECS}#" \
+    >"$script"
+  # Detach: a killed ssh session or Ctrl-C must not strand the service between
+  # bootout and bootstrap. That is exactly how the router was left down once.
+  # macOS ships no setsid, and a backgrounded subshell always reports success,
+  # so the fallback has to be chosen before the fork, not after it.
+  if command -v setsid >/dev/null 2>&1; then
+    setsid bash "$script" >/dev/null 2>&1 </dev/null &
+  else
+    nohup bash "$script" >/dev/null 2>&1 </dev/null &
+  fi
+  disown 2>/dev/null || true
+  local deadline=$((SECONDS + HEALTH_TIMEOUT_SECS))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    health_ok && { rm -f "$script"; return 0; }
+    sleep 2
+  done
+  rm -f "$script"
+  return 1
+}
+
+cmd_restart_daemon() {
+  take_lock
+  : >"$MAINTENANCE"
+  # The sentinel is removed on every exit path, including an interrupt, so a
+  # killed restart cannot also leave the watchdog muzzled.
+  trap 'rm -f "$MAINTENANCE" 2>/dev/null || true; release_lock' EXIT
+  log "restarting ${LABEL}"
+  if restart_daemon; then
+    log "health is answering again"
+  else
+    die "the service did not come back within ${HEALTH_TIMEOUT_SECS}s; check /var/log/subrouter-guard.log"
+  fi
+}
+
+cmd_install_supervisor() {
+  local candidate="${1:-}"
+  [ -n "$candidate" ] || { usage; exit 2; }
+  [ -f "$candidate" ] || die "$candidate does not exist"
+  [ -x "$candidate" ] || die "$candidate is not executable"
+  "$candidate" --help >/dev/null 2>&1 || die "$candidate does not answer --help; wrong arch or a corrupt download"
+  local candidate_sha current_sha
+  candidate_sha="$(sha_of "$candidate")"
+  current_sha="$(sha_of "$SUPERVISOR_BIN")"
+  [ "$candidate_sha" != "$current_sha" ] || { log "supervisor is already installed ($candidate_sha)"; exit 0; }
+  health_ok || die "public health is down right now; fix the outage before replacing the supervisor"
+
+  take_lock
+  : >"$MAINTENANCE"
+  trap 'rm -f "$MAINTENANCE" 2>/dev/null || true; release_lock' EXIT
+
+  local backup="${SUPERVISOR_BIN}.backup-$(date +%Y%m%d-%H%M%S)"
+  cp -p "$SUPERVISOR_BIN" "$backup"
+  log "current supervisor ${current_sha:0:12} saved to $backup"
+  install -m 0755 "$candidate" "${SUPERVISOR_BIN}.new"
+  mv -f "${SUPERVISOR_BIN}.new" "$SUPERVISOR_BIN"
+
+  if restart_daemon; then
+    log "installed supervisor ${candidate_sha:0:12}; health is answering"
+    return 0
+  fi
+  log "supervisor ${candidate_sha:0:12} did not bring the service back; restoring ${current_sha:0:12}"
+  install -m 0755 "$backup" "${SUPERVISOR_BIN}.rb"
+  mv -f "${SUPERVISOR_BIN}.rb" "$SUPERVISOR_BIN"
+  restart_daemon || log "the restored supervisor is not answering either; this needs a human"
+  die "supervisor install failed and the previous binary was restored"
+}
+
 case "${1:-}" in
   install) shift; cmd_install "$@" ;;
+  install-supervisor) shift; cmd_install_supervisor "$@" ;;
+  restart-daemon) shift; cmd_restart_daemon "$@" ;;
   rollback) shift; cmd_rollback "$@" ;;
   status) shift; cmd_status "$@" ;;
   -h|--help|help|"") usage ;;

--- a/deploy/macos/subrouter-guard.sh
+++ b/deploy/macos/subrouter-guard.sh
@@ -41,6 +41,13 @@ DEPLOY_LOCK_DIR="${SUBROUTER_DEPLOY_LOCK_DIR:-${STATE}/deploy.lock}"
 DEPLOY_LOCK_GRACE_MINS="${SUBROUTER_GUARD_DEPLOY_LOCK_GRACE_MINS:-5}"
 GUARD_LOCK_DIR="${SUBROUTER_GUARD_LOCK_DIR:-${STATE}/guard.lock}"
 GUARD_LOCK_STALE_MINS="${SUBROUTER_GUARD_LOCK_STALE_MINS:-10}"
+# A maintenance sentinel silences recovery for 90 minutes, which is right while
+# a human is working on the service. It is wrong when the service is not in the
+# launchd domain at all: that is what an interrupted `bootout` leaves behind,
+# and on 2026-09-04 it kept the router down with the watchdog muzzled. A hand
+# restart passes through that state for seconds, so the sentinel still wins for
+# a short grace, and after it the guard bootstraps a service nobody is running.
+MISSING_SERVICE_GRACE_MINS="${SUBROUTER_GUARD_MISSING_SERVICE_GRACE_MINS:-3}"
 
 mkdir -p "$STATE"
 now_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -144,7 +151,19 @@ strikes=$(( $(read_strikes) + 1 ))
 printf '%s\n' "$strikes" >"$STRIKES_FILE"
 
 if [ -e "$MAINTENANCE" ] && [ -n "$(find "$MAINTENANCE" -mmin -90 2>/dev/null)" ]; then
-  emit INFO "health down (strike ${strikes}); fresh maintenance sentinel, no recovery"
+  if "$LAUNCHCTL" print "system/${LABEL}" >/dev/null 2>&1 ||
+     [ -n "$(find "$MAINTENANCE" -mmin "-${MISSING_SERVICE_GRACE_MINS}" 2>/dev/null)" ]; then
+    emit INFO "health down (strike ${strikes}); fresh maintenance sentinel, no recovery"
+    exit 0
+  fi
+  emit ALERT "maintenance sentinel is set but ${LABEL} is not in the launchd domain after ${MISSING_SERVICE_GRACE_MINS}m; bootstrapping anyway"
+  [ -f "$PLIST" ] && "$LAUNCHCTL" bootstrap system "$PLIST" >/dev/null 2>&1
+  if wait_health; then
+    emit INFO "recovery succeeded: health answering again"
+    rm -f "$STRIKES_FILE"
+  else
+    emit ALERT "bootstrap under maintenance did not restore health; this needs a human"
+  fi
   exit 0
 fi
 

--- a/deploy/macos/tests/deploy-install-test.sh
+++ b/deploy/macos/tests/deploy-install-test.sh
@@ -165,5 +165,33 @@ after="$(shasum -a 256 "$ROOT/bin/subrouter" | awk '{print $1}')"
 check "rollback survives last-good being overwritten mid-install" $?
 teardown
 
+# 8. The restart sequence must finish even when the caller that started it is
+# killed. An interrupted `bootout` left the service out of the launchd domain
+# with the port closed on 2026-09-04.
+setup ok
+export SUBROUTER_SUPERVISOR_BIN="$ROOT/bin/subrouter-supervisor"
+export SUBROUTER_MAINTENANCE_FILE="$ROOT/state/maintenance"
+export SUBROUTER_LAUNCHCTL="$ROOT/bin/launchctl"
+cat >"$ROOT/bin/launchctl" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$LAUNCHCTL_CALLS"
+# The bootstrap step is what must still happen after the caller is gone.
+[ "${1:-}" = "bootstrap" ] && printf 'ok\n' >"$HEALTH_FILE"
+exit 0
+FAKE
+chmod 0755 "$ROOT/bin/launchctl"
+export LAUNCHCTL_CALLS="$ROOT/calls" HEALTH_FILE="$ROOT/health"
+: >"$LAUNCHCTL_CALLS"
+rm -f "$ROOT/health"
+# Kill the caller one second in: the detached sequence must still bootstrap.
+bash "$DEPLOY" restart-daemon >/dev/null 2>&1 &
+caller=$!
+sleep 1
+kill -KILL "$caller" 2>/dev/null
+for _ in $(seq 1 20); do grep -q "^bootstrap system " "$LAUNCHCTL_CALLS" && break; sleep 1; done
+grep -q "^bootout system/" "$LAUNCHCTL_CALLS" && grep -q "^bootstrap system " "$LAUNCHCTL_CALLS"
+check "a killed caller still leaves the service bootstrapped" $?
+teardown
+
 if [ "$failures" -ne 0 ]; then printf '%d check(s) failed\n' "$failures"; exit 1; fi
 printf 'all checks passed\n'

--- a/deploy/macos/tests/guard-rollback-test.sh
+++ b/deploy/macos/tests/guard-rollback-test.sh
@@ -107,7 +107,8 @@ unhealthy
 : >"$ROOT/state/maintenance"
 bash "$GUARD" >/dev/null 2>&1
 bash "$GUARD" >/dev/null 2>&1
-[ "$(cat "$ROOT/bin/subrouter")" = "broken" ] && [ ! -s "$LAUNCHCTL_CALLS" ]
+# A read-only `print` is not a recovery action; assert on the mutating verbs.
+[ "$(cat "$ROOT/bin/subrouter")" = "broken" ] && ! grep -qE "^(bootout|bootstrap|kickstart)" "$LAUNCHCTL_CALLS"
 check "fresh maintenance sentinel blocks rollback and restart" $?
 teardown
 
@@ -126,6 +127,26 @@ wait
 check "successful recovery clears the strike counter" $?
 teardown
 
+# 6b. A sentinel must not muzzle recovery once the service is gone from the
+# launchd domain. An interrupted bootout leaves exactly that state, and it kept
+# the router down on 2026-09-04.
+setup
+healthy
+bash "$GUARD" >/dev/null 2>&1
+unhealthy
+: >"$ROOT/state/maintenance"
+export LAUNCHCTL_PRINT_EXIT=1   # the service is not in the launchd domain
+bash "$GUARD" >/dev/null 2>&1
+bash "$GUARD" >/dev/null 2>&1
+[ ! -s "$LAUNCHCTL_CALLS" ] || ! grep -q "^bootstrap system " "$LAUNCHCTL_CALLS"
+check "a fresh sentinel still holds recovery for the grace window" $?
+touch -t "$(date -v-10M +%Y%m%d%H%M 2>/dev/null || date -d '10 minutes ago' +%Y%m%d%H%M)" "$ROOT/state/maintenance"
+bash "$GUARD" >/dev/null 2>&1
+grep -q "^bootstrap system " "$LAUNCHCTL_CALLS"
+check "after the grace window a missing service is bootstrapped anyway" $?
+unset LAUNCHCTL_PRINT_EXIT
+teardown
+
 # 7. A running deploy owns the outcome: no promotion, no restart, no rollback.
 setup
 healthy
@@ -137,7 +158,7 @@ check "no last-good promotion while a deploy holds the lock" $?
 unhealthy
 bash "$GUARD" >/dev/null 2>&1
 bash "$GUARD" >/dev/null 2>&1
-[ "$(cat "$ROOT/bin/subrouter")" = "candidate" ] && [ ! -s "$LAUNCHCTL_CALLS" ]
+[ "$(cat "$ROOT/bin/subrouter")" = "candidate" ] && ! grep -qE "^(bootout|bootstrap|kickstart)" "$LAUNCHCTL_CALLS"
 check "no rollback or restart while a deploy holds the lock" $?
 teardown
 


### PR DESCRIPTION
The router went down for two minutes today because a hand-typed restart was interrupted between `launchctl bootout` and `launchctl bootstrap`. Two things turned that into an outage rather than a blip: the sequence had no way to finish once its ssh session died, and the maintenance sentinel it had set to keep the watchdogs off also stopped `subrouter-guard.sh` from healing what it left behind. The service sat outside the launchd domain with port 31415 closed.

`subrouter-deploy.sh restart-daemon` and `install-supervisor` run the whole stop/start as one detached script, so an interrupted caller cannot strand the service, and they clear the sentinel on every exit path including an interrupt. `install-supervisor` keeps the outgoing supervisor and puts it back if health does not return, which is the same shape `install` already had for the worker.

`subrouter-guard.sh` still honours a fresh sentinel, with one exception: when the service is missing from the launchd domain entirely it bootstraps anyway once the sentinel is older than three minutes. A hand restart passes through that state for seconds; an interrupted one stays there.

Tests: a killed caller still reaches the bootstrap (the new caller-kill case in `deploy-install-test.sh`), and the sentinel holds recovery inside the grace window but not after it. Both suites pass, 13 and 17 checks.

https://claude.ai/code/session_01KhBTe7aDNkqgQLH14687j9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791114166&installation_model_id=21920&pr_number=311&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F311&signature=327d784262c92190d15a3398f2d87a72ea031b3a1972c7f5742f0a68bb348df8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the macOS router restart survive losing the shell that started it, so an interrupted hand-typed `launchctl bootout` no longer leaves the service down with the port closed and the watchdog muzzled.

- `restart-daemon` and `install-supervisor` run the whole stop/start as one detached script, so a killed caller can't strand the service between bootout and bootstrap.
- Both clear the maintenance sentinel on every exit path, and `install-supervisor` restores the outgoing binary if health doesn't return.
- The guard bootstraps a service missing from the launchd domain once the sentinel is older than three minutes; tests cover a killed caller reaching bootstrap and the sentinel holding recovery inside the grace window but not after.

<sup>Written for commit 33896bbb3b40875c69740ef7fb8fc15de4a9c436. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

