### PR TITLE
Apply the sampling hiccup rule to codex sessions too

### DIFF
--- a/cmd/subrouter-transport-observer/golden.go
+++ b/cmd/subrouter-transport-observer/golden.go
@@ -525,6 +525,7 @@ type goldenSessionSummary struct {
 	RSSSamples              int      `json:"rss_samples"`
 	ProcessSamples          int      `json:"process_samples"`
 	MaxProcessSampleGapMS   int64    `json:"max_process_sample_gap_ms"`
+	SampleGapsOverTarget    int      `json:"process_sample_gaps_over_target"`
 	PausedProcessSamples    int      `json:"paused_process_samples"`
 	MarkerCount             int      `json:"marker_count"`
 	ResumeMarkerCount       int      `json:"resume_marker_count"`
@@ -2648,8 +2649,12 @@ func (r *goldenRunner) recordGoldenProcessSample(pid int) {
 		session.mu.Lock()
 		if sampledAt.After(session.lastProcessSample) {
 			if !session.lastProcessSample.IsZero() {
-				if gap := sampledAt.Sub(session.lastProcessSample); gap > session.maxProcessSampleGap {
+				gap := sampledAt.Sub(session.lastProcessSample)
+				if gap > session.maxProcessSampleGap {
 					session.maxProcessSampleGap = gap
+				}
+				if gap > goldenProcessSampleMaxGap {
+					session.sampleGapsOverTarget++
 				}
 			}
 			session.lastProcessSample = sampledAt
@@ -2708,12 +2713,14 @@ func (r *goldenRunner) finalizeLocalDaemonRSS() error {
 
 // goldenSamplingGapUnacceptable separates a sampler that lost the process tree
 // from a runner that was briefly busy. One long gap can hide a memory spike, so
-// it fails outright; short gaps fail only once they stop being rare.
+// it fails outright. A single shorter gap is always tolerated: codex sessions
+// live for a few hundred milliseconds, so one hiccup would otherwise dominate
+// the ratio. Further gaps fail once they stop being rare.
 func goldenSamplingGapUnacceptable(maxGap time.Duration, gapsOverTarget, samples int) bool {
 	if maxGap > goldenProcessSampleHardCeiling {
 		return true
 	}
-	if maxGap <= goldenProcessSampleMaxGap || samples <= 0 {
+	if maxGap <= goldenProcessSampleMaxGap || samples <= 0 || gapsOverTarget <= 1 {
 		return false
 	}
 	return gapsOverTarget*100 > samples*goldenProcessSampleOverTargetPercentLimit
@@ -2941,6 +2948,7 @@ type goldenSession struct {
 	rssExceeded           bool
 	lastProcessSample     time.Time
 	maxProcessSampleGap   time.Duration
+	sampleGapsOverTarget  int
 	pausedProcessSamples  int
 	processSampleFailures int
 	monitoredPIDs         []int
@@ -4040,6 +4048,7 @@ func validateGoldenSessions(sessions []*goldenSession, resume bool) error {
 		rssSamples := session.rssSamples
 		rssExceeded := session.rssExceeded
 		maxSampleGap := session.maxProcessSampleGap
+		gapsOverTarget := session.sampleGapsOverTarget
 		pausedSamples := session.pausedProcessSamples
 		sampleFailures := session.processSampleFailures
 		session.mu.Unlock()
@@ -4093,7 +4102,7 @@ func validateGoldenSessions(sessions []*goldenSession, resume bool) error {
 		if sampleFailures != 0 {
 			return failGolden("process_sampling_failed")
 		}
-		if maxSampleGap > goldenProcessSampleMaxGap {
+		if goldenSamplingGapUnacceptable(maxSampleGap, gapsOverTarget, rssSamples) {
 			return failGolden("process_sampling_gap")
 		}
 	}
@@ -4816,6 +4825,7 @@ func summarizeGoldenSession(session, resume *goldenSession, _ int, before, after
 	peakRSS := session.peakRSSBytes
 	rssSamples := session.rssSamples
 	maxProcessSampleGap := session.maxProcessSampleGap
+	gapsOverTarget := session.sampleGapsOverTarget
 	pausedProcessSamples := session.pausedProcessSamples
 	preP99Gap := session.preP99Gap
 	allowedGap := session.allowedGap
@@ -4842,6 +4852,7 @@ func summarizeGoldenSession(session, resume *goldenSession, _ int, before, after
 		if resume.maxProcessSampleGap > maxProcessSampleGap {
 			maxProcessSampleGap = resume.maxProcessSampleGap
 		}
+		gapsOverTarget += resume.sampleGapsOverTarget
 		pausedProcessSamples += resume.pausedProcessSamples
 		resume.mu.Unlock()
 	}
@@ -4874,9 +4885,10 @@ func summarizeGoldenSession(session, resume *goldenSession, _ int, before, after
 		MaxChunkGapMillis: maxGap.Milliseconds(), PreDeployP99GapMillis: preP99Gap.Milliseconds(),
 		AllowedChunkGapMillis: allowedGap.Milliseconds(), DeployMaxChunkGapMillis: deployMaxGap.Milliseconds(),
 		PeakRSSBytes: peakRSS, RSSSamples: rssSamples, ProcessSamples: rssSamples,
-		MaxProcessSampleGapMS: maxProcessSampleGap.Milliseconds(), PausedProcessSamples: pausedProcessSamples,
-		MarkerCount:       markerCount,
-		ResumeMarkerCount: resumeMarkerCount, ResumeNonceCount: resumeNonceCount,
+		MaxProcessSampleGapMS: maxProcessSampleGap.Milliseconds(), SampleGapsOverTarget: gapsOverTarget,
+		PausedProcessSamples: pausedProcessSamples,
+		MarkerCount:          markerCount,
+		ResumeMarkerCount:    resumeMarkerCount, ResumeNonceCount: resumeNonceCount,
 		RetryCount: retries, ReconnectCount: reconnects, FallbackCount: fallbacks,
 		ErrorCount:       issueCount(issues) + resumeIssues + proxyErrors,
 		NonzeroExitCount: nonzero, DuplicateMarkerCount: duplicate,
@@ -5013,7 +5025,8 @@ func validateGoldenSummaryForCandidate(summary goldenSummary, testMode bool, can
 			session.FallbackCount != 0 || session.ErrorCount != 0 || session.NonzeroExitCount != 0 ||
 			session.DuplicateMarkerCount != 0 || session.PeakRSSBytes <= 0 || session.PeakRSSBytes > goldenCodexRSSLimitBytes ||
 			session.RSSSamples == 0 || session.ProcessSamples == 0 || session.PausedProcessSamples != 0 ||
-			session.MaxProcessSampleGapMS > goldenProcessSampleMaxGap.Milliseconds() ||
+			goldenSamplingGapUnacceptable(time.Duration(session.MaxProcessSampleGapMS)*time.Millisecond,
+				session.SampleGapsOverTarget, session.RSSSamples) ||
 			session.MaxChunkGapMillis > session.AllowedChunkGapMillis ||
 			session.AllowedChunkGapMillis < goldenChunkGapFloor.Milliseconds() ||
 			session.DeployMaxChunkGapMillis > session.AllowedChunkGapMillis {
@@ -5149,7 +5162,9 @@ func validateGoldenSummaryForCandidate(summary goldenSummary, testMode bool, can
 		}
 	}
 	if summary.LocalDaemonRSSSamples == 0 || summary.LocalDaemonProcessSamples == 0 ||
-		summary.LocalDaemonPausedSamples != 0 || summary.LocalDaemonMaxSampleGapMS > goldenProcessSampleMaxGap.Milliseconds() ||
+		summary.LocalDaemonPausedSamples != 0 ||
+		goldenSamplingGapUnacceptable(time.Duration(summary.LocalDaemonMaxSampleGapMS)*time.Millisecond,
+			summary.LocalDaemonSampleGapsOverTarget, summary.LocalDaemonRSSSamples) ||
 		summary.LocalDaemonPeakRSSBytes <= 0 || summary.LocalDaemonPeakRSSBytes > goldenRSSLimitBytes {
 		return failGolden("local_daemon_rss_missing")
 	}

--- a/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
+++ b/cmd/subrouter-transport-observer/golden_local_mac_harness_test.go
@@ -1105,13 +1105,26 @@ func TestGoldenSessionValidationRejectsEveryContinuityFailureClass(t *testing.T)
 		{name: "retry", edit: func(s *goldenSession) { s.issues["retry"] = 1 }, want: "codex_transport_issue_retry"},
 		{name: "fallback", edit: func(s *goldenSession) { s.issues["fallback"] = 1 }, want: "codex_transport_issue_fallback"},
 		{name: "error", edit: func(s *goldenSession) { s.issues["error"] = 1 }, want: "codex_transport_issue_error"},
-		{name: "process sampling gap", edit: func(s *goldenSession) { s.maxProcessSampleGap = goldenProcessSampleMaxGap + time.Millisecond }, want: "process_sampling_gap"},
+		{name: "one sampling hiccup is runner noise", edit: func(s *goldenSession) {
+			s.maxProcessSampleGap = goldenProcessSampleMaxGap + time.Millisecond
+			s.sampleGapsOverTarget = 1
+		}, want: ""},
+		{name: "process sampling blind spot", edit: func(s *goldenSession) { s.maxProcessSampleGap = goldenProcessSampleHardCeiling + time.Millisecond }, want: "process_sampling_gap"},
+		{name: "process sampling gaps stop being rare", edit: func(s *goldenSession) {
+			s.maxProcessSampleGap = goldenProcessSampleMaxGap + time.Millisecond
+			s.rssSamples = 8
+			s.sampleGapsOverTarget = 2
+		}, want: "process_sampling_gap"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			session := newSession()
 			test.edit(session)
-			if got := fixedGoldenFailure(validateGoldenSessions([]*goldenSession{session}, false)); got != test.want {
+			got := ""
+			if err := validateGoldenSessions([]*goldenSession{session}, false); err != nil {
+				got = fixedGoldenFailure(err)
+			}
+			if got != test.want {
 				t.Fatalf("failure = %q, want %q", got, test.want)
 			}
 		})

--- a/cmd/subrouter-transport-observer/golden_sampling_gap_test.go
+++ b/cmd/subrouter-transport-observer/golden_sampling_gap_test.go
@@ -18,6 +18,8 @@ func TestGoldenSamplingGapSeparatesBlindSpotsFromRunnerNoise(t *testing.T) {
 	}{
 		{"steady sampling", 40 * time.Millisecond, 0, 500, false},
 		{"one hiccup in a long run", 300 * time.Millisecond, 1, 500, false},
+		{"one hiccup in a short session", 300 * time.Millisecond, 1, 8, false},
+		{"two hiccups in a short session", 300 * time.Millisecond, 2, 8, true},
 		{"hiccups that stop being rare", 300 * time.Millisecond, 40, 500, true},
 		{"a blind spot long enough to hide a spike", 2 * time.Second, 1, 500, true},
 		{"no samples at all", 0, 0, 0, false},

--- a/cmd/subrouter-transport-observer/golden_slot_activation.go
+++ b/cmd/subrouter-transport-observer/golden_slot_activation.go
@@ -397,7 +397,7 @@ func (r *goldenRunner) requireGoldenSamplingStable(sessions []*goldenSession) er
 		exceeded := session.rssExceeded
 		paused := session.pausedProcessSamples != 0
 		failed := session.processSampleFailures != 0
-		gap := session.maxProcessSampleGap > goldenProcessSampleMaxGap
+		gap := goldenSamplingGapUnacceptable(session.maxProcessSampleGap, session.sampleGapsOverTarget, session.rssSamples)
 		session.mu.Unlock()
 		if missing {
 			return failGolden("process_rss_missing")


### PR DESCRIPTION
main is red since https://github.com/manaflow-ai/subrouter/pull/315 (a shell-only change). The failure is `process_sampling_gap` from `TestGoldenLocalMacHarnessOrchestratesAllModesWithoutContentEvidence`, with `sessions: null` in result.json. https://github.com/manaflow-ai/subrouter/pull/314 relaxed the rule for the local daemon only. The activation gate, session validation, and both summary checks still failed a codex session on any single interval over 100ms.

Sessions now count over-target gaps like the daemon and every gap site calls `goldenSamplingGapUnacceptable`. One short gap is always tolerated: a codex session lives a few hundred milliseconds, so one hiccup would dominate the 5% ratio. Two gaps in a short session, or any gap over one second, still fail. The session summary gains `process_sample_gaps_over_target`.

Verified locally: `go vet ./...` and `CGO_ENABLED=0 go test ./...` pass.

https://claude.ai/code/session_01BHhAPsQstN22tbt35JLiXj

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/subrouter/pr/317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791281989&installation_model_id=21920&pr_number=317&repository=manaflow-ai%2Fsubrouter&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fsubrouter%2Fpull%2F317&signature=d9e015fccc3161bd7211a062bc388922c315fb68042194ed41b59b4460daa4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the sampling hiccup rule to codex sessions so one short sampling gap no longer fails validation. Previously any interval over 100ms failed a session; now two gaps in a short session or a gap over one second still fail, and the session summary gains `process_sample_gaps_over_target`.

<sup>Written for commit ef4f6b516a7a2cc0e900fc0a2e2b5962aafd6f01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/subrouter/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Golden continuity validation now tolerates a single brief process-sampling gap caused by transient runner noise.
  * Repeated over-target gaps or gaps exceeding the hard limit continue to be flagged as sampling failures.
  * Validation behavior is now consistent across session, summary, and local-daemon checks.
  * Session summaries include the number of process-sampling gaps that exceeded the target interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->