### PR TITLE
fix: a restart must not disarm the operator's autoupdate pin

### DIFF
--- a/deploy/macos/subrouter-deploy.sh
+++ b/deploy/macos/subrouter-deploy.sh
@@ -129,13 +129,18 @@ take_lock() {
 # someone else's pin on exit would let the updater reinstall the release the
 # pin exists to keep out.
 HAD_INHIBIT=0
+WROTE_INHIBIT=0
 PREEXISTING_INHIBIT=""
 
 release_lock() {
+  # Only this run's own sentinel may be removed. restart-daemon and
+  # install-supervisor never write one, and deleting the operator's pin on
+  # their way out re-armed the updater on a host that is pinned precisely
+  # because the next release cannot become ready there.
   if [ "$HAD_INHIBIT" -eq 1 ]; then
     printf '%s\n' "$PREEXISTING_INHIBIT" >"$UPGRADE_INHIBIT_FILE" 2>/dev/null || true
     chmod 0600 "$UPGRADE_INHIBIT_FILE" 2>/dev/null || true
-  else
+  elif [ "$WROTE_INHIBIT" -eq 1 ]; then
     rm -f "$UPGRADE_INHIBIT_FILE" 2>/dev/null || true
   fi
   rmdir "$LOCK_DIR" 2>/dev/null || true
@@ -150,6 +155,7 @@ inhibit_autoupdate() {
   fi
   printf 'subrouter-deploy.sh running (pid %s)\n' "$$" >"$UPGRADE_INHIBIT_FILE"
   chmod 0600 "$UPGRADE_INHIBIT_FILE"
+  WROTE_INHIBIT=1
 }
 
 swap_and_verify() {

--- a/deploy/macos/tests/deploy-install-test.sh
+++ b/deploy/macos/tests/deploy-install-test.sh
@@ -251,5 +251,31 @@ check "bootstrap is retried until the job is in the launchd domain" $?
 unset BOOTSTRAP_SUCCEEDS_ON
 teardown
 
+# 10. A restart must not disarm the operator's autoupdate pin. This host is
+# pinned because the next release cannot become ready on it, and a restart that
+# cleared the pin let the updater install that release two minutes later.
+setup ok
+install_restart_launchctl
+mkdir -p "$(dirname "$SUBROUTER_UPGRADE_INHIBIT_FILE")"
+printf 'pinned by hand\n' >"$SUBROUTER_UPGRADE_INHIBIT_FILE"
+bash "$DEPLOY" restart-daemon >/dev/null 2>&1
+grep -q "pinned by hand" "$SUBROUTER_UPGRADE_INHIBIT_FILE" 2>/dev/null
+check "restart-daemon leaves an existing autoupdate pin in place" $?
+teardown
+
+# 11. Replacing the supervisor must not disarm it either.
+setup ok
+install_restart_launchctl
+export SUBROUTER_SUPERVISOR_BIN="$ROOT/bin/supervisor"
+printf '#!/bin/sh\nexit 0\n' >"$SUBROUTER_SUPERVISOR_BIN"; chmod 0755 "$SUBROUTER_SUPERVISOR_BIN"
+printf '#!/bin/sh\n# new\nexit 0\n' >"$ROOT/supervisor-candidate"; chmod 0755 "$ROOT/supervisor-candidate"
+mkdir -p "$(dirname "$SUBROUTER_UPGRADE_INHIBIT_FILE")"
+printf 'pinned by hand\n' >"$SUBROUTER_UPGRADE_INHIBIT_FILE"
+printf 'ok\n' >"$HEALTH_FILE"
+bash "$DEPLOY" install-supervisor "$ROOT/supervisor-candidate" >/dev/null 2>&1
+grep -q "pinned by hand" "$SUBROUTER_UPGRADE_INHIBIT_FILE" 2>/dev/null
+check "install-supervisor leaves an existing autoupdate pin in place" $?
+teardown
+
 if [ "$failures" -ne 0 ]; then printf '%d check(s) failed\n' "$failures"; exit 1; fi
 printf 'all checks passed\n'


### PR DESCRIPTION
`restart-daemon` and `install-supervisor` share `release_lock` with `install`, and it removed the autoupdate inhibit sentinel on every exit. Neither of them writes that sentinel, so a restart silently disarmed a pin somebody else set.

That is not theoretical. cmux-lawrence is pinned because every release after v0.1.125 gates readiness on a Codex usage-score sweep that cannot finish there. After tonight's supervisor restart the pin was gone, and the next `subrouter-autoupdate.sh` run began installing v0.1.130 on a host where it can never become ready. The updater's own rollback caught it, and the pin has been restored by hand.

`release_lock` now removes the sentinel only when this run wrote it: an existing one is restored as before, and one this run never created is left alone.

Two tests cover it, and both fail without the change: `restart-daemon` and `install-supervisor` each leave a hand-written pin in place.

https://claude.ai/code/session_01KhBTe7aDNkqgQLH14687j9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791117380&installation_model_id=21920&pr_number=315&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F315&signature=96b7284799a34fac3570ba31c351152e26932098f9ddc9d71308d4b097ce84c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a restart silently disarming the operator's autoupdate pin. `release_lock` previously removed the inhibit sentinel on every exit, so `restart-daemon` and `install-supervisor` deleted a pin they never wrote; it now removes the sentinel only when this run wrote it. Adds deploy tests proving both commands leave an existing pin in place.

<sup>Written for commit 169bb71297a4ae3a08148d9374f92b03f47a0d7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

