### PR TITLE
fix: retry bootstrap while the old job drains, and clear the sentinel from the detached script

### DIFF
--- a/deploy/macos/subrouter-deploy.sh
+++ b/deploy/macos/subrouter-deploy.sh
@@ -266,6 +266,11 @@ SUPERVISOR_BIN="__SUPERVISOR_BIN__"
 BIN="__BIN__"
 LAUNCHCTL="__LAUNCHCTL__"
 RESTART_WAIT_SECS="__RESTART_WAIT_SECS__"
+MAINTENANCE="__MAINTENANCE__"
+# This script, not the caller, clears the sentinel. A caller killed with
+# SIGKILL runs no trap, and a sentinel left behind is what stopped the guard
+# from healing an interrupted restart.
+trap 'rm -f "$MAINTENANCE" 2>/dev/null || true' EXIT
 "$LAUNCHCTL" bootout "system/${LABEL}" >/dev/null 2>&1 || true
 deadline=$((SECONDS + RESTART_WAIT_SECS))
 while [ "$SECONDS" -lt "$deadline" ]; do
@@ -276,7 +281,17 @@ done
 pids="$(pgrep -f "^${SUPERVISOR_BIN} supervise" 2>/dev/null; pgrep -f "^${BIN} serve " 2>/dev/null)"
 [ -n "$pids" ] && kill -KILL $pids 2>/dev/null
 sleep 1
-"$LAUNCHCTL" bootstrap system "$PLIST" >/dev/null 2>&1 || true
+# launchd answers "Input/output error" while the old job is still draining
+# under its ExitTimeOut, even after every process is gone. A single bootstrap
+# therefore loses the race and leaves the service out of the domain with the
+# port closed, which is how a restart turned into an outage. Retry until the
+# job is really in the domain.
+bootstrap_deadline=$((SECONDS + 120))
+while [ "$SECONDS" -lt "$bootstrap_deadline" ]; do
+  "$LAUNCHCTL" bootstrap system "$PLIST" >/dev/null 2>&1
+  "$LAUNCHCTL" print "system/${LABEL}" >/dev/null 2>&1 && break
+  sleep 2
+done
 BODY
 }
 
