### PR TITLE
fix: stop failing the golden run on a single sampling hiccup

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -30,22 +30,32 @@ import (
 )
 
 const (
-	goldenProbeInterval                       = 100 * time.Millisecond
-	goldenProbeScheduleTolerance              = 50 * time.Millisecond
-	goldenHTTPTimeout                         = 900 * time.Millisecond
-	goldenLocalEgressBindTimeout              = 2 * time.Second
-	goldenActionEvidenceLimit                 = 256 << 10
-	goldenActivationLimit                     = 30 * time.Second
-	goldenMigrationPropagationLimit           = 5 * time.Minute
-	goldenDestinationLivenessLimit            = 10 * time.Second
-	goldenBackendHealthStabilityLimit         = 5 * time.Minute
-	goldenRetirementLimit                     = 30 * time.Second
-	goldenChunkGapFloor                       = 5 * time.Second
-	goldenRSSLimitBytes                 int64 = 192 << 20
-	goldenCodexRSSLimitBytes            int64 = 512 << 20
-	goldenBaselineChunkSamples                = 20
-	goldenProcessSampleInterval               = 20 * time.Millisecond
+	goldenProbeInterval                     = 100 * time.Millisecond
+	goldenProbeScheduleTolerance            = 50 * time.Millisecond
+	goldenHTTPTimeout                       = 900 * time.Millisecond
+	goldenLocalEgressBindTimeout            = 2 * time.Second
+	goldenActionEvidenceLimit               = 256 << 10
+	goldenActivationLimit                   = 30 * time.Second
+	goldenMigrationPropagationLimit         = 5 * time.Minute
+	goldenDestinationLivenessLimit          = 10 * time.Second
+	goldenBackendHealthStabilityLimit       = 5 * time.Minute
+	goldenRetirementLimit                   = 30 * time.Second
+	goldenChunkGapFloor                     = 5 * time.Second
+	goldenRSSLimitBytes               int64 = 192 << 20
+	goldenCodexRSSLimitBytes          int64 = 512 << 20
+	goldenBaselineChunkSamples              = 20
+	goldenProcessSampleInterval             = 20 * time.Millisecond
+	// A sampler that stops for long enough to hide a memory spike is a real
+	// defect. A single scheduling hiccup on a shared runner is not: the
+	// sampler ticks every 20ms and shells out for a process table, so a busy
+	// host routinely exceeds 100ms once. Failing on that made this required
+	// check fail on pull requests that touch nothing near it, three times on
+	// 2026-09-04 alone. The target stays 100ms and is reported; the run fails
+	// only when one gap is long enough to be a real blind spot, or when gaps
+	// over the target stop being rare.
 	goldenProcessSampleMaxGap                 = 100 * time.Millisecond
+	goldenProcessSampleHardCeiling            = time.Second
+	goldenProcessSampleOverTargetPercentLimit = 5
 	goldenSamplingEvidenceQueueCapacity       = 4096
 	goldenPinnedPredecessorVersion            = "0.1.60"
 	goldenPinnedPredecessorSHA256             = "769e504b731ef8b43db67e7651dcfe9ae169516570c7d2d2d211a6f997be1a7c"
@@ -445,7 +455,11 @@ type goldenSummary struct {
 	LocalDaemonRSSSamples     int   `json:"local_daemon_rss_samples"`
 	LocalDaemonProcessSamples int   `json:"local_daemon_process_samples"`
 	LocalDaemonMaxSampleGapMS int64 `json:"local_daemon_max_process_sample_gap_ms"`
-	LocalDaemonPausedSamples  int   `json:"local_daemon_paused_samples"`
+	// LocalDaemonSampleGapsOverTarget counts intervals longer than the sampling
+	// target. Rare ones are runner noise; a rising count means the sampler is
+	// losing the process tree.
+	LocalDaemonSampleGapsOverTarget int `json:"local_daemon_process_sample_gaps_over_target"`
+	LocalDaemonPausedSamples        int `json:"local_daemon_paused_samples"`
 }
 
 type goldenActionSummary struct {
@@ -705,6 +719,7 @@ type goldenRunner struct {
 	localRSSMu          sync.Mutex
 	localPeakRSS        int64
 	localRSSSamples     int
+	localGapsOverTarget int
 	localRSSExceeded    bool
 	localLastSample     time.Time
 	localMaxSampleGap   time.Duration
@@ -2588,8 +2603,12 @@ func (r *goldenRunner) recordGoldenProcessSample(pid int) {
 	r.localRSSMu.Lock()
 	if sampledAt.After(r.localLastSample) {
 		if !r.localLastSample.IsZero() {
-			if gap := sampledAt.Sub(r.localLastSample); gap > r.localMaxSampleGap {
+			gap := sampledAt.Sub(r.localLastSample)
+			if gap > r.localMaxSampleGap {
 				r.localMaxSampleGap = gap
+			}
+			if gap > goldenProcessSampleMaxGap {
+				r.localGapsOverTarget++
 			}
 		}
 		r.localLastSample = sampledAt
@@ -2667,6 +2686,7 @@ func (r *goldenRunner) finalizeLocalDaemonRSS() error {
 	r.summary.LocalDaemonRSSSamples = r.localRSSSamples
 	r.summary.LocalDaemonProcessSamples = r.localRSSSamples
 	r.summary.LocalDaemonMaxSampleGapMS = r.localMaxSampleGap.Milliseconds()
+	r.summary.LocalDaemonSampleGapsOverTarget = r.localGapsOverTarget
 	r.summary.LocalDaemonPausedSamples = r.localPausedSamples
 	if r.localRSSExceeded || r.localPeakRSS > goldenRSSLimitBytes {
 		return failGolden("rss_limit_exceeded")
@@ -2680,10 +2700,23 @@ func (r *goldenRunner) finalizeLocalDaemonRSS() error {
 	if r.localSampleFailures != 0 {
 		return failGolden("process_sampling_failed")
 	}
-	if r.localMaxSampleGap > goldenProcessSampleMaxGap {
+	if goldenSamplingGapUnacceptable(r.localMaxSampleGap, r.localGapsOverTarget, r.localRSSSamples) {
 		return failGolden("process_sampling_gap")
 	}
 	return nil
+}
+
+// goldenSamplingGapUnacceptable separates a sampler that lost the process tree
+// from a runner that was briefly busy. One long gap can hide a memory spike, so
+// it fails outright; short gaps fail only once they stop being rare.
+func goldenSamplingGapUnacceptable(maxGap time.Duration, gapsOverTarget, samples int) bool {
+	if maxGap > goldenProcessSampleHardCeiling {
+		return true
+	}
+	if maxGap <= goldenProcessSampleMaxGap || samples <= 0 {
+		return false
+	}
+	return gapsOverTarget*100 > samples*goldenProcessSampleOverTargetPercentLimit
 }
 
 func goldenChildEnv(home string, overrides map[string]string) []string {

--- a/cmd/subrouter-transport-observer/golden_sampling_gap_test.go
+++ b/cmd/subrouter-transport-observer/golden_sampling_gap_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// The gap rule has to separate a sampler that lost the process tree from a
+// runner that was briefly busy. Failing on any interval over the 100ms target
+// made this required check fail on pull requests touching nothing near it.
+func TestGoldenSamplingGapSeparatesBlindSpotsFromRunnerNoise(t *testing.T) {
+	for _, testCase := range []struct {
+		name           string
+		maxGap         time.Duration
+		gapsOverTarget int
+		samples        int
+		unacceptable   bool
+	}{
+		{"steady sampling", 40 * time.Millisecond, 0, 500, false},
+		{"one hiccup in a long run", 300 * time.Millisecond, 1, 500, false},
+		{"hiccups that stop being rare", 300 * time.Millisecond, 40, 500, true},
+		{"a blind spot long enough to hide a spike", 2 * time.Second, 1, 500, true},
+		{"no samples at all", 0, 0, 0, false},
+		{"exactly at the target is not a gap", goldenProcessSampleMaxGap, 0, 100, false},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := goldenSamplingGapUnacceptable(testCase.maxGap, testCase.gapsOverTarget, testCase.samples)
+			if got != testCase.unacceptable {
+				t.Fatalf("goldenSamplingGapUnacceptable(%s, %d, %d) = %v, want %v",
+					testCase.maxGap, testCase.gapsOverTarget, testCase.samples, got, testCase.unacceptable)
+			}
+		})
+	}
+}
+
+// A stalled sampler must fail even when it produced few samples, because the
+// rarity rule has nothing to divide by.
+func TestGoldenSamplingGapFailsAStalledSamplerWithFewSamples(t *testing.T) {
+	if !goldenSamplingGapUnacceptable(5*time.Second, 1, 3) {
+		t.Fatal("a multi-second gap must fail regardless of sample count")
+	}
+}

--- a/cmd/subrouter-transport-observer/golden_slot_activation.go
+++ b/cmd/subrouter-transport-observer/golden_slot_activation.go
@@ -374,7 +374,7 @@ func (r *goldenRunner) requireGoldenSamplingStable(sessions []*goldenSession) er
 	localExceeded := r.localRSSExceeded
 	localPaused := r.localPausedSamples != 0
 	localFailed := r.localSampleFailures != 0
-	localGap := r.localMaxSampleGap > goldenProcessSampleMaxGap
+	localGap := goldenSamplingGapUnacceptable(r.localMaxSampleGap, r.localGapsOverTarget, r.localRSSSamples)
 	r.localRSSMu.Unlock()
 	if localMissing {
 		return failGolden("local_daemon_rss_missing")


### PR DESCRIPTION
`TestGoldenLocalMacHarnessOrchestratesAllModesWithoutContentEvidence` failed on three unrelated pull requests on 2026-09-04, twice on one that adds only shell scripts. Every failure was `process_sampling_gap`, and it is a required check, so each one cost a re-run and the merge path stalled behind it.

The rule was: fail if any interval between RSS samples exceeded 100ms. The sampler ticks every 20ms and shells out for a process table, so a shared runner routinely exceeds that once. What the check exists to guarantee is that the RSS evidence has no blind spot big enough to hide a spike, and one 150ms hiccup does not threaten that.

The target stays 100ms and is still reported. A run now fails when a single gap exceeds one second, which is a real blind spot, or when gaps over the target stop being rare (more than 5% of intervals), which is what a sampler losing the process tree looks like. The summary gains `local_daemon_process_sample_gaps_over_target` so the trend is visible rather than inferred from a single max.

Both call sites share one function, and it is unit tested for steady sampling, one hiccup in a long run, hiccups that stop being rare, a multi-second blind spot, and a stalled sampler with too few samples to divide by. The full `cmd/subrouter-transport-observer` package passes.

https://claude.ai/code/session_01KhBTe7aDNkqgQLH14687j9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791116285&installation_model_id=21920&pr_number=314&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F314&signature=8e43352a554521195fee6f8692f16bc5d70f7d2503ff1bcf6fb89ce508a090c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the golden sampling gap check tolerate a single sampling hiccup so the required `process_sampling_gap` check stops failing on unrelated PRs.

- Any interval over the 100ms target used to fail; now the run fails only when a gap exceeds one second or more than 5% of intervals are over target.
- The summary now reports `local_daemon_process_sample_gaps_over_target` so the trend is visible.
- Both call sites share one `goldenSamplingGapUnacceptable` function, covered by unit tests for steady sampling, rare hiccups, frequent hiccups, long blind spots, and a stalled sampler.

<sup>Written for commit 3ac02d6fb03fe3880219e3e1d57b7e3c0deb36ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

