### PR TITLE
fix: say which address family the public listener bound

### DIFF
--- a/cmd/subrouter/front.go
+++ b/cmd/subrouter/front.go
@@ -338,7 +338,30 @@ func openFreshPublicListener(address string) (net.Listener, error) {
 			network = "tcp6"
 		}
 	}
+	// `0.0.0.0:31415` is an IPv4 wildcard and binds IPv4 only, which is what it
+	// says. It is also what every macOS and GCP deployment template in this
+	// repo writes, so a host whose clients arrive over IPv6 loses them the
+	// moment its supervisor is upgraded to a build that honours the family.
+	// Say so at startup instead of leaving it to be discovered by the clients.
+	if network == "tcp4" && ip4WildcardHost(host) {
+		slog.Warn("public listener is IPv4 only; IPv6 clients cannot reach it",
+			"addr", address, "network", network,
+			"fix", "use :"+portOf(address)+" to serve both families")
+	}
+	slog.Info("opening public listener", "addr", address, "network", network)
 	return (&net.ListenConfig{}).Listen(context.Background(), network, address)
+}
+
+func ip4WildcardHost(host string) bool {
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsUnspecified() && ip.To4() != nil
+}
+
+func portOf(address string) string {
+	if _, port, err := net.SplitHostPort(address); err == nil {
+		return port
+	}
+	return ""
 }
 
 func openFrontPublicListener(address string) (net.Listener, bool, error) {

--- a/deploy/macos/DEPLOY.md
+++ b/deploy/macos/DEPLOY.md
@@ -54,6 +54,19 @@ sudo subrouter-deploy.sh install-supervisor /path/to/subrouter-supervisor
 `install-supervisor` keeps the outgoing binary and puts it back if health does
 not return.
 
+## Listen address
+
+Use `--addr :31415`, not `--addr 0.0.0.0:31415`. The IPv4 wildcard binds IPv4
+only, which is exactly what it means, and current supervisors honour it. Older
+builds bound dual stack from the same string, so upgrading a supervisor on a
+host whose clients arrive over IPv6, such as anything on the tailnet, silently
+drops those clients. That happened on cmux-lawrence on 2026-09-04. The
+supervisor now logs the family it bound and warns when it is IPv4 only.
+
+```bash
+curl -m 5 "http://[$(tailscale ip -6 <host> | head -1)]:31415/_subrouter/health"
+```
+
 ## Watchdogs
 
 `subrouter-guard.sh` (`ai.manaflow.subrouter-guard`, every 60s) records the


### PR DESCRIPTION
`0.0.0.0:31415` is an IPv4 wildcard and binds IPv4 only. That is correct, and current builds honour it. It is also what every macOS and GCP deployment template in this repo writes, and older supervisors bound dual stack from the same string, so upgrading the supervisor on a host whose clients arrive over IPv6 silently drops them.

That is not hypothetical: it happened on cmux-lawrence tonight. Health over the tailnet IPv4 address answered 200 while the IPv6 address refused connections, and the only visible difference was `IPv6` versus `IPv4` in one `lsof` line. The host's plist now says `:31415` and both families answer.

The listener now logs the family it bound, and warns explicitly when an IPv4 wildcard means IPv6 clients cannot reach it, with the fix in the message. `DEPLOY.md` documents the address choice and gives the IPv6 health probe.

Not changed: the meaning of `0.0.0.0`. A deployment that wants IPv4 only should keep saying so.

Follow-up worth doing separately: `deploy/gcp/install-front-slots.sh` still *requires* `0.0.0.0:3141[56]` and should accept `:3141[56]`.

https://claude.ai/code/session_01KhBTe7aDNkqgQLH14687j9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791115578&installation_model_id=21920&pr_number=313&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F313&signature=22a445eb138fa15c6f3b28b2611dc7fd99f84a771e1fa82a40eb407caf2a8e9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent loss of IPv6 clients when the public listener binds to an IPv4 wildcard address. The listener now logs the address family it bound and warns when IPv4-only prevents IPv6 clients from connecting, and `DEPLOY.md` documents the recommended `:31415` address with an IPv6 health probe.

- The meaning of `0.0.0.0` is unchanged; it still binds IPv4 only.

<sup>Written for commit 951bdce7b86a1d9fd940cebc31f33345e63e7842. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