@@ -287,6 +302,7 @@ restart_daemon() {
     | sed -e "s#__LABEL__#${LABEL}#" -e "s#__PLIST__#${PLIST}#" \
           -e "s#__SUPERVISOR_BIN__#${SUPERVISOR_BIN}#" -e "s#__BIN__#${BIN}#" \
           -e "s#__LAUNCHCTL__#${LAUNCHCTL}#" -e "s#__RESTART_WAIT_SECS__#${RESTART_WAIT_SECS}#" \
+          -e "s#__MAINTENANCE__#${MAINTENANCE}#" \
     >"$script"
   # Detach: a killed ssh session or Ctrl-C must not strand the service between
   # bootout and bootstrap. That is exactly how the router was left down once.

--- a/deploy/macos/tests/deploy-install-test.sh
+++ b/deploy/macos/tests/deploy-install-test.sh
@@ -86,6 +86,35 @@ setup() { # setup <upgrade-mode>
 
 teardown() { kill "$FAKE_PID" 2>/dev/null; wait "$FAKE_PID" 2>/dev/null; rm -rf "$ROOT"; }
 
+# A launchd stand-in for the restart path: it records every verb, refuses the
+# first bootstraps the way a draining job does, and only then reports the
+# service in the domain.
+install_restart_launchctl() {
+  export SUBROUTER_SUPERVISOR_BIN="$ROOT/bin/subrouter-supervisor"
+  export SUBROUTER_MAINTENANCE_FILE="$ROOT/state/maintenance"
+  export SUBROUTER_LAUNCHCTL="$ROOT/bin/launchctl"
+  export LAUNCHCTL_CALLS="$ROOT/calls"
+  export HEALTH_FILE="$ROOT/health"
+  export IN_DOMAIN_FILE="$ROOT/in-domain"
+  : >"$LAUNCHCTL_CALLS"
+  rm -f "$HEALTH_FILE" "$IN_DOMAIN_FILE"
+  cat >"$ROOT/bin/launchctl" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$LAUNCHCTL_CALLS"
+if [ "${1:-}" = "bootstrap" ]; then
+  attempts="$(grep -c '^bootstrap ' "$LAUNCHCTL_CALLS")"
+  if [ "${attempts}" -ge "${BOOTSTRAP_SUCCEEDS_ON:-1}" ]; then
+    printf 'ok\n' >"$HEALTH_FILE"
+    printf 'in-domain\n' >"$IN_DOMAIN_FILE"
+  fi
+  exit 0
+fi
+[ "${1:-}" = "print" ] && { [ -f "$IN_DOMAIN_FILE" ] || exit 1; exit 0; }
+exit 0
+FAKE
+  chmod 0755 "$ROOT/bin/launchctl"
+}
+
 # 1. A candidate that becomes ready is installed and recorded.
 setup ok
 bash "$DEPLOY" install "$ROOT/candidate" --label v9.9.9 >/dev/null 2>&1
@@ -191,6 +220,35 @@ kill -KILL "$caller" 2>/dev/null
 for _ in $(seq 1 20); do grep -q "^bootstrap system " "$LAUNCHCTL_CALLS" && break; sleep 1; done
 grep -q "^bootout system/" "$LAUNCHCTL_CALLS" && grep -q "^bootstrap system " "$LAUNCHCTL_CALLS"
 check "a killed caller still leaves the service bootstrapped" $?
+teardown
+
+# 8. The restart sequence must finish even when the caller that started it is
+# killed. An interrupted `bootout` left the service out of the launchd domain
+# with the port closed on 2026-09-04.
+setup ok
+install_restart_launchctl
+bash "$DEPLOY" restart-daemon >/dev/null 2>&1 &
+caller=$!
+sleep 1
+kill -KILL "$caller" 2>/dev/null
+for _ in $(seq 1 20); do grep -q "^bootstrap system " "$LAUNCHCTL_CALLS" && break; sleep 1; done
+grep -q "^bootout system/" "$LAUNCHCTL_CALLS" && grep -q "^bootstrap system " "$LAUNCHCTL_CALLS"
+check "a killed caller still leaves the service bootstrapped" $?
+for _ in $(seq 1 10); do [ -e "$SUBROUTER_MAINTENANCE_FILE" ] || break; sleep 1; done
+[ ! -e "$SUBROUTER_MAINTENANCE_FILE" ]
+check "a killed restart does not leave the watchdog muzzled" $?
+teardown
+
+# 9. launchd refuses a bootstrap while the old job drains. Doing it once is
+# what left the service out of the domain with the port closed.
+setup ok
+install_restart_launchctl
+export BOOTSTRAP_SUCCEEDS_ON=3
+bash "$DEPLOY" restart-daemon >/dev/null 2>&1
+for _ in $(seq 1 30); do [ -f "$HEALTH_FILE" ] && break; sleep 1; done
+[ "$(grep -c '^bootstrap ' "$LAUNCHCTL_CALLS")" -ge 3 ] && [ -f "$HEALTH_FILE" ]
+check "bootstrap is retried until the job is in the launchd domain" $?
+unset BOOTSTRAP_SUCCEEDS_ON
 teardown
 
 if [ "$failures" -ne 0 ]; then printf '%d check(s) failed\n' "$failures"; exit 1; fi


### PR DESCRIPTION
Two defects found by replaying tonight's outage against the restart path.

`launchctl bootstrap` answers "Input/output error" while the old job is still draining under its 600s `ExitTimeOut`, even after every process is gone. `restart-daemon` bootstrapped once and gave up, which is exactly how the service ended up outside the launchd domain with port 31415 closed. It now retries until `launchctl print` shows the job in the domain, bounded at 120s.

The maintenance sentinel was cleared by an EXIT trap in the caller. A caller killed with SIGKILL runs no trap, so the sentinel survived and muzzled `subrouter-guard.sh` for the whole outage. The detached script now owns the sentinel and clears it on its own exit, so a killed caller cannot leave the watchdog disabled.

Tests: a fake launchd that refuses the first bootstraps the way a draining job does, asserting the retry reaches the domain; and the caller-kill case now also asserts the sentinel is gone afterwards.

https://claude.ai/code/session_01KhBTe7aDNkqgQLH14687j9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791114587&installation_model_id=21920&pr_number=312&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F312&signature=7b4cb2dcff21278d5d52f6a8d1f6d0b491a170ca276492e0bce5e83fe6c1e897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS restart path so a restart can no longer leave the service out of the launchd domain or leave the watchdog muzzled after an interrupted deployment.

**Bug Fixes**

- Retries `launchctl bootstrap` until `launchctl print` shows the job in the domain, instead of giving up after the first "Input/output error" while the old job drains.
- Moves maintenance sentinel cleanup from the caller's EXIT trap into the detached script, so a SIGKILLed caller can't leave the sentinel behind and disable the watchdog.

<sup>Written for commit a2f00a12d43db77a4d91b9a41166448e79bf8279. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS daemon restarts to recover more reliably when the previous process is still shutting down.
  - Added automatic retry handling during service startup, reducing restart failures caused by temporary launch-system errors.
  - Ensured maintenance state is cleared after interrupted restarts, preventing the watchdog from remaining disabled.
  - Added safeguards to confirm the daemon is active before completing the restart process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->